### PR TITLE
Makefile: Fix `make install` into empty DESTDIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ mantle:
 install:
 	install -d $(DESTDIR)$(PREFIX)/lib/coreos-assembler
 	install -D -t $(DESTDIR)$(PREFIX)/lib/coreos-assembler $$(find src/ -maxdepth 1 -type f)
+	install -d $(DESTDIR)$(PREFIX)/bin
 	ln -sf ../lib/coreos-assembler/coreos-assembler $(DESTDIR)$(PREFIX)/bin/
 	install -D -t $(DESTDIR)$(PREFIX)/bin mantle/bin/{ore,kola}
 	install -d $(DESTDIR)$(PREFIX)/lib/kola/amd64


### PR DESCRIPTION
My `makesudoinstall` script:
https://github.com/cgwalters/homegit/blob/89c3a7e934695ffc8da50ae100b497b1be058b46/dotfiles/bashrc#L17
broke due to the previous change to move the binary into the srcdir.