### PR TITLE
Use `ln -sf` to help in-container upgrades

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ mantle:
 install:
 	install -d $(DESTDIR)$(PREFIX)/lib/coreos-assembler
 	install -D -t $(DESTDIR)$(PREFIX)/lib/coreos-assembler $$(find src/ -maxdepth 1 -type f)
-	ln -s ../lib/coreos-assembler/coreos-assembler $(DESTDIR)$(PREFIX)/bin/
+	ln -sf ../lib/coreos-assembler/coreos-assembler $(DESTDIR)$(PREFIX)/bin/
 	install -D -t $(DESTDIR)$(PREFIX)/bin mantle/bin/{ore,kola}
 	install -d $(DESTDIR)$(PREFIX)/lib/kola/amd64
 	install -D -m 0755 -t $(DESTDIR)$(PREFIX)/lib/kola/amd64 mantle/bin/amd64/kolet


### PR DESCRIPTION
This makes sure `sudo make install` keeps working for folks running from
inside their pet containers.