### PR TITLE
WIP: Clean /var after Anaconda

### DIFF
--- a/src/gf-post-virt-install
+++ b/src/gf-post-virt-install
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -xeuo pipefail
+
+dn=$(dirname $0)
+. ${dn}/cmdlib.sh
+. ${dn}/libguestfish.sh
+
+# Usage: gf-post-virt-install <input image>
+#
+# Currently we're using Anaconda which is primarily designed to
+# do per-system installs - the case we're doing here is "golden images",
+# so we need to "undo" some things that Anaconda does, e.g. persisting
+# /var/lib/systemd/random-seed.
+#
+# To make things crystal clear, we just blow away all of /var.  This
+# works with rpm-ostree since it will be re-created with systemd tmpfiles
+# on boot.
+
+src=$1
+shift
+
+coreos_gf_run_mount "${src}"
+coreos_gf glob rm-rf ${stateroot}'/var/*'
+# Note libostree also injects .ostree-selabeled, which
+# the glob currently keeps - that's fine.

--- a/src/virt-install
+++ b/src/virt-install
@@ -124,4 +124,8 @@ finally:
     subprocess.call(['virsh', '--connect=qemu:///session', 'undefine', domain])
     if tail_proc is not None:
         tail_proc.terminate()
-print("Completed install to disk image: {}".format(args.dest))
+
+print("Anaconda done")
+run_sync_verbose(['/usr/libexec/coreos-assembler/gf-post-virt-install', args.dest])
+print("Image complete: {}".format(args.dest))
+


### PR DESCRIPTION
This way we are truly starting from a clean slate.  It means
we know we won't have a `random-seed` for example.  OSTree is
designed to support this but unless we use it *by default*
we aren't really testing it.

This actually now breaks things since currently the creation of
the `core` user is in `image.ks`, which we need to fix:
https://github.com/coreos/coreos-metadata/pull/90#discussion_r202438581