### PR TITLE
WIP: Embed split-out anaconda install tree

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /root/containerbuild
 COPY ./build.sh ./deps.txt ./vmdeps.txt ./build-deps.txt /root/containerbuild/
 RUN ./build.sh configure_yum_repos
 RUN ./build.sh install_rpms
+RUN ./build.sh install_anaconda
 
 # Ok copy in the rest of them for the next few steps
 COPY ./ /root/containerbuild/

--- a/build.sh
+++ b/build.sh
@@ -75,6 +75,24 @@ install_rpms() {
 
 }
 
+# Store Anaconda (boot.iso + split vmlinuz/initrd.img) as used
+# by virt-install.
+install_anaconda() {
+    major=29
+    # This doesn't always match the pungi/rpm arch
+    arch=$(arch)
+    baseurl=https://dl.fedoraproject.org/pub/fedora/linux/releases/${major}/Everything/${arch}/os/
+
+    anaconda_dir=/usr/lib/coreos-assembler/anaconda
+    mkdir -p "${anaconda_dir}"
+    (cd "${anaconda_dir}"
+     mkdir -p images/pxeboot
+     curl -L --remote-name-all "${baseurl}"/.treeinfo "${baseurl}"/images/{install.img,pxeboot/vmlinuz,pxeboot/initrd.img}
+     mv install.img images
+     mv vmlinuz initrd.img images/pxeboot
+    )
+}
+
 make_and_makeinstall() {
 
     # Work around https://github.com/coreos/coreos-assembler/issues/27

--- a/src/cmd-build
+++ b/src/cmd-build
@@ -166,6 +166,15 @@ else
 fi
 echo "New build ID: ${buildid}"
 
+# Default to embedded boot.iso, but use provided iso if one exists
+installer="/usr/lib/coreos-assembler/anaconda"
+for f in "${workdir}"/installer/*.iso; do
+    if [ -f "${f}" ]; then
+        installer="${f}"
+        break
+    fi
+done
+
 imageprefix="${name:?}"-"${buildid}"
 # Make these two verbose
 set -x
@@ -176,7 +185,7 @@ img_qemu=${imageprefix}-qemu.qcow2
                --create-disk --kickstart "${kickstart_input}" --kickstart-out "$(pwd)"/tmp/flattened.ks \
                --ostree-remote="${name}" --ostree-stateroot="${name}" \
                --ostree-ref="${ref:-${commit}}" --ostree-repo="${workdir}"/repo \
-               --location "${workdir}"/installer/*.iso --console-log-file "$(pwd)"/install.log \
+               --location "${installer}" --console-log-file "$(pwd)"/install.log \
                --logs "$(pwd)"/tmp/anaconda
 /usr/lib/coreos-assembler/gf-anaconda-cleanup "$(pwd)"/"${img_base}"
 /usr/lib/coreos-assembler/gf-oemid "$(pwd)"/"${img_base}" "$(pwd)"/"${img_qemu}" qemu

--- a/src/cmd-init
+++ b/src/cmd-init
@@ -5,15 +5,14 @@ dn=$(dirname "$0")
 # shellcheck source=src/cmdlib.sh
 . "${dn}"/cmdlib.sh
 
-# Initialize FORCE to 0 and BRANCH/INSTALLER_DIR to an empty string
+# Initialize FORCE to 0 and BRANCH to an empty string
 FORCE=0
-INSTALLER_DIR=""
 BRANCH=""
 
 print_help() {
     cat 1>&2 <<'EOF'
 Usage: coreos-assembler init --help
-       coreos-assembler init [--force] [--branch BRANCH] [--installerdir INSTALLER_DIR] GITCONFIG [SUBDIR]
+       coreos-assembler init [--force] [--branch BRANCH] GITCONFIG [SUBDIR]
 
   For example, you can use https://github.com/coreos/fedora-coreos-config
   as GITCONFIG, or fork it.  Another option useful for local development
@@ -23,15 +22,12 @@ Usage: coreos-assembler init --help
 
   If specified, SUBDIR is a subdirectory of the git repository that should
   contain manifest.yaml and image.ks.
-
-  If you have the required install ISO and sha256sums already availble,
-  you can specify the location of the those files with the `--installerdir` flag.
 EOF
 }
 
 # Call getopt to validate the provided input.
 rc=0
-options=$(getopt --options hfb:i: --longoptions help,force,branch:,installerdir: -- "$@") || rc=$?
+options=$(getopt --options hfb:i: --longoptions help,force,branch: -- "$@") || rc=$?
 [ $rc -eq 0 ] || {
     print_help
     exit 1
@@ -52,18 +48,6 @@ while true; do
                 shift ;;
             *)
                 BRANCH="$2"
-                shift ;;
-        esac
-        ;;
-    -i | --installerdir)
-        case "$2" in
-            "")
-                shift ;;
-            *)
-                INSTALLER_DIR=$(readlink -f "$2")
-                if [ ! -d "$INSTALLER_DIR" ]; then
-                    fatal "installer must exist and be accessible: ${INSTALLER_DIR}"
-                fi
                 shift ;;
         esac
         ;;
@@ -120,8 +104,6 @@ repository_dirs[ppc64le]=fedora-secondary
 repository_dirs[s390x]=fedora-secondary
 
 repository_dir=${repository_dirs[$arch]}
-INSTALLER=https://download.fedoraproject.org/pub/$repository_dir/releases/$release/Everything/$arch/iso/Fedora-Everything-netinst-$arch-$release-1.1.iso
-INSTALLER_CHECKSUM=https://download.fedoraproject.org/pub/$repository_dir/releases/$release/Everything/$arch/iso/Fedora-Everything-$release-1.1-$arch-CHECKSUM
 
 set -x
 # Initialize sources (git)
@@ -146,33 +128,6 @@ mkdir -p src
          fatal "If using a custom configuration, be sure it has a manifest.yaml."
      fi
  fi)
-
-
-installer_bn=$(basename "${INSTALLER}")
-checksums_bn=$(basename "${INSTALLER_CHECKSUM}")
-mkdir -p installer
-
-if [ -n "${INSTALLER_DIR}" ]; then
-    if (cd "${INSTALLER_DIR}" && sha256sum -c "${checksums_bn}"); then
-        (cd installer
-         cp --reflink=auto "${INSTALLER_DIR}"/"${installer_bn}" .
-         cp --reflink=auto "${INSTALLER_DIR}"/"${checksums_bn}" .
-        )
-    fi
-fi
-
-(cd installer
- if ! [ -f "${installer_bn}" ]; then
-    mkdir -p tmp
-    (
-     cd tmp
-     curl -L --remote-name-all "${INSTALLER}" "${INSTALLER_CHECKSUM}"
-     sha256sum -c "${checksums_bn}"
-     mv "${installer_bn}" "${checksums_bn}" ..
-    )
-    rm tmp -rf
-  fi
-)
 
 mkdir -p cache
 mkdir -p builds

--- a/src/virt-install
+++ b/src/virt-install
@@ -158,7 +158,7 @@ try:
         vinstall_args.append("--filesystem=source={},target=/mnt/ostree-repo,accessmode=mapped".format(args.ostree_repo))
     vinstall_args.extend(["--wait={}".format(args.wait), "--noreboot", "--nographics",
                           "--memory={}".format(args.memory), get_libvirt_smp_arg(),
-                          "--os-variant=rhel7", "--rng=/dev/urandom",
+                          "--os-variant=rhel7.5", "--rng=/dev/urandom",
                           "--check", "path_in_use=off",
                           "--network=none",  # We want predictablity, disable networking
                           "--disk=path={},cache=unsafe".format(args.dest),


### PR DESCRIPTION
This doesn't quite work; the VM fails to find stage2 (`install.img`).