### PR TITLE
build: Don't inject internal KS in legacy mode

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -262,7 +262,12 @@ build_cloud_base() {
     if [ -f "${PWD}/${img_base}" ]; then
         return
     fi
-    run_virtinstall "${PWD}"/"${img_base}" --variant=cloud
+    local args=""
+    if ${image_config}; then
+        args="$args --variant=cloud"
+    fi
+    # shellcheck disable=SC2046 disable=SC2086
+    run_virtinstall "${PWD}"/"${img_base}" $args
 }
 
 declare -A images

--- a/src/virt-install
+++ b/src/virt-install
@@ -91,6 +91,7 @@ else:
 disk_size = None
 
 if args.variant is not None:
+    assert args.kickstart is None
     if args.variant == 'metal-uefi':
         variant_ks = 'metal'
     else:


### PR DESCRIPTION
We were still passing `--variant` even in "legacy mode" when an
external `.ks` was provided.  This injected our internal kickstarts
and could break things.