### PR TITLE
build: Actually replace link

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -98,4 +98,4 @@ cat > meta.json <<EOF
 EOF
 
 cd ${workdir}/builds
-ln -sfr "${buildid}" latest
+ln -Tsfr "${buildid}" latest


### PR DESCRIPTION
I tested that the previous commit created the link, not that it
swapped correctly.