### PR TITLE
deps: Include ShellCheck as dependency package

### DIFF
--- a/src/deps.txt
+++ b/src/deps.txt
@@ -38,3 +38,6 @@ ignition
 
 # For parsing ISO8601 dates
 python3-dateutil
+
+# shellcheck for test
+ShellCheck


### PR DESCRIPTION
shellcheck command is used in [tests](https://github.com/coreos/coreos-assembler/blob/master/tests/check.sh#L18) which is required during coreos-assembler container build.