### PR TITLE
main: Stop warning about non-builder users

### DIFF
--- a/coreos-assembler
+++ b/coreos-assembler
@@ -4,13 +4,8 @@ set -euo pipefail
 # Currently this just wraps the two binaries we have today
 # under a global entrypoint with subcommands.
 
+# docker/podman don't run through PAM, but we want this set
 export USER=${USER:-$(id -nu)}
-
-case $USER in
-    root) exec runuser -u builder -- $0 "$@";;
-    builder) ;;
-    *) echo "Executed as non-builder user; assuming sudo rights..." 1>&2;;
-esac
 
 # Ensure we've unshared our mount namespace so
 # the later umount doesn't affect the host potentially


### PR DESCRIPTION
It should be totally fine to run these tools from inside an
existing container, not a weird case.