### PR TITLE
virt-install: Use %post --erroronfail

### DIFF
--- a/src/virt-install
+++ b/src/virt-install
@@ -72,11 +72,11 @@ else:
     ks_tmp = tempfile.NamedTemporaryFile(prefix="coreos-virtinstall", suffix=".ks")
 run_sync_verbose(['ksflatten', '-c', args.kickstart], stdout=ks_tmp)
 
-# This is an implmentation detail of https://github.com/dustymabe/ignition-dracut
+# This is an implementation detail of https://github.com/dustymabe/ignition-dracut
 # So we hardcode it here.
 # See: https://github.com/dustymabe/ignition-dracut/pull/12
 ks_tmp.write("""
-%post
+%post --erroronfail
 touch /boot/coreos-firstboot
 %end
 """)


### PR DESCRIPTION
That should just be the default. The current `%post` is trivial, though
add it anyway to increase the odds it sticks around as more things get
added.

Also fix minor typo.