### PR TITLE
add depcheck() to verify RPMs installed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM registry.fedoraproject.org/fedora:29
 WORKDIR /root/containerbuild
 
 # Only need a few of our scripts for the first few steps
-COPY ./build.sh ./deps.txt ./vmdeps.txt ./build-deps.txt /root/containerbuild/
+COPY ./src/cmdlib.sh ./build.sh ./deps.txt ./vmdeps.txt ./build-deps.txt /root/containerbuild/
 RUN ./build.sh configure_yum_repos
 RUN ./build.sh install_rpms
 

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -2,7 +2,7 @@ FROM registry.redhat.io/rhel7:latest
 WORKDIR /root/containerbuild
 
 # Only need a few of our scripts for the first few steps
-COPY ./build.sh ./deps.txt ./vmdeps.txt ./build-deps.txt /root/containerbuild/
+COPY ./src/cmdlib.sh ./build.sh ./deps.txt ./vmdeps.txt ./build-deps.txt /root/containerbuild/
 COPY ./maipo/maipo.repo /etc/yum.repos.d/
 RUN ./build.sh configure_yum_repos
 # ostree-packages are on another line because all repos get configured to exclude

--- a/build.sh
+++ b/build.sh
@@ -73,6 +73,10 @@ install_rpms() {
 
     # Further cleanup
     yum clean all
+
+    # shellcheck source=src/cmdlib.sh
+    . "${srcdir}/cmdlib.sh"
+    depcheck "${deps}"
 }
 
 _prep_make_and_make_install() {
@@ -126,7 +130,7 @@ configure_user(){
 
 write_archive_info() {
     # shellcheck source=src/cmdlib.sh
-    . "${srcdir}/src/cmdlib.sh"
+    . "${srcdir}/cmdlib.sh"
     mkdir -p /cosa /lib/coreos-assembler
     touch -f /lib/coreos-assembler/.clean
     prepare_git_artifacts /root/containerbuild /cosa/coreos-assembler-git.tar.gz /cosa/coreos-assembler-git.json


### PR DESCRIPTION
(Updated description Feb 13)

When testing builds of the container image using different distros
(Fedora/EL7), it is possible for the image build to complete
successfully, only to find out that the `preflight()` check in
`src/cmdlib.sh` bails out because an RPM was not installed.
    
This change introduces `depcheck()` as a way to verify that the
requested RPMs were installed.  The new function is used in the
`build.sh` script and as part of `preflight()` in `src/cmdlib.sh`.
