### PR TITLE
write out sha256sums to files

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -181,7 +181,9 @@ set +x
 # make a version-less symlink to have a stable path
 ln -s "${img_qemu}" "${name}"-qemu.qcow2
 
-img_qemu_sha256=$(sha256sum "${img_qemu}" | cut -f 1 -d ' ')
+img_qemu_sha256_file="${img_qemu}.sha256sum"
+sha256sum "${img_qemu}" > "${img_qemu_sha256_file}"
+img_qemu_sha256="$(awk '{print $1}' < "${img_qemu_sha256_file}")"
 
 build_timestamp=$(date -u --iso-8601=seconds)
 
@@ -195,7 +197,8 @@ cat > tmp/meta.json <<EOF
  "coreos-assembler.kickstart-checksum": "${kickstart_checksum}",
  "images": {
     "qemu": { "path": "${img_qemu}",
-              "sha256": "${img_qemu_sha256}" }
+              "sha256": "${img_qemu_sha256}",
+              "sha256file": "${img_qemu_sha256_file}" }
  }
 }
 EOF

--- a/src/cmd-buildextend-openstack
+++ b/src/cmd-buildextend-openstack
@@ -19,6 +19,7 @@ with open('src/config/manifest.yaml') as f:
 base_name = manifest['rojig']['name']
 img_prefix = f'{base_name}-{args.build}'
 openstack_name = f'{img_prefix}-openstack.qcow2'
+openstack_sha256_file = f'{openstack_name}.sha256sum'
 
 builddir = f'builds/{args.build}'
 buildmeta_path = f'{builddir}/meta.json'
@@ -39,9 +40,12 @@ def generate_openstack():
     checksum = sha256sum_file(tmp_img_openstack)
     buildmeta_images['openstack'] = {
         'path': openstack_name,
-        'sha256': checksum
+        'sha256': checksum,
+        'sha256file': openstack_sha256_file
     }
     os.rename(tmp_img_openstack, f"{builddir}/{openstack_name}")
+    write_sha256_file(f"{builddir}/{openstack_sha256_file}",
+                        openstack_name, checksum)
     write_json(buildmeta_path, buildmeta)
     print(f"Updated: {buildmeta_path}")
 

--- a/src/cmdlib.py
+++ b/src/cmdlib.py
@@ -19,3 +19,10 @@ def sha256sum_file(filename):
         for b in iter(lambda: f.read(128 * 1024), b''):
             h.update(b)
     return h.hexdigest()
+
+def write_sha256_file(path, img, sha256):
+    dn = os.path.dirname(path)
+    f = tempfile.NamedTemporaryFile(mode='w', dir=dn, delete=False)
+    f.write(f"{sha256}  {img}")
+    os.fchmod(f.file.fileno(), 0o644)
+    os.rename(f.name, path)


### PR DESCRIPTION
In preparation for openshift/os#362, let's start writing out the `sha256sum` to files so that folks can do things like `sha256sum -c <file>`.

This writes a file per qcow2, but we could change it to write single file if that is preferred.