### PR TITLE
cmd/run: add preflight checks

### DIFF
--- a/src/cmd-run
+++ b/src/cmd-run
@@ -7,6 +7,9 @@
 
 set -euo pipefail
 
+dn=$(dirname $0)
+. ${dn}/cmdlib.sh
+
 VM_DISK=
 VM_MEMORY=2048
 VM_PERSIST=0
@@ -69,6 +72,8 @@ while [ $# -ge 1 ]; do
             die "Unknown argument $1";;
     esac
 done
+
+preflight
 
 if [ -z "${VM_DISK}" ]; then
     if [ -L ./builds/latest ]; then


### PR DESCRIPTION
The "run" subcommand internally uses qemu-kvm and can benefit from
environmental checks and /dev/kvm massaging in order to avoid
(permissions) errors when spawning a VM.