### PR TITLE
Pass `-E` to sudo, add RPMOSTREE_EXTRA_ARGS

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -231,15 +231,16 @@ EOF
 
     rm -f "${changed_stamp}"
 
+    # shellcheck disable=SC2086
     set - rpm-ostree compose tree --repo="${workdir}"/repo \
             --cachedir="${workdir}"/cache --touch-if-changed "${changed_stamp}" \
-            --unified-core "${manifest}" "$@"
+            --unified-core "${manifest}" ${RPMOSTREE_EXTRA_ARGS:-} "$@"
 
     echo "Running: $*"
 
     # this is the heart of the privs vs no privs dual path
     if has_privileges; then
-        sudo "$@"
+        sudo -E "$@"
         sudo chown -R -h "${USER}":"${USER}" "${workdir}"/repo
     else
         runvm "$@"


### PR DESCRIPTION
I want to be able to pass e.g. `RPMOSTREE_PRESERVE_TMPDIR`,
and also additional arguments when debugging/hacking on rpm-ostree.