### PR TITLE
Install to /usr/lib/coreos-assembler, not libexec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,6 @@ mantle:
 
 install:
 	install -D -t $(DESTDIR)$(PREFIX)/bin coreos-assembler
-	install -D -t $(DESTDIR)$(PREFIX)/libexec/coreos-assembler $$(find src/ -maxdepth 1 -type f)
+	install -D -t $(DESTDIR)$(PREFIX)/lib/coreos-assembler $$(find src/ -maxdepth 1 -type f)
 	install -D -t $(DESTDIR)$(PREFIX)/bin mantle/bin/{ore,kola}
 	install -D -m 0755 -t $(DESTDIR)$(PREFIX)/lib/kola/amd64 mantle/bin/amd64/kolet

--- a/coreos-assembler
+++ b/coreos-assembler
@@ -41,7 +41,7 @@ if [ -z "${cmd}" ]; then
 fi
 shift
 
-target=/usr/libexec/coreos-assembler/cmd-${cmd}
+target=/usr/lib/coreos-assembler/cmd-${cmd}
 if test -x "${target}"; then
     exec ${target} "$@"
 fi

--- a/src/cmd-build
+++ b/src/cmd-build
@@ -118,12 +118,12 @@ ostreesetup --nogpg --osname=coreos --remote=coreos --url=file:///mnt/ostree-rep
 EOF
 
 imageprefix=${name}-${version}-${image_genver}
-/usr/libexec/coreos-assembler/virt-install --dest=$(pwd)/${imageprefix}-base.qcow2 \
+/usr/lib/coreos-assembler/virt-install --dest=$(pwd)/${imageprefix}-base.qcow2 \
                --create-disk --kickstart $(pwd)/local.ks --kickstart-out $(pwd)/flattened.ks \
                --location ${workdir}/installer/*.iso --console-log-file $(pwd)/install.log \
                --local-repo=${workdir}/repo
 
-/usr/libexec/coreos-assembler/gf-oemid ${imageprefix}-base.qcow2 $(pwd)/${imageprefix}-qemu.qcow2 qemu
+/usr/lib/coreos-assembler/gf-oemid ${imageprefix}-base.qcow2 $(pwd)/${imageprefix}-qemu.qcow2 qemu
 
 cat > ${build_tmp}/meta.json <<EOF
 {


### PR DESCRIPTION
`/usr/lib/$pkg` is the new trend, it's really simple
to just have one data directory and not split things up.