### PR TITLE
install grub2 not grub2-pc

### DIFF
--- a/src/deps.txt
+++ b/src/deps.txt
@@ -48,4 +48,4 @@ ignition
 #FEDORA ShellCheck
 
 # for grub install when creating images without anaconda
-grub2-pc
+grub2


### PR DESCRIPTION
grub2-pc is a bios (and x86_64 only) specific package. Installing
grub2 pulls in the correct binary on all arches where grub2 is the
bootloader in use.

Signed-off-by: Dennis Gilmore <dennis@ausil.us>