### PR TITLE
Create deps.txt, use it for build and runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,6 @@ mantle:
 
 install:
 	install -D -t $(DESTDIR)$(PREFIX)/bin coreos-assembler
-	install -D -t $(DESTDIR)$(PREFIX)/lib/coreos-assembler $$(find src/ -maxdepth 1 -type f)
+	install -D -t $(DESTDIR)$(PREFIX)/lib/coreos-assembler deps.txt $$(find src/ -maxdepth 1 -type f)
 	install -D -t $(DESTDIR)$(PREFIX)/bin mantle/bin/{ore,kola}
 	install -D -m 0755 -t $(DESTDIR)$(PREFIX)/lib/kola/amd64 mantle/bin/amd64/kolet

--- a/build.sh
+++ b/build.sh
@@ -41,48 +41,8 @@ dnf copr -y enable dustymabe/ignition
 # they're cleaned up later
 self_builddeps="cargo golang"
 
-grep -v '^#' <<EOF | xargs dnf -y install
-${self_builddeps}
-
-# We default to builder user, but sudo where necessary
-sudo
-
-# dumb-init is a good idea in general, but specifically fixes things with
-# libvirt forking qemu and assuming the process gets reaped on shutdown.
-dumb-init
-
-# For composes
-rpm-ostree
-
-# rpmdistro-gitoverlay deps
-dnf-plugins-core createrepo_c dnf-utils fedpkg openssh-clients rpmdistro-gitoverlay
-
-# Currently a transitive req of rpmdistro-gitoverlay via mock, but we
-# expect people to use these explicitly in their repo configurations.
-distribution-gpg-keys
-# We need these for rojig
-selinux-policy-targeted rpm-build
-
-# Standard build tools
-make git rpm-build
-
-# virt-install dependencies
-libvirt libguestfs-tools qemu-kvm /usr/bin/qemu-img /usr/bin/virsh /usr/bin/virt-install
-# And we process kickstarts
-/usr/bin/ksflatten
-
-# ostree-releng-scripts dependencies
-rsync pygobject3-base python3-gobject-base
-
-# To support recursive containerization and manipulating images
-podman buildah skopeo
-
-# Miscellaneous tools
-jq awscli
-
-# For ignition file validation in cmd-run
-ignition
-EOF
+# Process our base dependencies + build dependencies
+(echo ${self_builddeps} && grep -v '^#' ${srcdir}/deps.txt) | xargs dnf -y install
 
 # The podman change to use systemd for cgroups broke our hack to use
 # podman-in-docker...we should fix our pipeline, but for now:

--- a/deps.txt
+++ b/deps.txt
@@ -1,0 +1,33 @@
+# We default to builder user, but sudo where necessary
+sudo
+
+# dumb-init is a good idea in general, but specifically fixes things with
+# libvirt forking qemu and assuming the process gets reaped on shutdown.
+dumb-init
+
+# For composes
+rpm-ostree
+
+# rpmdistro-gitoverlay deps
+dnf-plugins-core createrepo_c dnf-utils fedpkg openssh-clients rpmdistro-gitoverlay
+
+# Currently a transitive req of rpmdistro-gitoverlay via mock, but we
+# expect people to use these explicitly in their repo configurations.
+distribution-gpg-keys
+# We need these for rojig
+selinux-policy-targeted rpm-build
+
+# Standard build tools
+make git rpm-build
+
+# ostree-releng-scripts dependencies
+rsync python2-gobject-base python3-gobject-base
+
+# To support recursive containerization and manipulating images
+podman buildah skopeo
+
+# Miscellaneous tools
+jq awscli
+
+# For ignition file validation in cmd-run
+ignition

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -5,6 +5,18 @@ fatal() {
 }
 
 preflight() {
+    # Verify we have all dependencies
+    local deps=$(grep -v '^#' /usr/libexec/coreos-assembler/deps.txt)
+    if ! rpm -q ${deps} >/dev/null; then
+        local missing=""
+        for pkg in ${deps}; do
+            if ! rpm -q "${pkg}" >/dev/null; then
+                missing="$missing $pkg"
+            fi
+        done
+        fatal "Failed to find expected dependency packages: $missing"
+    fi
+
     if [ $(stat -f --printf="%T" .) = "overlayfs" ]; then
         fatal "$(pwd) must be a volume"
     fi


### PR DESCRIPTION
The recent requirement of `ignition` broke my workflow from
my dev container.  Let's verify upfront that everything we
expect is installed.

As a bonus, this is a text file easily parsed by other things
too rather than embedded inside shell script.