### PR TITLE
src/cmdlib.sh: improve virt runtime environments

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -285,6 +285,14 @@ runvm() {
 set -xeuo pipefail
 export PATH=/usr/sbin:$PATH
 workdir=${workdir}
+
+# use the builder user's id, otherwise some operations like
+# chmod will set ownership to root, not builder
+export USER=$(id -u)
+
+# ensure the user of files created do not have root ownership
+trap 'chown -h -R ${USER}:${USER} ${workdir}' EXIT
+
 $(cat "${DIR}"/supermin-init-prelude.sh)
 rc=0
 sh ${TMPDIR}/cmd.sh || rc=\$?

--- a/src/supermin-init-prelude.sh
+++ b/src/supermin-init-prelude.sh
@@ -15,6 +15,9 @@ LANG=C /sbin/load_policy  -i
 # set up networking
 /usr/sbin/dhclient eth0
 
+# set the umask so that anyone in the group can rwx
+umask 002
+
 # set up workdir
 mkdir -p "${workdir:?}"
 mount -t 9p -o rw,trans=virtio,version=9p2000.L workdir "${workdir}"
@@ -24,6 +27,10 @@ if [ -L "${workdir}"/src/config ]; then
 fi
 mkdir -p "${workdir}"/cache /host/container-work
 mount /dev/sdb1 "${workdir}"/cache
+
+if [ -f "${workdir}/tmp/supermin/supermin.env" ]; then
+    source "${workdir}/tmp/supermin/supermin.env";
+fi
 
 # /usr/sbin/ip{,6}tables is installed as a symlink to /etc/alternatives/ip{,6}tables but
 # the /etc/alternatives symlink to /usr/sbin/ip{,6}tables-legacy is missing.  This recreates

--- a/src/virt-install
+++ b/src/virt-install
@@ -31,7 +31,8 @@ parser.add_argument("--kickstart-out", help="Save flattened kickstart",
 parser.add_argument("--location", help="Installer location",
                     action='store', required=True)
 parser.add_argument("--memory", help="Memory size in MB",
-                    action='store', type=int, default=2048)
+                    action='store', type=int,
+                    default=os.environ.get("VIRT_INSTALL_MEMORY", 2048))
 parser.add_argument("--console-log-file", help="Console log file",
                     action='store')
 parser.add_argument("--logs", help="Copy Anaconda logs to DIR",
@@ -46,7 +47,8 @@ parser.add_argument("--ostree-ref", help="OSTree ref",
 parser.add_argument("--ostree-remote", help="OSTree remote",
                     action='store')
 parser.add_argument("--wait", help="Number of minutes to wait",
-                    action='store', type=int, default=10)
+                    action='store', type=int,
+                    default=os.environ.get("VIRT_INSTALL_WAIT", 10))
 args = parser.parse_args()
 
 # Copy of bits from https://pagure.io/standard-test-roles/pull-request/223


### PR DESCRIPTION
In some cases configuration files outside the supermin appliance are  needed inside. For example, `cmd/oscontainer` might need registry  credentials to push the container. RUNVM_CONFIG_FILES will take a string of NAME=FILE, where NAME will be an environment variable and FILE will point to the inside location.

Finally, this mock `sudo` to a function in the supermin appliance. Since the VM is running as root, the extra calls to `sudo` are superfluous.