### PR TITLE
build: Allocate a tmpdir for each build

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -86,6 +86,13 @@ buildid=${version}-${image_genver}
 
 mkdir -p "work/${buildid}"
 cd "work/${buildid}"
+# This is used by child processes inside here as a temporary directory, e.g. by
+# gf-oemid. We don't want `/tmp` as we want to be able to reliably `rename()`
+# directly.
+build_tmp=$(pwd)/build-tmp
+# Longer exported variable name for child processes
+export ASSEMBLER_BUILD_TMPDIR=${build_tmp}
+rm ${build_tmp} -rf && mkdir ${build_tmp}
 
 # Generate JSON
 if [ -n "${previous_commit}" ]; then
@@ -121,7 +128,7 @@ tail -F $(pwd)/install.log & # send output of virt-install to console
 
 /usr/libexec/coreos-assembler/gf-oemid ${imageprefix}-base.qcow2 $(pwd)/${imageprefix}-qemu.qcow2 qemu
 
-cat > tmp-meta.json <<EOF
+cat > ${build_tmp}/meta.json <<EOF
 {
  "coreos-assembler.image-input-checksum": "${image_input_checksum}",
  "coreos-assembler.image-genver": "${image_genver}",
@@ -129,9 +136,9 @@ cat > tmp-meta.json <<EOF
 }
 EOF
 # Merge all the JSON
-cat tmp-meta.json ${commitmeta_input_json} ${composejson} | jq -s add > meta.json
-rm -f tmp-meta.json
+cat ${build_tmp}/meta.json ${commitmeta_input_json} ${composejson} | jq -s add > meta.json
 
+rm "${build_tmp}" -rf
 cd ${workdir}/builds
 mv work/${buildid} .
 ln -Tsfr "${buildid}" latest

--- a/src/gf-oemid
+++ b/src/gf-oemid
@@ -23,7 +23,14 @@ fatal() {
     exit 1
 }
 
-tmpd=$(mktemp -d /tmp/qcow2-to-vagrant.XXXXXX)
+# We may have a tmpdir injected by an outer build process; if so use it,
+# otherwise make our own.
+if [ -n "${ASSEMBLER_BUILD_TMPDIR:-}" ]; then
+    tmpd=${ASSEMBLER_BUILD_TMPDIR}/gf-oemid
+    mkdir ${tmpd}
+else
+    tmpd=$(mktemp -d /tmp/gf-oemid.XXXXXX)
+fi
 tmp_dest=${tmpd}/box.img
 cp --reflink=auto ${src} ${tmp_dest}
 # <walters> I commonly chmod a-w VM images
@@ -69,3 +76,5 @@ gf upload ${tmpd}/grub.cfg ${grubcfg_src}
 gf umount-all
 guestfish --remote -- exit
 mv "${tmp_dest}" "${dest}"
+
+rm ${tmpd} -rf


### PR DESCRIPTION
While the `build` directory acts sort of like a tmpdir, we do end
up potentially reusing things if resuming a previous failed build.

Some tasks however do require a true tmpdir.  `gf-oemid` was allocating
its own in `/tmp`.  Let's pass our tmpdir down to it and hence
saving the image is just a `rename()` rather than a full copy.

The *real* reason I'm doing this though is I got confused by the
fact that the tmpdir name was `qcow2-to-vagrant` since I cargo-culted
this code from https://github.com/cgwalters/qcow2-to-vagrant
And I ended up killing a build job that I thought was using that
incorrectly.