### PR TITLE
WIP: Allow for Fedora or RHEL Images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 **/*.rs.bk
 src/__pycache__/*
 .gocache
+maipo/

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,0 +1,28 @@
+FROM registry.access.redhat.com/rhel7:latest
+WORKDIR /root/containerbuild
+
+# Only need a few of our scripts for the first few steps
+COPY ./scl-coreos-assembler ./build.sh ./src/deps-rhel.txt ./vmdeps.txt ./build-deps-rhel.txt /root/containerbuild/
+COPY ./maipo/maipo.repo /etc/yum.repos.d/
+RUN ./build.sh configure_yum_repos_rhel
+# ostree-packages are on another line so they don't get ostree related packages
+# set to ignition in the configure step
+COPY ./maipo/ostree-packages.repo /etc/yum.repos.d/
+RUN ./build.sh install_rpms_rhel
+
+# Ok copy in the rest of them for the next few steps
+COPY ./ /root/containerbuild/
+RUN ./build.sh make_and_makeinstall_rhel
+RUN ./build.sh configure_user
+
+# clean up scripts (it will get cached in layers, but oh well)
+WORKDIR /srv/
+RUN rm -rf /root/containerbuild
+
+# allow writing to /etc/passwd from arbitrary UID
+# https://docs.openshift.com/container-platform/3.10/creating_images/guidelines.html
+RUN chmod g=u /etc/passwd
+
+# run as `builder` user
+USER builder
+ENTRYPOINT ["/usr/bin/scl-coreos-assembler"]

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,10 @@ mantle:
 	cd mantle && ./build ore kola kolet
 
 install:
+	install -d $(DESTDIR)$(PREFIX)/bin
 	install -D -t $(DESTDIR)$(PREFIX)/bin coreos-assembler
+	install -d $(DESTDIR)$(PREFIX)/lib/coreos-assembler
 	install -D -t $(DESTDIR)$(PREFIX)/lib/coreos-assembler $$(find src/ -maxdepth 1 -type f)
 	install -D -t $(DESTDIR)$(PREFIX)/bin mantle/bin/{ore,kola}
+	install -d $(DESTDIR)$(PREFIX)/lib/kola/amd64
 	install -D -m 0755 -t $(DESTDIR)$(PREFIX)/lib/kola/amd64 mantle/bin/amd64/kolet

--- a/README.md
+++ b/README.md
@@ -131,8 +131,11 @@ $ alias coreos-assembler= podman run --rm --net=host -ti --privileged --userns=h
 ```
 
 To completely rebuild the coreos-assembler container image locally, execute
-`$ podman build .` from the `coreos-assembler` repository. You can upload your
-built image to a registry such as quay.io by doing the following:
+`$ podman build .` or `$ podman build -f Dockerfile.rhel` from the `coreos-assembler` repository.
+If building the RHEL version please note you will need a maipo directory with references to
+proper repositories.
+
+You can upload your built image to a registry such as quay.io by doing the following:
 
 ```
 $ podman push <image id> quay.io/<account name>/coreos-assembler

--- a/build-deps-rhel.txt
+++ b/build-deps-rhel.txt
@@ -1,0 +1,2 @@
+# Used by mantle
+golang golang-bin golang-src

--- a/build.sh
+++ b/build.sh
@@ -6,8 +6,11 @@ if [ $# -eq 0 ]; then
   echo "Supported commands:"
   echo "    configure_user"
   echo "    configure_yum_repos"
+  echo "    configure_yum_repos_rhel"
   echo "    install_rpms"
+  echo "    install_rpms_rhel"
   echo "    make_and_makeinstall"
+  echo "    make_and_makeinstall_rhel"
   exit 1
 fi
 
@@ -44,8 +47,18 @@ repo_gpgcheck=0
 enabled=1
 enabled_metadata=1
 EOF
-
 }
+
+configure_yum_repos_rhel() {
+    # Until we fix https://github.com/rpm-software-management/libdnf/pull/149
+    excludes='exclude=ostree ostree-libs ostree-grub2 rpm-ostree'
+    for repo in /etc/yum.repos.d/*.repo; do
+        # reworked to remove useless `cat` - https://github.com/koalaman/shellcheck/wiki/SC2002
+        (while read -r line; do if echo "$line" | grep -qE -e '^enabled=1'; then echo "${excludes}"; fi; echo "$line"; done < "${repo}") > "${repo}".new
+        mv "${repo}".new "${repo}"
+    done
+}
+
 
 install_rpms() {
 
@@ -72,11 +85,37 @@ install_rpms() {
     rpm -q grubby && dnf remove -y grubby
     # Further cleanup
     dnf clean all
-
 }
 
-make_and_makeinstall() {
 
+install_rpms_rhel() {
+    # First, a general update; this is best practice.  We also hit an issue recently
+    # where qemu implicitly depended on an updated libusbx but didn't have a versioned
+    # requires https://bugzilla.redhat.com/show_bug.cgi?id=1625641
+    yum -y distro-sync
+
+    # xargs is part of findutils, which may not be installed
+    yum -y install /usr/bin/xargs
+
+    # These are only used to build things in here.  Today
+    # we ship these in the container too to make it easier
+    # to use the container as a development environment for itself.
+    # Down the line we may strip these out, or have a separate
+    # development version.
+    self_builddeps=$(grep -v '^#' "${srcdir}"/build-deps-rhel.txt)
+
+    # Process our base dependencies + build dependencies
+    (echo "${self_builddeps}" && grep -v '^#' "${srcdir}"/deps-rhel.txt) | xargs yum -y install
+
+    # Commented out for now, see above
+    #dnf remove -y ${self_builddeps}
+    rpm -q grubby && yum remove -y grubby
+
+    # Further cleanup
+    yum clean all
+}
+
+_prep_make_and_make_install() {
     # Work around https://github.com/coreos/coreos-assembler/issues/27
     if ! test -d .git; then
         (git config --global user.email dummy@example.com
@@ -93,10 +132,22 @@ make_and_makeinstall() {
         echo -e "\033[1merror: submodules not initialized. Run: git submodule update --init\033[0m" 1>&2
         exit 1
     fi
+}
 
+make_and_makeinstall() {
+    _prep_make_and_make_install
     # And the main scripts
     make && make check && make install
 }
+
+make_and_makeinstall_rhel() {
+    _prep_make_and_make_install
+    # Copy our scl enabling script
+    cp "${srcdir}"/scl-coreos-assembler /usr/bin/
+    # And the main scripts through scl (for make check)
+    echo "make && make check && make install" | scl enable rh-python36 bash
+}
+
 
 configure_user(){
 

--- a/scl-coreos-assembler
+++ b/scl-coreos-assembler
@@ -1,0 +1,4 @@
+#!/usr/bin/dumb-init /bin/bash
+# See: https://access.redhat.com/solutions/527703
+source scl_source enable rh-python36
+coreos-assembler $@

--- a/src/deps-rhel.txt
+++ b/src/deps-rhel.txt
@@ -1,0 +1,43 @@
+# For privileged ops
+supermin
+
+# We default to builder user, but sudo where necessary
+sudo
+
+# dumb-init is a good idea in general, but specifically fixes things with
+# libvirt forking qemu and assuming the process gets reaped on shutdown.
+dumb-init
+
+# For composes
+rpm-ostree createrepo_c dnf-utils openssh-clients
+
+# We expect people to use these explicitly in their repo configurations.
+distribution-gpg-keys
+# We need these for rojig
+selinux-policy-targeted rpm-build
+
+# Standard build tools
+make git rpm-build
+
+# virt-install dependencies
+libvirt libguestfs-tools qemu-kvm /usr/bin/qemu-img /usr/bin/virsh /usr/bin/virt-install
+# And we process kickstarts
+/usr/bin/ksflatten
+
+# For RHEL
+scl-utils rh-python36
+
+# ostree-releng-scripts dependencies
+rsync python2-gobject-base python34-gobject-base
+
+# To support recursive containerization and manipulating images
+podman buildah skopeo
+
+# Miscellaneous tools
+jq awscli
+
+# For ignition file validation in cmd-run
+ignition
+
+# shellcheck for test
+ShellCheck


### PR DESCRIPTION
This PR adds the ability to for `coreos-assembler` to run on either Fedora or RHEL content. Some notes:

- A `maipo` directory is needed to build on RHEL. This content is in another repo due to needing some sensitive information. 
- Reuse of existing code was attempted,  though there are few copy/paste with minor modification spots. These can be fixed up via follow on PRs as needed.
- scl's Python3.6 packages are used to allow for modern style Python
- @miabbott and I worked together on this :raised_hands: 
- There is one outstanding issue running the container with scl + dumb-init that I'm working on. Once this is figured out AND @miabbott and I have tested the results we will remove WIP.

To build you will need to checkout the internal repo to `maipo/`, and then `podman build -f Dockerfile.rhel`.

/cc @imcleod 