### PR TITLE
build: Add unversioned stable symlink to qcow2

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -120,6 +120,8 @@ imageprefix=${name}-${version}-${image_genver}
                --local-repo=${workdir}/repo
 
 /usr/lib/coreos-assembler/gf-oemid tmp/${imageprefix}-base.qcow2 $(pwd)/${imageprefix}-qemu.qcow2 qemu
+# make a version-less symlink to have a stable path
+ln -s ${imageprefix}-qemu.qcow2 ${name}-qemu.qcow2
 
 cat > tmp/meta.json <<EOF
 {


### PR DESCRIPTION
So that I can consistently do

    $(realpath /srv/fcos/builds/latest/fedora-coreos-qemu.qcow2)

whenever I need to e.g. create a VM/export it out/etc...
Clearly useful as well once we start serving these files over HTTP.