### PR TITLE
src/cmd-init: Allow installer overriding

### DIFF
--- a/src/cmd-init
+++ b/src/cmd-init
@@ -123,6 +123,18 @@ repository_dir=${repository_dirs[$arch]}
 INSTALLER=https://download.fedoraproject.org/pub/$repository_dir/releases/$release/Everything/$arch/iso/Fedora-Everything-netinst-$arch-$release-1.1.iso
 INSTALLER_CHECKSUM=https://download.fedoraproject.org/pub/$repository_dir/releases/$release/Everything/$arch/iso/Fedora-Everything-$release-1.1-$arch-CHECKSUM
 
+# Overriding install URL
+if [ -n "${INSTALLER_URL_OVERRIDE}" ]; then
+    INSTALLER="${INSTALLER_URL_OVERRIDE}"
+    info "Overriding the install URL with contents of INSTALLER_URL_OVERRIDE"
+fi
+# Overriding install checksum URL
+if [ -n "${INSTALLER_CHECKSUM_URL_OVERRIDE}" ]; then
+    INSTALLER_CHECKSUM="${INSTALLER_CHECKSUM_URL_OVERRIDE}"
+    info "Overriding the install checksum URL with contents of INSTALLER_CHECKSUM_URL_OVERRIDE"
+fi
+
+
 set -x
 # Initialize sources (git)
 mkdir -p src


### PR DESCRIPTION
Allow overriding the installer locations via env variables:

- INSTALLER_URL_OVERRIDE: Custom location for install ISO
- INSTALLER_CHECKSUM_URL_OVERRIDE: Custom location for sum file

/cc @imcleod 