### PR TITLE
Include Anaconda in the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN ./build.sh install_rpms
 # Ok copy in the rest of them for the next few steps
 COPY ./ /root/containerbuild/
 RUN ./build.sh write_archive_info
+RUN ./build.sh install_anaconda
 RUN ./build.sh make_and_makeinstall
 RUN ./build.sh configure_user
 

--- a/build.sh
+++ b/build.sh
@@ -97,6 +97,54 @@ _prep_make_and_make_install() {
     fi
 }
 
+arch=$(uname -m)
+release="29"
+# Download url is different for primary and secondary fedora
+# Primary Fedora - https://download.fedoraproject.org/pub/fedora/linux/releases/
+# Secondary Fedora - https://download.fedoraproject.org/pub/fedora-secondary/releases/
+declare -A repository_dirs
+repository_dirs[aarch64]=fedora/linux
+repository_dirs[armhfp]=fedora/linux
+repository_dirs[x86_64]=fedora/linux
+repository_dirs[i386]=fedora-secondary
+repository_dirs[ppc64le]=fedora-secondary
+repository_dirs[s390x]=fedora-secondary
+
+repository_dir=${repository_dirs[$arch]}
+INSTALLER=https://download.fedoraproject.org/pub/$repository_dir/releases/$release/Everything/$arch/iso/Fedora-Everything-netinst-$arch-$release-1.2.iso
+INSTALLER_CHECKSUM=https://download.fedoraproject.org/pub/$repository_dir/releases/$release/Everything/$arch/iso/Fedora-Everything-$release-1.2-$arch-CHECKSUM
+
+install_anaconda() {
+    # Overriding install URL
+    if [ -n "${INSTALLER_URL_OVERRIDE-}" ]; then
+        INSTALLER="${INSTALLER_URL_OVERRIDE}"
+        info "Overriding the install URL with contents of INSTALLER_URL_OVERRIDE"
+    fi
+    # Overriding install checksum URL
+    if [ -n "${INSTALLER_CHECKSUM_URL_OVERRIDE-}" ]; then
+        INSTALLER_CHECKSUM="${INSTALLER_CHECKSUM_URL_OVERRIDE}"
+        info "Overriding the install checksum URL with contents of INSTALLER_CHECKSUM_URL_OVERRIDE"
+    fi
+
+    installer_bn=$(basename "${INSTALLER}")
+    checksums_bn=$(basename "${INSTALLER_CHECKSUM}")
+
+    anacondadir=/usr/lib/coreos-assembler-anaconda
+    if ! [ -f "${anacondadir}/${installer_bn}" ]; then
+        (
+            mkdir -p $anacondadir
+            cd $anacondadir
+            rm tmp -rf && mkdir -p tmp
+            cd tmp
+            curl -L --remote-name-all "${INSTALLER}" "${INSTALLER_CHECKSUM}"
+            sha256sum -c "${checksums_bn}"
+            mv "${installer_bn}" "${checksums_bn}" ..
+            cd ..
+            rmdir tmp
+        )
+    fi
+}
+
 make_and_makeinstall() {
     _prep_make_and_make_install
     # And the main scripts
@@ -106,7 +154,6 @@ make_and_makeinstall() {
         make && make check && make install
     fi
 }
-
 
 configure_user(){
     # /dev/kvm might be bound in, but will have the gid from the host, and not all distros

--- a/src/cmd-build
+++ b/src/cmd-build
@@ -238,8 +238,8 @@ else
 fi
 
 # forgive me for this sin
-iso_location="${workdir}/installer/$(basename "${INSTALLER}")"
-checksum_location="${workdir}/installer/$(basename "${INSTALLER_CHECKSUM}")"
+iso_location=$(find /usr/lib/coreos-assembler-anaconda/ -name '*.iso' | head -1)
+checksum_location=$(find /usr/lib/coreos-assembler-anaconda/ -name '*CHECKSUM' | head -1)
 
 set +x
 # This generates the "base image"; not specific to a platform.

--- a/src/cmd-init
+++ b/src/cmd-init
@@ -7,13 +7,12 @@ dn=$(dirname "$0")
 
 # Initialize FORCE to 0 and BRANCH/INSTALLER_DIR to an empty string
 FORCE=0
-INSTALLER_DIR=""
 BRANCH=""
 
 print_help() {
     cat 1>&2 <<'EOF'
 Usage: coreos-assembler init --help
-       coreos-assembler init [--force] [--branch BRANCH] [--installerdir INSTALLER_DIR] GITCONFIG [SUBDIR]
+       coreos-assembler init [--force] [--branch BRANCH] GITCONFIG [SUBDIR]
 
   For example, you can use https://github.com/coreos/fedora-coreos-config
   as GITCONFIG, or fork it.  Another option useful for local development
@@ -23,15 +22,12 @@ Usage: coreos-assembler init --help
 
   If specified, SUBDIR is a subdirectory of the git repository that should
   contain manifest.yaml and image.yaml (or image.ks).
-
-  If you have the required install ISO and sha256sums already available,
-  you can specify the location of those files with the `--installerdir` flag.
 EOF
 }
 
 # Call getopt to validate the provided input.
 rc=0
-options=$(getopt --options hfb:i: --longoptions help,force,branch:,installerdir: -- "$@") || rc=$?
+options=$(getopt --options hfb:i: --longoptions help,force,branch: -- "$@") || rc=$?
 [ $rc -eq 0 ] || {
     print_help
     exit 1
@@ -52,18 +48,6 @@ while true; do
                 shift ;;
             *)
                 BRANCH="$2"
-                shift ;;
-        esac
-        ;;
-    -i | --installerdir)
-        case "$2" in
-            "")
-                shift ;;
-            *)
-                INSTALLER_DIR=$(readlink -f "$2")
-                if [ ! -d "$INSTALLER_DIR" ]; then
-                    fatal "installer must exist and be accessible: ${INSTALLER_DIR}"
-                fi
                 shift ;;
         esac
         ;;
@@ -130,33 +114,6 @@ mkdir -p src
          fatal "If using a custom configuration, be sure it has a manifest.yaml."
      fi
  fi)
-
-
-installer_bn=$(basename "${INSTALLER}")
-checksums_bn=$(basename "${INSTALLER_CHECKSUM}")
-mkdir -p installer
-
-if [ -n "${INSTALLER_DIR}" ]; then
-    if (cd "${INSTALLER_DIR}" && sha256sum -c "${checksums_bn}"); then
-        (cd installer
-         cp --reflink=auto "${INSTALLER_DIR}"/"${installer_bn}" .
-         cp --reflink=auto "${INSTALLER_DIR}"/"${checksums_bn}" .
-        )
-    fi
-fi
-
-(cd installer
- if ! [ -f "${installer_bn}" ]; then
-    mkdir -p tmp
-    (
-     cd tmp
-     curl -L --remote-name-all "${INSTALLER}" "${INSTALLER_CHECKSUM}"
-     sha256sum -c "${checksums_bn}"
-     mv "${installer_bn}" "${checksums_bn}" ..
-    )
-    rm tmp -rf
-  fi
-)
 
 mkdir -p cache
 mkdir -p builds

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -32,38 +32,7 @@ fatal() {
 
 # Get target architecture
 arch=$(uname -m)
-release="29"
 export arch
-export release
-
-# Download url is different for primary and secondary fedora
-# Primary Fedora - https://download.fedoraproject.org/pub/fedora/linux/releases/
-# Secondary Fedora - https://download.fedoraproject.org/pub/fedora-secondary/releases/
-declare -A repository_dirs
-repository_dirs[aarch64]=fedora/linux
-repository_dirs[armhfp]=fedora/linux
-repository_dirs[x86_64]=fedora/linux
-repository_dirs[i386]=fedora-secondary
-repository_dirs[ppc64le]=fedora-secondary
-repository_dirs[s390x]=fedora-secondary
-
-repository_dir=${repository_dirs[$arch]}
-INSTALLER=https://download.fedoraproject.org/pub/$repository_dir/releases/$release/Everything/$arch/iso/Fedora-Everything-netinst-$arch-$release-1.2.iso
-INSTALLER_CHECKSUM=https://download.fedoraproject.org/pub/$repository_dir/releases/$release/Everything/$arch/iso/Fedora-Everything-$release-1.2-$arch-CHECKSUM
-
-# Overriding install URL
-if [ -n "${INSTALLER_URL_OVERRIDE-}" ]; then
-    INSTALLER="${INSTALLER_URL_OVERRIDE}"
-    info "Overriding the install URL with contents of INSTALLER_URL_OVERRIDE"
-fi
-# Overriding install checksum URL
-if [ -n "${INSTALLER_CHECKSUM_URL_OVERRIDE-}" ]; then
-    INSTALLER_CHECKSUM="${INSTALLER_CHECKSUM_URL_OVERRIDE}"
-    info "Overriding the install checksum URL with contents of INSTALLER_CHECKSUM_URL_OVERRIDE"
-fi
-
-export INSTALLER
-export INSTALLER_CHECKSUM
 
 _privileged=
 has_privileges() {


### PR DESCRIPTION
It's part of the implementation detail of cosa.  Let's embed
it inside our container rather than downloading it dynamically.
This ensures that if you have the container you have *all* of the tools;
there's nothing separate to deal with and mirror.

It makes building the container more painful, but eh.