### PR TITLE
build: Add `name` to metadata

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -200,6 +200,7 @@ build_timestamp=$(date -u --iso-8601=seconds)
 cat > tmp/meta.json <<EOF
 {
  "buildid": "${buildid}",
+ "name": "${name}",
  "coreos-assembler.build-timestamp": "${build_timestamp}",
  "coreos-assembler.image-input-checksum": "${image_input_checksum}",
  "coreos-assembler.image-genver": "${image_genver}",


### PR DESCRIPTION
This is another useful piece of data; I'm writing some scripts
to extend the AMI to multiple regions, and having the source
data here (rather than scraping it from the original AMI) would be
nicer.

Perhaps a better place for this would be in `builds.json` though?