### PR TITLE
src/cmdlib.sh: Work-around for OpenShift 3.9 not including .git [#320]

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -255,6 +255,36 @@ EOF
     return "$(cat "${workdir}"/tmp/rc)"
 }
 
+openshift_git_hack() {
+    # When OPENSHIFT_GIT_HACK is defined as a build environment variable,
+    # this will fetch the missing .git into the directory where its expected.
+
+    # Some versions of Openshift do not include the GIT repo in the checkout.
+    # This may be needed for Openshift versions 3.9 and earlier.
+    # See https://github.com/coreos/coreos-assembler/issues/320.
+
+    # $OPENSHIFT_GIT_HACK, $GIT_REF and $GIT_URL are environment variables,
+    # provided by Openshift or the container run time. See
+    # https://github.com/coreos/coreos-assembler/pull/324 for an example.
+
+    local gitd=${1}; shift;
+
+    if [ "${OPENSHIFT_GIT_HACK:-x}" == "x" ]; then
+        return
+    fi
+
+    if [ -d "${gitd}/.git" ]; then
+        return
+    fi
+
+    info "NOTICE: using workaround for Openshift missing .git"
+
+    if [ "${GIT_URL:-x}" == "x" ] ||  [ "${GIT_REF:-x}" ]; then
+        info "Checking out bare git of ${GIT_URL} to ${gitd}/.git, ref ${GIT_REF}"
+        git clone --depth 1 --bare -b "${GIT_REF}" "${GIT_URL}" "${gitd}/.git"
+    fi
+}
+
 
 prepare_git_artifacts() {
     # prepare_git_artifacts prepares two artifacts from a GIT repo:
@@ -263,6 +293,8 @@ prepare_git_artifacts() {
     local gitd="${1:?first argument must be the git directory}"; shift;
     local tarball="${1:?second argument me be the tarball name}"; shift;
     local json="${1:?third argument must be the json file name to emit}"; shift;
+
+    openshift_git_hack "${gitd}"
 
     local is_dirty="false"
     local head_ref="unknown"

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -319,17 +319,17 @@ prepare_git_artifacts() {
     if [[ -f "${gitd}"/.git/shallow || "${branch}" == "HEAD" ]]; then
         # When the checkout is shallow or a detached HEAD, assume the origin is the remote
         # shellcheck disable=SC2086
-        head_url="$($gc remote get-url origin || echo unknown)"
+        head_url="$($gc remote get-url origin 2> /dev/null || echo unknown)"
     else
         # Get the ref name, e.g. remote/origin/master
         # shellcheck disable=SC2086
         head_ref="$($gc symbolic-ref -q HEAD)"
         # Find the remote name, e.g. origin.
         # shellcheck disable=SC2086
-        head_remote="$($gc for-each-ref --format='%(upstream:remotename)' ${head_ref} || echo unknown)"
+        head_remote="$($gc for-each-ref --format='%(upstream:remotename)' ${head_ref} 2> /dev/null || echo unknown)"
         # Find the URL for the remote name, eg. https://github.com/coreos/coreos-assembler
         # shellcheck disable=SC2086
-        head_url="$($gc remote get-url ${head_remote} || echo unknown)" # get the URL for the remote
+        head_url="$($gc remote get-url ${head_remote} 2> /dev/null || echo unknown)" # get the URL for the remote
     fi
 
     info "Directory ${gitd}, is from branch ${branch}, commit ${rev}"


### PR DESCRIPTION
This address #320 by allowing for Opendshift s2i builds to work in 3.9. Example:
```
      strategy:                                                                                                                        
        dockerStrategy:                                                                                                                
          env:                                                                                                                         
              - name: GIT_URL                                                                                                          
                value: https://github.com/coreos/coreos-assembler                                                                                          
              - name: GIT_REF                                                                                                          
                value: master
              - name: OPENSHIFT_GIT_HACK                                                                                               
                value: "TRUE"                                                                                                          
          from:                                                                                                                        
            kind: ImageStreamTag                                                                                                       
            name: fedora:29                                                                                                            
```