### PR TITLE
build: Print versions of ostree/rpm-ostree

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -8,6 +8,9 @@ export LIBGUESTFS_BACKEND=direct
 
 prepare_build
 
+ostree --version
+rpm-ostree --version
+
 previous_commit=$(ostree --repo=${workdir}/repo rev-parse ${ref} || true)
 # Generate metadata that's *input* to the ostree commit
 config_gitrev=$(cd ${configdir} && git describe --tags --always --abbrev=42)


### PR DESCRIPTION
While we know the assembler is tracking FAHC, it's still
useful information in general since the feature set of these
is changing pretty quickly.

Ref: https://github.com/projectatomic/rpm-ostree/issues/1556