### PR TITLE
support RFC3339 timestamps on `builds.json`

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -61,6 +61,9 @@ prepare_build
 ostree --version
 rpm-ostree --version
 
+# RFC3339 formatter
+RFC3339="%Y-%m-%dT%H:%M:%SZ"
+
 previous_build=
 if [ -L "${workdir:?}"/builds/latest ]; then
     previous_build=$(readlink "${workdir}"/builds/latest)
@@ -183,7 +186,7 @@ ln -s "${img_qemu}" "${name}"-qemu.qcow2
 
 img_qemu_sha256=$(sha256sum "${img_qemu}" | cut -f 1 -d ' ')
 
-build_timestamp=$(date -u --iso-8601=seconds)
+build_timestamp=$(date -u +$RFC3339)
 
 cat > tmp/meta.json <<EOF
 {

--- a/src/cmd-prune
+++ b/src/cmd-prune
@@ -11,17 +11,21 @@ dn=$(dirname "$0")
 print_help() {
     cat 1>&2 <<'EOF'
 Usage: coreos-assembler prune --help
-       coreos-assembler prune [--keep=N]
+       coreos-assembler prune [--keep=N] [--timestamp-only]
 
   Delete older build artifacts. By default, only the last 3 builds are kept.
   This can be overridden with the `--keep` option.
+
+  The `--timestamp-only` option will just update the `timestamp` key of
+  `builds.json`
 EOF
 }
 
 # Parse options
 KEEP_LAST_N="3"
+TIMESTAMP=0
 rc=0
-options=$(getopt --options h --longoptions help,keep: -- "$@") || rc=$?
+options=$(getopt --options h --longoptions help,keep:,timestamp-only -- "$@") || rc=$?
 [ $rc -eq 0 ] || {
     print_help
     exit 1
@@ -36,6 +40,9 @@ while true; do
         --keep)
             shift
             KEEP_LAST_N="$1"
+            ;;
+        --timestamp-only)
+            TIMESTAMP=1
             ;;
         --)
             shift
@@ -56,4 +63,10 @@ if [ $# -ne 0 ]; then
 fi
 
 prepare_build
+
+if [ "${TIMESTAMP}" == 1 ]; then
+    "${dn}"/prune_builds --timestamp-only --workdir "${workdir:?}"
+    exit 0
+fi
+
 "${dn}"/prune_builds --keep-last-n "${KEEP_LAST_N}" --workdir "${workdir:?}"

--- a/src/prune_builds
+++ b/src/prune_builds
@@ -15,6 +15,8 @@ import subprocess
 
 import dateutil.parser
 
+from datetime import datetime
+
 sys.path.insert(0, '/usr/lib/coreos-assembler')
 from cmdlib import write_json
 
@@ -27,6 +29,8 @@ parser.add_argument("--keep-last-n", type=int, default=DEFAULT_KEEP_LAST_N,
                     help="Number of builds to keep (0 for all)")
 parser.add_argument("--insert-only", help="Append a new latest build, do not prune",
                     action='store')
+parser.add_argument("--timestamp-only", help="Update timestamp on builds.json",
+                    action='store_true')
 args = parser.parse_args()
 
 builds = []
@@ -39,9 +43,19 @@ if os.path.isfile(builds_json):
 else:
     builddata = {'builds': []}
 
+# generate RFC3339 timestamp
+now = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+
+# handle --timestamp-only
+if args.timestamp_only:
+    builddata['timestamp'] = now
+    write_json(builds_json, builddata)
+    sys.exit(0)
+
 # Handle --insert-only
 if args.insert_only:
     builddata['builds'].insert(0, args.insert_only)
+    builddata['timestamp'] = now
     write_json(builds_json, builddata)
     sys.exit(0)
 
@@ -79,6 +93,7 @@ if not skip_pruning and len(builds) > args.keep_last_n:
     del builds[args.keep_last_n:]
 
 builddata['builds'] = [x[0] for x in builds]
+builddata['timestamp'] = now
 write_json(builds_json, builddata)
 
 # if we're not pruning, then we're done!


### PR DESCRIPTION
We want to be able to prove the "freshness" of `builds.json` to consumers, so let's introduce a timestamp field.

This change causes the `build` process to insert a timestamp field on `builds.json`.  It also introduces the ability to *only* timestamp `builds.json`

I also changed `build_timestamp` in `meta.json` to match the rest.