### PR TITLE
Add a proper build-timestamp

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -161,8 +161,11 @@ set +x
 # make a version-less symlink to have a stable path
 ln -s ${imageprefix}-qemu.qcow2 ${name}-qemu.qcow2
 
+build_timestamp=$(date -u --iso-8601=seconds)
+
 cat > tmp/meta.json <<EOF
 {
+ "coreos-assembler.build-timestamp": "${build_timestamp}",
  "coreos-assembler.image-input-checksum": "${image_input_checksum}",
  "coreos-assembler.image-genver": "${image_genver}",
  "coreos-assembler.kickstart-checksum": "${kickstart_checksum}"

--- a/src/prune_builds
+++ b/src/prune_builds
@@ -49,7 +49,9 @@ with os.scandir(builds_dir) as it:
         # collect dirs and timestamps
         with open(meta_file) as f:
             j = json.load(f)
-        t = dateutil.parser.parse(j['ostree-timestamp'])
+        # Older versions only had ostree-timestamp
+        ts = j.get('build-timestamp') or j['ostree-timestamp']
+        t = dateutil.parser.parse(ts)
         builds.append((entry.name, t))
 
 builds = sorted(builds, key=lambda x: x[1], reverse=True)


### PR DESCRIPTION
In the case where just the kickstart changed, we'd end up with
multiple builds with the same timestamp.  Fix this by adding a
`coreos-assembler.build-timestamp` metadata key, and use it
if available when sorting/pruning.