### PR TITLE
virt-install: add optional installclass parameter

### DIFF
--- a/src/virt-install
+++ b/src/virt-install
@@ -113,6 +113,16 @@ elif args.kickstart:
 else:
     raise SystemExit("Either --kickstart or --image-conf must be specified")
 
+# To support different distro builds using Fedora anaconda,
+# installclass must be explicit for anaconda to find the correct directory.
+if subprocess.call(['ostree', f"--repo={args.ostree_repo}", 'ls', args.ostree_ref, "/usr/lib/ostree-boot/efi/EFI/redhat"], stderr=subprocess.DEVNULL) == 0:
+    print("Detected /usr/lib/ostree-boot/efi/EFI/redhat, adding Red Hat Enterprise Linux installclass.")
+    ks_tmp.write("""
+    %anaconda
+    installclass --name="Red Hat Enterprise Linux"
+    %end
+    """)
+
 # This is an implementation detail of https://github.com/coreos/ignition-dracut
 # So we hardcode it here.
 # See: https://github.com/coreos/ignition-dracut/pull/12


### PR DESCRIPTION
Support different distros by adding explicit installclass option to
image.yaml, which is required for Fedora anaconda to find the correct
directory to use for EFI builds.

Signed-off-by: Yu Qi Zhang <jerzhang@redhat.com>