### PR TITLE
README and build: add info on testing modified script locally, and boldness to build output error

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,3 +122,21 @@ Development
 ---
 
 The container image is built in [OpenShift CI](https://api.ci.openshift.org/console/project/rhcos/browse/builds/coreos-assembler?tab=history).
+
+When editing a script, a quick way to use the locally-modified script in
+`coreos-assembler` is to volume-mount the path to the script, for example:
+
+```
+$ alias coreos-assembler= podman run --rm --net=host -ti --privileged --userns=host -v $(pwd):/srv -v /path/to/coreos-assembler/src/cmd-run:/usr/lib/coreos-assembler/cmd-run --workdir /srv quay.io/coreos-assembler/coreos-assembler
+```
+
+To completely rebuild the coreos-assembler container image locally, execute
+`$ podman build .` from the `coreos-assembler` repository. You can upload your
+built image to a registry such as quay.io by doing the following:
+
+```
+$ podman push <image id> quay.io/<account name>/coreos-assembler
+```
+
+Replacing the container image argument in the `coreos-assembler` alias with
+`quay.io/<account name>/coreos-assembler` will pull your container image instead.

--- a/build.sh
+++ b/build.sh
@@ -90,7 +90,7 @@ make_and_makeinstall() {
     rsync -rlv "${srcdir}"/ostree-releng-scripts/ /usr/app/ostree-releng-scripts/
 
     if ! test -f mantle/README.md; then
-        echo "Run: git submodule update --init" 1>&2
+        echo -e "\033[1merror: submodules not initialized. Run: git submodule update --init\033[0m" 1>&2
         exit 1
     fi
 


### PR DESCRIPTION
Just some notes I made while hacking on this before, in case they can be of use.

The boldness edit to the build error is not very crucial, as with the script already being printed out it was quick to get the problem resolved. But adding the `error:` or something like that I find helps it stick out a bit when looking for what went wrong.