### PR TITLE
src/cmd*: use os.path.join() where appropriate

### DIFF
--- a/src/cmd-buildextend-ec2
+++ b/src/cmd-buildextend-ec2
@@ -26,8 +26,8 @@ with open('src/config/manifest.yaml') as f:
 base_name = manifest['rojig']['name']
 ami_name_version = f'{base_name}-{args.build}'
 
-builddir = f'builds/{args.build}'
-buildmeta_path = f'{builddir}/meta.json'
+builddir = os.path.join('builds', args.build)
+buildmeta_path = os.path.join(builddir, 'meta.json')
 with open(buildmeta_path) as f:
     buildmeta = json.load(f)
 
@@ -38,8 +38,8 @@ os.mkdir(tmpdir)
 
 def generate_ec2_vmdk():
     img_qemu = os.path.join(builddir, buildmeta['images']['qemu']['path'])
-    tmp_img_ec2 = f'{tmpdir}/{ami_name_version}.qcow2'
-    tmp_img_ec2_vmdk = f'{tmpdir}/{ami_name_version}.vmdk'
+    tmp_img_ec2 = os.path.join(tmpdir, (ami_name_version + '.qcow2'))
+    tmp_img_ec2_vmdk = os.path.join(tmpdir, (ami_name_version + '.vmdk'))
     run_verbose(['/usr/lib/coreos-assembler/gf-oemid',
                  img_qemu, tmp_img_ec2, 'ec2'])
     run_verbose(['qemu-img', 'convert', '-f', 'qcow2', '-O', 'vmdk',

--- a/src/cmd-buildextend-openstack
+++ b/src/cmd-buildextend-openstack
@@ -31,8 +31,8 @@ base_name = manifest['rojig']['name']
 img_prefix = f'{base_name}-{args.build}'
 openstack_name = f'{img_prefix}-openstack.qcow2'
 
-builddir = f'builds/{args.build}'
-buildmeta_path = f'{builddir}/meta.json'
+builddir = os.path.join('builds', args.build)
+buildmeta_path = os.path.join(builddir, 'meta.json')
 with open(buildmeta_path) as f:
     buildmeta = json.load(f)
 
@@ -45,7 +45,7 @@ os.mkdir(tmpdir)
 def generate_openstack():
     buildmeta_images = buildmeta['images']
     img_qemu = os.path.join(builddir, buildmeta_images['qemu']['path'])
-    tmp_img_openstack = f'{tmpdir}/{openstack_name}'
+    tmp_img_openstack = os.path.join(tmpdir, openstack_name)
     run_verbose(['/usr/lib/coreos-assembler/gf-oemid',
                  img_qemu, tmp_img_openstack, 'openstack'])
     checksum = sha256sum_file(tmp_img_openstack)

--- a/src/cmd-buildprep
+++ b/src/cmd-buildprep
@@ -26,9 +26,10 @@ def main():
 
     # now create the build dir itself
     buildid = buildmeta['buildid']
-    builddir = f'builds/{buildid}'
+    builddir = os.path.join('builds', buildid)
+    buildmeta_path = os.path.join(builddir, 'meta.json')
     os.makedirs(f'{builddir}', exist_ok=True)
-    write_json(f'{builddir}/meta.json', buildmeta)
+    write_json(buildmeta_path, buildmeta)
 
     if args.ostree_only or not args.buildmeta_only:
         fetch_ostree(args.url, args.full_ostree_commit, buildmeta)
@@ -76,7 +77,8 @@ def fetch_buildmeta(url):
         return (builds, None)
 
     buildid = builds['builds'][0]
-    buildmeta = fetch_json(url, f"builds/{buildid}/meta.json")
+    buildmeta_path = os.path.join('builds', buildid, 'meta.json')
+    buildmeta = fetch_json(url, buildmeta_path)
     return (builds, buildmeta)
 
 

--- a/src/cmd-compress
+++ b/src/cmd-compress
@@ -24,7 +24,7 @@ else:
 
 print(f"Targeting build: {build}")
 
-buildmeta_path = f'builds/{build}/meta.json'
+buildmeta_path = os.path.join('builds', build, 'meta.json')
 with open(buildmeta_path) as f:
     buildmeta = json.load(f)
 
@@ -44,13 +44,13 @@ imgs_to_compress = []
 for img_format in buildmeta['images']:
     img = buildmeta['images'][img_format]
     file = img['path']
-    filepath = f'builds/{build}/{file}'
+    filepath = os.path.join('builds', build, file)
     if not file.endswith('.gz'):
-        tmpfile = f'{tmpdir}/{file}.gz'
+        tmpfile = os.path.join(tmpdir, (file + '.gz'))
         # SHA256 for uncompressed image was already calculated during 'build'
         img['uncompressed-sha256'] = img['sha256']
         with open(tmpfile, 'wb') as f:
-            run_verbose(['gzip', '-c', f'builds/{build}/{file}'], stdout=f)
+            run_verbose(['gzip', '-c', filepath], stdout=f)
         file_gz = file + '.gz'
         filepath_gz = filepath + '.gz'
         img['path'] = file_gz
@@ -68,7 +68,7 @@ for img_format in buildmeta['images']:
 
 # finally, also update the unversioned qemu symlink
 symlink_src = f'{buildmeta["name"]}-{build}-qemu.qcow2.gz'
-symlink_dest = f'builds/{build}/{buildmeta["name"]}-qemu.qcow2.gz'
+symlink_dest = os.path.join('builds', build, (buildmeta["name"] + '-qemu.qcow2.gz'))
 if not os.path.islink(symlink_dest):
     os.symlink(symlink_src, symlink_dest)
 rm_allow_noent(symlink_dest[:-3])

--- a/src/cmd-oscontainer
+++ b/src/cmd-oscontainer
@@ -48,7 +48,7 @@ def oscontainer_extract(containers_storage, src, dest,
     cid = run_get_string(['podman', rootarg, 'create', '--entrypoint=/enoent', iid])
     mnt = run_get_string(['podman', rootarg, 'mount', cid])
     try:
-        src_repo = mnt+'/srv/repo'
+        src_repo = os.path.join(mnt, 'srv/repo')
         run_verbose(["ostree", "--repo="+dest, "pull-local", src_repo, commit])
     finally:
         subprocess.call(['podman', rootarg, 'umount', cid])
@@ -79,7 +79,7 @@ def oscontainer_build(containers_storage, src, ref, image_name_and_tag,
     bid = run_get_string(['buildah', rootarg, 'from', base_image])
     mnt = run_get_string(['buildah', rootarg, 'mount', bid])
     try:
-        dest_repo = mnt+'/srv/repo'
+        dest_repo = os.path.join(mnt, 'srv/repo')
         subprocess.check_call(['mkdir', '-p', dest_repo])
         subprocess.check_call(["ostree", "--repo="+dest_repo, "init", "--mode=archive"])
         # Note that oscontainers don't have refs
@@ -136,7 +136,7 @@ parser_build.add_argument("--push", help="Push to registry",
                           action='store_true')
 args = parser.parse_args()
 
-containers_storage=args.workdir+'/containers-storage'
+containers_storage = os.path.join(args.workdir, 'containers-storage')
 if os.path.exists(containers_storage):
     shutil.rmtree(containers_storage)
 


### PR DESCRIPTION
Split off from #270

This changes all the places where we muck with paths to use
`os.path.join()`.  Hopefully this is start of some coding standards as
discussed in #271.