### PR TITLE
buildextend*: use data from build meta.json

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -231,6 +231,7 @@ cat > tmp/meta.json <<EOF
 {
  "buildid": "${buildid}",
  "name": "${name}",
+ "summary": "${summary}",
  "coreos-assembler.build-timestamp": "${build_timestamp}",
  "coreos-assembler.image-input-checksum": "${image_input_checksum}",
  "coreos-assembler.image-genver": "${image_genver}",

--- a/src/cmd-buildextend-ec2
+++ b/src/cmd-buildextend-ec2
@@ -22,16 +22,14 @@ parser.add_argument("--grant-user", help="Grant user launch permission",
                     nargs="*", default=[])
 args = parser.parse_args()
 
-with open('src/config/manifest.yaml') as f:
-    manifest = yaml.safe_load(f)
-
-base_name = manifest['rojig']['name']
-ami_name_version = f'{base_name}-{args.build}'
 
 builddir = os.path.join('builds', args.build)
 buildmeta_path = os.path.join(builddir, 'meta.json')
 with open(buildmeta_path) as f:
     buildmeta = json.load(f)
+
+base_name = buildmeta['name']
+ami_name_version = f'{base_name}-{args.build}'
 
 tmpdir='tmp/buildpost-ec2'
 if os.path.isdir(tmpdir):
@@ -58,7 +56,7 @@ def run_ore():
                 '--bucket', args.bucket,
                 '--ami-name', ami_name_version,
                 '--name', ami_name_version,
-                '--ami-description', f"{manifest['rojig']['summary']} {args.build}",
+                '--ami-description', f"{buildmeta['summary']} {args.build}",
                 '--file', tmp_img_ec2_vmdk,
                 '--disk-size-inspect',
                 '--delete-object']

--- a/src/cmd-buildextend-openstack
+++ b/src/cmd-buildextend-openstack
@@ -26,17 +26,14 @@ if not args.build:
 
 print(f"Targeting build: {args.build}")
 
-with open('src/config/manifest.yaml') as f:
-    manifest = yaml.safe_load(f)
-
-base_name = manifest['rojig']['name']
-img_prefix = f'{base_name}-{args.build}'
-openstack_name = f'{img_prefix}-openstack.qcow2'
-
 builddir = os.path.join('builds', args.build)
 buildmeta_path = os.path.join(builddir, 'meta.json')
 with open(buildmeta_path) as f:
     buildmeta = json.load(f)
+
+base_name = buildmeta['name']
+img_prefix = f'{base_name}-{args.build}'
+openstack_name = f'{img_prefix}-openstack.qcow2'
 
 tmpdir = 'tmp/buildpost-openstack'
 if os.path.isdir(tmpdir):

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -118,10 +118,12 @@ prepare_build() {
     rpm-ostree compose tree --repo=repo --print-only "${manifest}" > "${manifest_tmp_json}"
 
     # Abuse the rojig/name as the name of the VM images
+    # Also grab rojig summary for image upload descriptions
     name=$(jq -r '.rojig.name' < "${manifest_tmp_json}")
+    summary=$(jq -r '.rojig.summary' < "${manifest_tmp_json}")
     # TODO - allow this to be unset
     ref=$(jq -r '.ref' < "${manifest_tmp_json}")
-    export name ref
+    export name ref summary
     rm -f "${manifest_tmp_json}"
 
     # This dir is no longer used


### PR DESCRIPTION
It would be preferable to use just data from the build
meta.json rather than having to pickup some content from
there and some from manifest.json from the "configs" repo
which could have changed since the last build occurred.