### PR TITLE
build: chown repo in privileged mode

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -163,6 +163,7 @@ EOF
     # this is the heart of the privs vs no privs dual path
     if has_privileges; then
         sudo "$@"
+        sudo chown -R -h "${USER}":"${USER}" "${workdir}"/repo
     else
         runvm "$@"
     fi


### PR DESCRIPTION
This is a a regression from the unprivileged work.  Previously
we had two repos, and only the `repo-build` was owned by root.
Now that we have one repo, in the privileged path `rpm-ostree` still
runs as uid `0` by default, so we need to `chown` the repo to
ensure that e.g. `ostree prune` (run unprivileged) can operate
on it.