### PR TITLE
build: Move mantle build into Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,15 @@
 PREFIX ?= /usr
 DESTDIR ?=
 
-.PHONY: all install
+.PHONY: all mantle install
 
-all:
+all: mantle
+
+mantle:
+	cd mantle && ./build ore kola kolet
 
 install:
 	install -D -t $(DESTDIR)$(PREFIX)/bin coreos-assembler $$(find src/compat -maxdepth 1 -type f)
 	install -D -t $(DESTDIR)$(PREFIX)/libexec/coreos-assembler $$(find src/ -maxdepth 1 -type f)
+	install -D -t $(DESTDIR)$(PREFIX)/bin mantle/bin/{ore,kola}
+	install -D -m 0755 -t $(DESTDIR)$(PREFIX)/lib/kola/amd64 mantle/bin/amd64/kolet

--- a/build.sh
+++ b/build.sh
@@ -88,17 +88,7 @@ mkdir -p /usr/app/
 rsync -rlv ${srcdir}/ostree-releng-scripts/ /usr/app/ostree-releng-scripts/
 
 # And the main scripts
-make install
-
-# Part of general image management
-(cd mantle
- # Add components as necessary
- ./build ore kola kolet
- for x in ore kola; do
-     mv bin/${x} /usr/bin
- done
-install -D -m 0755 -t /usr/lib/kola/amd64 bin/amd64/kolet
-)
+make && make install
 
 # Cleanup deps
 dnf remove -y ${self_builddeps}


### PR DESCRIPTION
Part of supporting building from git and installing into
an existing pet container.