### PR TITLE
 cmdlib: Default to --unified-core

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -84,7 +84,7 @@ manifest_get() {
 
 runcompose() {
     local treecompose_args=""
-    if grep -q '^# unified-core' "${manifest}"; then
+    if ! grep -q '^# disable-unified-core' "${manifest}"; then
         treecompose_args="${treecompose_args} --unified-core"
     fi
     sudo rpm-ostree compose tree --repo=${workdir}/repo-build --cachedir=${workdir}/cache ${treecompose_args} \

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -87,6 +87,8 @@ runcompose() {
     if ! grep -q '^# disable-unified-core' "${manifest}"; then
         treecompose_args="${treecompose_args} --unified-core"
     fi
+    set -x
     sudo rpm-ostree compose tree --repo=${workdir}/repo-build --cachedir=${workdir}/cache ${treecompose_args} \
          ${TREECOMPOSE_FLAGS:-} ${manifest} "$@"
+    set +x
 }


### PR DESCRIPTION

And require a magical comment to disable it.  We really want
people to use this by default.