### PR TITLE
provide explicit path to ISO for `virt-install`

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -229,6 +229,9 @@ else
     extraargs="${extraargs} --kickstart ${image_input}"
 fi
 
+# forgive me for this sin
+location="${workdir}/installer/$(basename "${INSTALLER}")"
+
 set +x
 # This generates the "base image"; not specific to a platform.
 run_virtinstall() {
@@ -241,7 +244,7 @@ run_virtinstall() {
                                            --kickstart-out "${PWD}"/tmp/flattened.ks \
                                            --ostree-remote="${name}" --ostree-stateroot="${name}" \
                                            --ostree-ref="${ref:-${commit}}" \
-                                           --location "${workdir}"/installer/*.iso \
+                                           --location "${location}" \
                                            --ostree-repo="${workdir}"/repo ${extraargs-} "$@"
     mv "${tmpdest}" "${dest}"
 }

--- a/src/cmd-build
+++ b/src/cmd-build
@@ -230,7 +230,8 @@ else
 fi
 
 # forgive me for this sin
-location="${workdir}/installer/$(basename "${INSTALLER}")"
+iso_location="${workdir}/installer/$(basename "${INSTALLER}")"
+checksum_location="${workdir}/installer/$(basename "${INSTALLER_CHECKSUM}")"
 
 set +x
 # This generates the "base image"; not specific to a platform.
@@ -244,7 +245,7 @@ run_virtinstall() {
                                            --kickstart-out "${PWD}"/tmp/flattened.ks \
                                            --ostree-remote="${name}" --ostree-stateroot="${name}" \
                                            --ostree-ref="${ref:-${commit}}" \
-                                           --location "${location}" \
+                                           --location "${iso_location}" \
                                            --ostree-repo="${workdir}"/repo ${extraargs-} "$@"
     mv "${tmpdest}" "${dest}"
 }
@@ -286,7 +287,7 @@ for itype in "${IMAGE_TYPES[@]}"; do
 done
 
 build_timestamp=$(date -u +$RFC3339)
-vm_iso_checksum=$(awk '/SHA256.*iso/{print$NF}' "${workdir}"/installer/*CHECKSUM)
+vm_iso_checksum=$(awk '/SHA256.*iso/{print$NF}' "${checksum_location}")
 
 src_location="container"
 if [ ! -f /lib/coreos-assembler/.clean ]; then

--- a/src/cmd-init
+++ b/src/cmd-init
@@ -104,37 +104,6 @@ elif [ ! -w . ]; then
     fatal "init: running unprivileged, and current directory not writable"
 fi
 
-# Get target architecture
-arch=$(uname -m)
-release="29"
-
-# Download url is different for primary and secondary fedora
-# Primary Fedora - https://download.fedoraproject.org/pub/fedora/linux/releases/
-# Secondary Fedora - https://download.fedoraproject.org/pub/fedora-secondary/releases/
-declare -A repository_dirs
-repository_dirs[aarch64]=fedora/linux
-repository_dirs[armhfp]=fedora/linux
-repository_dirs[x86_64]=fedora/linux
-repository_dirs[i386]=fedora-secondary
-repository_dirs[ppc64le]=fedora-secondary
-repository_dirs[s390x]=fedora-secondary
-
-repository_dir=${repository_dirs[$arch]}
-INSTALLER=https://download.fedoraproject.org/pub/$repository_dir/releases/$release/Everything/$arch/iso/Fedora-Everything-netinst-$arch-$release-1.2.iso
-INSTALLER_CHECKSUM=https://download.fedoraproject.org/pub/$repository_dir/releases/$release/Everything/$arch/iso/Fedora-Everything-$release-1.2-$arch-CHECKSUM
-
-# Overriding install URL
-if [ -n "${INSTALLER_URL_OVERRIDE-}" ]; then
-    INSTALLER="${INSTALLER_URL_OVERRIDE}"
-    info "Overriding the install URL with contents of INSTALLER_URL_OVERRIDE"
-fi
-# Overriding install checksum URL
-if [ -n "${INSTALLER_CHECKSUM_URL_OVERRIDE-}" ]; then
-    INSTALLER_CHECKSUM="${INSTALLER_CHECKSUM_URL_OVERRIDE}"
-    info "Overriding the install checksum URL with contents of INSTALLER_CHECKSUM_URL_OVERRIDE"
-fi
-
-
 set -x
 # Initialize sources (git)
 mkdir -p src

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -30,6 +30,41 @@ fatal() {
     echo "fatal: $*" 1>&2; exit 1
 }
 
+# Get target architecture
+arch=$(uname -m)
+release="29"
+export arch
+export release
+
+# Download url is different for primary and secondary fedora
+# Primary Fedora - https://download.fedoraproject.org/pub/fedora/linux/releases/
+# Secondary Fedora - https://download.fedoraproject.org/pub/fedora-secondary/releases/
+declare -A repository_dirs
+repository_dirs[aarch64]=fedora/linux
+repository_dirs[armhfp]=fedora/linux
+repository_dirs[x86_64]=fedora/linux
+repository_dirs[i386]=fedora-secondary
+repository_dirs[ppc64le]=fedora-secondary
+repository_dirs[s390x]=fedora-secondary
+
+repository_dir=${repository_dirs[$arch]}
+INSTALLER=https://download.fedoraproject.org/pub/$repository_dir/releases/$release/Everything/$arch/iso/Fedora-Everything-netinst-$arch-$release-1.2.iso
+INSTALLER_CHECKSUM=https://download.fedoraproject.org/pub/$repository_dir/releases/$release/Everything/$arch/iso/Fedora-Everything-$release-1.2-$arch-CHECKSUM
+
+# Overriding install URL
+if [ -n "${INSTALLER_URL_OVERRIDE-}" ]; then
+    INSTALLER="${INSTALLER_URL_OVERRIDE}"
+    info "Overriding the install URL with contents of INSTALLER_URL_OVERRIDE"
+fi
+# Overriding install checksum URL
+if [ -n "${INSTALLER_CHECKSUM_URL_OVERRIDE-}" ]; then
+    INSTALLER_CHECKSUM="${INSTALLER_CHECKSUM_URL_OVERRIDE}"
+    info "Overriding the install checksum URL with contents of INSTALLER_CHECKSUM_URL_OVERRIDE"
+fi
+
+export INSTALLER
+export INSTALLER_CHECKSUM
+
 _privileged=
 has_privileges() {
     if [ -z "${_privileged:-}" ]; then


### PR DESCRIPTION
Previously, `virt-install` was using a `*` wildcard, which would cause a failure if you had more than one ISO in the working directory.

This changes how `virt-install` is called, by providing an explicit path to the install ISO that was used during the `init` phase.

This was accomplished by moving some of the ISO logic into `cmdlib.sh` and exporting additional env vars to the rest of the tooling that way.
