### PR TITLE
build: Drop compat/ command entrypoints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ mantle:
 	cd mantle && ./build ore kola kolet
 
 install:
-	install -D -t $(DESTDIR)$(PREFIX)/bin coreos-assembler $$(find src/compat -maxdepth 1 -type f)
+	install -D -t $(DESTDIR)$(PREFIX)/bin coreos-assembler
 	install -D -t $(DESTDIR)$(PREFIX)/libexec/coreos-assembler $$(find src/ -maxdepth 1 -type f)
 	install -D -t $(DESTDIR)$(PREFIX)/bin mantle/bin/{ore,kola}
 	install -D -m 0755 -t $(DESTDIR)$(PREFIX)/lib/kola/amd64 mantle/bin/amd64/kolet

--- a/src/compat/coreos-oemid
+++ b/src/compat/coreos-oemid
@@ -1,2 +1,0 @@
-#!/bin/bash
-exec coreos-assembler gf-oemid "$@"

--- a/src/compat/coreos-virt-install
+++ b/src/compat/coreos-virt-install
@@ -1,2 +1,0 @@
-#!/bin/bash
-exec coreos-assembler virt-install "$@"


### PR DESCRIPTION
Everything should be either using the toplevel `coreos-assembler`
entrypoint, or know what they're doing.

The RHCOS builds are tagged to `:alpha` now so won't break with this.