### PR TITLE
Fix COPY of arch specific deps

### DIFF
--- a/deps-aarch64.txt
+++ b/deps-aarch64.txt
@@ -1,0 +1,1 @@
+src/deps-aarch64.txt

--- a/deps-x86_64.txt
+++ b/deps-x86_64.txt
@@ -1,0 +1,1 @@
+src/deps-x86_64.txt


### PR DESCRIPTION
The arch specific deps files exist in src/deps-$arch.txt. However the
Dockerfile COPY only copies from the base dir. This PR adds symlinks in
the same way as the base deps.txt file is symlinked.