### PR TITLE
main: Categorize commands

### DIFF
--- a/coreos-assembler
+++ b/coreos-assembler
@@ -18,12 +18,24 @@ if [ -e /sys/fs/selinux/status ]; then
 fi
 
 cmd=${1:-}
+build_commands="init fetch build run clean"
+other_commands="shell"
+utility_commands="gf-oemid virt-install"
 if [ -z "${cmd}" ]; then
     echo usage: "coreos-assembler CMD ..."
-    echo "Commands:"
-    ls /usr/libexec/coreos-assembler/cmd-* | while read cmd; do
-        bin=$(basename $cmd)
-        echo "  ${bin:4}"
+    echo "Build commands:"
+    for bin in ${build_commands}; do
+        echo "  ${bin}"
+    done
+
+    echo "Other commands:"
+    for bin in ${other_commands}; do
+        echo "  ${bin}"
+    done
+
+    echo "Utility commands:"
+    for bin in ${utility_commands}; do
+        echo "  ${bin}"
     done
     exit 1
 fi


### PR DESCRIPTION
Promote the ones that operate on a "builddir" first.

`shell` is a bit special.

Then the other "utility" commands are like `virt-install` where
we expose it as its own function to make it easier for downstreams
to reuse the logic outside of `cmd-build` for more custom things.
We will need this until we implement a config file to define
which image types are built for example.