### PR TITLE
 Support `image-postprocess` hook in the configdir

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -244,7 +244,7 @@ run_virtinstall() {
                                            --ostree-remote="${name}" --ostree-stateroot="${name}" \
                                            --ostree-ref="${ref:-${commit}}" \
                                            --location "${iso_location}" \
-                                           --image-config "${image_input}" \
+                                           --configdir="${configdir}" \
                                            --ostree-repo="${workdir}"/repo ${extraargs-} "$@"
     mv "${tmpdest}" "${dest}"
 }

--- a/src/virt-install
+++ b/src/virt-install
@@ -20,7 +20,7 @@ parser.add_argument("--dest", help="Destination disk",
                     action='store', required=True)
 parser.add_argument("--create-disk", help="Automatically create disk as qcow2, parsing kickstart for size",
                     action='store_true')
-parser.add_argument("--image-config", help="coreos-assembler image.yaml",
+parser.add_argument("--configdir", help="coreos-assembler configdir",
                     action='store', required=True)
 parser.add_argument("--variant", help="Use an internal (kickstart) config",
                     choices=('metal', 'metal-uefi', 'cloud'), default=None)
@@ -101,7 +101,7 @@ if args.variant is not None:
 with open('/usr/lib/coreos-assembler/image-base.ks') as basef:
     shutil.copyfileobj(basef, ks_tmp)
 image_conf = None
-with open(args.image_config) as f:
+with open(args.configdir + '/image.yaml') as f:
     image_conf = yaml.safe_load(f)
 disk_size = int(image_conf['size'])
 
@@ -252,6 +252,14 @@ try:
     # to ensure we fully control the code.
     cleanup_argv = ['/usr/lib/coreos-assembler/gf-anaconda-cleanup', args.dest]
     run_sync_verbose(cleanup_argv)
+
+    # This one is part of the "API" we provide to config repositories.  At least
+    # RHEL CoreOS will use it to change the OS to appear to have been provisioned
+    # from an oscontainer.
+    config_image_post = image_conf.get("postprocess-script")
+    if config_image_post is not None:
+        run_sync_verbose([os.path.join(args.configdir, config_image_post), args.dest])
+
 finally:
     subprocess.call(['virsh', '--connect=qemu:///session', 'undefine', '--nvram', domain])
     if tail_proc is not None:

--- a/src/virt-install
+++ b/src/virt-install
@@ -115,6 +115,10 @@ if subprocess.call(['ostree', f"--repo={args.ostree_repo}", 'ls', args.ostree_re
     %end
     """)
 
+# Undocumented hack until we change Ignition to handle this
+if image_conf.get('inject-core-user'):
+    ks_tmp.write("user --name=core --groups='wheel,sudo,adm,systemd-journal'\n")
+
 # This is an implementation detail of https://github.com/coreos/ignition-dracut
 # So we hardcode it here.
 # See: https://github.com/coreos/ignition-dracut/pull/12

--- a/src/virt-install
+++ b/src/virt-install
@@ -15,6 +15,9 @@ def fatal(msg):
     print('error: {}'.format(msg), file=sys.stderr)
     raise SystemExit(1)
 
+# Set of valid keys in image.yaml
+IMAGE_CONF_KEYS = ['size', 'inject-core-user', 'postprocess-script']
+
 parser = argparse.ArgumentParser()
 parser.add_argument("--dest", help="Destination disk",
                     action='store', required=True)
@@ -103,6 +106,9 @@ with open('/usr/lib/coreos-assembler/image-base.ks') as basef:
 image_conf = None
 with open(args.configdir + '/image.yaml') as f:
     image_conf = yaml.safe_load(f)
+for k in image_conf:
+    if not k in IMAGE_CONF_KEYS:
+        fatal(f"Unknown key '{k}' in image.yaml")
 disk_size = int(image_conf['size'])
 
 # To support different distro builds using Fedora anaconda,


### PR DESCRIPTION
Requires: https://github.com/coreos/coreos-assembler/pull/422

For RHEL CoreOS we ship via an oscontainer; today cosa doesn't
support configuring that, and our pipeline opens up the image
and changes the origin, and fixes up the sha256sum.

There are probably other tweaks people will want to make too.
Previously those types of things ended up in a `%post` run
via Anaconda.  This hook just provides the disk image; the
caller can use e.g. `libguestfs` on it (as the RHCOS pipeline
will do).

This operates before we do the checksum, so we don't do silly
things like checksumming, edit, checksum again.