### PR TITLE
cmd/init: Only recreate cache.qcow2 if it's missing

### DIFF
--- a/src/cmd-init
+++ b/src/cmd-init
@@ -178,7 +178,7 @@ mkdir -p cache
 mkdir -p builds
 mkdir -p tmp
 ostree --repo=repo init --mode=archive
-if ! has_privileges; then
+if ! has_privileges && [ ! -f cache/cache.qcow2 ]; then
     qemu-img create -f qcow2 cache/cache.qcow2 10G
     LIBGUESTFS_BACKEND=direct virt-format --filesystem=xfs -a cache/cache.qcow2
 fi


### PR DESCRIPTION
Match the idempotency of the rest of the script by only recreating the
qcow2 if it's missing.