### PR TITLE
cmd-run: Use ignition-validate instead of jq

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -34,6 +34,9 @@ fi
 dnf -y install /usr/bin/xargs dnf-utils dnf-plugins-core
 dnf copr -y enable walters/buildtools-fedora
 
+# For now, since we get builds slightly faster there
+dnf copr -y enable dustymabe/ignition
+
 # These are only used to build things in here, we define them separately because
 # they're cleaned up later
 self_builddeps="cargo golang"
@@ -76,6 +79,9 @@ podman buildah skopeo
 
 # Miscellaneous tools
 jq awscli
+
+# For ignition file validation in cmd-run
+ignition
 EOF
 
 # The podman change to use systemd for cgroups broke our hack to use

--- a/src/cmd-run
+++ b/src/cmd-run
@@ -99,12 +99,13 @@ if [ -z "${IGNITION_CONFIG_FILE:-}" ]; then
 {"ignition": {"config": {}, "security": {"tls": {}}, "timeouts": {}, "version": "2.2.0"}, "networkd": {}, "passwd": {"users": [{"groups": ["sudo"], "name": "core"}]}, "storage": {}, "systemd": {"units": [{"name": "serial-getty@ttyS0.service", "dropins": [{"name": "autologin-core.conf", "contents": "[Service]\nTTYVTDisallocate=no\nExecStart=\nExecStart=-/usr/sbin/agetty --autologin core --noclear %I \$TERM\n"}]}${ign_var_srv_mount}]}}
 EOF
     exec 3<>${f}
-    if ! jq . < ${f} >/dev/null; then
-        cat "${f}"
-        exit 1
-    fi
     rm -f ${f}
     IGNITION_CONFIG_FILE=/proc/self/fd/3
+
+    if ! jq . < ${IGNITION_CONFIG_FILE} >/dev/null; then
+        cat "${IGNITION_CONFIG_FILE}"
+        exit 1
+    fi
 fi
 set -- -fw_cfg name=opt/com.coreos/config,file="${IGNITION_CONFIG_FILE}" "$@"
 

--- a/src/cmd-run
+++ b/src/cmd-run
@@ -102,7 +102,7 @@ EOF
     rm -f ${f}
     IGNITION_CONFIG_FILE=/proc/self/fd/3
 
-    if ! jq . < ${IGNITION_CONFIG_FILE} >/dev/null; then
+    if ! ignition-validate ${IGNITION_CONFIG_FILE}; then
         cat "${IGNITION_CONFIG_FILE}"
         exit 1
     fi


### PR DESCRIPTION
`jq` checks for syntax errors, whereas `ignition-validate` also checks
for semantic errors.