### PR TITLE
build: Add Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "coreos-assembler"
+version = "0.1.0"
+authors = ["Colin Walters <walters@verbum.org>"]
+
+[dependencies]
+clap = "~2.28"
+failure = "0.1.1"
+
+[[bin]]
+name = "coreos-assembler-rs"
+path = "src/coreos-assembler.rs"

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,19 @@
 PREFIX ?= /usr
 DESTDIR ?=
 
-.PHONY: all mantle install
+.PHONY: all rust mantle install
 
-all: mantle
+all: mantle rust
+
+rust:
+	cargo build --release
 
 mantle:
 	cd mantle && ./build ore kola kolet
 
 install:
 	install -D -t $(DESTDIR)$(PREFIX)/bin coreos-assembler $$(find src/compat -maxdepth 1 -type f)
+	install -D -t $(DESTDIR)$(PREFIX)/libexec target/release/coreos-assembler-rs
 	install -D -t $(DESTDIR)$(PREFIX)/libexec/coreos-assembler $$(find src/ -maxdepth 1 -type f)
 	install -D -t $(DESTDIR)$(PREFIX)/bin mantle/bin/{ore,kola}
 	install -D -m 0755 -t $(DESTDIR)$(PREFIX)/lib/kola/amd64 mantle/bin/amd64/kolet

--- a/src/coreos-assembler.rs
+++ b/src/coreos-assembler.rs
@@ -1,0 +1,38 @@
+extern crate clap;
+#[macro_use]
+extern crate failure;
+
+use failure::Error;
+use clap::{App, SubCommand};
+
+fn hello() -> Result<(), Error> {
+    println!("🦀");
+    Ok(())
+}
+
+fn run() -> Result<(), Error> {
+    let matches = App::new("coreos-assembler")
+        .version("0.1")
+        .about("CoreOS assembler")
+        .subcommand(
+            SubCommand::with_name("hello")
+                .about("Say hello")
+        )
+        .get_matches();
+
+    match matches.subcommand() {
+        ("hello", _) => hello(),
+        ("", _) => bail!("No command given"),
+        _ => unreachable!(),
+    }
+}
+
+fn main() {
+    match run() {
+        Ok(_) => {}
+        Err(e) => {
+            eprintln!("{:?}", e);
+            std::process::exit(1)
+        }
+    }
+}


### PR DESCRIPTION
So far we have lots of shell script, some Python, Go from mantle...
clearly, we need to add Rust!

More seriously so...I like the language, I am not excited about
writing more dynamically typed and slow shell script/Python.

There's a definite argument for Go, since we could share code
with Mantle.  I personally like Rust a lot though...but
this is an RFE to see how people feel.

My vision for this was that we could start implementing some of
the VM installation work in it, along with defining Serde
structs for the metadata, etc.