### PR TITLE
explicitly set $USER variable

### DIFF
--- a/coreos-assembler
+++ b/coreos-assembler
@@ -4,7 +4,9 @@ set -euo pipefail
 # Currently this just wraps the two binaries we have today
 # under a global entrypoint with subcommands.
 
-case $(id -un) in
+export USER=${USER:-$(id -nu)}
+
+case $USER in
     root) exec runuser -u builder -- $0 "$@";;
     builder) ;;
     *) echo "Executed as non-builder user; assuming sudo rights..." 1>&2;;


### PR DESCRIPTION
if running via podman or docker the $USER var is not
set automatically. Let's set it so that the rest of
our scripts can use $USER as they please.