### PR TITLE
src/cmd-build: Add `ostree` target

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -8,17 +8,20 @@ dn=$(dirname "$0")
 print_help() {
     cat 1>&2 <<'EOF'
 Usage: coreos-assembler build --help
-       coreos-assembler build [--force] [--skip-prune] [IMAGETYPES]
+       coreos-assembler build [--force] [--skip-prune] [TARGETS]
 
   Build OSTree and image artifacts from previously fetched packages.
-  The IMAGETYPES argument is a list of image types; if unspecified it defaults
-  to "qemu".
+  The TARGETS argument is a list of artifact types to build; if unspecified it
+  defaults to "qemu".
 
-  Valid image types:
+  Valid targets:
 
+    - ostree
     - qemu
     - metal-bios
     - metal-uefi
+
+  Note that all image targets also require the "ostree" target.
 EOF
 }
 
@@ -59,16 +62,21 @@ while true; do
     shift
 done
 
+if [ $# -eq 0 ]; then
+    set -- qemu
+fi
+
 declare -a IMAGE_TYPES
 IMAGE_TYPES=()
 # shellcheck disable=SC2068
-for itype in $@; do
-    IMAGE_TYPES+=("$itype")
+for target in $@; do
+    if [[ $target != ostree ]]; then
+        IMAGE_TYPES+=("$target")
+    fi
 done
-if [ "${#IMAGE_TYPES[@]}" == 0 ]; then
-    IMAGE_TYPES=(qemu)
+if [ "${#IMAGE_TYPES[@]}" != 0 ]; then
+    echo "Image types: ${IMAGE_TYPES[*]}"
 fi
-echo "Image types: ${IMAGE_TYPES[*]}"
 
 export LIBGUESTFS_BACKEND=direct
 


### PR DESCRIPTION
I'm often just iterating on the OSTree content itself and don't require
new images. In such cases, it's a waste of time to wait for images to be
generated when all I want is the treecompose. But using
`coreos-assembler build` is still more convenient than dropping down to
`rpm-ostree compose tree`, especially with the virtualization wrapper.

Add a new `--ostree-only` option in which we only generate a commit to
the OSTree repo. This is a natural extension of #302. Crucially though,
we still create a build directory under `builds/` with metadata about
the built commit. The only practical difference is that there are no
image files and no subkeys under `images` in `meta.json`.

(I didn't bother breaking the idempotency coupling here wrt the
kickstart since (1) it's going away, and (2) this is really just for the
local dev case where you're iterating on the tools, like rpm-ostree, or
the content, like the treefile.)