### PR TITLE
Use stdlib for date parsing

### DIFF
--- a/src/deps.txt
+++ b/src/deps.txt
@@ -36,8 +36,5 @@ jq awscli
 # For ignition file validation in cmd-run
 ignition
 
-# For parsing ISO8601 dates
-python3-dateutil python3-pytz
-
 # shellcheck for test
 ShellCheck

--- a/src/prune_builds
+++ b/src/prune_builds
@@ -13,12 +13,26 @@ import argparse
 import subprocess
 import collections
 
-import pytz
-import dateutil.parser
-from datetime import timedelta, datetime
+from datetime import timedelta, datetime, timezone
 
 sys.path.insert(0, '/usr/lib/coreos-assembler')
 from cmdlib import write_json, rfc3339_time
+
+
+def parse_date_string(date_string):
+    """
+    Parses the date strings expected from the build system. Returned
+    datetime instances will be in utc.
+
+    :param date_string: string to turn into date. Format: %Y-%m-%dT%H:%M:%SZ
+    :type date_string: str
+    :returns: datetime instance from the date string
+    :rtype: datetime.datetime
+    :raises: ValueError, TypeError
+    """
+    dt = datetime.strptime(date_string, '%Y-%m-%dT%H:%M:%SZ')
+    return dt.replace(tzinfo=timezone.utc)
+
 
 Build = collections.namedtuple('Build', ['id', 'timestamp',
                                          'ostree_timestamp'])
@@ -45,7 +59,7 @@ if args.keep_last_days is not None:
     if args.keep_last_days <= 0:
         raise argparse.ArgumentTypeError("value must be positive: %d" %
                                          args.keep_last_days)
-    keep_younger_than = (datetime.now(pytz.utc) -
+    keep_younger_than = (datetime.now(timezone.utc) -
                          timedelta(days=args.keep_last_days))
 
 
@@ -99,9 +113,9 @@ with os.scandir(builds_dir) as it:
             j = json.load(f)
         # Older versions only had ostree-timestamp
         ts = j.get('build-timestamp') or j['ostree-timestamp']
-        t = dateutil.parser.parse(ts)
+        t = parse_date_string(ts)
         ostree_ts = j['ostree-timestamp']
-        ostree_t = dateutil.parser.parse(ostree_ts)
+        ostree_t = parse_date_string(ostree_ts)
         builds.append(Build(id=entry.name, timestamp=t,
                             ostree_timestamp=ostree_t))
 


### PR DESCRIPTION
`pytz` and `dateutil` are not available for all bases we want to build
with. Instead of trying to create new packages and get them approved
this change moves to using the python standard library. While not
as pretty, the same or similar enough functionality is provided.

NOTE: All dates are treated as UTC.