### PR TITLE
cmd-build: Handle case of missing ref more gracefully

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -46,10 +46,10 @@ fi
 previous_commit=
 if [ -n "${ref:-}" ]; then
     previous_commit=$(ostree --repo=${workdir}/repo rev-parse ${ref} || true)
-else
-    if [ -n "${previous_build}" ]; then
-        previous_commit=$(jq -r '.["ostree-commit"]' < "${previous_builddir}/meta.json")
-    fi
+fi
+# If the ref was unset or missing, look at the previous build
+if [ -z "${previous_commit}" ] && [ -n "${previous_build}" ]; then
+    previous_commit=$(jq -r '.["ostree-commit"]' < "${previous_builddir}/meta.json")
 fi
 # Generate metadata that's *input* to the ostree commit
 config_gitrev=$(cd ${configdir} && git describe --tags --always --abbrev=42)


### PR DESCRIPTION
In some RHCOS Jenkins work I didn't have the ref in the `repo-build`, and
the semantics here were confusing.  Let's pull the previous checksum
out of the previous build if we do have that.