### PR TITLE
cmd-build: Use buildid for image names too

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -172,7 +172,7 @@ else
     previous_commit_json=null
 fi
 
-imageprefix=${name}-${version}-${image_genver}
+imageprefix=${name}-${buildid}
 # Make these two verbose
 set -x
 mkdir -p tmp/anaconda


### PR DESCRIPTION
I missed this when doing
https://github.com/coreos/coreos-assembler/pull/168
AKA ec023cd5ddfaf0e35991a91cb2dcc230663ab82e

This way the image name doesn't have a weird `-0` in it.