### PR TITLE
Print only useful commands

### DIFF
--- a/coreos-assembler
+++ b/coreos-assembler
@@ -9,8 +9,9 @@ cmd=${1:-}
 if [ -z "${cmd}" ]; then
     echo usage: "coreos-assembler CMD ..."
     echo "Commands:"
-    ls /usr/libexec/coreos-assembler | while read cmd; do
-        echo "  ${cmd}"
+    ls /usr/libexec/coreos-assembler/cmd-* | while read cmd; do
+        bin=$(basename $cmd)
+        echo "  ${bin:4}"
     done
     exit 1
 fi


### PR DESCRIPTION
When `coreos-assembler` is inoked without options, the command prints
out a list of options to use.  However, only a few of them are useful
to the user (`build`, `init`).  This changes the command to just print
those.