### PR TITLE
cmd-build: Update the summary again

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -86,6 +86,7 @@ prepare_build() {
 
     manifest_tmp_json=${workdir}/tmp/manifest.json
     rpm-ostree compose tree --repo=repo --print-only ${manifest} > ${manifest_tmp_json}
+    ostree --repo=repo summary -u
 
     # Abuse the rojig/name as the name of the VM images
     export name=$(jq -r '.rojig.name' < ${manifest_tmp_json})


### PR DESCRIPTION
It took me a while to debug why my newly built images had old
ostree commits in them; the summary update was removed in
https://github.com/coreos/coreos-assembler/pull/190

Let's add it back in.