### PR TITLE
build: Use chmod, not chown for objects

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -10,7 +10,12 @@ prepare_build
 
 # Build uses cached data
 runcompose --cache-only
-sudo chown -R -h $USER: ${workdir}/repo-build
+# https://github.com/ostreedev/ostree/issues/1562#issuecomment-385393872
+# The passwd files (among others) don't have world readability.  This won't
+# actually corrupt the repository as the *canonical* permissions are stored
+# as xattrs.  Probably what we should do is have an ostree option to specify
+# a permission mask for objects.
+sudo chmod -R a+rX ${workdir}/repo-build/objects
 ostree --repo=${workdir}/repo pull-local ${workdir}/repo-build "${ref}"
 ostree --repo=${workdir}/repo summary -u
 commit=$(ostree --repo=${workdir}/repo rev-parse "${ref}")


### PR DESCRIPTION
This will fix: https://github.com/cgwalters/fedora-coreos-config/issues/1

Due to the way we're using hardlink checkouts for our roots, `chown`ing
the objects means that any data derived from them via scripts will
end up with that UID.

The *canonical* permissions in a `bare-user` OSTree repo are stored
as xattrs, but for new objects we won't know to use root.
(Probably we should require new objects unknown to a package to be
 root?)

All we really want here is for the objects to be accessible to
`pull-local`, so let's `chmod` and not `chown`.