### PR TITLE
qemu-kvm is not available in other arches

### DIFF
--- a/src/cmd-run
+++ b/src/cmd-run
@@ -186,6 +186,7 @@ fi
 
 set -- -drive if=virtio"${vm_drive_args:-}",file="${VM_DISK}" "$@"
 
+# There is no BIOS on aarch64, so we need a firmware to boot the system
 if [ "$(arch)" == "aarch64" ]; then
     set -- -bios /usr/share/AAVMF/AAVMF_CODE.fd "$@"
 fi

--- a/src/cmd-run
+++ b/src/cmd-run
@@ -186,6 +186,10 @@ fi
 
 set -- -drive if=virtio"${vm_drive_args:-}",file="${VM_DISK}" "$@"
 
+if [ "$(arch)" == "aarch64" ]; then
+    set -- -bios /usr/share/AAVMF/AAVMF_CODE.fd "$@"
+fi
+
 # shellcheck disable=SC2086
 exec ${QEMU_KVM} -name coreos -m "${VM_MEMORY}" -nographic \
               -netdev user,id=eth0,hostname=coreos"${hostfwd:-}" \

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -250,7 +250,13 @@ EOF
 if [ -x /usr/libexec/qemu-kvm ]; then
     QEMU_KVM="/usr/libexec/qemu-kvm"
 else
-    QEMU_KVM="qemu-system-$(arch) -accel kvm"
+    # Enable arch-specific options for qemu
+    case "$(arch)" in
+        "x86_64")  QEMU_KVM="qemu-system-$(arch) -accel kvm"         ;;
+        "aarch64") QEMU_KVM="qemu-system-$(arch) -accel kvm -M virt" ;;
+        "ppc64le") QEMU_KVM="qemu-system-ppc64 -accel kvm"           ;;
+        *)         fatal "Architecture $(arch) not supported"
+    esac
 fi
 
 runvm() {
@@ -293,7 +299,7 @@ EOF
         srcvirtfs=("-virtfs" "local,id=source,path=${workdir}/src/config,security_model=none,mount_tag=source")
     fi
 
-    ${QEMU_KVM} -nodefaults -nographic -m 2048 -no-reboot \
+    ${QEMU_KVM} -nodefaults -nographic -m 2048 -no-reboot -cpu host \
         -kernel "${vmbuilddir}/kernel" \
         -initrd "${vmbuilddir}/initrd" \
         -netdev user,id=eth0,hostname=supermin \

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -299,12 +299,18 @@ EOF
         srcvirtfs=("-virtfs" "local,id=source,path=${workdir}/src/config,security_model=none,mount_tag=source")
     fi
 
+    # 'pci' bus doesn't work on aarch64
+    pcibus=pci.0
+    if [ "$(arch)" = "aarch64" ]; then
+        pcibus=pcie.0
+    fi
+
     ${QEMU_KVM} -nodefaults -nographic -m 2048 -no-reboot -cpu host \
         -kernel "${vmbuilddir}/kernel" \
         -initrd "${vmbuilddir}/initrd" \
         -netdev user,id=eth0,hostname=supermin \
         -device virtio-net-pci,netdev=eth0 \
-        -device virtio-scsi-pci,id=scsi0,bus=pci.0,addr=0x3 \
+        -device virtio-scsi-pci,id=scsi0,bus=${pcibus},addr=0x3 \
         -drive if=none,id=drive-scsi0-0-0-0,snapshot=on,file="${vmbuilddir}/root" \
         -device scsi-hd,bus=scsi0.0,channel=0,scsi-id=0,lun=0,drive=drive-scsi0-0-0-0,id=scsi0-0-0-0,bootindex=1 \
         -drive if=none,id=drive-scsi0-0-0-1,discard=unmap,file="${workdir}/cache/cache.qcow2" \

--- a/src/gf-oemid
+++ b/src/gf-oemid
@@ -71,7 +71,11 @@ coreos_gf_run_mount "${tmp_dest}"
 # * grub config
 # * BLS config (for subsequent config regeneration)
 # First, the grub config.
-grubcfg_path=/boot/loader/grub.cfg
+if coreos_gf exists "/boot/efi"; then
+    grubcfg_path=/boot/efi/EFI/fedora/grub.cfg
+else
+    grubcfg_path=/boot/loader/grub.cfg
+fi
 coreos_gf download "${grubcfg_path}" "${tmpd}"/grub.cfg
 # Remove any oemid currently there
 sed -i -e 's, coreos.oem.id=[a-zA-Z0-9]*,,g' "${tmpd}"/grub.cfg

--- a/src/gf-oemid
+++ b/src/gf-oemid
@@ -47,7 +47,12 @@ done
 EOF
 # Expand QEMU_KVM
 # shellcheck disable=SC2086 disable=SC2016
-echo "exec ${QEMU_KVM} "'-cpu host,pmu=off "${args[@]}"' >> "${qemu_wrapper}"
+# Only x86_64 supports pmu=off option
+if [ "$(arch)" == "x86_64" ]; then
+    echo "exec ${QEMU_KVM} "'-cpu host,pmu=off "${args[@]}"' >> "${qemu_wrapper}"
+else
+    echo "exec ${QEMU_KVM} "'-cpu host "${args[@]}"' >> "${qemu_wrapper}"
+fi
 chmod +x "${qemu_wrapper}"
 
 # This qemu wrapper doesn't work for some reason on EL7, so just skip


### PR DESCRIPTION
Also when using qemu make sure to account for arch-specific options.

WIP because it's more for awareness of the changes needed so far. I can build a FCOS image but when running it I'm not dropped into a console.
