### PR TITLE
commitmeta_to_json: Byteswap on little-endian platforms

### DIFF
--- a/src/commitmeta_to_json
+++ b/src/commitmeta_to_json
@@ -19,6 +19,8 @@ r.open(None)
 [_, rev] = r.resolve_rev(args.rev, True)
 [_, commit, _] = r.load_commit(rev)
 commitmeta = commit.get_child_value(0)
+if sys.byteorder != 'big':
+    commitmeta = commitmeta.byteswap()
 
 g = Json.Generator.new()
 g.set_root(Json.gvariant_serialize(commitmeta))


### PR DESCRIPTION
Otherwise all numeric values will be wonky. OSTree canonicalizes to big
endian.