### PR TITLE
EL7 compatibility fixes

### DIFF
--- a/src/cmd-oscontainer
+++ b/src/cmd-oscontainer
@@ -42,7 +42,7 @@ def oscontainer_extract(containers_storage, src, dest,
     if commit is None:
         raise SystemExit("Failed to find label '{}'".format(OSCONTAINER_COMMIT_LABEL))
     iid = inspect['Id']
-    print(f"Preparing to extract cid: {iid}")
+    print("Preparing to extract cid: {}".format(iid))
     # We're not actually going to run the container. The main thing `create` does
     # then for us is "materialize" the merged rootfs, so we can mount it.
     # In theory we shouldn't need --entrypoint=/enoent here, but

--- a/src/deps.txt
+++ b/src/deps.txt
@@ -25,7 +25,9 @@ selinux-policy-targeted rpm-build
 make git rpm-build
 
 # virt-install dependencies
-libvirt libguestfs-tools qemu-kvm /usr/bin/qemu-img /usr/bin/virsh /usr/bin/virt-install
+libvirt libguestfs-tools /usr/bin/qemu-img /usr/bin/virsh /usr/bin/virt-install
+#FEDORA qemu-kvm
+#EL7 qemu-kvm-rhev
 
 # And we process kickstarts
 /usr/bin/ksflatten

--- a/src/deps.txt
+++ b/src/deps.txt
@@ -14,7 +14,9 @@ rpm-ostree createrepo_c openssh-clients
 #EL7 yum-utils
 
 # For generating ISO images
-genisoimage syslinux-nonlinux
+genisoimage
+#FEDORA syslinux-nonlinux
+#EL7 syslinux
 
 # We expect people to use these explicitly in their repo configurations.
 #FEDORA distribution-gpg-keys


### PR DESCRIPTION
Against my better judgement, I've been trying to get the EL7 build of the `cosa` image to be usable.  This may not be all the required changes, but it got me to a point where I could build the image and then run `fetch/build/run/shell/compress` successfully.

The last papercut noted [here](https://github.com/coreos/coreos-assembler/pull/329#issuecomment-461610378) was solved by @cgwalters suggestion to use `qemu-kvm-rhev`.  (On that note, #329 is required for these fixes to be useful)

I also had to tweak the `deps.txt` to get `syslinux` successfully installed (although, I did not test generating an ISO)

Finally, the `cmd-oscontainer` script needed a small change to use `.format()` instead of f-strings.

Depends: #329