### PR TITLE
virt-install: Quiet HTTP logs

### DIFF
--- a/src/virt-install
+++ b/src/virt-install
@@ -187,7 +187,10 @@ try:
         vinstall_args.append("--console=log.file={}".format(args.console_log_file))
         tail_proc = subprocess.Popen(['tail', '-F', args.console_log_file])
     # Start webserver to serve the ostree content to be retrieved during install
-    http_proc = subprocess.Popen(['python3', '-m', 'http.server', '--bind', ipv4, '8000'], cwd=args.ostree_repo)
+    # Sadly this logs to stderr by default, so let's silence it.  Also this is currently
+    # racy, we need to at some point poll for the webserver to be up.
+    http_proc = subprocess.Popen(['python3', '-m', 'http.server', '--bind', ipv4, '8000'], cwd=args.ostree_repo,
+                                 stderr=subprocess.DEVNULL)
     if args.logs:
         vinstall_args.append("--filesystem=source={},target=/mnt/logs,accessmode=mapped".format(args.logs))
     vinstall_args.extend(["--wait={}".format(args.wait), "--noreboot", "--nographics",


### PR DESCRIPTION
Printing a line per request is quite slow and takes over
the terminal.  No need to log them, Anaconda has basic stats
that we already get.

(And we should move at least towards a virtio socket for this
 anyways)