### PR TITLE
cmd-run: Fix argument ordering for -drive

### DIFF
--- a/src/cmd-run
+++ b/src/cmd-run
@@ -156,7 +156,7 @@ if [ "${VM_PERSIST}" = 0 ]; then
     vm_drive_args=",cache=unsafe"
 fi
 
-set -- -drive if=virtio,file=${VM_DISK}${vm_drive_args:-} "$@"
+set -- -drive if=virtio${vm_drive_args:-},file=${VM_DISK} "$@"
 
 exec qemu-kvm -name coreos -m ${VM_MEMORY} -nographic \
               -netdev user,id=eth0,hostname=coreos${hostfwd:-} \


### PR DESCRIPTION
Otherwise `qemu-kvm` can get confused thinking that the `,cache=unsafe`
is part of the filename:

    qemu-system-x86_64: -drive if=virtio,file=/srv/fcos/builds/29.1-1/fedora-coreos-29.1-1-qemu.qcow2: Could not open '/srv/fcos/builds/29.1-1/fedora-coreos-29.1-1-qemu.qcow2,cache=unsafe': No such file or directory