### PR TITLE
build: remove MCS SELinux labels from built image

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -217,6 +217,9 @@ fi
 /usr/lib/coreos-assembler/gf-anaconda-cleanup "$(pwd)"/"${img_base}"
 /usr/lib/coreos-assembler/gf-oemid "$(pwd)"/"${img_base}" "$(pwd)"/"${img_qemu}" qemu
 set +x
+# Clear the MCS SELinux labels
+# See https://github.com/coreos/coreos-assembler/issues/292
+chcon -vl s0 "${img_qemu}"
 # make a version-less symlink to have a stable path
 ln -s "${img_qemu}" "${name}"-qemu.qcow2
 


### PR DESCRIPTION
If we don't do this we end up with an image with MCS labels which means
that a subsequent run of a container (i.e. `coreos-assembler run`) will
fail.

With this we go from:

```
system_u:object_r:container_file_t:s0:c255,c505
```

to:

```
system_u:object_r:container_file_t:s0
```

Fixes #292