### PR TITLE
Chown everything to builder, stop using ACLs

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -50,6 +50,7 @@ sudo rpm-ostree compose tree --repo=${workdir}/repo-build --cachedir=${workdir}/
 if ! [ -f work/treecompose.changed ] ; then
     exit 0
 fi
+sudo chown -R -h builder: ${workdir}/repo-build
 ostree --repo=${workdir}/repo pull-local ${workdir}/repo-build "${ref}"
 ostree --repo=${workdir}/repo summary -u
 fi

--- a/src/cmd-init
+++ b/src/cmd-init
@@ -6,7 +6,7 @@ dn=$(dirname $0)
 
 preflight
 
-sudo setfacl -d -m u:builder:rwX .
+sudo chown builder: .
 
 INSTALLER=https://dl.fedoraproject.org/pub/fedora/linux/releases/28/Everything/x86_64/iso/Fedora-Everything-netinst-x86_64-28-1.1.iso
 INSTALLER_CHECKSUM=https://dl.fedoraproject.org/pub/fedora/linux/releases/28/Everything/x86_64/iso/Fedora-Everything-28-1.1-x86_64-CHECKSUM


### PR DESCRIPTION
I thought I was being clever using ACLs, it *mostly* worked
but the problem is that some of the objects aren't world readable,
and due to the way [effective ACLs](https://unix.stackexchange.com/questions/152477/how-does-acl-calculate-the-effective-permissions-on-a-file)
work, those objects weren't readable to `builder`.

This approach of doing the chown after treecompose matches what
FAHC does too.