### PR TITLE
mantle: use mantle rpm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,15 @@
 PREFIX ?= /usr
 DESTDIR ?=
 
-.PHONY: all mantle install
+.PHONY: all install
 
-all: mantle
+all:
 
 check:
 	./tests/check.sh
-
-mantle:
-	cd mantle && ./build ore kola kolet
 
 install:
 	install -d $(DESTDIR)$(PREFIX)/lib/coreos-assembler
 	install -D -t $(DESTDIR)$(PREFIX)/lib/coreos-assembler $$(find src/ -maxdepth 1 -type f)
 	install -d $(DESTDIR)$(PREFIX)/bin
 	ln -sf ../lib/coreos-assembler/coreos-assembler $(DESTDIR)$(PREFIX)/bin/
-	install -D -t $(DESTDIR)$(PREFIX)/bin mantle/bin/{ore,kola}
-	install -d $(DESTDIR)$(PREFIX)/lib/kola/amd64
-	install -D -m 0755 -t $(DESTDIR)$(PREFIX)/lib/kola/amd64 mantle/bin/amd64/kolet

--- a/build-deps.txt
+++ b/build-deps.txt
@@ -1,5 +1,1 @@
-# Used by mantle
-golang 
-
-# pull in these on EL7
-#EL7 golang-bin golang-src
+# List dependencies needed for building here

--- a/build.sh
+++ b/build.sh
@@ -120,11 +120,6 @@ _prep_make_and_make_install() {
     mkdir -p /usr/app/
     rsync -rlv "${srcdir}"/ostree-releng-scripts/ /usr/app/ostree-releng-scripts/
 
-    if ! test -f mantle/README.md; then
-        echo -e "\033[1merror: submodules not initialized. Run: git submodule update --init\033[0m" 1>&2
-        exit 1
-    fi
-
     # Can only (easily) get gobject-introspection in Python2 on EL7
     if [ -n "${ISEL}" ]; then
       sed -i 's|^#!/usr/bin/python3|#!/usr/bin/python2|' src/commitmeta_to_json

--- a/src/deps.txt
+++ b/src/deps.txt
@@ -49,3 +49,9 @@ ignition
 
 # for grub install when creating images without anaconda
 grub2
+
+# Mantle suite
+#FEDORA mantle-kola
+#FEDORA mantle-kolet
+#FEDORA mantle-plume
+#FEDORA mantle-ore


### PR DESCRIPTION
This means we can stop building it during the container build.

It also means we get multi-arch by default. The rpm is built against:
    - x86_64, ppc64le, aarch64, i686, s390x, armv7hl