### PR TITLE
README: Use `cosa` in examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ install:
 	install -D -t $(DESTDIR)$(PREFIX)/lib/coreos-assembler $$(find src/ -maxdepth 1 -type f)
 	install -d $(DESTDIR)$(PREFIX)/bin
 	ln -sf ../lib/coreos-assembler/coreos-assembler $(DESTDIR)$(PREFIX)/bin/
+	ln -sf ../lib/coreos-assembler/cosa $(DESTDIR)$(PREFIX)/bin/
 	install -D -t $(DESTDIR)$(PREFIX)/bin mantle/bin/{ore,kola}
 	install -d $(DESTDIR)$(PREFIX)/lib/kola/amd64
 	install -D -m 0755 -t $(DESTDIR)$(PREFIX)/lib/kola/amd64 mantle/bin/amd64/kolet


### PR DESCRIPTION
This allows for us to save some keystrokes. Also added
cosa -> coreos-assembler symlink to make it support
the "running inside the container" use case as well.

Fixes #291