### PR TITLE
Make input disk image explicit for guestfish bits

### DIFF
--- a/src/gf-oemid
+++ b/src/gf-oemid
@@ -29,7 +29,7 @@ cp --reflink=auto ${src} ${tmp_dest}
 # <walters> I commonly chmod a-w VM images
 chmod u+w ${tmp_dest}
 
-coreos_gf_run_mount
+coreos_gf_run_mount "${tmp_dest}"
 # For now we just modify the grub config, but *not* the /boot/loader
 # entry that generated it, because...well it's simpler and in theory
 # we only need the OEM ID for the first boot where Ignition runs.  Might

--- a/src/libguestfish.sh
+++ b/src/libguestfish.sh
@@ -5,11 +5,13 @@
 # http://libguestfs.org/guestfish.1.html#using-remote-control-robustly-from-shell-scripts
 GUESTFISH_PID=
 coreos_gf_launch() {
+    local src=$1
+    shift
     local guestfish
     guestfish[0]="guestfish"
     guestfish[1]="--listen"
     guestfish[3]="-a"
-    guestfish[4]="${tmp_dest}"
+    guestfish[4]="${src}"
 
     eval $("${guestfish[@]}")
     if [ -z "$GUESTFISH_PID" ]; then
@@ -29,7 +31,7 @@ coreos_gf() {
 # Run libguestfs and mount the root and boot partitions.
 # Export `stateroot` and `deploydir` variables.
 coreos_gf_run_mount() {
-    coreos_gf_launch
+    coreos_gf_launch "$@"
     coreos_gf run
     local root=$(coreos_gf findfs-label root)
     coreos_gf mount "${root}" /


### PR DESCRIPTION
The library was referencing `${tmp_dest}` rather than an explicitly
provided variable.