### PR TITLE
src/cmd-buildextend-ec2: allow prefixing AMI names

### DIFF
--- a/src/cmd-buildextend-ec2
+++ b/src/cmd-buildextend-ec2
@@ -20,6 +20,7 @@ parser.add_argument("--bucket", help="S3 Bucket",
                     required=True)
 parser.add_argument("--grant-user", help="Grant user launch permission",
                     nargs="*", default=[])
+parser.add_argument("--prefix", help="String to prepend to AMI filename")
 args = parser.parse_args()
 
 
@@ -30,6 +31,8 @@ with open(buildmeta_path) as f:
 
 base_name = buildmeta['name']
 ami_name_version = f'{base_name}-{args.build}'
+if args.prefix:
+    ami_name_version = f'{prefix}-{base_name}-{args.build}'
 
 tmpdir='tmp/buildpost-ec2'
 if os.path.isdir(tmpdir):


### PR DESCRIPTION
It is desirable to be able to prefix AMI names when running a mix of
automated production and development pipelines.  This helps to avoid
reuse of the AMI snapshots when the filename is the same.