### PR TITLE
New command: run

### DIFF
--- a/coreos-assembler
+++ b/coreos-assembler
@@ -11,6 +11,7 @@ case $(id -un) in
 esac
 
 cmd=${1:-}
+shift
 
 if [ -z "${cmd}" ]; then
     echo usage: "coreos-assembler CMD ..."

--- a/src/cmd-run
+++ b/src/cmd-run
@@ -1,0 +1,126 @@
+#!/bin/bash
+# Forked from https://github.com/coreos/scripts/blob/master/build_library/qemu_template.sh
+# Changed to have command line arguments, drop non-x86_64/non-KVM support
+# Automatically uses `-snapshot` if the target disk isn't writable
+# Uses -nographic by default, and most importantly, contains a default
+# Ignition config that auto-logins on the console
+
+set -euo pipefail
+
+VM_DISK=
+VM_MEMORY=2048
+VM_PERSIST=0
+VM_NCPUS="${VM_NCPUS:-$(nproc)}"
+VM_SRV_MNT=
+SSH_PORT=${SSH_PORT:-}
+USAGE="Usage: $0 /path/to/disk.qcow2 [--] [qemu options...]
+Options:
+    -d DISK     Root disk drive (won't be changed by default)
+    --persist   Don't create a temporary snapshot
+    -i FILE     File containing an Ignition config
+    --srv src   Mount (via 9p) src on the host as /var/srv in guest
+    -m MB       RAM size in MB (2048)
+    -p PORT     The port on localhost to map to the VM's sshd. [2222]
+    -h          this ;-)
+
+This script is a wrapper around qemu for starting CoreOS virtual machines,
+it will auto-log you into the console, and by default for read-only disk
+images makes a transient snapshot.
+
+Any arguments after -- will be passed through to qemu. See the qemu(1) man page
+for more details.
+"
+
+die(){
+	echo "${1}" 1>&2
+	exit 1
+}
+
+while [ $# -ge 1 ]; do
+    case "$1" in
+        -d)
+            VM_DISK="$2"
+            shift 2 ;;
+        --persist)
+            VM_PERSIST=1
+            shift 1 ;;
+        -i|--ignition-config)
+            IGNITION_CONFIG_FILE="$2"
+            shift 2 ;;
+        --srv)
+            VM_SRV_MNT="$2"
+            shift 2 ;;
+        -m)
+            VM_MEMORY="$2"
+            shift 2 ;;
+        -p|--ssh-port)
+            SSH_PORT="$2"
+            shift 2 ;;
+        -v|--verbose)
+            set -x
+            shift ;;
+        -h|--help)
+            echo "$USAGE"
+            exit ;;
+        --)
+            shift
+            break ;;
+        *)
+            die "Unknown argument $1";;
+    esac
+done
+
+if [ -z "${VM_DISK}" ]; then
+    if [ -L ./builds/latest ]; then
+        latest_build=$(readlink builds/latest)
+        VM_DISK=$(ls builds/${latest_build}/*-qemu.qcow2)
+    else
+        die "No builds/latest, and no -d argument provided"
+    fi
+fi
+
+# Emulate the host CPU closely in both features and cores.
+set -- -machine accel=kvm -cpu host -smp "${VM_NCPUS}" "$@"
+
+if [ -n "${VM_SRV_MNT}" ]; then
+    set -- --fsdev local,id=var-srv,path=${VM_SRV_MNT},security_model=mapped,readonly "$@"
+    ign_var_srv_mount=',{
+"name": "var-srv.mount",
+"enabled": true,
+"contents": "[Mount]\nWhat=/var/srv\nWhere=/var/srv\nType=9p\nOptions=ro,trans=virtio,version=9p2000.L\n[Install]\nWantedBy=multi-user.target\n"
+}'
+else
+    ign_var_srv_mount=""
+fi
+
+if [ -z "${IGNITION_CONFIG_FILE:-}" ]; then
+    f=$(mktemp)
+    cat > ${f} <<EOF
+{"ignition": {"config": {}, "security": {"tls": {}}, "timeouts": {}, "version": "2.2.0"}, "networkd": {}, "passwd": {"users": [{"groups": ["sudo"], "name": "core"}]}, "storage": {}, "systemd": {"units": [{"name": "serial-getty@ttyS0.service", "dropins": [{"name": "autologin-core.conf", "contents": "[Service]\nTTYVTDisallocate=no\nExecStart=\nExecStart=-/usr/sbin/agetty --autologin core --noclear %I \$TERM\n"}]}${ign_var_srv_mount}]}}
+EOF
+    exec 3<>${f}
+    if ! jq . < ${f} >/dev/null; then
+        cat "${f}"
+        exit 1
+    fi
+    rm -f ${f}
+    IGNITION_CONFIG_FILE=/proc/self/fd/3
+fi
+set -- -fw_cfg name=opt/com.coreos/config,file="${IGNITION_CONFIG_FILE}" "$@"
+
+if [ -n "${SSH_PORT}" ]; then
+   hostfwd=",hostfwd=tcp::"${SSH_PORT}"-:22"
+fi
+
+if [ "${VM_PERSIST}" = 0 ]; then
+    set -- -snapshot "$@"
+    vm_drive_args=",cache=unsafe"
+fi
+
+set -- -drive if=virtio,file=${VM_DISK}${vm_drive_args:-} "$@"
+
+exec qemu-kvm -name coreos -m ${VM_MEMORY} -nographic \
+              -netdev user,id=eth0,hostname=coreos${hostfwd:-} \
+              -device virtio-net-pci,netdev=eth0 \
+              -object rng-random,filename=/dev/urandom,id=rng0 -device virtio-rng-pci,rng=rng0 \
+              "$@"


### PR DESCRIPTION
This is a copy of my
https://github.com/cgwalters/playground/blob/master/coreos-run-qemu
script.  Which I know overlaps a lot with `kola spawn`, but as
is noted in the header:

 - Uses `-snapshot` by default to avoid writing to the disk
 - Contains a default  Ignition config that auto-logins on the console

Also, this runs as non-root.

The main change I made from the playground one is small but important
one:

`coreos-assembler run`

finds the latest disk image and runs it this way.  I find this *very*
convenient.