### PR TITLE
Clean out /var for images

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -173,6 +173,7 @@ img_qemu=${imageprefix}-qemu.qcow2
                --ostree-ref="${ref:-${commit}}" --ostree-repo="${workdir}"/repo \
                --location "${workdir}"/installer/*.iso --console-log-file "$(pwd)"/install.log \
                --logs "$(pwd)"/tmp/anaconda
+/usr/lib/coreos-assembler/gf-anaconda-cleanup "$(pwd)"/"${img_base}"
 /usr/lib/coreos-assembler/gf-oemid "$(pwd)"/"${img_base}" "$(pwd)"/"${img_qemu}" qemu
 set +x
 # make a version-less symlink to have a stable path

--- a/src/gf-anaconda-cleanup
+++ b/src/gf-anaconda-cleanup
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+dn=$(dirname "$0")
+# shellcheck source=src/cmdlib.sh
+. "${dn}"/cmdlib.sh
+# shellcheck source=src/libguestfish.sh
+. "${dn}"/libguestfish.sh
+
+src="$1"
+
+set -x
+coreos_gf_run_mount "${src}"
+
+# Both of these are written by Anaconda
+coreos_gf rm-rf "${deploydir}/etc/sysconfig/anaconda"
+coreos_gf rm-rf "${deploydir}/etc/systemd/system/default.target"
+# And blow away all of /var - we want systemd-tmpfiles to be
+# canonical
+coreos_gf rm-rf "${stateroot}/var/*"
+
+coreos_gf_shutdown


### PR DESCRIPTION
OSTree was designed from the very start to support having `/var`
be empty on boot, but for Fedora we ended up using Anaconda which
meant we had to carry a lot of hacks to run `systemd-tmpfiles`
in the root to support `%post`.  And when I say "hacks", I mean
seriously ugly hacks.

For Fedora CoreOS, since we're requiring Ignition and moving
away from Anaconda, we can use OSTree as it was designed
in a clean fashion.

For now since our build side is still using Anaconda, let's just
remove all contents in `/var` as a postprocessing step.

This is also a preparatory change for having images with a `/var`
partition pre-configured.

Requires: https://github.com/coreos/fedora-coreos-config/pull/29