### PR TITLE
build: Fix cosa link in container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ install:
 	install -D -t $(DESTDIR)$(PREFIX)/lib/coreos-assembler $$(find src/ -maxdepth 1 -type f)
 	install -d $(DESTDIR)$(PREFIX)/bin
 	ln -sf ../lib/coreos-assembler/coreos-assembler $(DESTDIR)$(PREFIX)/bin/
-	ln -sf ../lib/coreos-assembler/cosa $(DESTDIR)$(PREFIX)/bin/
+	ln -sf coreos-assembler $(DESTDIR)$(PREFIX)/bin/cosa
 	install -D -t $(DESTDIR)$(PREFIX)/bin mantle/bin/{ore,kola}
 	install -d $(DESTDIR)$(PREFIX)/lib/kola/amd64
 	install -D -m 0755 -t $(DESTDIR)$(PREFIX)/lib/kola/amd64 mantle/bin/amd64/kolet


### PR DESCRIPTION
Simplify things and have it just point to `coreos-assembler` in
the bindir.