### PR TITLE
virt-install: fix virt undefine error

### DIFF
--- a/src/virt-install
+++ b/src/virt-install
@@ -267,7 +267,7 @@ try:
         cleanup_argv.append('--skip-partition-fixups')
     run_sync_verbose(cleanup_argv)
 finally:
-    subprocess.call(['virsh', '--connect=qemu:///session', 'undefine', domain])
+    subprocess.call(['virsh', '--connect=qemu:///session', 'undefine', '--nvram', domain])
     if tail_proc is not None:
         tail_proc.terminate()
     if http_proc is not None:


### PR DESCRIPTION
For UEFI domains we get the following error unless we add
`--nvram` to the call to undefine:

```
error: Failed to undefine domain coreos-inst-597-1552671442
error: Requested operation is not valid: cannot undefine domain with nvram
```