### PR TITLE
src/deps: add grub2-pc

### DIFF
--- a/src/deps.txt
+++ b/src/deps.txt
@@ -46,3 +46,6 @@ ignition
 
 # shellcheck for test
 #FEDORA ShellCheck
+
+# for grub install when creating images without anaconda
+grub2-pc


### PR DESCRIPTION
Add grub2-pc to make working on removing anaconda easier. This is mostly a quality of life improvement for me so I don't need to keep either installing it on container entry or rebuilding the container to keep up with master.