### PR TITLE
Auto-recreate `cache.qcow2` if deleted

### DIFF
--- a/src/cmd-init
+++ b/src/cmd-init
@@ -193,7 +193,3 @@ mkdir -p cache
 mkdir -p builds
 mkdir -p tmp
 ostree --repo=repo init --mode=archive
-if ! has_privileges && [ ! -f cache/cache.qcow2 ]; then
-    qemu-img create -f qcow2 cache/cache.qcow2 10G
-    LIBGUESTFS_BACKEND=direct virt-format --filesystem=xfs -a cache/cache.qcow2
-fi

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -100,8 +100,11 @@ prepare_build() {
     preflight
     if ! [ -d repo ]; then
         fatal "No $(pwd)/repo found; did you run coreos-assembler init?"
-    elif ! has_privileges && [ ! -f cache/cache.qcow2 ]; then
-        fatal "No cache.qcow2 found; did you run coreos-assembler init?"
+    elif ! has_privileges; then
+        if [ ! -f cache/cache.qcow2 ]; then
+            qemu-img create -f qcow2 cache/cache.qcow2 10G
+            LIBGUESTFS_BACKEND=direct virt-format --filesystem=xfs -a cache/cache.qcow2
+        fi
     fi
 
     workdir="$(pwd)"


### PR DESCRIPTION
Since it's a cache, let's support deleting it.  I killed a build
that was too slow and got a stale lock file in my cache and wanted
to be able to just `rm` it.