### PR TITLE
init: Require specifying a config repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,17 +32,18 @@ $ alias coreos-assembler='podman run --rm --net=host -ti --privileged -v $(pwd):
 Initializing
 ---
 
-You only need to do this once; it will create various directories and also
+You only need to do this once; it will clone the specified
+configuration repo, create various directories and also
 download an installer image (used to make VMs).
 
 ```
-$ coreos-assembler init
+$ coreos-assembler init https://github.com/cgwalters/fedora-coreos-config
 ```
 
-One thing to note is you'll have a `/srv/coreos/src/config` directory.  By
-default, this is a clone of https://github.com/cgwalters/fedora-coreos-config
-If you're doing something custom, you likely want to fork it and edit.  Just
-replace the `src/config` directory with your git clone.
+The specified git repository will be cloned into `/srv/coreos/src/config`.
+
+If you're doing something custom, you likely want to fork that upstream
+repository.
 
 Performing a build
 ---

--- a/src/cmd-init
+++ b/src/cmd-init
@@ -4,6 +4,21 @@ set -xeuo pipefail
 dn=$(dirname $0)
 . ${dn}/cmdlib.sh
 
+source="${1:-}"
+if [ -z "${source}" ] && ! [ -e src/config ]; then
+    set +x
+    cat 1>&2 <<'EOF'
+Usage: coreos-assembler init GITCONFIG
+
+  For example, you can use https://github.com/cgwalters/fedora-coreos-config
+  as GITCONFIG, or fork it.  Another option useful for local development
+  (if you're running a shell inside this container) is to pass a file path
+  starting with `/` - a symlink to it will be created and then used directly."
+EOF
+    exit 1
+fi
+shift
+
 preflight
 
 sudo chown $USER: .
@@ -14,8 +29,16 @@ INSTALLER_CHECKSUM=https://dl.fedoraproject.org/pub/fedora/linux/releases/28/Eve
 # Initialize sources (git)
 mkdir -p src
 (cd src
- if ! test -d config; then
-     git clone https://github.com/cgwalters/fedora-coreos-config config
+ if ! test -e config; then
+     case "${source}" in
+         /*) ln -sr "${source}" config;;
+         *) git clone "${source}" config;;
+     esac
+     manifest=config/manifest.yaml
+     if ! [ -f "${manifest}" ]; then
+         echo 1>&2 "Failed to find src/${manifest}"
+         fatal "If using a custom configuration, be sure it has a manifest.yaml."
+     fi
  fi)
 
 mkdir -p installer

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -28,8 +28,8 @@ prepare_build() {
     export configdir=${workdir}/src/config
     export manifest=${configdir}/manifest.yaml
 
-    if ! [ -f "${manifest}" -a -f "${configdir}/fedora-coreos.yaml" ]; then
-        export manifest="${configdir}/fedora-coreos.yaml"
+    if ! [ -f "${manifest}" ]; then
+        fatal "Failed to find ${manifest}"
     fi
 
     echo "Using manifest: ${manifest}"


### PR DESCRIPTION
It's a bit too magical to have hardcoded config defaults.  We really
want anyone doing custom builds to use their own repository, and
requiring them to specify it upfront will highlight that.

For local development, it's very convenient now to just pass a
local file path, without having another clone sitting around.

Note that I pushed
https://github.com/cgwalters/fedora-coreos-config/commit/0a2c02a60589b936da0b5c0c9cce20ae9fb81f74
which is used by this.