### PR TITLE
cmd-[build|fetch]: Drop set -x

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -xeuo pipefail
+set -euo pipefail
 
 dn=$(dirname $0)
 . ${dn}/cmdlib.sh
@@ -15,7 +15,7 @@ previous_commit=$(ostree --repo=${workdir}/repo rev-parse ${ref} || true)
 # Generate metadata that's *input* to the ostree commit
 config_gitrev=$(cd ${configdir} && git describe --tags --always --abbrev=42)
 config_dirty=false
-if ! git -C ${configdir} diff --exit-code; then
+if ! git -C ${configdir} diff --quiet --exit-code; then
     config_dirty=true
 fi
 commitmeta_input_json=$(pwd)/work/commit-metadata-input.json

--- a/src/cmd-fetch
+++ b/src/cmd-fetch
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -xeuo pipefail
+set -euo pipefail
 
 dn=$(dirname $0)
 . ${dn}/cmdlib.sh


### PR DESCRIPTION
The scripts are becoming more involved, and all the output we get from
`-x` mostly distracts from the meaningful output. Let's just drop those
and we can always add back some strategic `echo` statements if we feel
like any are missing.

(Note we still leave it in `cmd-clean` for now; it's much shorter and
it's an easy way to see what's getting nuked.)