### PR TITLE
Koji Content Generator prep work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN ./build.sh install_rpms
 
 # Ok copy in the rest of them for the next few steps
 COPY ./ /root/containerbuild/
+RUN ./build.sh write_repo
 RUN ./build.sh make_and_makeinstall
 RUN ./build.sh configure_user
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN ./build.sh install_rpms
 
 # Ok copy in the rest of them for the next few steps
 COPY ./ /root/containerbuild/
-RUN ./build.sh write_repo
+RUN ./build.sh write_archive_info
 RUN ./build.sh make_and_makeinstall
 RUN ./build.sh configure_user
 

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel7:latest
+FROM registry.redhat.io/rhel7:latest
 WORKDIR /root/containerbuild
 
 # Only need a few of our scripts for the first few steps

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -12,7 +12,7 @@ RUN ./build.sh install_rpms
 
 # Ok copy in the rest of them for the next few steps
 COPY ./ /root/containerbuild/
-RUN ./build.sh write_repo
+RUN ./build.sh write_archive_info
 RUN ./build.sh make_and_makeinstall
 RUN ./build.sh configure_user
 

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -12,6 +12,7 @@ RUN ./build.sh install_rpms
 
 # Ok copy in the rest of them for the next few steps
 COPY ./ /root/containerbuild/
+RUN ./build.sh write_repo
 RUN ./build.sh make_and_makeinstall
 RUN ./build.sh configure_user
 

--- a/build.sh
+++ b/build.sh
@@ -158,8 +158,9 @@ configure_user(){
 write_archive_info() {
     # shellcheck source=src/cmdlib.sh
     . "${srcdir}/src/cmdlib.sh"
-    mkdir -p /lib/coreos-assembler/src
-    prepare_git_artifacts /root/containerbuild /lib/coreos-assembler/src/archive.tar.gz /lib/coreos-assembler/src/git.json
+    mkdir -p /cosa /lib/coreos-assembler
+    touch -f /lib/coreos-assembler/.clean
+    prepare_git_artifacts /root/containerbuild /cosa/coreos-assembler-git.tar.gz /cosa/coreos-assembler-git.json
 }
 
 # Run the function specified by the calling script

--- a/build.sh
+++ b/build.sh
@@ -38,7 +38,7 @@ configure_yum_repos() {
     done
 
     # For Fedora we'll add a FAHC and COPR repo
-    if [ -n "${ISFEDORA}" ]; then  
+    if [ -n "${ISFEDORA}" ]; then
         # Enable FAHC https://pagure.io/fedora-atomic-host-continuous
         # so we have ostree/rpm-ostree git master for our :latest
         # NOTE: The canonical copy of this code lives in rpm-ostree's CI:
@@ -127,7 +127,7 @@ _prep_make_and_make_install() {
 make_and_makeinstall() {
     _prep_make_and_make_install
     # And the main scripts
-    if [ -n "${ISEL}" ]; then  
+    if [ -n "${ISEL}" ]; then
         echo "make && make check && make install" | scl enable rh-python36 bash
     else
         make && make check && make install
@@ -153,6 +153,13 @@ configure_user(){
     # At some point we may make this the default.
     useradd builder --uid 1000 -G wheel,kvm,kvm78,kvm124,kvm232
     echo '%wheel ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers.d/wheel-nopasswd
+}
+
+write_repo() {
+    # shellcheck source=src/cmdlib.sh
+    . "${srcdir}/src/cmdlib.sh"
+    mkdir -p /lib/coreos-assembler/src
+    prepare_git_artifacts /root/containerbuild /lib/coreos-assembler/src/archive.tar.gz /lib/coreos-assembler/src/git.json
 }
 
 # Run the function specified by the calling script

--- a/build.sh
+++ b/build.sh
@@ -155,7 +155,7 @@ configure_user(){
     echo '%wheel ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers.d/wheel-nopasswd
 }
 
-write_repo() {
+write_archive_info() {
     # shellcheck source=src/cmdlib.sh
     . "${srcdir}/src/cmdlib.sh"
     mkdir -p /lib/coreos-assembler/src

--- a/src/cmd-build
+++ b/src/cmd-build
@@ -123,11 +123,16 @@ cat > "${commitmeta_input_json}" <<EOF
 }
 EOF
 
-# Generate an archive metadata about the config GIT checkout, but
-# only if the build is from a Git Recipe.
+set -x
 if [ -e "${workdir}/src/config-git" ]; then
-    prepare_git_artifacts "${workdir}/src/config-git" "$(pwd)/config.tar.gz" "$(pwd)/config-git.json"
+    config_git_dir="${workdir}/src/config-git"
+elif [ -e "${workdir}/src/config" ]; then
+    config_git_dir="${workdir}/src/config"
+else
+    fatal "Git config directory doesn't exist"
 fi
+
+prepare_git_artifacts "${config_git_dir}" "$(pwd)/coreos-assembler-config.tar.gz" "$(pwd)/coreos-assembler-config-git.json"
 
 # These need to be absolute paths right now for rpm-ostree
 composejson=$(pwd)/tmp/compose.json
@@ -233,6 +238,16 @@ img_qemu_size=$(stat --format=%s "${img_qemu}")
 build_timestamp=$(date -u +$RFC3339)
 vm_iso_checksum=$(awk '/SHA256.*iso/{print$NF}' "${workdir}"/installer/*CHECKSUM)
 
+src_location="container"
+if [ ! -f /lib/coreos-assembler/.clean ]; then
+    info "This version of coreos-assembler is running code from outside the container."
+    src_location="bind mount"
+fi
+
+# Record locations for code sources.
+# If the following condition is true, then /lib/coreos-assembler has been bind
+# mounted in and is using a different build tree.
+# shellcheck disable=SC2046
 cat > tmp/meta.json <<EOF
 {
  "buildid": "${buildid}",
@@ -242,7 +257,10 @@ cat > tmp/meta.json <<EOF
  "coreos-assembler.image-config-checksum": "${image_config_checksum}",
  "coreos-assembler.image-genver": "${image_genver}",
  "coreos-assembler.image-input-checksum": "${image_input_checksum}",
+ "coreos-assembler.code-source": "${src_location}",
  "coreos-assembler.vm-iso-checksum": "${vm_iso_checksum}",
+ "coreos-assembler.container-config-git": $(jq -M '.git' $(pwd)/coreos-assembler-config-git.json),
+ "coreos-assembler.image-git": $(jq -M '.git' /cosa/coreos-assembler-git.json),
  "images": {
     "qemu": { "path": "${img_qemu}",
               "sha256": "${img_qemu_sha256}",
@@ -252,19 +270,9 @@ cat > tmp/meta.json <<EOF
 }
 EOF
 
-# Record locations for code sources.
-# shellcheck disable=SC2046
-cat > tmp/git.json <<EOF
-{
-  "coreos-assembler.image-git": $(jq -M '.git' /lib/coreos-assembler/src/git.json),
-  "coreos-assembler.config-git": $(jq -M '.git' $(pwd)/config-git.json)
-}
-EOF
-
 # Merge all the JSON; note that we want ${composejson} first
 # since we may be overriding data from a previous build.
-cat "${composejson}" tmp/meta.json "${commitmeta_input_json}" tmp/git.json \
-    | tee | jq -s add > meta.json
+cat "${composejson}" tmp/meta.json "${commitmeta_input_json}" | jq -s add > meta.json
 
 # And add the commit metadata itself, which includes notably the rpmdb pkglist
 # in a format that'd be easy to generate diffs out of for higher level tools

--- a/src/cmd-build
+++ b/src/cmd-build
@@ -231,7 +231,7 @@ ln -s "${img_qemu}" "${name}"-qemu.qcow2
 img_qemu_sha256=$(sha256sum "${img_qemu}" | cut -f 1 -d ' ')
 img_qemu_size=$(stat --format=%s "${img_qemu}")
 build_timestamp=$(date -u +$RFC3339)
-kickstart_checksum=$(awk '/SHA256.*iso/{print$NF}' "${workdir}"/installer/*CHECKSUM)
+vm_iso_checksum=$(awk '/SHA256.*iso/{print$NF}' "${workdir}"/installer/*CHECKSUM)
 
 cat > tmp/meta.json <<EOF
 {
@@ -242,7 +242,7 @@ cat > tmp/meta.json <<EOF
  "coreos-assembler.image-config-checksum": "${image_config_checksum}",
  "coreos-assembler.image-genver": "${image_genver}",
  "coreos-assembler.image-input-checksum": "${image_input_checksum}",
- "coreos-assembler.kickstart-checksum": "${kickstart_checksum}",
+ "coreos-assembler.vm-iso-checksum": "${vm_iso_checksum}",
  "images": {
     "qemu": { "path": "${img_qemu}",
               "sha256": "${img_qemu_sha256}",

--- a/src/cmd-build
+++ b/src/cmd-build
@@ -61,9 +61,6 @@ prepare_build
 ostree --version
 rpm-ostree --version
 
-# RFC3339 formatter
-RFC3339="%Y-%m-%dT%H:%M:%SZ"
-
 previous_build=
 if [ -L "${workdir:?}"/builds/latest ]; then
     previous_build=$(readlink "${workdir}"/builds/latest)
@@ -119,12 +116,19 @@ if ! git diff --quiet --exit-code; then
 fi
 popd
 commitmeta_input_json=$(pwd)/tmp/commit-metadata-input.json
-cat >"${commitmeta_input_json}" <<EOF
+cat > "${commitmeta_input_json}" <<EOF
 {
   "coreos-assembler.config-gitrev": "${config_gitrev}",
-  "coreos-assembler.config-dirty": ${config_dirty}
+  "coreos-assembler.config-dirty": "${config_dirty}"
 }
 EOF
+
+# Generate an archive metadata about the config GIT checkout, but
+# only if the build is from a Git Recipe.
+if [ -e "${workdir}/src/config-git" ]; then
+    prepare_git_artifacts "${workdir}/src/config-git" "$(pwd)/config.tar.gz" "$(pwd)/config-git.json"
+fi
+
 # These need to be absolute paths right now for rpm-ostree
 composejson=$(pwd)/tmp/compose.json
 # --cache-only is here since `fetch` is a separate verb.
@@ -216,16 +220,18 @@ fi
 
 /usr/lib/coreos-assembler/gf-anaconda-cleanup "$(pwd)"/"${img_base}"
 /usr/lib/coreos-assembler/gf-oemid "$(pwd)"/"${img_base}" "$(pwd)"/"${img_qemu}" qemu
-set +x
+
 # Clear the MCS SELinux labels
 # See https://github.com/coreos/coreos-assembler/issues/292
 chcon -vl s0 "${img_qemu}"
+set +x
 # make a version-less symlink to have a stable path
 ln -s "${img_qemu}" "${name}"-qemu.qcow2
 
 img_qemu_sha256=$(sha256sum "${img_qemu}" | cut -f 1 -d ' ')
-
+img_qemu_size=$(stat --format=%s "${img_qemu}")
 build_timestamp=$(date -u +$RFC3339)
+kickstart_checksum=$(awk '/SHA256.*iso/{print$NF}' "${workdir}"/installer/*CHECKSUM)
 
 cat > tmp/meta.json <<EOF
 {
@@ -233,18 +239,32 @@ cat > tmp/meta.json <<EOF
  "name": "${name}",
  "summary": "${summary}",
  "coreos-assembler.build-timestamp": "${build_timestamp}",
- "coreos-assembler.image-input-checksum": "${image_input_checksum}",
- "coreos-assembler.image-genver": "${image_genver}",
  "coreos-assembler.image-config-checksum": "${image_config_checksum}",
+ "coreos-assembler.image-genver": "${image_genver}",
+ "coreos-assembler.image-input-checksum": "${image_input_checksum}",
+ "coreos-assembler.kickstart-checksum": "${kickstart_checksum}",
  "images": {
     "qemu": { "path": "${img_qemu}",
-              "sha256": "${img_qemu_sha256}" }
+              "sha256": "${img_qemu_sha256}",
+              "size": "${img_qemu_size}"
+    }
  }
 }
 EOF
+
+# Record locations for code sources.
+# shellcheck disable=SC2046
+cat > tmp/git.json <<EOF
+{
+  "coreos-assembler.image-git": $(jq -M '.git' /lib/coreos-assembler/src/git.json),
+  "coreos-assembler.config-git": $(jq -M '.git' $(pwd)/config-git.json)
+}
+EOF
+
 # Merge all the JSON; note that we want ${composejson} first
 # since we may be overriding data from a previous build.
-cat "${composejson}" tmp/meta.json "${commitmeta_input_json}" | jq -s add > meta.json
+cat "${composejson}" tmp/meta.json "${commitmeta_input_json}" tmp/git.json \
+    | tee | jq -s add > meta.json
 
 # And add the commit metadata itself, which includes notably the rpmdb pkglist
 # in a format that'd be easy to generate diffs out of for higher level tools

--- a/src/cmd-build
+++ b/src/cmd-build
@@ -261,7 +261,7 @@ cat > tmp/meta.json <<EOF
  "coreos-assembler.code-source": "${src_location}",
  "coreos-assembler.vm-iso-checksum": "${vm_iso_checksum}",
  "coreos-assembler.container-config-git": $(jq -M '.git' ${PWD}/coreos-assembler-config-git.json),
- "coreos-assembler.image-git": $(jq -M '.git' /cosa/coreos-assembler-git.json),
+ "coreos-assembler.container-image-git": $(jq -M '.git' /cosa/coreos-assembler-git.json),
  "images": {
     "qemu": { "path": "${img_qemu}",
               "sha256": "${img_qemu_sha256}",

--- a/src/cmd-build
+++ b/src/cmd-build
@@ -115,7 +115,7 @@ if ! git diff --quiet --exit-code; then
     config_dirty=true
 fi
 popd
-commitmeta_input_json=$(pwd)/tmp/commit-metadata-input.json
+commitmeta_input_json=${PWD}/tmp/commit-metadata-input.json
 cat > "${commitmeta_input_json}" <<EOF
 {
   "coreos-assembler.config-gitrev": "${config_gitrev}",
@@ -132,10 +132,10 @@ else
     fatal "Git config directory doesn't exist"
 fi
 
-prepare_git_artifacts "${config_git_dir}" "$(pwd)/coreos-assembler-config.tar.gz" "$(pwd)/coreos-assembler-config-git.json"
+prepare_git_artifacts "${config_git_dir}" "${PWD}/coreos-assembler-config.tar.gz" "${PWD}/coreos-assembler-config-git.json"
 
 # These need to be absolute paths right now for rpm-ostree
-composejson=$(pwd)/tmp/compose.json
+composejson=${PWD}/tmp/compose.json
 # --cache-only is here since `fetch` is a separate verb.
 runcompose --cache-only ${FORCE} --add-metadata-from-json "${commitmeta_input_json}" \
            --write-composejson-to "${composejson}"
@@ -205,7 +205,7 @@ img_qemu=${imageprefix}-qemu.qcow2
 # 9pfs isn't an option for EL7 so copying out anaconda logs doesn't work
 extraargs=
 if [ -n "${ISFEDORA}" ]; then
-    extraargs="${extraargs} --console-log-file $(pwd)/install.log --logs $(pwd)/tmp/anaconda"
+    extraargs="${extraargs} --console-log-file ${PWD}/install.log --logs ${PWD}/tmp/anaconda"
 fi
 
 if ${image_config}; then
@@ -216,20 +216,21 @@ fi
 
 # We want extraargs var to be split on words
 # shellcheck disable=SC2086
-/usr/lib/coreos-assembler/virt-install --dest="$(pwd)"/"${img_base}" \
-               --create-disk --kickstart-out "$(pwd)"/tmp/flattened.ks \
+/usr/lib/coreos-assembler/virt-install --dest="${PWD}"/"${img_base}" \
+               --create-disk --kickstart-out "${PWD}"/tmp/flattened.ks \
                --ostree-remote="${name}" --ostree-stateroot="${name}" \
                --ostree-ref="${ref:-${commit}}" \
                --location "${workdir}"/installer/*.iso \
                --ostree-repo="${workdir}"/repo ${extraargs-}
 
-/usr/lib/coreos-assembler/gf-anaconda-cleanup "$(pwd)"/"${img_base}"
-/usr/lib/coreos-assembler/gf-oemid "$(pwd)"/"${img_base}" "$(pwd)"/"${img_qemu}" qemu
+/usr/lib/coreos-assembler/gf-anaconda-cleanup "${PWD}"/"${img_base}"
+/usr/lib/coreos-assembler/gf-oemid "${PWD}"/"${img_base}" "${PWD}"/"${img_qemu}" qemu
 
 # Clear the MCS SELinux labels
 # See https://github.com/coreos/coreos-assembler/issues/292
 chcon -vl s0 "${img_qemu}"
 set +x
+
 # make a version-less symlink to have a stable path
 ln -s "${img_qemu}" "${name}"-qemu.qcow2
 
@@ -247,7 +248,7 @@ fi
 # Record locations for code sources.
 # If the following condition is true, then /lib/coreos-assembler has been bind
 # mounted in and is using a different build tree.
-# shellcheck disable=SC2046
+# shellcheck disable=SC2046 disable=SC2086
 cat > tmp/meta.json <<EOF
 {
  "buildid": "${buildid}",
@@ -259,7 +260,7 @@ cat > tmp/meta.json <<EOF
  "coreos-assembler.image-input-checksum": "${image_input_checksum}",
  "coreos-assembler.code-source": "${src_location}",
  "coreos-assembler.vm-iso-checksum": "${vm_iso_checksum}",
- "coreos-assembler.container-config-git": $(jq -M '.git' $(pwd)/coreos-assembler-config-git.json),
+ "coreos-assembler.container-config-git": $(jq -M '.git' ${PWD}/coreos-assembler-config-git.json),
  "coreos-assembler.image-git": $(jq -M '.git' /cosa/coreos-assembler-git.json),
  "images": {
     "qemu": { "path": "${img_qemu}",

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 # Shared shell script library
 
 DIR=$(dirname "$0")
+RFC3339="%Y-%m-%dT%H:%M:%SZ"
 
 # Set PYTHONUNBUFFERED=1 so that we get unbuffered output. We should
 # be able to do this on the shebang lines but env doesn't support args
@@ -252,4 +253,66 @@ EOF
         fatal "Couldn't find rc file, something went terribly wrong!"
     fi
     return "$(cat "${workdir}"/tmp/rc)"
+}
+
+prepare_git_artifacts() {
+    # prepare_git_artifacts prepares two artifacts from a GIT repo:
+    #   1. JSON describing the GIT tree.
+    #   2. A tarball of the source.
+    local gitd="${1:?first argument must be the git directory}"; shift;
+    local tarball="${1:?second argument me be the tarball name}"; shift;
+    local json="${1:?third argument must be the json file name to emit}"; shift;
+
+    local head_ref="unknown"
+    local head_remote="unknown"
+    local head_url="unknown"
+
+    local gc="git --git-dir=${gitd}/.git"
+    local gc_state="clean"
+
+    # shellcheck disable=SC2086
+    if ! ${gc} diff --quiet --exit-code; then
+        gc_state="dirty"
+    fi
+
+    tar -C "${gitd}" -czf "${tarball}" --exclude-vcs .
+    chmod 0444 "${tarball}"
+
+    # Find the git reference name for HEAD, e.g. refs/head/meta.
+    # shellcheck disable=SC2086
+    head_ref="$($gc symbolic-ref -q HEAD)"
+    # Find the remote name, e.g. origin.
+    # shellcheck disable=SC2086
+    head_remote="$($gc for-each-ref --format='%(upstream:remotename)' ${head_ref} || echo unknown)"
+    # Find the URL for the remote name, eg. https://github.com/coreos/coreos-assembler
+    # shellcheck disable=SC2086
+    head_url="$($gc remote get-url ${head_remote} || echo unknown)" # get the URL for the remote
+
+    # shellcheck disable=SC2046 disable=SC2086
+    cat > "${json}" <<EOC
+{
+    "date": "$(date -u +$RFC3339)",
+    "git": {
+        "branch": "$(${gc} symbolic-ref -q HEAD --short)",
+        "commit": "$(${gc} rev-parse HEAD)",
+        "origin": "${head_url}",
+        "state": "${gc_state}"
+    },
+    "file": {
+        "checksum": "$(sha256sum ${tarball} | awk '{print$1}')",
+        "checksum_type": "sha256",
+        "format": "tar.gz",
+        "name": "$(basename ${tarball})",
+        "size": "$(stat --format=%s ${tarball})"
+    }
+}
+EOC
+    chmod 0444 "${json}"
+}
+
+jq_git() {
+    # jq_git extracts JSON elements generated using prepare_git_artifacts.
+    # ARG1 is the element name, and ARG2 is the location of the
+    # json document.
+    jq -rM ".git.$1" "${2}"
 }

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -268,11 +268,11 @@ prepare_git_artifacts() {
     local head_url="unknown"
 
     local gc="git --git-dir=${gitd}/.git"
-    local gc_state="clean"
+    local is_dirty="false"
 
     # shellcheck disable=SC2086
     if ! ${gc} diff --quiet --exit-code; then
-        gc_state="dirty"
+        is_dirty="true"
     fi
 
     tar -C "${gitd}" -czf "${tarball}" --exclude-vcs .
@@ -296,7 +296,7 @@ prepare_git_artifacts() {
         "branch": "$(${gc} symbolic-ref -q HEAD --short)",
         "commit": "$(${gc} rev-parse HEAD)",
         "origin": "${head_url}",
-        "state": "${gc_state}"
+        "dirty": "${is_dirty}"
     },
     "file": {
         "checksum": "$(sha256sum ${tarball} | awk '{print$1}')",


### PR DESCRIPTION
Embed the source and meta-data about the  container build _in_ the container as part of enabling COSA to act as a Koji Content Generator. The spec for Koji requires that we capture information about the build, including the source so that someone can re-create the build. 