### PR TITLE
cmd/init: Create empty overrides/rpm directory

### DIFF
--- a/src/cmd-init
+++ b/src/cmd-init
@@ -118,4 +118,5 @@ mkdir -p src
 mkdir -p cache
 mkdir -p builds
 mkdir -p tmp
+mkdir -p overrides/rpm
 ostree --repo=repo init --mode=archive


### PR DESCRIPTION
Create this directory upfront to eliminate an additional step of
creating it manually when overriding RPMs locally.

Originally brought up in #427.