### PR TITLE
cmds: Properly support --help

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -4,11 +4,20 @@ set -euo pipefail
 dn=$(dirname $0)
 . ${dn}/cmdlib.sh
 
+print_help() {
+    cat 1>&2 <<'EOF'
+Usage: coreos-assembler build --help
+       coreos-assembler build [--force] [--skip-prune]
+
+  Build OSTree and image artifacts from previously fetched packages.
+EOF
+}
+
 # Parse options
 FORCE=
 SKIP_PRUNE=0
 rc=0
-options=$(getopt --options f --longoptions force,skip-prune -- "$@") || rc=$?
+options=$(getopt --options hf --longoptions help,force,skip-prune -- "$@") || rc=$?
 [ $rc -eq 0 ] || {
     print_help
     exit 1
@@ -16,6 +25,10 @@ options=$(getopt --options f --longoptions force,skip-prune -- "$@") || rc=$?
 eval set -- "$options"
 while true; do
     case "$1" in
+        -h | --help)
+            print_help
+            exit 0
+            ;;
         -f | --force)
             FORCE="--force-nocache"
             ;;
@@ -33,6 +46,12 @@ while true; do
     esac
     shift
 done
+
+if [ $# -ne 0 ]; then
+    print_help
+    fatal "ERROR: Too many arguments"
+    exit 1
+fi
 
 export LIBGUESTFS_BACKEND=direct
 

--- a/src/cmd-build
+++ b/src/cmd-build
@@ -7,8 +7,9 @@ dn=$(dirname $0)
 # Parse options
 FORCE=
 SKIP_PRUNE=0
-options=$(getopt --options f --longoptions force,skip-prune -- "$@")
-[ $? -eq 0 ] || {
+rc=0
+options=$(getopt --options f --longoptions force,skip-prune -- "$@") || rc=$?
+[ $rc -eq 0 ] || {
     print_help
     exit 1
 }

--- a/src/cmd-clean
+++ b/src/cmd-clean
@@ -4,6 +4,46 @@ set -xeuo pipefail
 dn=$(dirname $0)
 . ${dn}/cmdlib.sh
 
+print_help() {
+    cat 1>&2 <<'EOF'
+Usage: coreos-assembler clean --help
+       coreos-assembler clean
+
+  Delete all build artifacts.
+EOF
+}
+
+rc=0
+options=$(getopt --options h --longoptions help -- "$@") || rc=$?
+[ $rc -eq 0 ] || {
+    print_help
+    exit 1
+}
+eval set -- "$options"
+while true; do
+    case "$1" in
+        -h | --help)
+            print_help
+            exit 0
+            ;;
+        --)
+            shift
+            break
+            ;;
+        *)
+            fatal "$0: unrecognized option: $1"
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+if [ $# -ne 0 ]; then
+    print_help
+    fatal "ERROR: Too many arguments"
+    exit 1
+fi
+
 # This has some useful sanity checks
 prepare_build
 

--- a/src/cmd-fetch
+++ b/src/cmd-fetch
@@ -4,5 +4,45 @@ set -euo pipefail
 dn=$(dirname $0)
 . ${dn}/cmdlib.sh
 
+print_help() {
+    cat 1>&2 <<'EOF'
+Usage: coreos-assembler fetch --help
+       coreos-assembler fetch
+
+  Fetch and import the latest packages.
+EOF
+}
+
+rc=0
+options=$(getopt --options h --longoptions help -- "$@") || rc=$?
+[ $rc -eq 0 ] || {
+    print_help
+    exit 1
+}
+eval set -- "$options"
+while true; do
+    case "$1" in
+        -h | --help)
+            print_help
+            exit 0
+            ;;
+        --)
+            shift
+            break
+            ;;
+        *)
+            fatal "$0: unrecognized option: $1"
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+if [ $# -ne 0 ]; then
+    print_help
+    fatal "ERROR: Too many arguments"
+    exit 1
+fi
+
 prepare_build
 runcompose --download-only

--- a/src/cmd-init
+++ b/src/cmd-init
@@ -15,7 +15,7 @@ Usage: coreos-assembler init --help
   For example, you can use https://github.com/coreos/fedora-coreos-config
   as GITCONFIG, or fork it.  Another option useful for local development
   (if you're running a shell inside this container) is to pass a file path
-  starting with `/` - a symlink to it will be created and then used directly."
+  starting with `/` - a symlink to it will be created and then used directly.
 EOF
 }
 

--- a/src/cmd-init
+++ b/src/cmd-init
@@ -20,8 +20,9 @@ EOF
 }
 
 # Call getopt to validate the provided input.
-options=$(getopt --options hf --longoptions help,force -- "$@")
-[ $? -eq 0 ] || {
+rc=0
+options=$(getopt --options hf --longoptions help,force -- "$@") || rc=$?
+[ $rc -eq 0 ] || {
     print_help
     exit 1
 }

--- a/src/cmd-init
+++ b/src/cmd-init
@@ -49,7 +49,6 @@ while true; do
     shift
 done
 
-
 # If user did not provide a repo then error out
 if [ $# -ne 1 ]; then
     print_help

--- a/src/cmd-prune
+++ b/src/cmd-prune
@@ -11,8 +11,9 @@ prepare_build
 
 # Parse options
 KEEP_LAST_N=
-options=$(getopt --options '' --longoptions keep: -- "$@")
-[ $? -eq 0 ] || {
+rc=0
+options=$(getopt --options '' --longoptions keep: -- "$@") || rc=$?
+[ $rc -eq 0 ] || {
     print_help
     exit 1
 }

--- a/src/cmd-prune
+++ b/src/cmd-prune
@@ -7,12 +7,20 @@ set -euo pipefail
 dn=$(dirname $0)
 . ${dn}/cmdlib.sh
 
-prepare_build
+print_help() {
+    cat 1>&2 <<'EOF'
+Usage: coreos-assembler prune --help
+       coreos-assembler prune [--keep=N]
+
+  Delete older build artifacts. By default, only the last 3 builds are kept.
+  This can be overridden with the `--keep` option.
+EOF
+}
 
 # Parse options
 KEEP_LAST_N=
 rc=0
-options=$(getopt --options '' --longoptions keep: -- "$@") || rc=$?
+options=$(getopt --options h --longoptions help,keep: -- "$@") || rc=$?
 [ $rc -eq 0 ] || {
     print_help
     exit 1
@@ -20,6 +28,10 @@ options=$(getopt --options '' --longoptions keep: -- "$@") || rc=$?
 eval set -- "$options"
 while true; do
     case "$1" in
+        -h | --help)
+            print_help
+            exit 0
+            ;;
         --keep)
             shift
             KEEP_LAST_N="--keep-last-n $1"
@@ -35,5 +47,13 @@ while true; do
     esac
     shift
 done
+
+if [ $# -ne 0 ]; then
+    print_help
+    fatal "ERROR: Too many arguments"
+    exit 1
+fi
+
+prepare_build
 
 ${dn}/prune_builds ${KEEP_LAST_N} --workdir ${workdir}


### PR DESCRIPTION
We had a bunch of copy-pasted stanzas that called out to `print_help`,
except that function is only defined in the `init` command.

Consistently define a `print_help` function, and make sure we support a
`-h/--help` option which prints it and exits nicely like in `init`.

Also explicitly check for too many args in functions that don't support
any extra positional args.