### PR TITLE
main: Fix the placement of `shift`

### DIFF
--- a/coreos-assembler
+++ b/coreos-assembler
@@ -23,8 +23,6 @@ if [ -e /sys/fs/selinux/status ]; then
 fi
 
 cmd=${1:-}
-shift
-
 if [ -z "${cmd}" ]; then
     echo usage: "coreos-assembler CMD ..."
     echo "Commands:"
@@ -34,6 +32,7 @@ if [ -z "${cmd}" ]; then
     done
     exit 1
 fi
+shift
 
 target=/usr/libexec/coreos-assembler/cmd-${cmd}
 if test -x "${target}"; then


### PR DESCRIPTION
The idea is you should get a help message if you just type
`coreos-assembler`, but previously we errored out since
`shift` failed.