### PR TITLE
libguestfish: Mount /boot/efi if present

### DIFF
--- a/src/libguestfish.sh
+++ b/src/libguestfish.sh
@@ -56,6 +56,12 @@ coreos_gf_run_mount() {
     boot=$(coreos_gf findfs-label boot)
     coreos_gf mount "${boot}" /boot
     var=$(coreos_gf -findfs-label var 2>/dev/null || true)
+    # As far as I can tell libguestfs doesn't have a "find partition by GPT type" API,
+    # let's hack this and assume it's the first if present.
+    EFI_SYSTEM_PARTITION_GUID="C12A7328-F81F-11D2-BA4B-00A0C93EC93B"
+    if [ "$(coreos_gf part-get-gpt-type /dev/sda 1)" = "${EFI_SYSTEM_PARTITION_GUID}" ]; then
+        coreos_gf mount /dev/sda1 /boot/efi
+    fi
 
     # Export these variables for further use
     stateroot=/ostree/deploy/$(coreos_gf ls /ostree/deploy)


### PR DESCRIPTION
This is prep for making `gf-oemid` work on UEFI, which we need
for e.g. aarch64.