### PR TITLE
Turn on simple Travis CI checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+sudo: required
+
+language: sh
+
+services:
+  - docker
+
+before_script:
+  - docker pull docker.io/koalaman/shellcheck
+
+script:
+  # shellcheck validate
+  - docker run -v "$PWD:/mnt:ro" docker.io/koalaman/shellcheck -x $(find . -path ./mantle -prune -and -path ./ostree-releng-scripts -prune -o -type f -exec grep -l '^#!.*bash' {} \;)

--- a/src/cmd-init
+++ b/src/cmd-init
@@ -62,7 +62,7 @@ fi
 
 # If the current working dir is not empty then error out
 # unless force provided
-if [ "$FORCE" != "1" ] && [ ! -z "$(ls -A ./)" ]; then
+if [ "$FORCE" != "1" ] && [ -n "$(ls -A ./)" ]; then
    fatal "init: current directory is not empty, override with --force"
 fi
 


### PR DESCRIPTION
This does a `shellcheck` on the bash files and tries to do a container build.

Will require one of the repo admins to enable Travis CI access.