### PR TITLE
cmd-build: Refactor to support multiple artifact types

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -8,9 +8,15 @@ dn=$(dirname "$0")
 print_help() {
     cat 1>&2 <<'EOF'
 Usage: coreos-assembler build --help
-       coreos-assembler build [--force] [--skip-prune]
+       coreos-assembler build [--force] [--skip-prune] [IMAGETYPES]
 
   Build OSTree and image artifacts from previously fetched packages.
+  The IMAGETYPES argument is a list of image types; if unspecified it defaults
+  to "qemu".
+
+  Valid image types:
+
+    - qemu
 EOF
 }
 
@@ -40,18 +46,23 @@ while true; do
             shift
             break
             ;;
-        *)
+        -*)
             fatal "$0: unrecognized option: $1"
             exit 1
+            ;;
+        *)
+            break
             ;;
     esac
     shift
 done
 
-if [ $# -ne 0 ]; then
-    print_help
-    fatal "ERROR: Too many arguments"
-    exit 1
+declare -a IMAGE_TYPES
+for itype in "$@"; do
+    IMAGE_TYPES[]="$itype"
+done
+if [ "${IMAGE_TYPES[*]}" == 0 ]; then
+    IMAGE_TYPES=(qemu)
 fi
 
 export LIBGUESTFS_BACKEND=direct
@@ -198,7 +209,6 @@ imageprefix="${name:?}"-"${buildid}"
 set -x
 mkdir -p tmp/anaconda
 img_base=tmp/${imageprefix}-base.qcow2
-img_qemu=${imageprefix}-qemu.qcow2
 
 # These options don't work for EL7 so don't pass for now
 # virt-install --console=log.file doesn't work for qemu in EL7
@@ -214,6 +224,7 @@ else
     extraargs="${extraargs} --kickstart ${image_input}"
 fi
 
+# This generates the "base image"; not specific to a platform.
 # We want extraargs var to be split on words
 # shellcheck disable=SC2086
 /usr/lib/coreos-assembler/virt-install --dest="${PWD}"/"${img_base}" \
@@ -222,20 +233,27 @@ fi
                --ostree-ref="${ref:-${commit}}" \
                --location "${workdir}"/installer/*.iso \
                --ostree-repo="${workdir}"/repo ${extraargs-}
-
-/usr/lib/coreos-assembler/gf-anaconda-cleanup "${PWD}"/"${img_base}"
-/usr/lib/coreos-assembler/gf-oemid "${PWD}"/"${img_base}" "${PWD}"/"${img_qemu}" qemu
-
-# Clear the MCS SELinux labels
-# See https://github.com/coreos/coreos-assembler/issues/292
-chcon -vl s0 "${img_qemu}"
+/usr/lib/coreos-assembler/gf-anaconda-cleanup "$(pwd)"/"${img_base}"
 set +x
 
-# make a version-less symlink to have a stable path
-ln -s "${img_qemu}" "${name}"-qemu.qcow2
+declare -A images
+for itype in "${IMAGE_TYPES[@]}"; do
+    case $itype in
+        qemu) img_qemu=${imageprefix}-qemu.qcow2
+              images[$itype]="${img_qemu}"
+              /usr/lib/coreos-assembler/gf-oemid "$(pwd)"/"${img_base}" "$(pwd)"/"${img_qemu}" qemu
+              # Clear the MCS SELinux labels
+              # See https://github.com/coreos/coreos-assembler/issues/292
+              chcon -vl s0 "${img_qemu}"
+              # make a version-less symlink to have a stable path
+              # TODO: Remove this, things should be parsing the metadata
+              ln -s "${img_qemu}" "${name}"-qemu.qcow2
+              ;;
+        *) fatal "Unrecognized image type: $itype"
+           ;;
+    esac
+done
 
-img_qemu_sha256=$(sha256sum "${img_qemu}" | cut -f 1 -d ' ')
-img_qemu_size=$(stat --format=%s "${img_qemu}")
 build_timestamp=$(date -u +$RFC3339)
 vm_iso_checksum=$(awk '/SHA256.*iso/{print$NF}' "${workdir}"/installer/*CHECKSUM)
 
@@ -245,7 +263,7 @@ if [ ! -f /lib/coreos-assembler/.clean ]; then
     src_location="bind mount"
 fi
 
-# Record locations for code sources.
+# The base metadata, plus locations for code sources.
 # If the following condition is true, then /lib/coreos-assembler has been bind
 # mounted in and is using a different build tree.
 # shellcheck disable=SC2046 disable=SC2086
@@ -260,15 +278,22 @@ cat > tmp/meta.json <<EOF
  "coreos-assembler.image-input-checksum": "${image_input_checksum}",
  "coreos-assembler.code-source": "${src_location}",
  "coreos-assembler.vm-iso-checksum": "${vm_iso_checksum}",
- "coreos-assembler.container-config-git": $(jq -M '.git' ${PWD}/coreos-assembler-config-git.json),
- "images": {
-    "qemu": { "path": "${img_qemu}",
-              "sha256": "${img_qemu_sha256}",
-              "size": "${img_qemu_size}"
-    }
- }
+ "coreos-assembler.container-config-git": $(jq -M '.git' ${PWD}/coreos-assembler-config-git.json)
 }
 EOF
+
+# The `images:` section
+first=true
+(echo '{ "images": {'
+ for image in "${!images[@]}"; do
+     path=${images[${image}]}
+     checksum=$(sha256sum "${path}" | cut -f 1 -d ' ')
+     size=$(stat -c '%s' "${path}")
+     if ${first}; then first=false; else echo ','; fi
+     echo '"'"${image}"'": {"path": "'"${path}"'", "sha256": "'"${checksum}"'", "size": "'"${size}"'"}'
+ done
+ echo "}}"
+) > tmp/images.json
 
 # And the build information about our container, if we are executing
 # from a container.
@@ -282,7 +307,7 @@ fi
 
 # Merge all the JSON; note that we want ${composejson} first
 # since we may be overriding data from a previous build.
-cat "${composejson}" tmp/meta.json tmp/cosa-image.json "${commitmeta_input_json}" | jq -s add > meta.json
+cat "${composejson}" tmp/meta.json tmp/images.json tmp/cosa-image.json "${commitmeta_input_json}" | jq -s add > meta.json
 
 # And add the commit metadata itself, which includes notably the rpmdb pkglist
 # in a format that'd be easy to generate diffs out of for higher level tools


### PR DESCRIPTION
Change the code so that it's prepared to handle e.g.:
`coreos-assembler build qemu metal-uefi metal-bios openstack`.

There's more work we'll need to do for adding any more image
types, this just lays the groundwork.