### PR TITLE
 Support not specifying a ref in manifest

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -363,7 +363,9 @@ cat "${composejson}" tmp/meta.json tmp/images.json tmp/cosa-image.json "${commit
 "${dn}"/commitmeta_to_json "${workdir}/repo" "${commit}" > commitmeta.json
 
 # Clean up our temporary data
-rm tmp -rf
+saved_build_tmpdir="${workdir}/tmp/last-build-tmp"
+rm -rf "${saved_build_tmpdir}"
+mv -T tmp "${saved_build_tmpdir}"
 # Back to the toplevel build directory, so we can rename this one
 cd "${workdir}"/builds
 # We create a .build-commit file to note that we're in the

--- a/src/cmd-build
+++ b/src/cmd-build
@@ -237,6 +237,10 @@ else
     extraargs="${extraargs} --kickstart ${image_input}"
 fi
 
+if [ -n "${ref_is_temp}" ]; then
+    extraargs="${extraargs} --delete-ostree-ref"
+fi
+
 # forgive me for this sin
 iso_location="${workdir}/installer/$(basename "${INSTALLER}")"
 checksum_location="${workdir}/installer/$(basename "${INSTALLER_CHECKSUM}")"

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -172,8 +172,12 @@ prepare_build() {
     # Also grab rojig summary for image upload descriptions
     name=$(jq -r '.rojig.name' < "${manifest_tmp_json}")
     summary=$(jq -r '.rojig.summary' < "${manifest_tmp_json}")
-    # TODO - allow this to be unset
     ref=$(jq -r '.ref' < "${manifest_tmp_json}")
+    ref_is_temp=""
+    if [ "${ref}" = "null" ]; then
+        ref="tmpref-${name}"
+        ref_is_temp=1
+    fi
     export name ref summary
     rm -f "${manifest_tmp_json}"
 
@@ -206,27 +210,36 @@ runcompose() {
     # Implement support for automatic local overrides:
     # https://github.com/coreos/coreos-assembler/issues/118
     local overridesdir=${workdir}/overrides
-    if [ -d "${overridesdir}"/rpm ]; then
-        (cd "${overridesdir}"/rpm && createrepo_c .)
-        echo "Using RPM overrides from: ${overridesdir}/rpm"
-        local tmp_overridesdir=${TMPDIR}/override
+    local tmp_overridesdir=${TMPDIR}/override
+    local override_manifest="${tmp_overridesdir}"/coreos-assembler-override-manifest.yaml
+    if [ -d "${overridesdir}"/rpm ] || [ -n "${ref_is_temp}" ]; then
         mkdir "${tmp_overridesdir}"
-        cat > "${tmp_overridesdir}"/coreos-assembler-override-manifest.yaml <<EOF
+        cat > "${override_manifest}" <<EOF
 include: ${workdir}/src/config/manifest.yaml
-repos:
-  - coreos-assembler-local-overrides
 EOF
         # Because right now rpm-ostree doesn't look for .repo files in
         # each included dir.
         # https://github.com/projectatomic/rpm-ostree/issues/1628
         cp "${workdir}"/src/config/*.repo "${tmp_overridesdir}"/
+        manifest=${override_manifest}
+    fi
+    if [ -n "${ref_is_temp}" ]; then
+        echo 'ref: "'"${ref}"'"' >> "${override_manifest}"
+    fi
+    if [ -d "${overridesdir}"/rpm ]; then
+        (cd "${overridesdir}"/rpm && createrepo_c .)
+        echo "Using RPM overrides from: ${overridesdir}/rpm"
+        local tmp_overridesdir=${TMPDIR}/override
+        cat >> "${override_manifest}" <<EOF
+repos:
+  - coreos-assembler-local-overrides
+EOF
         cat > "${tmp_overridesdir}"/coreos-assembler-local-overrides.repo <<EOF
 [coreos-assembler-local-overrides]
 name=coreos-assembler-local-overrides
 baseurl=file://${workdir}/overrides/rpm
 gpgcheck=0
 EOF
-        manifest=${tmp_overridesdir}/coreos-assembler-override-manifest.yaml
     fi
 
     rm -f "${changed_stamp}"

--- a/src/virt-install
+++ b/src/virt-install
@@ -44,6 +44,8 @@ parser.add_argument("--ostree-stateroot", help="OSTree stateroot",
                     action='store')
 parser.add_argument("--ostree-ref", help="OSTree ref",
                     action='store')
+parser.add_argument("--delete-ostree-ref", help="Delete the OSTree ref after installation",
+                    action='store_true')
 parser.add_argument("--ostree-remote", help="OSTree remote",
                     action='store')
 parser.add_argument("--wait", help="Number of minutes to wait",
@@ -151,7 +153,15 @@ systemctl daemon-reload
 systemctl start coreos-virtinstall-logs
 %end
     """)
-ks_tmp.flush()
+
+# Support using commits only
+if args.delete_ostree_ref:
+    print("virt-install: Will remove ostree ref")
+    ks_tmp.write(f"""
+%post --erroronfail
+ostree refs --delete ${args.ostree_remote}:${args.ostree_ref}
+%end
+""")
 
 # This is an "extension" to kickstart files that we implement as a comment.
 if args.create_disk and args.kickstart:
@@ -196,6 +206,8 @@ http_proc = None
 # stderr and not stdout.
 have_virtinstall_2 = int(subprocess.check_output(['virt-install', '--version'],
                                                  stderr=subprocess.STDOUT).strip().decode('UTF-8').split('.')[0]) >= 2
+
+ks_tmp.flush()
 
 try:
     vinstall_args = ["virt-install", "--connect=qemu:///session",


### PR DESCRIPTION

For Red Hat Enterprise Linux CoreOS, we will be shipping updates
via "oscontainers"; see the `oscontainer` command history for
some more details.

Support not specifying a ref in the manifest.  The semantics
result in the ref being deleted in the disk image.

Today the RHCOS build system adds a bit in the kickstart to do
this, but we want to get away from supporting external kickstarts.

This patch is my 3rd attempt at implementing this; it turns out
to be by far easiest to override the manifest and add the ref temporarily.
Anaconda today requires a ref and not a commit.  And if we didn't
have a ref in the local repo, then the prune logic goes wrong, and
it also breaks `automatic_version_prefix` etc.

So we have a `tmpref-${name}` ref in the repo, and just strip
it from the generated disk image.