### PR TITLE
buildextend-openstack: New command to add OpenStack image

### DIFF
--- a/coreos-assembler
+++ b/coreos-assembler
@@ -34,7 +34,7 @@ if [ -e /sys/fs/selinux/status ]; then
 fi
 
 cmd=${1:-}
-build_commands="init fetch build buildextend-ec2 run prune clean"
+build_commands="init fetch build buildextend-ec2 buildextend-openstack run prune clean"
 other_commands="shell"
 utility_commands="gf-oemid virt-install oscontainer"
 if [ -z "${cmd}" ]; then

--- a/src/cmd-buildextend-openstack
+++ b/src/cmd-buildextend-openstack
@@ -1,0 +1,49 @@
+#!/usr/bin/python3 -u
+# An operation that mutates a build by generating an OpenStack image.
+
+import os,sys,json,yaml,shutil,argparse,subprocess,re,collections
+import tempfile,hashlib,gzip
+
+sys.path.insert(0, '/usr/lib/coreos-assembler')
+from cmdlib import run_verbose, write_json, sha256sum_file
+
+# Parse args and dispatch
+parser = argparse.ArgumentParser()
+parser.add_argument("--build", help="Build ID",
+                    required=True)
+args = parser.parse_args()
+
+with open('src/config/manifest.yaml') as f:
+    manifest = yaml.safe_load(f)
+
+base_name = manifest['rojig']['name']
+img_prefix = f'{base_name}-{args.build}'
+openstack_name = f'{img_prefix}-openstack.qcow2'
+
+builddir = f'builds/{args.build}'
+buildmeta_path = f'{builddir}/meta.json'
+with open(buildmeta_path) as f:
+    buildmeta = json.load(f)
+
+tmpdir='tmp/buildpost-openstack'
+if os.path.isdir(tmpdir):
+    shutil.rmtree(tmpdir)
+os.mkdir(tmpdir)
+
+def generate_openstack():
+    buildmeta_images = buildmeta['images']
+    img_qemu = os.path.join(builddir, buildmeta_images['qemu']['path'])
+    tmp_img_openstack = f'{tmpdir}/{openstack_name}'
+    run_verbose(['/usr/lib/coreos-assembler/gf-oemid',
+                 img_qemu, tmp_img_openstack, 'openstack'])
+    checksum = sha256sum_file(tmp_img_openstack)
+    buildmeta_images['openstack'] = {
+        'path': openstack_name,
+        'checksum': checksum
+    }
+    os.rename(tmp_img_openstack, f"{builddir}/{openstack_name}")
+    write_json(buildmeta_path, buildmeta)
+    print(f"Updated: {buildmeta_path}")
+
+# Do it!
+generate_openstack()

--- a/src/cmdlib.py
+++ b/src/cmdlib.py
@@ -1,6 +1,6 @@
 # Python version of cmdlib.sh
 
-import os,json,tempfile,subprocess
+import os,json,tempfile,subprocess,hashlib
 
 def run_verbose(args, **kwargs):
     print("+ {}".format(subprocess.list2cmdline(args)))
@@ -12,3 +12,10 @@ def write_json(path, data):
     json.dump(data, f)
     os.fchmod(f.file.fileno(), 0o644)
     os.rename(f.name, path)
+
+def sha256sum_file(filename):
+    h = hashlib.sha256()
+    with open(filename, 'rb', buffering=0) as f:
+        for b in iter(lambda: f.read(128 * 1024), b''):
+            h.update(b)
+    return h.hexdigest()


### PR DESCRIPTION
Building on the prior art of `buildextend-ec2`.  We really want
a config file or arguments for `build` or so, but for now this
fixes a regression in our switch to coreos-assembler for RHCOS
in that we need an OpenStack image.