### PR TITLE
build: Use work/ dir until complete

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -39,8 +39,8 @@ if [ -n "${previous_build}" ]; then
     fi
 fi
 
-mkdir -p "${buildid}"
-cd "${buildid}"
+mkdir -p "work/${buildid}"
+cd "work/${buildid}"
 
 # Generate JSON
 if [ -n "${previous_commit}" ]; then
@@ -82,4 +82,5 @@ cat > meta.json <<EOF
 EOF
 
 cd ${workdir}/builds
+mv work/${buildid} .
 ln -Tsfr "${buildid}" latest


### PR DESCRIPTION
This way only *completed* builds live in the `builds/` directory,
and the last failed build lives in `work/`.  Since `work/` is
pruned before building again, you don't accumulate failed builds.