### PR TITLE
cmd/prune: Add --keep-last-days=N switch

### DIFF
--- a/src/cmd-prune
+++ b/src/cmd-prune
@@ -11,7 +11,7 @@ dn=$(dirname "$0")
 print_help() {
     cat 1>&2 <<'EOF'
 Usage: coreos-assembler prune --help
-       coreos-assembler prune [--keep=N]
+       coreos-assembler prune [--keep=N] [--keep-last-days=N]
 
   Delete older untagged build artifacts. By default, only the last 3 untagged
   builds are kept.  This can be overridden with the `--keep` option.
@@ -19,9 +19,10 @@ EOF
 }
 
 # Parse options
-KEEP_LAST_N="3"
+KEEP_LAST_N=
+KEEP_LAST_DAYS=
 rc=0
-options=$(getopt --options h --longoptions help,keep: -- "$@") || rc=$?
+options=$(getopt --options h --longoptions help,keep:,keep-last-days: -- "$@") || rc=$?
 [ $rc -eq 0 ] || {
     print_help
     exit 1
@@ -36,6 +37,10 @@ while true; do
         --keep)
             shift
             KEEP_LAST_N="$1"
+            ;;
+        --keep-last-days)
+            shift
+            KEEP_LAST_DAYS="$1"
             ;;
         --)
             shift
@@ -55,6 +60,19 @@ if [ $# -ne 0 ]; then
     exit 1
 fi
 
+# just support one of the two for now
+if [ -n "${KEEP_LAST_N:-}" ] && [ -n "${KEEP_LAST_DAYS:-}" ]; then
+    fatal "ERROR: Only one of --keep or --keep-last-days allowed"
+elif [ -z "${KEEP_LAST_N:-}" ] && [ -z "${KEEP_LAST_DAYS:-}" ]; then
+    KEEP_LAST_N=3
+fi
+
+if [ -n "${KEEP_LAST_DAYS:-}" ]; then
+    set -- --keep-last-days "${KEEP_LAST_DAYS}"
+else
+    set -- --keep-last-n "${KEEP_LAST_N}"
+fi
+
 prepare_build
 
-"${dn}"/prune_builds --keep-last-n "${KEEP_LAST_N}" --workdir "${workdir:?}"
+"${dn}"/prune_builds --workdir "${workdir:?}" "$@"

--- a/src/cmdlib.py
+++ b/src/cmdlib.py
@@ -38,6 +38,10 @@ def fatal(msg):
 def rfc3339_time(t=None):
     if t is None:
         t = datetime.utcnow()
+    else:
+        # if the need arises, we can convert to UTC, but let's just enforce
+        # this doesn't slip by for now
+        assert t.tzname() == 'UTC', "Timestamp must be in UTC format"
     return t.strftime("%Y-%m-%dT%H:%M:%SZ")
 
 

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -8,7 +8,7 @@ info() {
 }
 
 fatal() {
-    info "$@"; exit 1
+    echo "fatal: $*" 1>&2; exit 1
 }
 
 _privileged=

--- a/src/prune_builds
+++ b/src/prune_builds
@@ -29,12 +29,11 @@ parser = argparse.ArgumentParser()
 parser.add_argument("--workdir", required=True, help="Path to workdir")
 parser.add_argument("--keep-last-n", type=int, default=DEFAULT_KEEP_LAST_N,
                     help="Number of untagged builds to keep (0 for all)")
-parser.add_argument("--insert-only",
-                    help="Append a new latest build, do not prune",
-                    action='store')
 parser.add_argument("--timestamp-only",
                     help="Update timestamp on builds.json",
                     action='store_true')
+parser.add_argument("--insert-only", metavar="BUILDID", action='store',
+                    help="Append a new latest build, do not prune")
 args = parser.parse_args()
 
 builds = []

--- a/src/prune_builds
+++ b/src/prune_builds
@@ -13,8 +13,9 @@ import argparse
 import subprocess
 import collections
 
+import pytz
 import dateutil.parser
-from datetime import timedelta
+from datetime import timedelta, datetime
 
 sys.path.insert(0, '/usr/lib/coreos-assembler')
 from cmdlib import write_json, rfc3339_time
@@ -27,14 +28,26 @@ DEFAULT_KEEP_LAST_N = 3
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--workdir", required=True, help="Path to workdir")
-parser.add_argument("--keep-last-n", type=int, default=DEFAULT_KEEP_LAST_N,
-                    help="Number of untagged builds to keep (0 for all)")
-parser.add_argument("--timestamp-only",
-                    help="Update timestamp on builds.json",
+parser.add_argument("--timestamp-only", help="Update timestamp on builds.json",
                     action='store_true')
 parser.add_argument("--insert-only", metavar="BUILDID", action='store',
                     help="Append a new latest build, do not prune")
+keep_options = parser.add_mutually_exclusive_group()
+keep_options.add_argument("--keep-last-n", type=int, metavar="N",
+                          default=DEFAULT_KEEP_LAST_N,
+                          help="Number of untagged builds to keep (0 for all)")
+keep_options.add_argument("--keep-last-days", metavar="N", type=int,
+                          help="Keep untagged builds within number of days")
 args = parser.parse_args()
+
+keep_younger_than = None
+if args.keep_last_days is not None:
+    if args.keep_last_days <= 0:
+        raise argparse.ArgumentTypeError("value must be positive: %d" %
+                                         args.keep_last_days)
+    keep_younger_than = (datetime.now(pytz.utc) -
+                         timedelta(days=args.keep_last_days))
+
 
 builds = []
 builds_dir = os.path.join(args.workdir, "builds")
@@ -59,7 +72,7 @@ if args.insert_only:
     write_json(builds_json, builddata)
     sys.exit(0)
 
-skip_pruning = (args.keep_last_n == 0)
+skip_pruning = (not keep_younger_than and args.keep_last_n == 0)
 
 # collect all builds being pointed to by tags
 tagged_builds = set([tag['target'] for tag in builddata.get('tags', [])])
@@ -106,23 +119,32 @@ builds_to_delete = []
 if skip_pruning:
     new_builds = builds
 else:
-    n = args.keep_last_n
-    assert(n > 0)
-    for build in builds:
-        # skip tagged builds and don't count them towards the limit
-        if build.id in tagged_builds:
-            print(f"Skipping tagged build {build.id}")
-            new_builds.append(build)
-            continue
+    if keep_younger_than:
+        for build in builds:
+            if build.id in tagged_builds:
+                print(f"Skipping tagged build {build.id}")
+                new_builds.append(build)
+                continue
 
-        if n == 0:
-            builds_to_delete.append(build)
-        else:
-            new_builds.append(build)
-            n = n - 1
+            if build.timestamp < keep_younger_than:
+                builds_to_delete.append(build)
+            else:
+                new_builds.append(build)
+    else:
+        n = args.keep_last_n
+        assert(n > 0)
+        for build in builds:
+            # skip tagged builds and don't count them towards the limit
+            if build.id in tagged_builds:
+                print(f"Skipping tagged build {build.id}")
+                new_builds.append(build)
+                continue
 
-# either we didn't prune so it's the same builds, or we did, and keep_last_n>0
-assert(len(new_builds) > 0)
+            if n == 0:
+                builds_to_delete.append(build)
+            else:
+                new_builds.append(build)
+                n = n - 1
 
 builddata['builds'] = [x.id for x in new_builds]
 builddata['timestamp'] = rfc3339_time()


### PR DESCRIPTION
So right now, `prune` only knows `--keep=N` for fine-tuning the prune
operation. But humans are temporal beings and care more about the *age*
of a build rather than its index in the `builds[]` array.

This patch adds a `--keep-last-days=N` switch to accommodate this. I
initially was looking for a generic "fuzzy" parser that could parse e.g.
"2 weeks ago", and there is one (dateparser) but it's not packaged in
Fedora and I didn't want to start relying on pypi for this. Anyway, in
the prod context, I'd prefer we use something less fuzzy like
`--keep-last-days=14`.