### PR TITLE
build: ensure git submodules have been initialized

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN ./build.sh install_rpms
 COPY ./ /root/containerbuild/
 RUN ./build.sh write_archive_info
 RUN ./build.sh install_anaconda
+RUN git submodule update --init
 RUN ./build.sh make_and_makeinstall
 RUN ./build.sh configure_user
 


### PR DESCRIPTION
If the developer hasn't initialized submodules before attempting to
create the coreos-assembler container image, they'll be met with an
error similar to the following:

    error: submodules not initialized. Run: git submodule update --init

Adding this to the Dockerfile ensures that this command has been run. It
is safe to run multiple times, so this shouldn't introduce problems for
those who initialized submodules before the container build process.