### PR TITLE
virt-install: host cpu passthrough

### DIFF
--- a/src/virt-install
+++ b/src/virt-install
@@ -169,6 +169,7 @@ try:
     vinstall_args.extend(["--wait={}".format(args.wait), "--noreboot", "--nographics",
                           "--memory={}".format(args.memory), get_libvirt_smp_arg(),
                           "--os-variant=rhel7", "--rng=/dev/urandom",
+                          "--cpu=host-passthrough",
                           "--check", "path_in_use=off",
                           "--network=user",  # user mode networking
                           "--disk=path={},cache=unsafe".format(args.dest),


### PR DESCRIPTION
for KVM to work on aarch64 --cpu=host-passthrough has to be passed
to virt-install https://bugzilla.redhat.com/show_bug.cgi?id=1531076

Signed-off-by: Dennis Gilmore <dennis@ausil.us>