### PR TITLE
build.sh: switch commitmeta_to_json to python2

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -116,6 +116,11 @@ _prep_make_and_make_install() {
         echo -e "\033[1merror: submodules not initialized. Run: git submodule update --init\033[0m" 1>&2
         exit 1
     fi
+
+    # Can only (easily) get gobject-introspection in Python2 on EL7
+    if [ -n "${ISEL}" ]; then
+      sed -i 's|^#!/usr/bin/python3|#!/usr/bin/python2|' src/commitmeta_to_json
+    fi
 }
 
 make_and_makeinstall() {


### PR DESCRIPTION
Because there is no `gobject-introspection` module available to the
Python 3.6 stack from the SCL, we have to use Python 2 in the EL7
container case.  This will change the shebang on the script to use
`/usr/bin/python2` (for EL7 only), which avoids the SCL and
provides the ability to use `import gi`.