### PR TITLE
Updates the MOTD to indicate no ICMP traffic

### DIFF
--- a/src/cmd-run
+++ b/src/cmd-run
@@ -145,7 +145,7 @@ if [ -z "${IGNITION_CONFIG_FILE:-}" ]; then
             {
                 "name": "serial-getty-motd.service",
                 "enabled": true,
-                "contents": "[Unit]\\nDescription=Helper message to exit QEMU monitor to /etc/motd\\nBefore=getty.target\\n[Service]\\nType=oneshot\\nExecStart=/bin/sh -c '/usr/bin/echo \\"To exit, press Ctrl-A and then X.\\\\n\\" >> /etc/motd'\\n[Install]\\nWantedBy=getty.target\\n"
+                "contents": "[Unit]\\nDescription=Helper message to exit QEMU monitor to /etc/motd\\nBefore=getty.target\\n[Service]\\nType=oneshot\\nExecStart=/bin/sh -c '/usr/bin/echo \\"ICMP traffic (ping) does not work with QEMU and user mode networking.\\\\nTo exit, press Ctrl-A and then X.\\\\n\\" >> /etc/motd'\\n[Install]\\nWantedBy=getty.target\\n"
             }
             ${ign_var_srv_mount}
         ]


### PR DESCRIPTION
Updates the MOTD to indicate that ICMP traffic is unavailable.

For example:

```sh
eth0: 10.0.2.15 fec0::5054:ff:fe12:3456

coreos login: core (automatic login)

Fedora CoreOS (preview)
https://github.com/coreos/fedora-coreos-tracker
WARNING: All aspects subject to change, highly experimental
---

ICMP traffic (ping) does not work with QEMU and user mode networking.
To exit, press Ctrl-A and then X.
```