### PR TITLE
Don't allow `gf-oemid` to operate on  compressed images

### DIFF
--- a/src/cmdlib.py
+++ b/src/cmdlib.py
@@ -24,7 +24,10 @@ def run_verbose(args, **kwargs):
     :raises: CalledProcessError
     """
     print("+ {}".format(subprocess.list2cmdline(args)))
-    subprocess.check_call(args, **kwargs)
+    try:
+        subprocess.check_call(args, **kwargs)
+    except subprocess.CalledProcessError:
+        fatal("Error running command " + args[0])
 
 
 def write_json(path, data):

--- a/src/gf-oemid
+++ b/src/gf-oemid
@@ -18,6 +18,11 @@ src="$1"
 dest="$2"
 oemid="$3"
 
+if [[ $src == *.gz ]]; then
+    img="$(basename "$src")"
+    fatal "Cannot change coreos.oem.id on $img; not an uncompressed image"
+fi
+
 set -x
 tmpd=$(mktemp -td gf-oemid.XXXXXX)
 tmp_dest=${tmpd}/box.img


### PR DESCRIPTION
I was mucking around with the `assembler` and tried running the `buildextend-openstack` command after I had used `compress`.  And the result was `gf-oemid` being very unhappy.

This changes `gf-oemid` to check the extension is `.qcow2` before running.  And also updates the `run_verbose()` function to catch the exception raised by a failed command.

New output for an incompatible image looks like this:

```
$ coreos-assembler buildextend-openstack 
Targeting build: 47.3
+ /usr/lib/coreos-assembler/gf-oemid builds/47.3/redhat-coreos-maipo-47.3-qemu.qcow2.gz tmp/buildpost-openstack/redhat-coreos-maipo-47.3-openstack.qcow2 openstack
fatal: Cannot change coreos.oem.id on redhat-coreos-maipo-47.3-qemu.qcow2.gz; not an uncompressed QCOW2
fatal: Error running command /usr/lib/coreos-assembler/gf-oemid

$ coreos-assembler buildextend-ec2 --build 47.3 --region us-east-1 --bucket rhcos-ci
+ /usr/lib/coreos-assembler/gf-oemid builds/47.3/redhat-coreos-maipo-47.3-qemu.qcow2.gz tmp/buildpost-ec2/redhat-coreos-maipo-47.3.qcow2 ec2
fatal: Cannot change coreos.oem.id on redhat-coreos-maipo-47.3-qemu.qcow2.gz; not an uncompressed QCOW2
fatal: Error running command /usr/lib/coreos-assembler/gf-oemid
```