### PR TITLE
README: add coreos-assembler bash function, overhaul docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,12 +57,6 @@ from the `coreos-assembler` repository. If building the RHEL version please
 note you will need a maipo directory with references to
 proper repositories.
 
-You can optionally upload your built image to a registry such as quay.io by
-doing the following:
-
-```
-$ sudo podman push <image id> example.com/<account name>/coreos-assembler
-```
 
 ### Setup
 ---

--- a/README.md
+++ b/README.md
@@ -16,39 +16,137 @@ and to keep them as similar as possible:
 See [fedora-coreos-ci](https://github.com/dustymabe/fedora-coreos-ci) as an
 example pipeline.
 
-Getting started - prerequisites
+### Getting started - prerequisites
 ---
 
-You can use `podman` or `docker`. These examples use `podman`. Note the
-container must be privileged, as the build process uses container functionality
-itself - we're using [recursive containers](https://github.com/projectatomic/bubblewrap/issues/284).
-
-Secondly, in order to build VM images, the container must have access to
-`/dev/kvm`.  If you're running this in a VM, you must enable
-[nested virt](https://docs.fedoraproject.org/en-US/quick-docs/using-nested-virtualization-in-kvm/).
+You can use `podman` or `docker`. These examples use `podman`. Note
+that we support running in a privileged or unprivileged mode (detailed
+below). Regardless of whether you are using privileged or unprivileged
+mode you'll need access to `/dev/kvm` as the build process runs a
+virtual machine in order to generate the target image. If you're running
+this in a VM, you must enable [nested virt](https://docs.fedoraproject.org/en-US/quick-docs/using-nested-virtualization-in-kvm/).
 See also [GCE nested virt](https://cloud.google.com/compute/docs/instances/enable-nested-virtualization-vm-instances).
 
-Setup
+#### Unprivileged Mode
+
+Unprivileged mode is designed to work with very minimal privileges by
+doing all "privileged" operations inside of a VM. VMs can be started
+as a normal user as long as `/dev/kvm` is accessible (a prerequisite
+mentioned above) and thus we are able to perform a compose as a normal
+user. This allows us to run inside of a locked down OpenShift
+environment, which is where we are running our builds for Fedora
+CoreOS currently. 
+
+We recommend you use unprivileged mode when building locally if you
+are hacking on Fedora CoreOS so that you can mimic our build
+environment as much as possible.
+
+#### Privileged Mode
+
+In privileged mode the rpm-ostree compose uses container features
+itself, thus requires a privileged container in order to perform the
+compose. This is known as [recursive containers](https://github.com/projectatomic/bubblewrap/issues/284).
+
+### Container Build
 ---
 
-Here we store data in `/srv/coreos` on our host system.  You can choose
-any directory you like.  You should run these commands as `root`.
+To completely rebuild the coreos-assembler container image locally, execute
+`$ sudo podman build -t localhost/coreos-assembler .` or
+`$ sudo podman build -t localhost/coreos-assembler -f Dockerfile.rhel .`
+from the `coreos-assembler` repository. If building the RHEL version please 
+note you will need a maipo directory with references to
+proper repositories.
+
+You can optionally upload your built image to a registry such as quay.io by
+doing the following:
 
 ```
-$ mkdir /srv/coreos
-$ cd /srv/coreos
-$ alias coreos-assembler='podman run --rm -ti --privileged --userns=host -v $(pwd):/srv --workdir /srv quay.io/coreos-assembler/coreos-assembler'
+$ sudo podman push <image id> example.com/<account name>/coreos-assembler
 ```
 
-If you need access to CA certificates on your host (for example, when you need to access
-a git repo that is not on the public Internet), you can mount in the host certificates
-as read-only.  For example, on a Fedora host the alias would change to:
+### Setup
+---
 
-`$ alias coreos-assembler='podman run --rm -ti --privileged --userns=host -v /etc/pki:/etc/pki:ro -v $(pwd):/srv --workdir /srv quay.io/coreos-assembler/coreos-assembler'`
+Let's set up our working directory first. We'll create and use `./srv-coreos`
+on our host system. You can choose any directory you like. 
 
-See this [Stack Overflow question](https://stackoverflow.com/questions/26028971/docker-container-ssl-certificates) for additional discussion.
+```
+$ mkdir ./srv-coreos
+$ setfacl -m u:1000:rwx ./srv-coreos
+$ setfacl -d -m u:1000:rwx ./srv-coreos
+$ chcon system_u:object_r:container_file_t:s0 ./srv-coreos
+$ cd ./srv-coreos
+```
 
-Initializing
+In the above commands we:
+
+- created the `./srv-coreos` directory
+- set file ACLs so that the `builder` user (uid `1000` inside the container) can write files
+- set file ACLs so that new files get created with ACLs that allow the `builder` user
+- gave the directory an SELinux file context for sharing with containers
+- changed our working directory into `./srv-coreos`
+
+Now we'll define a bash function that we can use to call the assembler
+container:
+
+```
+$ coreos-assembler() {
+    env | grep COREOS_ASSEMBLER
+    set -x # so we can see what command gets run
+    sudo podman run --rm -ti -v ${PWD}:/srv/ --userns=host --device /dev/kvm --name coreos-assembler \
+               ${COREOS_ASSEMBLER_PRIVILEGED:+--privileged}                                          \
+               ${COREOS_ASSEMBLER_CONFIG_GIT:+-v $COREOS_ASSEMBLER_CONFIG_GIT:/srv/src/config/:ro}   \
+               ${COREOS_ASSEMBLER_GIT:+-v $COREOS_ASSEMBLER_GIT/src/:/usr/lib/coreos-assembler/:ro}  \
+               ${COREOS_ASSEMBLER_CONTAINER_RUNTIME_ARGS}                                            \
+               ${COREOS_ASSEMBLER_CONTAINER:-quay.io/coreos-assembler/coreos-assembler:latest} $@
+    rc=$?; set +x; return $rc
+}
+```
+
+This is a bit more complicated than a simple alias, but it allows for
+hacking on the assembler or the configs and prints out the environment and
+the command that ultimately gets run. Let's step through each part:
+
+- `sudo podman run --rm -ti`: standard container invocation
+- `-v ${PWD}:/srv/`: mount local working dir under `/srv/` in container
+- `--userns=host`: the default for podman anyway, but required for docker
+- `--device /dev/kvm`: needed for creating VMs
+- `--name coreos-assembler`: just a name, feel free to change it
+
+
+The environment variables are special purpose:
+
+
+- `COREOS_ASSEMBLER_PRIVILEGED`
+
+Setting `COREOS_ASSEMBLER_PRIVILEGED=true` (or any value) will cause
+`--privileged` to get added on the command line.
+
+- `COREOS_ASSEMBLER_CONFIG_GIT`
+
+Allows you to specifiy a local directory that contains the configs for
+the ostree you are trying to compose.
+
+- `COREOS_ASSEMBLER_GIT`
+
+Allows you to specify a local directory that contains the CoreOS
+Assembler scripts. This allows for quick hacking on the assembler
+itself.
+
+- `COREOS_ASSEMBLER_CONTAINER_RUNTIME_ARGS`
+
+Allows for adding arbitrary mounts or args to the container runtime.
+
+- `COREOS_ASSEMBLER_CONTAINER`
+
+Allows for overriding the default assembler container which is
+currently `quay.io/coreos-assembler/coreos-assembler:latest`.
+
+See the [Hacking](#hacking) section below for examples of how to use these
+variables:
+
+
+### Initializing
 ---
 
 You only need to do this once; it will clone the specified
@@ -64,7 +162,7 @@ The specified git repository will be cloned into `/srv/coreos/src/config`.
 If you're doing something custom, you likely want to fork that upstream
 repository.
 
-Performing a build
+### Performing a build
 ---
 
 First, we fetch all the metadata and packages:
@@ -86,7 +184,7 @@ Next, rerun `coreos-assembler build` and notice the system correctly
 deduces that nothing changed.  You can run `coreos-assembler fetch`
 again to check for updated RPMs.
 
-Running
+### Running
 ---
 
 ```
@@ -97,8 +195,20 @@ This invokes QEMU on the image in `builds/latest`.  It uses `-snapshot`,
 so any changes are thrown away after you exit qemu.  To exit, type
 `Ctrl-a x`.  For more options, type `Ctrl-a ?`.
 
-Making changes
+
+### Hacking
 ---
+
+#### Hacking on CoreOS Git Configs
+
+We can hack on some local input configs by exporting them in the
+`COREOS_ASSEMBLER_CONFIG_GIT` env variable. For example:
+
+```
+$ export COREOS_ASSEMBLER_CONFIG_GIT=/path/to/github.com/coreos/fedora-coreos-config/
+$ coreos-assembler init --force /dev/null
+$ coreos-assembler fetch && coreos-assembler build
+```
 
 Currently, the assembler only takes two input files that are from `src/config`:
 
@@ -118,28 +228,52 @@ Another thing to try is editing `src/config/manifest.yaml` - add or
 remove entries from `packages`.  You can also add local rpm-md `file:///`
 repositories.
 
-Development
----
+#### Hacking on CoreOS Assembler Scripts
 
-The container image is built in [OpenShift CI](https://api.ci.openshift.org/console/project/rhcos/browse/builds/coreos-assembler?tab=history).
-
-When editing a script, a quick way to use the locally-modified script in
-`coreos-assembler` is to volume-mount the path to the script, for example:
-
-```
-$ alias coreos-assembler='podman run --rm --net=host -ti --privileged --userns=host -v $(pwd):/srv -v /path/to/coreos-assembler/src/cmd-run:/usr/lib/coreos-assembler/cmd-run --workdir /srv quay.io/coreos-assembler/coreos-assembler'
-```
-
-To completely rebuild the coreos-assembler container image locally, execute
-`$ podman build .` or `$ podman build -f Dockerfile.rhel` from the `coreos-assembler` repository.
-If building the RHEL version please note you will need a maipo directory with references to
-proper repositories.
-
-You can upload your built image to a registry such as quay.io by doing the following:
+If you find yourself wanting to hack on CoreOS Assembler itself then
+you can easily mount the scripts into the container and prevent
+rebuilding the container to test every change. This can be done using
+the `COREOS_ASSEMBLER_GIT` env var.
 
 ```
-$ podman push <image id> quay.io/<account name>/coreos-assembler
+$ export COREOS_ASSEMBLER_GIT=/path/to/github.com/coreos/coreos-assembler/
+$ coreos-assembler init https://github.com/coreos/fedora-coreos-config.git
+$ coreos-assembler fetch && coreos-assembler build
 ```
 
-Replacing the container image argument in the `coreos-assembler` alias with
-`quay.io/<account name>/coreos-assembler` will pull your container image instead.
+#### Running in privileged mode
+
+If you'd like to run the Assembler in [privileged mode](#privileged-mode)
+you can use the `COREOS_ASSEMBLER_PRIVILEGED` env var:
+
+```
+$ export COREOS_ASSEMBLER_PRIVILEGED=true
+$ coreos-assembler init https://github.com/coreos/fedora-coreos-config.git
+$ coreos-assembler fetch && coreos-assembler build
+```
+
+
+#### Using a locally built Assembler container
+
+If you have [built a local assembler container](#container-build)
+you can tell the container runtime to use it instead of the default
+by setting the `COREOS_ASSEMBLER_CONTAINER` env var:
+
+```
+$ export COREOS_ASSEMBLER_CONTAINER=localhost/coreos-assembler
+$ coreos-assembler init https://github.com/coreos/fedora-coreos-config.git
+$ coreos-assembler fetch && coreos-assembler build
+```
+
+#### Using different CA certificates
+
+If you need access to CA certificates on your host (for example, when you need to access
+a git repo that is not on the public Internet), you can mount in the host certificates
+using the `COREOS_ASSEMBLER_CONTAINER_RUNTIME_ARGS` variable.
+
+```
+$ export COREOS_ASSEMBLER_CONTAINER_RUNTIME_ARGS='-v /etc/pki:/etc/pki:ro'
+$ coreos-assembler init https://github.com/coreos/fedora-coreos-config.git
+$ coreos-assembler fetch && coreos-assembler build
+```
+See this [Stack Overflow question](https://stackoverflow.com/questions/26028971/docker-container-ssl-certificates) for additional discussion.

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ download an installer image (used to make VMs).
 $ coreos-assembler init https://github.com/coreos/fedora-coreos-config
 ```
 
-The specified git repository will be cloned into `/srv/coreos/src/config`.
+The specified git repository will be cloned into `$PWD/src/config/`.
 
 If you're doing something custom, you likely want to fork that upstream
 repository.
@@ -171,8 +171,8 @@ And now we can build from these inputs:
 $ coreos-assembler build
 ```
 
-Each build will write an OSTree commit into `/srv/coreos/repo` as well
-as generate VM images in `/srv/coreos/builds/`.
+Each build will write an OSTree commit into `$PWD/repo/` as well
+as generate VM images in `$PWD/builds/`.
 
 Next, rerun `coreos-assembler build` and notice the system correctly
 deduces that nothing changed.  You can run `coreos-assembler fetch`

--- a/build.sh
+++ b/build.sh
@@ -151,7 +151,7 @@ configure_user(){
     # running as non-root is much better for the libvirt stack in particular
     # for the cases where we have --privileged in the container run for other reasons.
     # At some point we may make this the default.
-    useradd builder -G wheel,kvm,kvm78,kvm124,kvm232
+    useradd builder --uid 1000 -G wheel,kvm,kvm78,kvm124,kvm232
     echo '%wheel ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers.d/wheel-nopasswd
 }
 


### PR DESCRIPTION
This adds the cosa bash function, which brings support for various
environment variables to tweak functionality at runtime. Having this
functionality allows us to overhaul the rest of the documentation to
use it instead of adding new aliases in various places.