### PR TITLE
gf-oemid: Don't use the container's /tmp

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -281,9 +281,6 @@ for itype in "${IMAGE_TYPES[@]}"; do
               images[$itype]="${img_qemu}"
               build_cloud_base
               /usr/lib/coreos-assembler/gf-oemid "$(pwd)"/"${img_base}" "$(pwd)"/"${img_qemu}" qemu
-              # Clear the MCS SELinux labels
-              # See https://github.com/coreos/coreos-assembler/issues/292
-              chcon -vl s0 "${img_qemu}"
               # make a version-less symlink to have a stable path
               # TODO: Remove this, things should be parsing the metadata
               ln -s "${img_qemu}" "${name}"-qemu.qcow2

--- a/src/gf-oemid
+++ b/src/gf-oemid
@@ -24,7 +24,11 @@ if [[ $src == *.gz ]]; then
 fi
 
 set -x
-tmpd=$(mktemp -td gf-oemid.XXXXXX)
+# Work in a tmpdir on the destination so that we don't inherit some MCS labeling
+# from the /tmp dir in the container. This also ensures that the final move is a
+# pure `rename()`.
+# See also: https://github.com/coreos/coreos-assembler/issues/292
+tmpd=$(mktemp -tdp "$(dirname "${dest}")" gf-oemid.XXXXXX)
 tmp_dest=${tmpd}/box.img
 
 # Work around for https://github.com/coreos/coreos-assembler/issues/198


### PR DESCRIPTION
We were previously hitting issues with the final images having an MCS
label. This turned out to be due to the `gf-oemid` using `/tmp` within
the container. In the unprivileged path, the whole container filesystem
uses MCS and so the image created there would inherit that label.

Just fix this by making `gf-oemid` use a tmpdir in the destination path;
we're already in a temporary work directory anyway when calling it from
`cmd-build`. Staying on the same bind mount also ensures that we're not
copying the image across filesystems (and with reflinks on, even the
first copy is a no-op!), so this should make the build process a bit
faster too.

Finally, this also allows us to drop the call to `chcon`, which is
problematic for systems without SELinux enabled on the host.