### PR TITLE
Add support for building an overlay RPM

### DIFF
--- a/src/build_rpm_from_dir
+++ b/src/build_rpm_from_dir
@@ -1,0 +1,52 @@
+#!/bin/bash
+set -euo pipefail
+
+srcdir=$1; shift
+name=$1; shift
+outdir=$1; shift
+
+sha256=$(cd "${srcdir}" && find . ! -type d -print0 | xargs -0 -r sha256sum \
+            | sha256sum | cut -f 1 -d ' ')
+
+latest_rpm=$(find "$outdir/" -iname "$name-*.rpm" | sort -Vr | head -n 1)
+
+if rpm -qp "$latest_rpm" --qf '%{DESCRIPTION}' | grep -q "(sha256:$sha256)"; then
+    echo "Re-using ${latest_rpm} ($sha256)."
+    exit 0
+fi
+
+# shellcheck disable=SC2154
+cat > "$name.spec" << EOF
+Name: $name
+Version: $(date +%s)
+Release: ${sha256::7}
+BuildArch: noarch
+Summary: $summary overlay
+License: $license
+# this shows up then in rpm -qi (XXX: don't hardcode this)
+URL: https://github.com/coreos/fedora-coreos-config
+
+BuildRequires: rsync
+
+%description
+%{summary} (sha256:$sha256)
+
+%build
+# Nothing to build
+
+%install
+rsync -av "${srcdir}/" %{buildroot}
+
+%files
+$(cd "${srcdir}" && find . ! -type d | cut -c 2-)
+EOF
+
+rm -rf rpms
+rpmbuild -ba \
+  --define "_sourcedir $PWD" \
+  --define "_specdir $PWD" \
+  --define "_builddir $PWD/.build" \
+  --define "_srcrpmdir $PWD/rpms" \
+  --define "_rpmdir $PWD/rpms" \
+  --define "_buildrootdir $PWD/.buildroot" "$name.spec"
+cp rpms/noarch/*.rpm "$outdir"

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -142,13 +142,14 @@ prepare_build() {
     # Also grab rojig summary for image upload descriptions
     name=$(jq -r '.rojig.name' < "${manifest_tmp_json}")
     summary=$(jq -r '.rojig.summary' < "${manifest_tmp_json}")
+    license=$(jq -r '.rojig.license' < "${manifest_tmp_json}")
     ref=$(jq -r '.ref' < "${manifest_tmp_json}")
     ref_is_temp=""
     if [ "${ref}" = "null" ]; then
         ref="tmpref-${name}"
         ref_is_temp=1
     fi
-    export name ref summary
+    export name ref summary license
     rm -f "${manifest_tmp_json}"
 
     # This dir is no longer used
@@ -182,7 +183,7 @@ runcompose() {
     local overridesdir=${workdir}/overrides
     local tmp_overridesdir=${TMPDIR}/override
     local override_manifest="${tmp_overridesdir}"/coreos-assembler-override-manifest.yaml
-    if [ -d "${overridesdir}"/rpm ] || [ -n "${ref_is_temp}" ]; then
+    if [ -d "${overridesdir}"/rpm ] || [ -n "${ref_is_temp}" ] || [ -d "${configdir}/overlay" ]; then
         mkdir "${tmp_overridesdir}"
         cat > "${override_manifest}" <<EOF
 include: ${workdir}/src/config/manifest.yaml
@@ -195,6 +196,14 @@ EOF
     fi
     if [ -n "${ref_is_temp}" ]; then
         echo 'ref: "'"${ref}"'"' >> "${override_manifest}"
+    fi
+    if [ -d "${configdir}/overlay" ]; then
+        cat >> "${override_manifest}" <<EOF
+packages:
+  - ${name}-overlay
+EOF
+        mkdir tmp/overlay-build
+        (cd tmp/overlay-build && "${DIR}"/build_rpm_from_dir "${configdir}/overlay" "${name}-overlay" "${workdir}/overrides/rpm")
     fi
     if [ -d "${overridesdir}"/rpm ]; then
         (cd "${overridesdir}"/rpm && createrepo_c .)


### PR DESCRIPTION
This patch adds support for an overlay RPM defined by a rootfs in the
source repo at `overlay/`. Unlike FAH, FCOS is much more opinionated
about various things. And these opinions express themselves through e.g.
config file overlays, systemd units, Ignition base configs, etc... These
files don't clearly belong in any particular "component" package, but
rather provide the glue that makes FCOS feel like FCOS. This is similar
to CL's [init](https://github.com/coreos/init) package.

Right now, a lot of these files are just written out as part of the
postprocess script in the treefile. Splitting them out has the major
benefit of being able to track them in the rpmdb so one actually knows
where they come from. It'd also mean a cleaner manifest and easier
hacking on those files and tracking in git.

We can probably teach rpm-ostree to do this directly later on and
deprecate/automatically translate `add-files` along with it.