### PR TITLE
build: Add a --force option

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -4,6 +4,31 @@ set -euo pipefail
 dn=$(dirname $0)
 . ${dn}/cmdlib.sh
 
+# Parse options
+FORCE=
+options=$(getopt --options f --longoptions force -- "$@")
+[ $? -eq 0 ] || {
+    print_help
+    exit 1
+}
+eval set -- "$options"
+while true; do
+    case "$1" in
+        -f | --force)
+            FORCE="--force-nocache"
+            ;;
+        --)
+            shift
+            break
+            ;;
+        *)
+            fatal "$0: unrecognized option: $1"
+            exit 1
+            ;;
+    esac
+    shift
+done
+
 export LIBGUESTFS_BACKEND=direct
 
 prepare_build
@@ -42,7 +67,7 @@ EOF
 composejson=$(pwd)/tmp/compose.json
 changed_stamp=$(pwd)/tmp/treecompose.changed
 # --cache-only is here since `fetch` is a separate verb.
-runcompose --cache-only --add-metadata-from-json ${commitmeta_input_json} \
+runcompose --cache-only ${FORCE} --add-metadata-from-json ${commitmeta_input_json} \
            --touch-if-changed "${changed_stamp}" \
            --write-composejson-to ${composejson}
 # Very special handling for --write-composejson-to as rpm-ostree doesn't


### PR DESCRIPTION
Sometimes I'm hacking on rpm-ostree and want to force a rebuild
to test my changes to rpm-ostree.

There are also cases where rpm-ostree today doesn't correctly
detect changes, such as with external `postprocess-script` files.