### PR TITLE
virt-install: Disable networking

### DIFF
--- a/src/virt-install
+++ b/src/virt-install
@@ -103,6 +103,7 @@ try:
                           "--memory={}".format(args.memory), get_libvirt_smp_arg(),
                           "--os-variant=rhel7", "--rng=/dev/urandom",
                           "--check", "path_in_use=off",
+                          "--network=none",  # We want predictablity, disable networking
                           "--disk=path={},cache=unsafe".format(args.dest),
                           "--location={}".format(args.location),
                           "--initrd-inject={}".format(ks_tmp.name),


### PR DESCRIPTION
We don't want Anaconda to find a network device and do DHCP,
and try to encode anything about the build environment.

Further, we want all of the content to come from the container;
nothing potentially from the Internet.  Downloading content in `%post`
is a no-no.

Since we currently inject convent via 9p, disable networking
in the installer.

This will break RHCOS builds, but we'll adapt them to use this.
Right now it's tagged to `:alpha`.