### PR TITLE
don't use --net=host

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,14 @@ any directory you like.  You should run these commands as `root`.
 ```
 $ mkdir /srv/coreos
 $ cd /srv/coreos
-$ alias coreos-assembler='podman run --rm --net=host -ti --privileged --userns=host -v $(pwd):/srv --workdir /srv quay.io/coreos-assembler/coreos-assembler'
+$ alias coreos-assembler='podman run --rm -ti --privileged --userns=host -v $(pwd):/srv --workdir /srv quay.io/coreos-assembler/coreos-assembler'
 ```
 
 If you need access to CA certificates on your host (for example, when you need to access
 a git repo that is not on the public Internet), you can mount in the host certificates
 as read-only.  For example, on a Fedora host the alias would change to:
 
-`$ alias coreos-assembler='podman run --rm --net=host -ti --privileged --userns=host -v /etc/pki:/etc/pki:ro -v $(pwd):/srv --workdir /srv quay.io/coreos-assembler/coreos-assembler'`
+`$ alias coreos-assembler='podman run --rm -ti --privileged --userns=host -v /etc/pki:/etc/pki:ro -v $(pwd):/srv --workdir /srv quay.io/coreos-assembler/coreos-assembler'`
 
 See this [Stack Overflow question](https://stackoverflow.com/questions/26028971/docker-container-ssl-certificates) for additional discussion.
 

--- a/bottlecap
+++ b/bottlecap
@@ -101,4 +101,4 @@ fi
 
 # we actually want work splitting here since $volumes is multiple args
 # shellcheck disable=SC2086
-$runtime run --rm --net=host -ti --privileged --userns=host $volumes --workdir /srv $entrypoint "$container" "$@"
+$runtime run --rm -ti --privileged --userns=host $volumes --workdir /srv $entrypoint "$container" "$@"


### PR DESCRIPTION
In dec465c we switched from using 9pfs to a network based solution
for sharing our ostree into the Anaconda install environment. As a
result of this we needed to predictably obtain the ip address of the
container and reliably know we could access an http server started
on the container's port 8000.

Using `--net=host` conflicts with this because it decreases the
probability of us choosing the right ip address and not requiring
us to poke holes in a firewall.