### PR TITLE
init: don't error out if INSTALLER_URL_OVERRIDE not set

### DIFF
--- a/src/cmd-init
+++ b/src/cmd-init
@@ -124,12 +124,12 @@ INSTALLER=https://download.fedoraproject.org/pub/$repository_dir/releases/$relea
 INSTALLER_CHECKSUM=https://download.fedoraproject.org/pub/$repository_dir/releases/$release/Everything/$arch/iso/Fedora-Everything-$release-1.1-$arch-CHECKSUM
 
 # Overriding install URL
-if [ -n "${INSTALLER_URL_OVERRIDE}" ]; then
+if [ -n "${INSTALLER_URL_OVERRIDE-}" ]; then
     INSTALLER="${INSTALLER_URL_OVERRIDE}"
     info "Overriding the install URL with contents of INSTALLER_URL_OVERRIDE"
 fi
 # Overriding install checksum URL
-if [ -n "${INSTALLER_CHECKSUM_URL_OVERRIDE}" ]; then
+if [ -n "${INSTALLER_CHECKSUM_URL_OVERRIDE-}" ]; then
     INSTALLER_CHECKSUM="${INSTALLER_CHECKSUM_URL_OVERRIDE}"
     info "Overriding the install checksum URL with contents of INSTALLER_CHECKSUM_URL_OVERRIDE"
 fi


### PR DESCRIPTION
If we don't substitue in a default value then we'll get
`cmd-init: line 127: INSTALLER_URL_OVERRIDE: unbound variable`.
Substitute a default value of '' so that we still fail the `-n`
check but don't error on unbound variable.