### PR TITLE
virt-install: Detect default route instead of hardcoding eth0

### DIFF
--- a/src/virt-install
+++ b/src/virt-install
@@ -94,7 +94,8 @@ touch /boot/ignition.firstboot
 
 
 # Grab the ipv4 address of the container
-output = subprocess.check_output(['ip', '-4', '-oneline', 'addr', 'show', 'eth0'])
+default_iface = subprocess.check_output(['ip', '-4', 'route', 'list', '0/0']).split()[4]
+output = subprocess.check_output(['ip', '-4', '-oneline', 'addr', 'show', default_iface])
 ipv4 = re.match('.*inet ([\d.]+)/\d\d.*', str(output)).group(1)
 
 if args.ostree_repo:


### PR DESCRIPTION
My development workflow is to install coreos-assembler inside
my dev containers which use `--net=host`.  In particular I commonly
want to hack on rpm-ostree and test it with coreos-assembler.

Dropping 9p made sense but hardcoding `eth0` broke support for
using my dev containers.  Let's detect the default route and work
in both cases.

(Though we should also probably dynamically grab a port but eh
 I can easily keep 8000 free locally)