### PR TITLE
init: drop -C option in git checkout in --branch

### DIFF
--- a/src/cmd-init
+++ b/src/cmd-init
@@ -146,7 +146,7 @@ mkdir -p src
             if [ -n "${BRANCH}" ]; then
                 # On EL7 git doesn't support -C option so use pushd/popd
                 pushd config >/dev/null
-                git -C config checkout "${BRANCH}"
+                git checkout "${BRANCH}"
                 popd
             fi
             if [ -n "${subdir}" ]; then


### PR DESCRIPTION
Do the checkout directly now that pushd sets the working directory
to "config". Previously gave an error on the directory "config"
not existing.