### PR TITLE
src/cmd-oscontainer: quiet the output from wrapper script

### DIFF
--- a/src/cmd-oscontainer
+++ b/src/cmd-oscontainer
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -xeou pipefail
+set -eou pipefail
 
 dn=$(dirname "$0")
 # shellcheck source=src/cmdlib.sh
@@ -21,5 +21,6 @@ fi
 if has_privileges; then
     "$@"
 else
+    info "Required privileges not detected; running via supermin appliance"
     runvm "${osc}" --workdir /host/container-work "$@"
 fi


### PR DESCRIPTION
The wrapper script was using `set -x`, making the output very chatty.
Just print an `info` message about the unprivileged case.