### PR TITLE
bottlecap*: small tweaks for consistency

### DIFF
--- a/bottlecap
+++ b/bottlecap
@@ -1,10 +1,11 @@
-#!/bin/sh
+#!/usr/bin/env bash
+set -euo pipefail
 
 # bottlecap, 'cause it's kinda like cork... get it?
 
 usage() {
 	echo "usage:"
-	echo "bottlecap [--dev] [--dry-run] [--runtime $runtime] [--build-dir $build_dir]  [--container $container] assemblerargs..."
+	echo "bottlecap [--dev] [--dry-run] [--runtime $runtime] [--build-dir $build_dir] [--container $container] assemblerargs..."
 	echo "  --dev: rebuild and reinstall mantle, the build scripts, and the ostree-releng-scipts before running coreos-assembler"
 	echo "  --dry-run: do not run CoreOS Assembler; print what commands would be executed instead"
 	echo "  --runtime: (auto) specify whether to use podman or docker. Defaults to podman if it is in \$PATH"
@@ -19,7 +20,7 @@ help=0
 runtime="podman"
 command -v podman > /dev/null || runtime="docker"
 build_dir="$(pwd)"
-container="quay.io/cgwalters/coreos-assembler"
+container="quay.io/coreos-assembler/coreos-assembler"
 
 rc=0
 TEMP=$(getopt -o 'dr:b:c:h' --long 'dev,dry-run,runtime:,build-dir:,container:,help' -- "$@") || rc=$?

--- a/bottlecap-shim
+++ b/bottlecap-shim
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
 pushd /host/src/ || exit 1
 sudo ./build.sh make_and_makeinstall


### PR DESCRIPTION
- Switch shebang to `/usr/bin/env bash`, which is most common for the
repo
- Use most of "unofficial bash strict mode" -
http://redsymbol.net/articles/unofficial-bash-strict-mode/
- Update container to latest image in use