### PR TITLE
 Dockerfile: Wrap entrypoint with `dumb-init`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,4 @@ WORKDIR /root/src
 COPY . /root/src
 RUN ./build.sh
 USER builder
-ENTRYPOINT ["/usr/bin/coreos-assembler"]
+ENTRYPOINT ["/usr/bin/dumb-init", "/usr/bin/coreos-assembler"]

--- a/src/cmd-build
+++ b/src/cmd-build
@@ -94,7 +94,10 @@ EOF
 
 imageprefix=${name}-${version}-${image_genver}
 tail -F $(pwd)/install.log & # send output of virt-install to console
-/usr/libexec/coreos-assembler/virt-install --dest=$(pwd)/${imageprefix}-base.qcow2 --create-disk --kickstart $(pwd)/local.ks --kickstart-out $(pwd)/flattened.ks --location ${workdir}/installer/*.iso --console-log-file $(pwd)/install.log --local-repo=${workdir}/repo
+/usr/libexec/coreos-assembler/virt-install --dest=$(pwd)/${imageprefix}-base.qcow2 \
+               --create-disk --kickstart $(pwd)/local.ks --kickstart-out $(pwd)/flattened.ks \
+               --location ${workdir}/installer/*.iso --console-log-file $(pwd)/install.log \
+               --local-repo=${workdir}/repo
 
 /usr/libexec/coreos-assembler/gf-oemid ${imageprefix}-base.qcow2 $(pwd)/${imageprefix}-qemu.qcow2 qemu
 


### PR DESCRIPTION

This is just a good idea in general (e.g. for our `shell` verb),
but it will specifically fix the issue that `virt-install` forks
`libvirt` which forks `qemu`, and libvirt won't know that a VM
is shut down until the `qemu` process is actually reaped by pid 1.