### PR TITLE
Find qemu in /usr/libexec or via qemu-system-$(arch)

### DIFF
--- a/src/cmd-run
+++ b/src/cmd-run
@@ -186,7 +186,8 @@ fi
 
 set -- -drive if=virtio"${vm_drive_args:-}",file="${VM_DISK}" "$@"
 
-exec qemu-kvm -name coreos -m "${VM_MEMORY}" -nographic \
+# shellcheck disable=SC2086
+exec ${QEMU_KVM} -name coreos -m "${VM_MEMORY}" -nographic \
               -netdev user,id=eth0,hostname=coreos"${hostfwd:-}" \
               -device virtio-net-pci,netdev=eth0 \
               -object rng-random,filename=/dev/urandom,id=rng0 -device virtio-rng-pci,rng=rng0 \

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -199,6 +199,12 @@ EOF
     fi
 }
 
+if [ -x /usr/libexec/qemu-kvm ]; then
+    QEMU_KVM="/usr/libexec/qemu-kvm"
+else
+    QEMU_KVM="qemu-system-$(arch) -accel kvm"
+fi
+
 runvm() {
     local vmpreparedir=${workdir}/tmp/supermin.prepare
     local vmbuilddir=${workdir}/tmp/supermin.build
@@ -239,7 +245,7 @@ EOF
         srcvirtfs=("-virtfs" "local,id=source,path=${workdir}/src/config,security_model=none,mount_tag=source")
     fi
 
-    qemu-kvm -nodefaults -nographic -m 2048 -no-reboot \
+    ${QEMU_KVM} -nodefaults -nographic -m 2048 -no-reboot \
         -kernel "${vmbuilddir}/kernel" \
         -initrd "${vmbuilddir}/initrd" \
         -netdev user,id=eth0,hostname=supermin \

--- a/src/gf-oemid
+++ b/src/gf-oemid
@@ -44,8 +44,10 @@ while [ $# -gt 0 ]; do
         shift ;;
     esac
 done
-exec qemu-kvm -cpu host,pmu=off "${args[@]}"
 EOF
+# Expand QEMU_KVM
+# shellcheck disable=SC2086 disable=SC2016
+echo "exec ${QEMU_KVM} "'-cpu host,pmu=off "${args[@]}"' >> "${qemu_wrapper}"
 chmod +x "${qemu_wrapper}"
 
 # This qemu wrapper doesn't work for some reason on EL7, so just skip


### PR DESCRIPTION
`qemu-kvm` is going away in Fedora; invoke qemu how libvirt does it.

Similarly on RHEL, it's in `/usr/libexec` as QEMU is an implementation
detail of libvirt (or something), so let's find it there.