### PR TITLE
Add rpmdistro-gitoverlay as a submodule rather than RPM

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "ostree-releng-scripts"]
 	path = ostree-releng-scripts
 	url = https://github.com/ostreedev/ostree-releng-scripts
+[submodule "rpmdistro-gitoverlay"]
+	path = rpmdistro-gitoverlay
+	url = https://github.com/projectatomic/rpmdistro-gitoverlay

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,19 @@
 PREFIX ?= /usr
 DESTDIR ?=
 
-.PHONY: all mantle install
+.PHONY: all mantle rdgo install
 
-all: mantle
+all: mantle rdgo
 
 mantle:
 	cd mantle && ./build ore kola kolet
+
+rdgo:
+	(cd rpmdistro-gitoverlay && ./autogen.sh --prefix=$(PREFIX) --sysconfdir=/etc && make)
 
 install:
 	install -D -t $(DESTDIR)$(PREFIX)/bin coreos-assembler
 	install -D -t $(DESTDIR)$(PREFIX)/lib/coreos-assembler $$(find src/ -maxdepth 1 -type f)
 	install -D -t $(DESTDIR)$(PREFIX)/bin mantle/bin/{ore,kola}
 	install -D -m 0755 -t $(DESTDIR)$(PREFIX)/lib/kola/amd64 mantle/bin/amd64/kolet
+	(cd rpmdistro-gitoverlay && make install)

--- a/build.sh
+++ b/build.sh
@@ -18,21 +18,6 @@ configure_yum_repos() {
         mv ${repo}.new ${repo}
     done
 
-    # enable `walters/buildtools-fedora` copr
-	# pulled from https://copr.fedorainfracloud.org/coprs/walters/buildtools-fedora/repo/fedora-28/walters-buildtools-fedora-fedora-28.repo
-    cat > /etc/yum.repos.d/walters-buildtools-fedora-fedora-28.repo  <<'EOF'
-[walters-buildtools-fedora]
-name=Copr repo for buildtools-fedora owned by walters
-baseurl=https://copr-be.cloud.fedoraproject.org/results/walters/buildtools-fedora/fedora-$releasever-$basearch/
-type=rpm-md
-skip_if_unavailable=True
-gpgcheck=1
-gpgkey=https://copr-be.cloud.fedoraproject.org/results/walters/buildtools-fedora/pubkey.gpg
-repo_gpgcheck=0
-enabled=1
-enabled_metadata=1
-EOF
-
     # enable `dustymabe/ignition` copr
 	# pulled from https://copr.fedorainfracloud.org/coprs/dustymabe/ignition/repo/fedora-28/dustymabe-ignition-fedora-28.repo
     cat > /etc/yum.repos.d/dustymabe-ignition-fedora-28.repo <<'EOF'

--- a/src/deps.txt
+++ b/src/deps.txt
@@ -9,7 +9,7 @@ dumb-init
 rpm-ostree
 
 # rpmdistro-gitoverlay deps
-dnf-plugins-core createrepo_c dnf-utils fedpkg openssh-clients rpmdistro-gitoverlay
+dnf-plugins-core createrepo_c dnf-utils fedpkg openssh-clients
 
 # Currently a transitive req of rpmdistro-gitoverlay via mock, but we
 # expect people to use these explicitly in their repo configurations.


### PR DESCRIPTION
We want the ability to make breaking changes to how we build
RPMs; having it as a submodule will allow us to break things.

Further, today COPR doesn't support e.g. aarch64, which imposes
an artificial limitation on building this container.
(Today we're using the Ignition from COPR, but actually for
 validating configs we could probably just use the main repo)

Obsoletes: https://github.com/coreos/coreos-assembler/pull/30