### PR TITLE
Allow running as current non-root user

### DIFF
--- a/coreos-assembler
+++ b/coreos-assembler
@@ -7,7 +7,7 @@ set -euo pipefail
 case $(id -un) in
     root) exec runuser -u builder -- $0 "$@";;
     builder) ;;
-    *) echo "Executed as non-builder user" 1>&2; exit 1;;
+    *) echo "Executed as non-builder user; assuming sudo rights..." 1>&2;;
 esac
 
 cmd=${1:-}

--- a/src/cmd-build
+++ b/src/cmd-build
@@ -50,7 +50,7 @@ sudo rpm-ostree compose tree --repo=${workdir}/repo-build --cachedir=${workdir}/
 if ! [ -f work/treecompose.changed ] ; then
     exit 0
 fi
-sudo chown -R -h builder: ${workdir}/repo-build
+sudo chown -R -h $UID: ${workdir}/repo-build
 ostree --repo=${workdir}/repo pull-local ${workdir}/repo-build "${ref}"
 ostree --repo=${workdir}/repo summary -u
 fi

--- a/src/cmd-init
+++ b/src/cmd-init
@@ -6,7 +6,7 @@ dn=$(dirname $0)
 
 preflight
 
-sudo chown builder: .
+sudo chown $UID: .
 
 INSTALLER=https://dl.fedoraproject.org/pub/fedora/linux/releases/28/Everything/x86_64/iso/Fedora-Everything-netinst-x86_64-28-1.1.iso
 INSTALLER_CHECKSUM=https://dl.fedoraproject.org/pub/fedora/linux/releases/28/Everything/x86_64/iso/Fedora-Everything-28-1.1-x86_64-CHECKSUM


### PR DESCRIPTION
To make it easier to run in pet containers, just assume that the current
user has sudo privs. But still try to `runuser -u builder` if started as
root. This also requires using `$UID` instead of `builder` in the actual
command scripts to keep it generic.