### PR TITLE
libguestfish: Also mount `var` if such a partition exists

### DIFF
--- a/src/libguestfish.sh
+++ b/src/libguestfish.sh
@@ -42,10 +42,16 @@ coreos_gf_run_mount() {
     local boot
     boot=$(coreos_gf findfs-label boot)
     coreos_gf mount "${boot}" /boot
+    var=$(coreos_gf -findfs-label var || true)
 
     # Export these variables for further use
     stateroot=/ostree/deploy/$(coreos_gf ls /ostree/deploy)
     deploydir="${stateroot}"/deploy/$(coreos_gf ls "${stateroot}"/deploy | grep -v \.origin)
+    if [ -n "${var}" ]; then
+        # Since it doesn't look like libguestfs supports bind mounts, and other
+        # code processes the stateroot directory, let's mount it there.
+        coreos_gf mount "${var}" "${stateroot}"/var
+    fi
     export stateroot deploydir
 }
 


### PR DESCRIPTION
We discussed possibly using a `var` partition for FCOS in
https://github.com/coreos/fedora-coreos-tracker/issues/18

I would like to do so for my own Silverblue install, and possibly
for Silverblue by default.

So let's mount that partition if it exists, which means the other
code that cleans out what Anaconda did in `/var` will work.