### PR TITLE
src/supermin-init-prelude.sh: mount /dev/shm

### DIFF
--- a/src/supermin-init-prelude.sh
+++ b/src/supermin-init-prelude.sh
@@ -3,6 +3,10 @@ mount -t proc /proc /proc
 mount -t sysfs /sys /sys
 mount -t devtmpfs devtmpfs /dev
 
+# need /dev/shm for podman
+mkdir -p /dev/shm
+mount -t tmpfs tmpfs /dev/shm
+
 # load selinux policy
 LANG=C /sbin/load_policy  -i
 


### PR DESCRIPTION
Add `/dev/shm` to Supermin appliance. This was surfaced when we switched from Fedora 28 to Fedora 29 for our RHEL building.