### PR TITLE
Update mantle, and buildextend-ec2: Use new ore --disk-size-inspect

### DIFF
--- a/src/cmd-buildextend-ec2
+++ b/src/cmd-buildextend-ec2
@@ -58,6 +58,7 @@ def run_ore():
                 '--name', ami_name_version,
                 '--ami-description', f"{manifest['rojig']['summary']} {args.build}",
                 '--file', tmp_img_ec2_vmdk,
+                '--disk-size-inspect',
                 '--delete-object']
     for user in args.grant_user:
         ore_args.extend(['--grant-user', user])


### PR DESCRIPTION
This way we can use 16GB by default for RHCOS, and FCOS isn't
tethered to 8gb.