### PR TITLE
Feature/ova

### DIFF
--- a/src/example_ova_parameters.json
+++ b/src/example_ova_parameters.json
@@ -1,0 +1,10 @@
+{ "ovf_cpu_count": "2",
+  "ovf_memory_mb": "4096",
+  "vsphere_image_name": "Red Hat CoreOS",
+  "vsphere_product_name": "Red Hat CoreOS",
+  "vsphere_product_vendor_name": "Red Hat Inc.",
+  "vsphere_product_version": "4.0.0",
+  "vsphere_virtual_system_type": "vmx-07 vmx-08",
+  "vsphere_os_type": "other26xLinux64Guest",
+  "vsphere_scsi_controller_type": "VirtualSCSI",
+  "vsphere_network_controller_type": "VmxNet3" }

--- a/src/generate-ova-from-template.py
+++ b/src/generate-ova-from-template.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+
+import struct
+import tempfile
+import os
+import sys
+import json
+from subprocess import check_call
+from stat import *
+from shutil import rmtree
+import tarfile
+
+# Usage: generate-ova-from-template.py input_image.qcow2 input_template.xml example_ova_parameters.json output_image.ova
+
+def qcow_disk_size(filename):
+    """
+    Detect if an image is in qcow format
+    If it is, return the size
+    If it isn't, return None
+    Borrowed from Image Factory and modified
+
+    For interested parties, this is the QCOW header struct in C
+    struct qcow_header {
+       uint32_t magic;
+       uint32_t version;
+       uint64_t backing_file_offset;
+       uint32_t backing_file_size;
+       uint32_t cluster_bits;
+       uint64_t size; /* in bytes */
+       uint32_t crypt_method;
+       uint32_t l1_size;
+       uint64_t l1_table_offset;
+       uint64_t refcount_table_offset;
+       uint32_t refcount_table_clusters;
+       uint32_t nb_snapshots;
+       uint64_t snapshots_offset;
+    };
+    """
+
+    # And in Python struct format string-ese
+    qcow_struct=">IIQIIQIIQQIIQ" # > means big-endian
+    qcow_magic = 0x514649FB # 'Q' 'F' 'I' 0xFB
+
+    f = open(filename,"rb")
+    pack = f.read(struct.calcsize(qcow_struct))
+    f.close()
+
+    unpack = struct.unpack(qcow_struct, pack)
+
+    if unpack[0] == qcow_magic:
+        # uint64_t size  <--- from above
+        return unpack[5]
+    else:
+        return None
+
+input_image = sys.argv[1]
+input_template_file = sys.argv[2]
+input_template = open(input_template_file).read()
+image_parameters_file = sys.argv[3]
+image_parameters = json.loads(open(image_parameters_file).read())
+output_image = sys.argv[4]
+
+vmdk_working_path = tempfile.mkdtemp(dir="/tmp")
+os.chmod(vmdk_working_path, S_IRUSR|S_IWUSR|S_IXUSR|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH)
+
+vmdk_image = os.path.join(vmdk_working_path, "disk.vmdk")
+check_call([ "qemu-img", "convert", "-f", "qcow2", "-O", "vmdk", "-o", 
+             "adapter_type=lsilogic,subformat=streamOptimized,compat6",
+             input_image, vmdk_image ])
+
+virtual_disk_size = str(qcow_disk_size(input_image))
+vmdk_size = str(os.stat(vmdk_image).st_blocks*512)
+
+image_parameters['virtual_disk_size'] = virtual_disk_size
+image_parameters['vmdk_size'] = vmdk_size
+vmdk_xml = input_template.format(**image_parameters)
+
+vmdk_xml_filename = os.path.join(vmdk_working_path, "desc.ovf")
+with open(vmdk_xml_filename, "w") as vmdk_xml_file:
+    vmdk_xml_file.write(vmdk_xml)
+
+with tarfile.open(output_image, 'w') as tar:
+    tar.add(vmdk_xml_filename, arcname="desc.ovf")
+    tar.add(vmdk_image, arcname="disk.vmdk")
+
+rmtree(vmdk_working_path)

--- a/src/vmware-template.xml
+++ b/src/vmware-template.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0"?>
+<Envelope xmlns="http://schemas.dmtf.org/ovf/envelope/1" xmlns:cim="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" vmw:buildId="build-880146">
+  <References>
+	  <File ovf:href="disk.vmdk" ovf:id="file1" ovf:size="{virtual_disk_size}"/>
+  </References>
+  <DiskSection>
+    <Info>Virtual disk information</Info>
+    <Disk ovf:capacity="{virtual_disk_size}" ovf:capacityAllocationUnits="byte" ovf:diskId="vmdisk1" ovf:fileRef="file1" ovf:format="http://www.vmware.com/interfaces/specifications/vmdk.html#streamOptimized" ovf:populatedSize="{vmdk_size}"/>
+  </DiskSection>
+  <NetworkSection>
+    <Info>The list of logical networks</Info>
+    <Network ovf:name="VM Network">
+      <Description>The VM Network network</Description>
+    </Network>
+  </NetworkSection>
+  <VirtualSystem ovf:id="image">
+    <Info>A virtual machine</Info>
+    <Name>{vsphere_image_name}</Name>
+    <OperatingSystemSection ovf:id="80" ovf:version="6" vmw:osType="{vsphere_os_type}">
+      <Info>The kind of installed guest operating system</Info>
+    </OperatingSystemSection>
+    <VirtualHardwareSection ovf:transport="com.vmware.guestInfo">
+      <Info>Virtual hardware requirements</Info>
+      <System>
+        <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
+        <vssd:InstanceID>0</vssd:InstanceID>
+        <vssd:VirtualSystemIdentifier>image</vssd:VirtualSystemIdentifier>
+	<vssd:VirtualSystemType>{vsphere_virtual_system_type}</vssd:VirtualSystemType>
+      </System>
+      <Item>
+        <rasd:AllocationUnits>hertz * 10^6</rasd:AllocationUnits>
+        <rasd:Description>Number of Virtual CPUs</rasd:Description>
+        <rasd:ElementName>2 virtual CPU(s)</rasd:ElementName>
+        <rasd:InstanceID>1</rasd:InstanceID>
+        <rasd:ResourceType>3</rasd:ResourceType>
+	<rasd:VirtualQuantity>{ovf_cpu_count}</rasd:VirtualQuantity>
+      </Item>
+      <Item>
+        <rasd:AllocationUnits>byte * 2^20</rasd:AllocationUnits>
+        <rasd:Description>Memory Size</rasd:Description>
+        <rasd:ElementName>4096 MB of memory</rasd:ElementName>
+        <rasd:InstanceID>2</rasd:InstanceID>
+        <rasd:ResourceType>4</rasd:ResourceType>
+	<rasd:VirtualQuantity>{ovf_memory_mb}</rasd:VirtualQuantity>
+      </Item>
+      <Item ovf:required="false">
+        <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
+        <rasd:ElementName>VirtualVMCIDevice</rasd:ElementName>
+        <rasd:InstanceID>7</rasd:InstanceID>
+        <rasd:ResourceSubType>vmware.vmci</rasd:ResourceSubType>
+        <rasd:ResourceType>1</rasd:ResourceType>
+        <vmw:Config ovf:required="false" vmw:key="allowUnrestrictedCommunication" vmw:value="false"/>
+      </Item>
+      <Item>
+        <rasd:Address>0</rasd:Address>
+        <rasd:Description>SCSI Controller</rasd:Description>
+        <rasd:ElementName>SCSI Controller 0</rasd:ElementName>
+        <rasd:InstanceID>3</rasd:InstanceID>
+	<rasd:ResourceSubType>{vsphere_scsi_controller_type}</rasd:ResourceSubType>
+        <rasd:ResourceType>6</rasd:ResourceType>
+      </Item>
+      <Item>
+        <rasd:AddressOnParent>0</rasd:AddressOnParent>
+        <rasd:ElementName>Hard disk 0</rasd:ElementName>
+        <rasd:HostResource>ovf:/disk/vmdisk1</rasd:HostResource>
+        <rasd:InstanceID>4</rasd:InstanceID>
+        <rasd:Parent>3</rasd:Parent>
+        <rasd:ResourceType>17</rasd:ResourceType>
+        <vmw:Config ovf:required="false" vmw:key="backing.writeThrough" vmw:value="false"/>
+      </Item>
+      <Item>
+        <rasd:AddressOnParent>7</rasd:AddressOnParent>
+        <rasd:AutomaticAllocation>true</rasd:AutomaticAllocation>
+        <rasd:Connection>VM Network</rasd:Connection>
+        <rasd:Description>VmxNet3 ethernet adapter on "VM Network"</rasd:Description>
+        <rasd:ElementName>Network adapter 1</rasd:ElementName>
+        <rasd:InstanceID>5</rasd:InstanceID>
+	<rasd:ResourceSubType>{vsphere_network_controller_type}</rasd:ResourceSubType>
+        <rasd:ResourceType>10</rasd:ResourceType>
+        <vmw:Config ovf:required="false" vmw:key="connectable.allowGuestControl" vmw:value="true"/>
+        <vmw:Config ovf:required="false" vmw:key="wakeOnLanEnabled" vmw:value="false"/>
+      </Item>
+    </VirtualHardwareSection>
+    <ProductSection>
+      <Info>Information about the installed software</Info>
+      <Product>{vsphere_product_name}</Product>
+      <Vendor>{vsphere_product_vendor_name}</Vendor>
+      <Version>{vsphere_product_version}</Version>
+      <Property ovf:userConfigurable="true" ovf:type="string"
+                ovf:key="guestinfo.coreos.config.data" ovf:value="">
+        <Label>CoreOS config data</Label>
+        <Description>Inline cloud-config data</Description>
+      </Property>
+    </ProductSection>
+  </VirtualSystem>
+</Envelope>


### PR DESCRIPTION
This is a simple string template approach to OVA generation inspired by feedback from Ben and Benjamin on how they do this in Container Linux and Ubuntu.  The template in this PR merges some XML fragments from Container Linux related to the guest parameters with the core XML that is output by Image Factory when generating OVA files.

With this, right now, by hand, you should be able to:

```
gf-oemid core-qemu.qcow2 coreos-vmware.qcow2 vmware
generate-ova-from-template.py coreos-vmware.qcow2 vmware-template.xml example_ova_parameters.json coreos-vmware.ova
```

And then import `coreos-vmware.ova` into your vSphere instance.