### PR TITLE
Consistently set tmp/treecompose.changed

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -66,10 +66,8 @@ cat >${commitmeta_input_json} <<EOF
 EOF
 # These need to be absolute paths right now for rpm-ostree
 composejson=$(pwd)/tmp/compose.json
-changed_stamp=$(pwd)/tmp/treecompose.changed
 # --cache-only is here since `fetch` is a separate verb.
 runcompose --cache-only ${FORCE} --add-metadata-from-json ${commitmeta_input_json} \
-           --touch-if-changed "${changed_stamp}" \
            --write-composejson-to ${composejson}
 # Very special handling for --write-composejson-to as rpm-ostree doesn't
 # write it if the commit didn't change.

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -73,6 +73,9 @@ prepare_build() {
     # didn't create this in `init`.
     mkdir -p ${workdir}/tmp
 
+    # Needs to be absolute for rpm-ostree today
+    export changed_stamp=$(pwd)/tmp/treecompose.changed
+
     # Allocate temporary space for this build
     tmp_builddir=${workdir}/tmp/build
     rm ${tmp_builddir} -rf
@@ -121,8 +124,11 @@ EOF
         manifest=${tmp_overridesdir}/coreos-assembler-override-manifest.yaml
     fi
 
+    rm -f ${changed_stamp}
     set -x
-    sudo rpm-ostree compose tree --repo=${workdir}/repo-build --cachedir=${workdir}/cache ${treecompose_args} \
+    sudo rpm-ostree compose tree --repo=${workdir}/repo-build --cachedir=${workdir}/cache \
+         --touch-if-changed "${changed_stamp}" \
+         ${treecompose_args} \
          ${TREECOMPOSE_FLAGS:-} ${manifest} "$@"
     set +x
 }


### PR DESCRIPTION
This will allow e.g. an orchestrating Jenkins job to look for
the file afterwards and only trigger a `build` if something changed.
This is better than doing it in one job since then the secondary
build job will only have actual builds.

This also fixes a subtle bug in that we weren't clearing the stamp
file before doing a build, so we could spuriously think something
did change.