### PR TITLE
Ensure git submodules work with Openshift [#340]

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -84,13 +84,6 @@ install_rpms() {
 }
 
 _prep_make_and_make_install() {
-    # Work around https://github.com/coreos/coreos-assembler/issues/27
-    if ! test -d .git; then
-        (git config --global user.email dummy@example.com
-         git init && git add . && git commit -a -m 'dummy commit'
-         git tag -m tag dummy-tag) >/dev/null
-    fi
-
     # TODO: install these as e.g.
     # /usr/bin/ostree-releng-script-rsync-repos
     mkdir -p /usr/app/

--- a/build.sh
+++ b/build.sh
@@ -96,7 +96,7 @@ _prep_make_and_make_install() {
     mkdir -p /usr/app/
     rsync -rlv "${srcdir}"/ostree-releng-scripts/ /usr/app/ostree-releng-scripts/
 
-    if ! test -f mantle/README.md; then
+    if [ "$(git submodule status mantle | head -c1)" == "-" ]; then
         echo -e "\033[1merror: submodules not initialized. Run: git submodule update --init\033[0m" 1>&2
         exit 1
     fi


### PR DESCRIPTION
Some versions of Openshift [1] do not include `.git` when building Docker containers [2]. In [3], we discovered that Git submodules are also affected. Further, since `mantle` run `git describe --dirty`, check on its source is insufficient. 

This is a follow-on PR to #320 that resolves #340. 