### PR TITLE
image-cloud.ks: Use DHCP_CLIENT_ID=mac

### DIFF
--- a/src/image-cloud.ks
+++ b/src/image-cloud.ks
@@ -9,6 +9,9 @@ bootloader --timeout=1 --append="no_timer_check console=ttyS0,115200n8 console=t
 %post --erroronfail
 # By default, we do DHCP.  Also, due to the above disabling
 # of biosdevname/net.ifnames, this uses eth0.
+# The DHCP_CLIENT_ID="mac" bit is so that we match what dhclient
+# does in the initrd, and the DHCP server gives us the same lease
+# if possible. See https://github.com/coreos/fedora-coreos-config/issues/58.
 cat <<EOF > /etc/sysconfig/network-scripts/ifcfg-eth0
 DEVICE="eth0"
 BOOTPROTO="dhcp"
@@ -16,5 +19,6 @@ ONBOOT="yes"
 TYPE="Ethernet"
 PERSISTENT_DHCLIENT="yes"
 NM_CONTROLLED="yes"
+DHCP_CLIENT_ID="mac"
 EOF
 %end


### PR DESCRIPTION
Right now in FCOS, VMs are getting *two* IP addresses when testing
locally in libvirt. The root of the issue is that the first request in
the initrd is using a different client ID than the one from NM in the
real root. This throws off at least dnsmasq, which then refuses to give
out the same IP again. Tell NM to also use the MAC address as the client
ID, to match what `dhclient` also does in the initrd.

For more background information, see:
https://github.com/coreos/fedora-coreos-config/issues/58

Closes: coreos/fedora-coreos-config#58