### PR TITLE
virt-install: conditionalize locations for ignition.firstboot

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -71,6 +71,11 @@ install_rpms() {
         rpm -q grubby && yum remove -y grubby
     fi
 
+    # Open up permissions on /boot/efi files so we can copy them
+    # for our ISO installer image
+    find /boot/efi -type f -print0 | xargs -0 chmod +r
+    find /boot/efi -type d -print0 | xargs -0 chmod +rx
+
     # Further cleanup
     yum clean all
 

--- a/src/cmd-buildextend-installer
+++ b/src/cmd-buildextend-installer
@@ -48,9 +48,13 @@ if os.path.isdir(tmpdir):
     shutil.rmtree(tmpdir)
 
 tmpisoroot = os.path.join(tmpdir, 'installer')
+tmpisoimages = os.path.join(tmpisoroot, 'images')
+tmpisoisolinux = os.path.join(tmpisoroot, 'isolinux')
 
 os.mkdir(tmpdir)
 os.mkdir(tmpisoroot)
+os.mkdir(tmpisoimages)
+os.mkdir(tmpisoisolinux)
 
 def generate_iso():
     tmpisofile = os.path.join(tmpdir, iso_name)
@@ -70,9 +74,9 @@ def generate_iso():
     for file in ['initramfs.img', 'vmlinuz']:
         run_verbose(['/usr/bin/ostree', '--repo=./repo', 'checkout',
                      '--user-mode', '--subpath', os.path.join(moduledir, file),
-                     f"{buildmeta_commit}", tmpisoroot])
+                     f"{buildmeta_commit}", tmpisoimages])
         # initramfs isn't world readable by default so let's open up perms
-        os.chmod(os.path.join(tmpisoroot, file), 0o755)
+        os.chmod(os.path.join(tmpisoimages, file), 0o755)
 
     # Grab all the contents from the installer dir from the configs
     run_verbose(["rsync", "-a", "src/config/installer/", f"{tmpisoroot}/"])
@@ -84,14 +88,21 @@ def generate_iso():
                      ('/usr/share/syslinux/libutil.c32',  0o755),
                      ('/usr/share/syslinux/vesamenu.c32', 0o755)]
     for src, mode in isolinuxfiles:
-        dst = os.path.join(tmpisoroot, os.path.basename(src))
+        dst = os.path.join(tmpisoisolinux, os.path.basename(src))
         shutil.copyfile(src, dst)
         os.chmod(dst, mode)
 
     # Generate the ISO image
-    run_verbose(['/usr/bin/genisoimage', '-b', 'isolinux.bin', '-c', 'boot.cat',
-                 '-no-emul-boot', '-boot-load-size', '4', '-boot-info-table',
-                 '-rock', '-J', '--verbose', '-o', tmpisofile, tmpisoroot])
+    run_verbose(['/usr/bin/genisoimage',
+                 '-b', 'isolinux/isolinux.bin',
+                 '-c', 'isolinux/boot.cat',
+                 '-no-emul-boot',
+                 '-boot-load-size', '4',
+                 '-boot-info-table',
+                 '-rock',
+                 '-J',
+                 '--verbose',
+                 '-o', tmpisofile, tmpisoroot])
     checksum = sha256sum_file(tmpisofile)
     buildmeta['images']['iso'] = {
         'path': iso_name,

--- a/src/cmd-buildextend-installer
+++ b/src/cmd-buildextend-installer
@@ -9,6 +9,7 @@ import json
 import yaml
 import shutil
 import argparse
+import tempfile
 
 sys.path.insert(0, '/usr/lib/coreos-assembler')
 from cmdlib import run_verbose, write_json, sha256sum_file
@@ -42,6 +43,7 @@ if 'iso' in buildmeta['images'] and not args.force:
 base_name = buildmeta['name']
 img_prefix = f'{base_name}-{args.build}'
 iso_name = f'{img_prefix}.iso'
+name_version = f'{base_name}-{args.build}'
 
 tmpdir = 'tmp/buildpost-installer'
 if os.path.isdir(tmpdir):
@@ -78,8 +80,11 @@ def generate_iso():
         # initramfs isn't world readable by default so let's open up perms
         os.chmod(os.path.join(tmpisoimages, file), 0o755)
 
+    # TODO ignore EFI dir
     # Grab all the contents from the installer dir from the configs
     run_verbose(["rsync", "-a", "src/config/installer/", f"{tmpisoroot}/"])
+
+    ### For x86_64 legacy boot (BIOS) booting 
 
     # Install binaries from syslinux package
     isolinuxfiles = [('/usr/share/syslinux/isolinux.bin', 0o755),
@@ -92,16 +97,45 @@ def generate_iso():
         shutil.copyfile(src, dst)
         os.chmod(dst, mode)
 
-    # Generate the ISO image
-    run_verbose(['/usr/bin/genisoimage',
-                 '-b', 'isolinux/isolinux.bin',
-                 '-c', 'isolinux/boot.cat',
+    ### For x86_64 UEFI booting
+
+    # Create the efiboot.img file. This is a fat32 formatted
+    # filesystem that contains all the files needed for EFI boot
+    # from an ISO.
+    with tempfile.TemporaryDirectory() as tmpefidir:
+        # Install binaries from the grub2-efi and shim rpms (installed
+        # in our COSA container
+        run_verbose(["rsync", "-a",
+                     "/boot/efi/EFI/", f"{tmpefidir}/EFI/"])
+
+        # Grab all the contents from the installer EFI dir from the configs
+        run_verbose(["rsync", "-a",
+                     "src/config/installer/EFI/", f"{tmpefidir}/EFI/"])
+
+        # Create the efiboot.img file (a fat filesystem) in the images/ dir
+        # Note: virt-make-fs lets us do this as non-root
+        efibootfile = os.path.join(tmpisoimages, 'efiboot.img')
+        run_verbose(['virt-make-fs', '--type=vfat',
+                     tmpefidir, efibootfile])
+
+    # Generate the ISO image. Lots of good info here:
+    # https://fedoraproject.org/wiki/User:Pjones/BootableCDsForBIOSAndUEFI
+    run_verbose(['/usr/bin/genisoimage', '-verbose',
+                 '-volset', f"{name_version}",
+                 # For  greater portability, consider using both
+                 # Joliet and Rock Ridge extensions. Umm, OK :)
+                 '-rock', '-J', '-joliet-long',
+                 # for legacy bios boot AKA eltorito boot
+                 '-eltorito-boot', 'isolinux/isolinux.bin',
+                 '-eltorito-catalog', 'isolinux/boot.cat',
                  '-no-emul-boot',
                  '-boot-load-size', '4',
                  '-boot-info-table',
-                 '-rock',
-                 '-J',
-                 '--verbose',
+                 # for EFI boot
+                 '-eltorito-alt-boot',
+                 '-efi-boot', 'images/efiboot.img',
+                 '-no-emul-boot',
+                 # Define inputs and outputs
                  '-o', tmpisofile, tmpisoroot])
     checksum = sha256sum_file(tmpisofile)
     buildmeta['images']['iso'] = {

--- a/src/deps.txt
+++ b/src/deps.txt
@@ -56,3 +56,6 @@ ignition
 
 # for grub install when creating images without anaconda
 grub2
+
+# For creating bootable UEFI media on x86_64
+shim-x64 grub2-efi-x64

--- a/src/virt-install
+++ b/src/virt-install
@@ -113,12 +113,20 @@ elif args.kickstart:
 else:
     raise SystemExit("Either --kickstart or --image-conf must be specified")
 
+
 # This is an implementation detail of https://github.com/coreos/ignition-dracut
 # So we hardcode it here.
 # See: https://github.com/coreos/ignition-dracut/pull/12
-ks_tmp.write("""
+# 
+# if uefi we need to put the file in the efi partition
+# https://github.com/coreos/coreos-assembler/issues/383
+if args.variant == 'metal-uefi':
+    firstboot_file = '/boot/efi/ignition.firstboot'
+else:
+    firstboot_file = '/boot/ignition.firstboot'
+ks_tmp.write(f"""
 %post --erroronfail
-touch /boot/ignition.firstboot
+touch {firstboot_file}
 %end
 """)
 


### PR DESCRIPTION
On EFI systems the grub.cfg lives in sda1, which
is mounted under /boot/efi. On BIOS systems it lives
on sda1, which is mounted under /boot/. We need to
put the file in the right place so that the grub
snippet can pick it up.

Fixes #383