### PR TITLE
preflight: Verify sudo works, also move /dev/kvm adjustments here

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -118,8 +118,6 @@ ostreesetup --nogpg --osname=coreos --remote=coreos --url=file:///mnt/ostree-rep
 EOF
 
 imageprefix=${name}-${version}-${image_genver}
-# permissions on /dev/kvm vary by distro. Recreate it so we know it's what we expect
-sudo rm -f /dev/kvm; sudo mknod /dev/kvm c 10 232 && sudo setfacl -m u:$USER:rw /dev/kvm
 /usr/libexec/coreos-assembler/virt-install --dest=$(pwd)/${imageprefix}-base.qcow2 \
                --create-disk --kickstart $(pwd)/local.ks --kickstart-out $(pwd)/flattened.ks \
                --location ${workdir}/installer/*.iso --console-log-file $(pwd)/install.log \

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -10,11 +10,23 @@ preflight() {
     fi
 
     if ! stat /dev/kvm >/dev/null; then
-        fatal "Unable to access /dev/kvm"
+        fatal "Unable to find /dev/kvm"
     fi
 
     if ! capsh --print | grep -q 'Current.*cap_sys_admin'; then
         fatal "This container must currently be run with --privileged"
+    fi
+
+    if ! sudo true; then
+        fatal "The user must currently have sudo privileges"
+    fi
+
+    # permissions on /dev/kvm vary by (host) distro.  If it's
+    # not writable, recreate it.
+    if ! [ -w /dev/kvm ]; then
+        sudo rm -f /dev/kvm
+        sudo mknod /dev/kvm c 10 232
+        sudo setfacl -m u:$USER:rw /dev/kvm
     fi
 }
 


### PR DESCRIPTION
Let's verify upfront that `sudo` works along with the rest
of our preflight checks.

Then use `sudo` to do the `/dev/kvm` adjustments here rather
than just deep in `cmd-build`, so it's clearer where these
types of things happen.