### PR TITLE
add some helper functions to `cmdlib.py`

### DIFF
--- a/src/cmdlib.py
+++ b/src/cmdlib.py
@@ -1,6 +1,7 @@
 # Python version of cmdlib.sh
 
-import os,json,tempfile,subprocess,hashlib
+import os,json,tempfile,subprocess,hashlib,sys
+from datetime import datetime
 
 def run_verbose(args, **kwargs):
     print("+ {}".format(subprocess.list2cmdline(args)))
@@ -19,3 +20,10 @@ def sha256sum_file(filename):
         for b in iter(lambda: f.read(128 * 1024), b''):
             h.update(b)
     return h.hexdigest()
+
+def fatal(msg):
+    print('error: {}'.format(msg), file=sys.stderr)
+    raise SystemExit(1)
+
+def rfc3339_time():
+    return datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/src/cmdlib.py
+++ b/src/cmdlib.py
@@ -1,11 +1,18 @@
 # Python version of cmdlib.sh
 
-import os,json,tempfile,subprocess,hashlib,sys
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import tempfile
 from datetime import datetime
+
 
 def run_verbose(args, **kwargs):
     print("+ {}".format(subprocess.list2cmdline(args)))
     subprocess.check_call(args, **kwargs)
+
 
 def write_json(path, data):
     dn = os.path.dirname(path)
@@ -14,6 +21,7 @@ def write_json(path, data):
     os.fchmod(f.file.fileno(), 0o644)
     os.rename(f.name, path)
 
+
 def sha256sum_file(filename):
     h = hashlib.sha256()
     with open(filename, 'rb', buffering=0) as f:
@@ -21,9 +29,11 @@ def sha256sum_file(filename):
             h.update(b)
     return h.hexdigest()
 
+
 def fatal(msg):
     print('error: {}'.format(msg), file=sys.stderr)
     raise SystemExit(1)
+
 
 def rfc3339_time():
     return datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/src/prune_builds
+++ b/src/prune_builds
@@ -25,9 +25,11 @@ parser = argparse.ArgumentParser()
 parser.add_argument("--workdir", required=True, help="Path to workdir")
 parser.add_argument("--keep-last-n", type=int, default=DEFAULT_KEEP_LAST_N,
                     help="Number of builds to keep (0 for all)")
-parser.add_argument("--insert-only", help="Append a new latest build, do not prune",
+parser.add_argument("--insert-only",
+                    help="Append a new latest build, do not prune",
                     action='store')
-parser.add_argument("--timestamp-only", help="Update timestamp on builds.json",
+parser.add_argument("--timestamp-only",
+                    help="Update timestamp on builds.json",
                     action='store_true')
 args = parser.parse_args()
 
@@ -100,6 +102,7 @@ if skip_pruning:
 for build_dir, _ in builds_to_delete:
     shutil.rmtree(os.path.join(builds_dir, build_dir))
 
+
 # and finally prune OSTree repos
 def ostree_prune(repo_name, sudo=False):
     repo = os.path.join(args.workdir, repo_name)
@@ -108,7 +111,8 @@ def ostree_prune(repo_name, sudo=False):
         argv.extend(['sudo', '--'])
     print(f"Pruning {repo_name}")
     argv.extend(["ostree", "prune", "--repo", repo, "--refs-only",
-                    f"--depth={args.keep_last_n-1}"])
+                f"--depth={args.keep_last_n-1}"])
     subprocess.run(argv, check=True)
+
 
 ostree_prune('repo')

--- a/src/prune_builds
+++ b/src/prune_builds
@@ -15,10 +15,8 @@ import subprocess
 
 import dateutil.parser
 
-from datetime import datetime
-
 sys.path.insert(0, '/usr/lib/coreos-assembler')
-from cmdlib import write_json
+from cmdlib import write_json, rfc3339_time
 
 # Let's just hardcode this here for now
 DEFAULT_KEEP_LAST_N = 3
@@ -43,19 +41,16 @@ if os.path.isfile(builds_json):
 else:
     builddata = {'builds': []}
 
-# generate RFC3339 timestamp
-now = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
-
 # handle --timestamp-only
 if args.timestamp_only:
-    builddata['timestamp'] = now
+    builddata['timestamp'] = rfc3339_time()
     write_json(builds_json, builddata)
     sys.exit(0)
 
 # Handle --insert-only
 if args.insert_only:
     builddata['builds'].insert(0, args.insert_only)
-    builddata['timestamp'] = now
+    builddata['timestamp'] = rfc3339_time()
     write_json(builds_json, builddata)
     sys.exit(0)
 
@@ -93,12 +88,12 @@ if not skip_pruning and len(builds) > args.keep_last_n:
     del builds[args.keep_last_n:]
 
 builddata['builds'] = [x[0] for x in builds]
-builddata['timestamp'] = now
+builddata['timestamp'] = rfc3339_time()
 write_json(builds_json, builddata)
 
 # if we're not pruning, then we're done!
 if skip_pruning:
-    sys.exit()
+    sys.exit(0)
 
 # now delete other build dirs not in the manifest
 


### PR DESCRIPTION
The `fatal()` function provides a common way to print an error message
and exit.
    
The `rfc3339_time()` function generates a RFC3339 timestamp.

Snuck in some `pycodestyle` fixes too.