### PR TITLE
build.sh: add "-r" flag to xargs to not error out if no file(s)/dir(s) exist

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -73,8 +73,8 @@ install_rpms() {
 
     # Open up permissions on /boot/efi files so we can copy them
     # for our ISO installer image
-    find /boot/efi -type f -print0 | xargs -0 chmod +r
-    find /boot/efi -type d -print0 | xargs -0 chmod +rx
+    find /boot/efi -type f -print0 | xargs -r -0 chmod +r
+    find /boot/efi -type d -print0 | xargs -r -0 chmod +rx
 
     # Further cleanup
     yum clean all


### PR DESCRIPTION
I have hit this on ppc64le as efi dir tree exist on /boot, but the tree is empty.