### PR TITLE
cmdlib: Fix --touch-if-changed for rpm-ostree

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -55,5 +55,6 @@ runcompose() {
         treecompose_args="${treecompose_args} --unified-core"
     fi
     export previous_commit=$(ostree --repo=${workdir}/repo rev-parse ${ref} || true)
-    sudo rpm-ostree compose tree --repo=${workdir}/repo-build --cachedir=${workdir}/cache ${treecompose_args} --touch-if-changed work/treecompose.changed ${TREECOMPOSE_FLAGS:-} ${manifest} "$@"
+    sudo rpm-ostree compose tree --repo=${workdir}/repo-build --cachedir=${workdir}/cache ${treecompose_args} \
+         --touch-if-changed $(pwd)/work/treecompose.changed ${TREECOMPOSE_FLAGS:-} ${manifest} "$@"
 }


### PR DESCRIPTION
It requires an absolute path for historical reasons.