### PR TITLE
build: Add `buildid` to metadata

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -199,6 +199,7 @@ build_timestamp=$(date -u --iso-8601=seconds)
 
 cat > tmp/meta.json <<EOF
 {
+ "buildid": "${buildid}",
  "coreos-assembler.build-timestamp": "${build_timestamp}",
  "coreos-assembler.image-input-checksum": "${image_input_checksum}",
  "coreos-assembler.image-genver": "${image_genver}",


### PR DESCRIPTION
I'm now parsing the `meta.json` in several places and it'd be
really convenient if we had this property, since then one can just
`open('builds/latest/meta.json)'` and have what one needs.

(Why not `coreos-assembler.buildid`?  Um...I dunno.  I missed
 adding that to `amis` and `images` too and eh...we're not going
 to collide with rpm-ostree.)