### PR TITLE
cmdlib: Fix overrides when using subdir paths

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -108,13 +108,15 @@ runcompose() {
         echo "Using RPM overrides from: ${overridesdir}/rpm"
         local tmp_overridesdir=${TMPDIR}/override
         mkdir ${tmp_overridesdir}
-        local manifestdir=$(dirname ${manifest})
-        rsync -rl ${manifestdir}/ ${tmp_overridesdir}/
         cat > ${tmp_overridesdir}/coreos-assembler-override-manifest.yaml <<EOF
-include: $(basename ${manifest})
+include: ${workdir}/src/config/manifest.yaml
 repos:
   - coreos-assembler-local-overrides
 EOF
+        # Because right now rpm-ostree doesn't look for .repo files in
+        # each included dir.
+        # https://github.com/projectatomic/rpm-ostree/issues/1628
+        cp ${workdir}/src/config/*.repo ${tmp_overridesdir}/
         cat > ${tmp_overridesdir}/coreos-assembler-local-overrides.repo <<EOF
 [coreos-assembler-local-overrides]
 name=coreos-assembler-local-overrides


### PR DESCRIPTION
I'm using the subpath bit, and the fact that we were only copying
the subpath from the git repo broke things for me since our
base configs live in `..` from the subpath.

Actually now that rpm-ostree fixes have landed around treefile
parsing, rather than copying the whole input dir, simply make a new
one that inherits from it.  The last gap here unfixed in rpm-ostree
is finding the `.repo` files, so let's just copy those in.