### PR TITLE
build/virt-install: Support for scraping out the Anaconda logs 

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -125,11 +125,13 @@ fi
 imageprefix=${name}-${version}-${image_genver}
 # Make these two verbose
 set -x
+mkdir -p tmp/anaconda
 /usr/lib/coreos-assembler/virt-install --dest=$(pwd)/tmp/${imageprefix}-base.qcow2 \
                --create-disk --kickstart ${kickstart_input} --kickstart-out $(pwd)/tmp/flattened.ks \
                --ostree-remote=${name} --ostree-stateroot=${name} \
-               --ostree-ref=${ref} --ostree-repo=${workdir}/repo \
-               --location ${workdir}/installer/*.iso --console-log-file $(pwd)/install.log
+               --ostree-ref=${ref:-${commit}} --ostree-repo=${workdir}/repo \
+               --location ${workdir}/installer/*.iso --console-log-file $(pwd)/install.log \
+               --logs $(pwd)/tmp/anaconda
 /usr/lib/coreos-assembler/gf-oemid tmp/${imageprefix}-base.qcow2 $(pwd)/${imageprefix}-qemu.qcow2 qemu
 set +x
 # make a version-less symlink to have a stable path

--- a/src/virt-install
+++ b/src/virt-install
@@ -28,6 +28,8 @@ parser.add_argument("--memory", help="Memory size in MB",
                     action='store', type=int, default=2048)
 parser.add_argument("--console-log-file", help="Console log file",
                     action='store')
+parser.add_argument("--logs", help="Copy Anaconda logs to DIR",
+                    action='store', metavar="DIR")
 # Note https://bugzilla.redhat.com/show_bug.cgi?id=1379389
 parser.add_argument("--ostree-repo", help="Pass through OSTree repo via 9p",
                     action='store', required=True)
@@ -90,6 +92,25 @@ mkdir -p /mnt/ostree-repo
 mount -t 9p -o ro,trans=virtio,version=9p2000.L /mnt/ostree-repo /mnt/ostree-repo
 %end
     """)
+# Hacky bits to copy out all of the Anaconda logs on shutdown
+if args.logs:
+    ks_tmp.write("""
+%pre
+set -euo pipefail
+mkdir -p /mnt/logs
+mount -t 9p -o rw,trans=virtio,version=9p2000.L /mnt/logs /mnt/logs
+cat >/etc/systemd/system/coreos-virtinstall-logs.service <<EOF
+[Unit]
+RequiresMountsFor=/mnt/logs
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStop=/bin/sh -c 'cp /tmp/*.log /mnt/logs'
+EOF
+systemctl daemon-reload
+systemctl start coreos-virtinstall-logs
+%end
+    """)
 ks_tmp.flush()
 
 # This is an "extension" to kickstart files that we implement as a comment.
@@ -131,6 +152,8 @@ try:
     if args.console_log_file:
         vinstall_args.append("--console=log.file={}".format(args.console_log_file))
         tail_proc = subprocess.Popen(['tail', '-F', args.console_log_file])
+    if args.logs:
+        vinstall_args.append("--filesystem=source={},target=/mnt/logs,accessmode=mapped".format(args.logs))
     if args.ostree_repo:
         vinstall_args.append("--filesystem=source={},target=/mnt/ostree-repo,accessmode=mapped".format(args.ostree_repo))
     vinstall_args.extend(["--wait={}".format(args.wait), "--noreboot", "--nographics",


### PR DESCRIPTION
This helped me debug an `ostree admin deploy` failure since then
I have `program.log`.