### PR TITLE
Run one depcheck for all deps

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -82,7 +82,7 @@ install_rpms() {
 
     # shellcheck source=src/cmdlib.sh
     . "${srcdir}/cmdlib.sh"
-    depcheck "${deps}"
+    depcheck "${deps} ${archdeps}"
 }
 
 _prep_make_and_make_install() {

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -86,8 +86,7 @@ preflight() {
     deps=$(sed "s/${filter}//" /usr/lib/coreos-assembler/deps.txt | grep -v '^#')
     archdeps=$(sed "s/${filter}//" /usr/lib/coreos-assembler/deps-"$(arch)".txt | grep -v '^#')
 
-    depcheck "${deps}"
-    depcheck "${archdeps}"
+    depcheck "${deps} ${archdeps}"
 
     if [ "$(stat -f --printf="%T" .)" = "overlayfs" ]; then
         fatal "$(pwd) must be a volume"


### PR DESCRIPTION
This avoids a situation where one of the deps is empty, causing depcheck
to fail. Additionally it allows the rpm -q to run against one list
instead of 2.