### PR TITLE
clean up bash shebangs + test upgrades

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,23 @@
-sudo: required
+dist: xenial
 
-language: sh
+language: python
+python:
+    - "3.6"
 
-services:
-  - docker
+env:
+    - SCVERSION="stable"
 
-before_script:
-  - docker pull docker.io/koalaman/shellcheck
+before_install:
+    - sudo apt-get install -y xz-utils
 
 script:
-  # shellcheck validate
-  - docker run -v "$PWD:/mnt:ro" docker.io/koalaman/shellcheck -x $(find . -path ./mantle -prune -and -path ./ostree-releng-scripts -prune -o -type f -exec grep -l '^#!.*bash' {} \;)
+    - python3 -V
+    - sudo rm $(command -v shellcheck)
+    - wget https://storage.googleapis.com/shellcheck/shellcheck-${SCVERSION}.linux.x86_64.tar.xz
+    - tar --xz -xvf shellcheck-${SCVERSION}.linux.x86_64.tar.xz
+    - sudo cp shellcheck-${SCVERSION}/shellcheck /usr/bin/
+    - shellcheck --version
+    - tests/check.sh
 
 notifications:
   email: false

--- a/src/cmd-run
+++ b/src/cmd-run
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
+set -euo pipefail
 # Forked from https://github.com/coreos/scripts/blob/master/build_library/qemu_template.sh
 # Changed to have command line arguments, drop non-x86_64/non-KVM support
 # Automatically uses `-snapshot` if the target disk isn't writable
 # Uses -nographic by default, and most importantly, contains a default
 # Ignition config that auto-logins on the console
 
-set -euo pipefail
 
 dn=$(dirname "$0")
 # shellcheck source=src/cmdlib.sh

--- a/src/cmd-shell
+++ b/src/cmd-shell
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 if [ $# -eq 0 ]; then
     # If no arguments then offer user bash prompt inside the container

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 # Shared shell script library
 
 DIR=$(dirname "$0")

--- a/src/libguestfish.sh
+++ b/src/libguestfish.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 # Helper library for using libguestfs on CoreOS-style images.
 # A major assumption here is that the disk image uses OSTree
 # and also has `boot` and `root` filesystem labels.

--- a/tests/check.sh
+++ b/tests/check.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 dn=$(dirname "$0")
 srcdir=$(cd "${dn}"/.. && pwd)/src

--- a/tests/check.sh
+++ b/tests/check.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 dn=$(dirname "$0")
-srcdir=$(cd "${dn}"/.. && pwd)/src
+srcdir=$(cd "${dn}"/.. && pwd)
 
 # We want to make use of the `-x|--external-sources` flag, which was made
 # available in v0.4.0.  So check for the flag and disable the use of
@@ -18,10 +18,21 @@ if [[ ${HASSHELLCHECK} -ne 1 ]]; then
             "Shell script checking is disabled."
 fi
 
+# Build the list of files to syntax check
+# The whitelist of directories is:
+#  - ./
+#  - ./src
+#  - ./tests
+#
+tmpdir=$(mktemp -d)
+find "${srcdir}" -maxdepth 1 -type f -executable -print > "${tmpdir}/files"
+find "${srcdir}/src" -maxdepth 1 -type f -executable -print >> "${tmpdir}/files"
+find "${srcdir}/tests" -maxdepth 1 -type f -executable -print >> "${tmpdir}files"
+
 # Verify syntax for sources
 # see https://github.com/koalaman/shellcheck/wiki/SC2044
 # for explanation of this use of while
-while IFS= read -r -d '' f
+while IFS= read -r f
 do
     shebang=$(head -1 "$f")
     if [[ $shebang =~ ^#!/.*/python ]]; then
@@ -37,4 +48,5 @@ do
             continue
         fi
     fi
-done <  <(find "${srcdir}" -type f -executable -print0)
+done < "${tmpdir}/files"
+rm -rf "${tmpdir}"


### PR DESCRIPTION
With #277 merged, this should standardize the `bash` shebang across all our shell scripts to `#!/usr/bin/env bash`.

Additionally, this changes how `tests/check.sh` runs and expands the files we are syntax checking.  This also forced me to redo how the Travis CI job ran, so now that uses the same `check.sh` script that one would use locally.

TODO:
- [ ] determine if using the `set -euo pipefail` part of [bash strict mode](http://redsymbol.net/articles/unofficial-bash-strict-mode/) can be used on the shell scripts which don't currently have it enabled.