### PR TITLE
entrypoint: Tweak command help output

### DIFF
--- a/coreos-assembler
+++ b/coreos-assembler
@@ -34,25 +34,33 @@ if [ -e /sys/fs/selinux/status ]; then
 fi
 
 cmd=${1:-}
-build_commands="init fetch build buildextend-ec2 buildextend-openstack tag compress bump-timestamp run prune clean"
+# commands we'd expect to use in the local dev path
+build_commands="init fetch build run prune clean"
+# commands more likely to be used in a prod pipeline only
+advanced_build_commands="buildextend-ec2 buildextend-openstack oscontainer"
+utility_commands="tag compress bump-timestamp"
 other_commands="shell"
-utility_commands="gf-oemid virt-install oscontainer"
 if [ -z "${cmd}" ]; then
-    echo usage: "coreos-assembler CMD ..."
+    echo Usage: "coreos-assembler CMD ..."
     echo "Build commands:"
     for bin in ${build_commands}; do
         echo "  ${bin}"
-    done
+    done # don't sort these ones, they're roughly in the order they're used
 
-    echo "Other commands:"
-    for bin in ${other_commands}; do
+    echo "Advanced build commands:"
+    for bin in ${advanced_build_commands}; do
         echo "  ${bin}"
-    done
+    done | sort
 
     echo "Utility commands:"
     for bin in ${utility_commands}; do
         echo "  ${bin}"
-    done
+    done | sort
+
+    echo "Other commands:"
+    for bin in ${other_commands}; do
+        echo "  ${bin}"
+    done | sort
     exit 1
 fi
 shift


### PR DESCRIPTION
Split the build commands (roughly) into commands one would likely use in
the developer path vs others we'd use more likely in a pipeline context
only.

As part of that reshuffle, move `tag`, `compress`, and `bump-timestamp`
into the "utility" category since they don't create brand new artifacts,
only slightly modify existing ones. And also move `oscontainer` from the
"utility" category and into "advanced build" for the converse reason.

Finally, also remove `gf-oemid` and `virt-install` which aren't actually
user-facing commands.

Output:

```
Usage: coreos-assembler CMD ...
Build commands:
  init
  fetch
  build
  run
  prune
  clean
Advanced build commands:
  buildextend-ec2
  buildextend-openstack
  oscontainer
Utility commands:
  bump-timestamp
  compress
  tag
Other commands:
  shell
```