### PR TITLE
cmdlib: Create overrides dir if there's an overlay

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -208,7 +208,6 @@ EOF
     if [ -d "${overridesdir}"/rpm ]; then
         (cd "${overridesdir}"/rpm && createrepo_c .)
         echo "Using RPM overrides from: ${overridesdir}/rpm"
-        local tmp_overridesdir=${TMPDIR}/override
         cat >> "${override_manifest}" <<EOF
 repos:
   - coreos-assembler-local-overrides

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -202,6 +202,7 @@ EOF
 packages:
   - ${name}-overlay
 EOF
+        mkdir -p "${overridesdir}"/rpm
         mkdir tmp/overlay-build
         (cd tmp/overlay-build && "${DIR}"/build_rpm_from_dir "${configdir}/overlay" "${name}-overlay" "${workdir}/overrides/rpm")
     fi


### PR DESCRIPTION
Otherwise we'll error out if the user has no overrides.
Regression from #414.