### PR TITLE
build: Drop support for el7

### DIFF
--- a/build-deps.txt
+++ b/build-deps.txt
@@ -1,5 +1,2 @@
 # Used by mantle
 golang 
-
-# pull in these on EL7
-#EL7 golang-bin golang-src

--- a/src/deps-x86_64.txt
+++ b/src/deps-x86_64.txt
@@ -1,6 +1,5 @@
 # For generating ISO images
-#FEDORA syslinux-nonlinux
-#EL7 syslinux
+syslinux-nonlinux
 
 # For creating bootable UEFI media on x86_64
 shim-x64 grub2-efi-x64

--- a/src/deps.txt
+++ b/src/deps.txt
@@ -10,8 +10,7 @@ dumb-init
 
 # For composes
 rpm-ostree createrepo_c openssh-clients
-#FEDORA dnf-utils
-#EL7 yum-utils
+dnf-utils
 
 # For generating ISO images
 genisoimage
@@ -26,19 +25,14 @@ make git rpm-build
 
 # virt-install dependencies
 libvirt libguestfs-tools /usr/bin/qemu-img /usr/bin/virsh /usr/bin/virt-install
-#FEDORA qemu-kvm
-#EL7 qemu-kvm-rhev
+qemu-kvm
 
 # And we process kickstarts
 /usr/bin/ksflatten
 
-# scl and python36 For EL7
-#EL7 scl-utils rh-python36 rh-python36-PyYAML
-
 # ostree-releng-scripts dependencies
 rsync
-#FEDORA python2-gobject-base python3-gobject-base
-#EL7 python-gobject
+python2-gobject-base python3-gobject-base
 
 # To support recursive containerization and manipulating images
 podman buildah skopeo
@@ -50,7 +44,7 @@ jq awscli
 ignition
 
 # shellcheck for test
-#FEDORA ShellCheck
+ShellCheck
 
 # for grub install when creating images without anaconda
 grub2

--- a/src/gf-oemid
+++ b/src/gf-oemid
@@ -59,11 +59,7 @@ else
 fi
 chmod +x "${qemu_wrapper}"
 
-# This qemu wrapper doesn't work for some reason on EL7, so just skip
-# it on EL7 for now
-if [ -n "${ISFEDORA}" ]; then
-    export LIBGUESTFS_HV="${qemu_wrapper}"
-fi
+export LIBGUESTFS_HV="${qemu_wrapper}"
 
 cp --reflink=auto "${src}" "${tmp_dest}"
 # <walters> I commonly chmod a-w VM images


### PR DESCRIPTION
Anyone wanting support for this can use the last stable tag `0.4.0`.