### PR TITLE
virt-install: Cut Anaconda RAM to 1024

### DIFF
--- a/src/virt-install
+++ b/src/virt-install
@@ -32,7 +32,7 @@ parser.add_argument("--location", help="Installer location",
                     action='store', required=True)
 parser.add_argument("--memory", help="Memory size in MB",
                     action='store', type=int,
-                    default=os.environ.get("VIRT_INSTALL_MEMORY", 2048))
+                    default=os.environ.get("VIRT_INSTALL_MEMORY", 1024))
 parser.add_argument("--console-log-file", help="Console log file",
                     action='store')
 parser.add_argument("--logs", help="Copy Anaconda logs to DIR",


### PR DESCRIPTION
Seems to work well here, did a few runs.