### PR TITLE
cmd-run: Add coreos-assembler-quiet-tty.service

### DIFF
--- a/src/cmd-run
+++ b/src/cmd-run
@@ -125,6 +125,11 @@ if [ -z "${IGNITION_CONFIG_FILE:-}" ]; then
                         "contents": "[Service]\nTTYVTDisallocate=no\nExecStart=\nExecStart=-/usr/sbin/agetty --autologin core --noclear %I \$TERM\n"
                     }
                 ]
+            },
+            {
+                "name": "coreos-assembler-quiet-tty.service",
+                "enabled": true,
+                "contents": "[Service]\nExecStart=/usr/sbin/sysctl kernel.printk='3 4 1 7'\n[Install]\nWantedBy=multi-user.target\n"
             }
             ${ign_var_srv_mount}
         ]

--- a/src/cmd-run
+++ b/src/cmd-run
@@ -96,7 +96,40 @@ fi
 if [ -z "${IGNITION_CONFIG_FILE:-}" ]; then
     f=$(mktemp)
     cat > ${f} <<EOF
-{"ignition": {"config": {}, "security": {"tls": {}}, "timeouts": {}, "version": "2.2.0"}, "networkd": {}, "passwd": {"users": [{"groups": ["sudo"], "name": "core"}]}, "storage": {}, "systemd": {"units": [{"name": "serial-getty@ttyS0.service", "dropins": [{"name": "autologin-core.conf", "contents": "[Service]\nTTYVTDisallocate=no\nExecStart=\nExecStart=-/usr/sbin/agetty --autologin core --noclear %I \$TERM\n"}]}${ign_var_srv_mount}]}}
+{
+    "ignition": {
+        "config": {},
+        "security": {
+            "tls": {}
+        },
+        "timeouts": {},
+        "version": "2.2.0"
+    },
+    "networkd": {},
+    "passwd": {
+        "users": [
+            {
+                "groups": ["sudo"],
+                "name": "core"
+            }
+        ]
+    },
+    "storage": {},
+    "systemd": {
+        "units": [
+            {
+                "name": "serial-getty@ttyS0.service",
+                "dropins": [
+                    {
+                        "name": "autologin-core.conf",
+                        "contents": "[Service]\nTTYVTDisallocate=no\nExecStart=\nExecStart=-/usr/sbin/agetty --autologin core --noclear %I \$TERM\n"
+                    }
+                ]
+            }
+            ${ign_var_srv_mount}
+        ]
+    }
+}
 EOF
     exec 3<>${f}
     if ! jq . < ${f} >/dev/null; then


### PR DESCRIPTION
Right now, we're running at the default log level, which is DEBUG (7).
The text gets interspersed with user input/program output on the tty.
Bump the default to ERROR (3).

This uses a systemd service hack instead of a `sysctl.d` drop-in. The
reason is that Ignition relabeling right now happens too late in the
process for `systemd-sysctl.service`, so it trips on SELinux issues.
Looking to fix that soon.