### PR TITLE
cmdlib: fix location of deps.txt

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -6,7 +6,7 @@ fatal() {
 
 preflight() {
     # Verify we have all dependencies
-    local deps=$(grep -v '^#' /usr/libexec/coreos-assembler/deps.txt)
+    local deps=$(grep -v '^#' /usr/lib/coreos-assembler/deps.txt)
     if ! rpm -q ${deps} >/dev/null; then
         local missing=""
         for pkg in ${deps}; do


### PR DESCRIPTION
The Makefile installs `deps.txt` to `/usr/lib/coreos-assembler`, so
point `preflight()` to that location.