### PR TITLE
Use builder user by default, add sudo for rpm-ostree compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,5 @@ FROM registry.fedoraproject.org/fedora:28
 WORKDIR /root/src
 COPY . /root/src
 RUN ./build.sh
+USER builder
 ENTRYPOINT ["/usr/bin/coreos-assembler"]

--- a/src/cmd-build
+++ b/src/cmd-build
@@ -44,20 +44,19 @@ if [ -z "${SKIPCOMPOSE:-}" ]; then
 rm -rf work
 mkdir -p work
 previous_commit=$(ostree --repo=${workdir}/repo rev-parse ${ref} || true)
-rpm-ostree compose tree --repo=${workdir}/repo-build --cachedir=${workdir}/cache ${treecompose_args} --touch-if-changed work/treecompose.changed ${TREECOMPOSE_FLAGS:-} ${manifest}
+# This one needs sudo, since it uses container features itself
+# But see also https://github.com/projectatomic/rpm-ostree/issues/1011
+sudo rpm-ostree compose tree --repo=${workdir}/repo-build --cachedir=${workdir}/cache ${treecompose_args} --touch-if-changed work/treecompose.changed ${TREECOMPOSE_FLAGS:-} ${manifest}
 if ! [ -f work/treecompose.changed ] ; then
     exit 0
 fi
 ostree --repo=${workdir}/repo pull-local ${workdir}/repo-build "${ref}"
 ostree --repo=${workdir}/repo summary -u
-setfacl -R -m u:builder:rwX ${workdir}/repo
 fi
 commit=$(ostree --repo=${workdir}/repo rev-parse "${ref}")
 version=$(ostree --repo=${workdir}/repo-build show --print-metadata-key=version ${commit} | sed -e "s,',,g")
 
 mkdir -p "${buildid}"
-setfacl -R -d -m u:builder:rwX "${buildid}"
-setfacl -R -m u:builder:rwX "${buildid}"
 cd "${buildid}"
 
 # Generate JSON
@@ -84,8 +83,7 @@ ostreesetup --nogpg --osname=coreos --remote=coreos --url=file:///mnt/ostree-rep
 EOF
 
 imageprefix=${name}-${version}
-# Having a `builder` user is a bit painful too.  Hmm.
-runuser -u builder -- /usr/libexec/coreos-assembler/virt-install --dest=$(pwd)/${imageprefix}-base.qcow2 --create-disk --kickstart $(pwd)/local.ks --kickstart-out $(pwd)/flattened.ks --location ${workdir}/installer/*.iso --console-log-file $(pwd)/install.log --local-repo=${workdir}/repo
+/usr/libexec/coreos-assembler/virt-install --dest=$(pwd)/${imageprefix}-base.qcow2 --create-disk --kickstart $(pwd)/local.ks --kickstart-out $(pwd)/flattened.ks --location ${workdir}/installer/*.iso --console-log-file $(pwd)/install.log --local-repo=${workdir}/repo
 
 /usr/libexec/coreos-assembler/gf-oemid ${imageprefix}-base.qcow2 $(pwd)/${imageprefix}-qemu.qcow2 qemu
 

--- a/src/cmd-init
+++ b/src/cmd-init
@@ -6,6 +6,8 @@ dn=$(dirname $0)
 
 preflight
 
+sudo setfacl -d -m u:builder:rwX .
+
 INSTALLER=https://dl.fedoraproject.org/pub/fedora/linux/releases/28/Everything/x86_64/iso/Fedora-Everything-netinst-x86_64-28-1.1.iso
 INSTALLER_CHECKSUM=https://dl.fedoraproject.org/pub/fedora/linux/releases/28/Everything/x86_64/iso/Fedora-Everything-28-1.1-x86_64-CHECKSUM
 
@@ -35,5 +37,3 @@ mkdir -p cache
 mkdir -p builds
 ostree --repo=repo init --mode=archive
 ostree --repo=repo-build init --mode=bare-user
-setfacl -R -d -m u:builder:rwX .
-setfacl -R -m u:builder:rwX .


### PR DESCRIPTION
Today it's only `rpm-ostree compose tree` that wants privileges,
so let's flip the defaults to running unprivileged.  This drops
a whole lot of hacky bits; we only `setfacl` once in `init`.