### PR TITLE
Add ppc64le specific deps file

### DIFF
--- a/deps-ppc64le.txt
+++ b/deps-ppc64le.txt
@@ -1,0 +1,1 @@
+src/deps-ppc64le.txt

--- a/src/deps-ppc64le.txt
+++ b/src/deps-ppc64le.txt
@@ -1,0 +1,2 @@
+# Place-holder for ppc64le arch specific dependencies
+


### PR DESCRIPTION
At this point ppc64le doesn't have specific pkg dependencies, this PR
adds a placeholder file containing a blank line to ensure the pkg
install and depcheck tasks still works.