### PR TITLE
Install distribution-gpg-keys explicitly

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -28,6 +28,9 @@ dumb-init
 # rpmdistro-gitoverlay deps
 dnf-plugins-core createrepo_c dnf-utils fedpkg openssh-clients rpmdistro-gitoverlay
 
+# Currently a transitive req of rpmdistro-gitoverlay via mock, but we
+# expect people to use these explicitly in their repo configurations.
+distribution-gpg-keys
 # We need these for rojig
 selinux-policy-targeted rpm-build
 


### PR DESCRIPTION
I think using these in treefiles should be a best practice,
rather than /etc/pki/rpm-gpg, as installing things there can
affect the base system.