### PR TITLE
Drop rd.neednet ip=dhcp from default kernel arguments

### DIFF
--- a/src/image-cloud.ks
+++ b/src/image-cloud.ks
@@ -1,10 +1,9 @@
-# ip=dhcp and rd.neednet=1 enable networking in the initramfs
 # We use net.ifnames in cloud environments
 # no_timer_check is something we're cargo culting around
 # console= args are also for clouds
 # The other ones are for Ignition and are also in image-metal.ks;
 # change them there first.
-bootloader --timeout=1 --append="no_timer_check console=ttyS0,115200n8 console=tty0 net.ifnames=0 biosdevname=0 ip=dhcp rd.neednet=1 rootflags=defaults,prjquota rw $ignition_firstboot"
+bootloader --timeout=1 --append="no_timer_check console=ttyS0,115200n8 console=tty0 net.ifnames=0 biosdevname=0 rootflags=defaults,prjquota rw $ignition_firstboot"
 
 %post --erroronfail
 # By default, we do DHCP.  Also, due to the above disabling


### PR DESCRIPTION
Instead this will be handled by our Ignition bootloader logic:
https://github.com/coreos/ignition-dracut/pull/57/commits/c62a108c79db49cecb9f323d6567d33a86fa6dc7