### PR TITLE
gf-oemid: fix logic for `coreos_gf exists`

### DIFF
--- a/src/gf-oemid
+++ b/src/gf-oemid
@@ -71,7 +71,7 @@ coreos_gf_run_mount "${tmp_dest}"
 # * grub config
 # * BLS config (for subsequent config regeneration)
 # First, the grub config.
-if coreos_gf exists "/boot/efi"; then
+if [ "$(coreos_gf exists '/boot/efi')" == 'true' ]; then
     grubcfg_path=/boot/efi/EFI/fedora/grub.cfg
 else
     grubcfg_path=/boot/loader/grub.cfg


### PR DESCRIPTION
The command returns the string `true` or `false`.
The exit code is successful if it was able to determine
the existance of the file, not if the file exists or not.

i.e. rc=0 + value == 'false' is valid.