### PR TITLE
build: Also output commitmeta.json

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -206,6 +206,10 @@ EOF
 # since we may be overriding data from a previous build.
 cat "${composejson}" tmp/meta.json "${commitmeta_input_json}" | jq -s add > meta.json
 
+# And add the commit metadata itself, which includes notably the rpmdb pkglist
+# in a format that'd be easy to generate diffs out of for higher level tools
+"${dn}"/commitmeta_to_json "${workdir}/repo" "${commit}" > commitmeta.json
+
 # Clean up our temporary data
 rm tmp -rf
 # Back to the toplevel build directory, so we can rename this one

--- a/src/commitmeta_to_json
+++ b/src/commitmeta_to_json
@@ -1,0 +1,27 @@
+#!/usr/bin/python3 -u
+
+import argparse
+import gi
+import sys
+
+gi.require_version('OSTree', '1.0')
+gi.require_version('Json', '1.0')
+from gi.repository import GLib, Gio, OSTree, Json
+
+parser = argparse.ArgumentParser()
+parser.add_argument("repo", help="OSTree repo")
+parser.add_argument("rev", help="Revision to inspect")
+args = parser.parse_args()
+
+r = OSTree.Repo.new(Gio.File.new_for_path(args.repo))
+r.open(None)
+
+[_, rev] = r.resolve_rev(args.rev, True)
+[_, commit, _] = r.load_commit(rev)
+commitmeta = commit.get_child_value(0)
+
+g = Json.Generator.new()
+g.set_root(Json.gvariant_serialize(commitmeta))
+stdout = Gio.UnixOutputStream.new(sys.stdout.fileno(), False)
+g.set_pretty(True)
+g.to_stream(stdout)


### PR DESCRIPTION
This is generally useful but especially so for the pkglist alone for
higher level tools displaying releases/build outputs.

Closes: #197