### PR TITLE
shell: Fix re-execution

### DIFF
--- a/src/cmd-shell
+++ b/src/cmd-shell
@@ -5,6 +5,6 @@ if [ $# -eq 0 ]; then
     # If no arguments then offer user bash prompt inside the container
     exec /usr/bin/env PS1='[coreos-assembler]$ ' /usr/bin/bash
 else
-    # They provided arguments so just run the commands
-    exec /usr/bin/bash -c "$@"
+    # They provided arguments so just run the command
+    exec "$@"
 fi


### PR DESCRIPTION
It doesn't make sense to pass an array of arguments to `bash -c`.
Fixes doing e.g. `cosa shell sleep 5`.