### PR TITLE
build: Create a `latest` symlink

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -96,3 +96,6 @@ cat > meta.json <<EOF
  "version": "${version}"
 }
 EOF
+
+cd ${workdir}/builds
+ln -sfr "${buildid}" latest


### PR DESCRIPTION
So we don't need to hit `TAB` a lot in bash and compare numbers.