### PR TITLE
tests/check.sh: disable ShellCheck if older than 0.4.0

### DIFF
--- a/tests/check.sh
+++ b/tests/check.sh
@@ -3,6 +3,21 @@ set -euo pipefail
 dn=$(dirname "$0")
 srcdir=$(cd "${dn}"/.. && pwd)/src
 
+# We want to make use of the `-x|--external-sources` flag, which was made
+# available in v0.4.0.  So check for the flag and disable the use of
+# ShellCheck if not present.
+HASSHELLCHECK=0
+set +eo pipefail
+if shellcheck |& grep -q -- --external-sources; then
+  HASSHELLCHECK=1
+fi
+set -eo pipefail
+
+if [[ ${HASSHELLCHECK} -ne 1 ]]; then
+    echo -e "WARNING: installed ShellCheck does not support --external-sources. " \
+            "Shell script checking is disabled."
+fi
+
 # Verify syntax for sources
 # see https://github.com/koalaman/shellcheck/wiki/SC2044
 # for explanation of this use of while
@@ -14,10 +29,12 @@ do
         echo "OK ${f}"
         continue
     fi
-    if [[ $shebang =~ ^#!/.*/bash.* ]] || [[ $shebang =~ ^#!/.*/env\ bash ]]; then
-        shellcheck -x "$f"
-        bash -n "$f"
-        echo "OK ${f}"
-        continue
+    if [[ ${HASSHELLCHECK} == 1 ]]; then
+        if [[ $shebang =~ ^#!/.*/bash.* ]] || [[ $shebang =~ ^#!/.*/env\ bash ]]; then
+            shellcheck -x "$f"
+            bash -n "$f"
+            echo "OK ${f}"
+            continue
+        fi
     fi
 done <  <(find "${srcdir}" -type f -executable -print0)


### PR DESCRIPTION
Split out from #270

TL;DR - ShellCheck is disabled unless version 0.4.0 or newer is
installed.

The ShellCheck test makes use of the `--external-sources` option, so
we can load in external libraries during the checks.  But that
option is only available in version 0.4.0 and newer.  Older versions
of ShellCheck will barf on the `shellcheck source=src/cmdlib.sh`
directives and trying to tell ShellCheck to exclude the raised error
was not successful.