### PR TITLE
Estimate commit size for bare metal

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -240,6 +240,7 @@ run_virtinstall() {
     # We want extraargs var to be split on words
     # shellcheck disable=SC2086
     /usr/lib/coreos-assembler/virt-install --create-disk --dest=${tmpdest} \
+                                           --tmpdir "${PWD}/tmp" \
                                            --kickstart-out "${PWD}"/tmp/flattened.ks \
                                            --ostree-remote="${name}" --ostree-stateroot="${name}" \
                                            --ostree-ref="${ref:-${commit}}" \

--- a/src/estimate-commit-disk-size
+++ b/src/estimate-commit-disk-size
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+#
+# Given an OSTree commit, estimate how much disk space it will take
+# Derived from ostree-releng-scripts/print-commitsize
+#
+# Copyright 2018 Red Hat, Inc
+# Licensed under the new-BSD license (http://www.opensource.org/licenses/bsd-license.php)
+
+import argparse,json
+import gi
+gi.require_version('OSTree', '1.0')
+import sys,os
+from gi.repository import GLib, Gio, OSTree
+
+parser = argparse.ArgumentParser()
+# Current XFS defaults as of RHEL8.0
+parser.add_argument("--isize", type=int, default=512)
+parser.add_argument("--blksize", type=int, default=4096)
+# This is fairly arbitrary
+parser.add_argument("--metadata-overhead-percent", type=int, default=5)
+# This is an arbitrary number of course.  We need enough to not trip e.g. ostree's min-free-space-percent
+# checks etc.
+parser.add_argument("--add-percent", help="Additional space (integer percentage) to reserve", type=int, default=15)
+parser.add_argument("--repo", help="Repository", required=True)
+parser.add_argument("ref", help="Ref")
+args = parser.parse_args()
+
+r = OSTree.Repo.new(Gio.File.new_for_path(args.repo))
+r.open(None)
+
+[_,rev] = r.resolve_rev(args.ref, False)
+
+[_,reachable] = r.traverse_commit(rev, 0, None)
+n_meta = 0
+blks_meta = 0
+n_regfiles = 0
+blks_regfiles = 0
+n_symlinks = 0
+blks_symlinks = 0
+for k,v in reachable.iteritems():
+    csum,objtype = k.unpack()
+    if objtype == OSTree.ObjectType.FILE:
+        [_,_,finfo,_] = r.load_file(csum, None)
+        if finfo.get_file_type() == Gio.FileType.REGULAR:
+            n_regfiles += 1
+            sz = finfo.get_size()
+            blks_regfiles += (sz // args.blksize) + 1
+        else:
+            n_symlinks += 1
+            sz = len(finfo.get_symlink_target())
+            blks_symlinks += (sz // args.blksize) + 1
+    else:
+        [_,sz] = r.query_object_storage_size(objtype, csum, None)
+        n_meta += 1
+        blks_meta += (sz // args.blksize) + 1
+
+blks_per_mb = (1024*1024) // args.blksize
+total_data_mb = (blks_meta + blks_regfiles + blks_symlinks) // blks_per_mb
+add_percent = args.metadata_overhead_percent + args.add_percent
+add_percent_modifier = (100.0+add_percent)/100.0
+estimate_mb = int(total_data_mb * add_percent_modifier) + 1
+res = {
+    'meta': {'count': n_meta,
+             'blocks': blks_meta,},
+    'regfiles': {'count': n_regfiles,
+                 'blocks': blks_regfiles,},
+    'symlinks': {'count': n_symlinks,
+                 'blocks': blks_symlinks,},
+    'estimate-mb': {'base': total_data_mb,
+                    'final': estimate_mb },
+}
+json.dump(res, sys.stdout, indent=4)

--- a/src/image-base.ks
+++ b/src/image-base.ks
@@ -25,8 +25,13 @@ clearpart --initlabel --all --disklabel=gpt
 # You can change this partition layout, but note that the `boot` and `root`
 # filesystem labels are currently mandatory (they're interpreted by coreos-assembler).
 reqpart --add-boot
-# Note no reflinks for /boot since the bootloader may not understand them
-part / --size=3000 --fstype="xfs" --label=root --grow --mkfsoptions="-m reflink=1"
+# Explicitly enable reflinks since at least as of Fedora 29 it wasn't enabled by default
+# The 1000 here doesn't matter too much, the disk size is either defined by
+# image.yaml, or for bare metal the size is calculated to fit in virt-install.
+# Either way we use --grow to expand to the outer size.  And then when the system
+# boots for real, the coreos-growpart.service will run to fit the provisioned space
+# (e.g. in AWS the root volume size, on bare metal the size of the physical disk, etc.)
+part / --size=1000 --fstype="xfs" --label=root --grow --mkfsoptions="-m reflink=1"
 
 reboot
 

--- a/src/virt-install
+++ b/src/virt-install
@@ -9,7 +9,10 @@
 # one or both.
 
 import os,sys,argparse,subprocess,io,time,re,multiprocessing
-import tempfile,shutil,yaml,platform
+import tempfile,shutil,yaml,platform,json
+
+# Soon we should create the filesystem outside of anaconda
+ANACONDA_BOOT_SIZE_MB = 1024
 
 def fatal(msg):
     print('error: {}'.format(msg), file=sys.stderr)
@@ -17,6 +20,8 @@ def fatal(msg):
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--dest", help="Destination disk",
+                    action='store', required=True)
+parser.add_argument("--tmpdir", help="Temporary directory",
                     action='store', required=True)
 parser.add_argument("--create-disk", help="Automatically create disk as qcow2, parsing kickstart for size",
                     action='store_true')
@@ -168,10 +173,22 @@ ostree refs --delete {args.ostree_remote}:{args.ostree_ref}
 if args.create_disk:
     if args.variant in ('metal', 'metal-uefi'):
         fmt = 'raw'
+        size_estimate_path = os.path.join(args.tmpdir, 'ostree-size.json')
+        # The OSTree size is shared among disk images, so we compute it once per build
+        if not os.path.exists(size_estimate_path):
+            subprocess.check_call(['/usr/lib/coreos-assembler/estimate-commit-disk-size',
+                                   f"--repo={args.ostree_repo}", args.ostree_ref],
+                                  stdout=open(size_estimate_path, 'w'))
+        with open(size_estimate_path) as f:
+            size_estimate = json.load(f)
+        print(f"OSTree commit size:\n{size_estimate}")
+        final_size_mb = size_estimate['estimate-mb']['final'] + ANACONDA_BOOT_SIZE_MB
+        size = f"{final_size_mb}M"
     else:
         fmt = 'qcow2'
-    run_sync_verbose(['qemu-img', 'create', '-f', fmt, args.dest, '{}G'.format(disk_size)])
-    print("Created initial disk: {} with size {}G".format(args.dest, disk_size))
+        size = f'{disk_size}G'
+    run_sync_verbose(['qemu-img', 'create', '-f', fmt, args.dest, size])
+    print(f"Created initial disk: {args.dest} with size {size}")
 
 # Now a hack to avoid libvirt race conditions; it's
 # activated by the cmdline (and exits after 30s), and in virt-install the daemon


### PR DESCRIPTION
We don't need to use a full 8GB raw for bare metal; we can shrink
it to fit the space, assuming it will expand to the real physical
disk size.