### PR TITLE
Use f29 for coreos-assembler

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:28
+FROM registry.fedoraproject.org/fedora:29
 WORKDIR /root/containerbuild
 
 # Only need a few of our scripts for the first few steps

--- a/build.sh
+++ b/build.sh
@@ -88,6 +88,14 @@ install_rpms() {
     deps=$(sed "s/${filter}//" "${srcdir}"/deps.txt | grep -v '^#')
     echo "${builddeps}" "${deps}" | xargs yum -y install
 
+    # grab virt-install from updates testing for now
+    # https://bugzilla.redhat.com/show_bug.cgi?id=1659242
+    # can delete once https://bodhi.fedoraproject.org/updates/FEDORA-2019-c38a307cd5
+    # is stable
+    if [ -n "${ISFEDORA}" ]; then
+        yum upgrade -y virt-install --enablerepo=updates-testing
+    fi
+
     # Commented out for now, see above
     #dnf remove -y $builddeps}
     # can't remove grubby on el7 because libguestfs-tools depends on it

--- a/src/cmd-init
+++ b/src/cmd-init
@@ -106,7 +106,7 @@ fi
 
 # Get target architecture
 arch=$(uname -m)
-release="28"
+release="29"
 
 # Download url is different for primary and secondary fedora
 # Primary Fedora - https://download.fedoraproject.org/pub/fedora/linux/releases/
@@ -120,8 +120,8 @@ repository_dirs[ppc64le]=fedora-secondary
 repository_dirs[s390x]=fedora-secondary
 
 repository_dir=${repository_dirs[$arch]}
-INSTALLER=https://download.fedoraproject.org/pub/$repository_dir/releases/$release/Everything/$arch/iso/Fedora-Everything-netinst-$arch-$release-1.1.iso
-INSTALLER_CHECKSUM=https://download.fedoraproject.org/pub/$repository_dir/releases/$release/Everything/$arch/iso/Fedora-Everything-$release-1.1-$arch-CHECKSUM
+INSTALLER=https://download.fedoraproject.org/pub/$repository_dir/releases/$release/Everything/$arch/iso/Fedora-Everything-netinst-$arch-$release-1.2.iso
+INSTALLER_CHECKSUM=https://download.fedoraproject.org/pub/$repository_dir/releases/$release/Everything/$arch/iso/Fedora-Everything-$release-1.2-$arch-CHECKSUM
 
 # Overriding install URL
 if [ -n "${INSTALLER_URL_OVERRIDE-}" ]; then


### PR DESCRIPTION
- Use registry.fedoraproject.org/fedora:29 as base
- Use an f29 installer ISO

This is enabled by fixing:
https://bugzilla.redhat.com/show_bug.cgi?id=1659242

Fixes: #195 