### PR TITLE
build: fix sourcing of cmdlib.sh in write_archive_info

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -130,7 +130,7 @@ configure_user(){
 
 write_archive_info() {
     # shellcheck source=src/cmdlib.sh
-    . "${srcdir}/cmdlib.sh"
+    . "${srcdir}/src/cmdlib.sh"
     mkdir -p /cosa /lib/coreos-assembler
     touch -f /lib/coreos-assembler/.clean
     prepare_git_artifacts /root/containerbuild /cosa/coreos-assembler-git.tar.gz /cosa/coreos-assembler-git.json


### PR DESCRIPTION
This fixes a regression in 1e2db9443e064573efb7902204081e629156e4d2