### PR TITLE
build: Move 9p fully into virt-install

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -124,28 +124,14 @@ else
     previous_commit_json=null
 fi
 
-# HACK: pull out the magic bit; we should have virt-install
-# handle this with the ksflatten
-grep -e "--coreos-virt-install-disk-size-gb" ${kickstart_input} > tmp/local.ks
-# https://github.com/coreos/coreos-assembler/pull/12
-# AKA commit 1d2150cf5607ade19780e4bd6f195e5c0efdb0ac
-# TODO: move this into coreos-virt-install
-cat >>tmp/local.ks <<EOF
-%include ${kickstart_input}
-%pre
-mkdir -p /mnt/ostree-repo
-mount -t 9p -o ro,trans=virtio,version=9p2000.L /mnt/ostree-repo /mnt/ostree-repo
-%end
-ostreesetup --nogpg --osname=coreos --remote=coreos --url=file:///mnt/ostree-repo --ref="${ref}"
-EOF
-
 imageprefix=${name}-${version}-${image_genver}
 # Make these two verbose
 set -x
 /usr/lib/coreos-assembler/virt-install --dest=$(pwd)/tmp/${imageprefix}-base.qcow2 \
-               --create-disk --kickstart $(pwd)/tmp/local.ks --kickstart-out $(pwd)/tmp/flattened.ks \
-               --location ${workdir}/installer/*.iso --console-log-file $(pwd)/install.log \
-               --local-repo=${workdir}/repo
+               --create-disk --kickstart ${kickstart_input} --kickstart-out $(pwd)/tmp/flattened.ks \
+               --ostree-remote=${name} --ostree-stateroot=${name} \
+               --ostree-ref=${ref} --ostree-repo=${workdir}/repo \
+               --location ${workdir}/installer/*.iso --console-log-file $(pwd)/install.log
 /usr/lib/coreos-assembler/gf-oemid tmp/${imageprefix}-base.qcow2 $(pwd)/${imageprefix}-qemu.qcow2 qemu
 set +x
 # make a version-less symlink to have a stable path

--- a/src/virt-install
+++ b/src/virt-install
@@ -28,15 +28,14 @@ parser.add_argument("--memory", help="Memory size in MB",
                     action='store', type=int, default=2048)
 parser.add_argument("--console-log-file", help="Console log file",
                     action='store')
-# You can use this with e.g.:
-# ostreesetup --nogpg --osname=coreos --remote=coreos --url=file:///mnt/ostree-repo --ref=fedora/x86_64/coreos
-# %pre
-# mkdir -p /mnt/ostree-repo
-# mount -t 9p -o ro,trans=virtio,version=9p2000.L /mnt/ostree-repo /mnt/ostree-repo
-# %end
-# But note: https://bugzilla.redhat.com/show_bug.cgi?id=1379389
-
-parser.add_argument("--local-repo", help="Pass through local repo via 9p",
+# Note https://bugzilla.redhat.com/show_bug.cgi?id=1379389
+parser.add_argument("--ostree-repo", help="Pass through OSTree repo via 9p",
+                    action='store', required=True)
+parser.add_argument("--ostree-stateroot", help="OSTree stateroot",
+                    action='store')
+parser.add_argument("--ostree-ref", help="OSTree ref",
+                    action='store')
+parser.add_argument("--ostree-remote", help="OSTree remote",
                     action='store')
 parser.add_argument("--wait", help="Number of minutes to wait",
                     action='store', type=int, default=10)
@@ -80,6 +79,17 @@ ks_tmp.write("""
 touch /boot/coreos-firstboot
 %end
 """)
+if args.ostree_repo:
+    assert args.ostree_stateroot
+    assert args.ostree_remote
+    assert args.ostree_ref
+    ks_tmp.write(f"""
+ostreesetup --nogpg --osname={args.ostree_stateroot} --remote={args.ostree_remote} --url=file:///mnt/ostree-repo --ref="{args.ostree_ref}"
+%pre
+mkdir -p /mnt/ostree-repo
+mount -t 9p -o ro,trans=virtio,version=9p2000.L /mnt/ostree-repo /mnt/ostree-repo
+%end
+    """)
 ks_tmp.flush()
 
 # This is an "extension" to kickstart files that we implement as a comment.
@@ -121,8 +131,8 @@ try:
     if args.console_log_file:
         vinstall_args.append("--console=log.file={}".format(args.console_log_file))
         tail_proc = subprocess.Popen(['tail', '-F', args.console_log_file])
-    if args.local_repo:
-        vinstall_args.append("--filesystem=source={},target=/mnt/ostree-repo,accessmode=mapped".format(args.local_repo))
+    if args.ostree_repo:
+        vinstall_args.append("--filesystem=source={},target=/mnt/ostree-repo,accessmode=mapped".format(args.ostree_repo))
     vinstall_args.extend(["--wait={}".format(args.wait), "--noreboot", "--nographics",
                           "--memory={}".format(args.memory), get_libvirt_smp_arg(),
                           "--os-variant=rhel7", "--rng=/dev/urandom",


### PR DESCRIPTION
That's where it logically belongs since we're also setting up the 9p
bits there.
    
Prep for further 9p usage.
