### PR TITLE
deps: Add virt-install bits, fix deps.txt

### DIFF
--- a/deps.txt
+++ b/deps.txt
@@ -20,6 +20,11 @@ selinux-policy-targeted rpm-build
 # Standard build tools
 make git rpm-build
 
+# virt-install dependencies
+libvirt libguestfs-tools qemu-kvm /usr/bin/qemu-img /usr/bin/virsh /usr/bin/virt-install
+# And we process kickstarts
+/usr/bin/ksflatten
+
 # ostree-releng-scripts dependencies
 rsync python2-gobject-base python3-gobject-base
 


### PR DESCRIPTION
When I was originally splitting off `deps.txt` I ended up trying
to reorder/change things to use `/usr/bin` so I could test file
paths, but ended up backing that out.

In backing it out I apparently lost the dependency on the virt-install
stack.  Readd that.

And then that reveals the other problem, which is our dependencies
are a mix of file paths and packages, so support both of those.

(Potentially...we should build an rpm of our binaries
 and just use `Requires:`...)