### PR TITLE
overlay: Only keep the latest overlay RPM around

### DIFF
--- a/src/build_rpm_from_dir
+++ b/src/build_rpm_from_dir
@@ -49,4 +49,7 @@ rpmbuild -ba \
   --define "_srcrpmdir $PWD/rpms" \
   --define "_rpmdir $PWD/rpms" \
   --define "_buildrootdir $PWD/.buildroot" "$name.spec"
+
+# delete any older RPMs first
+rm -f "$outdir/$name"-*.rpm
 cp rpms/noarch/*.rpm "$outdir"


### PR DESCRIPTION
Just before pushing out our new RPM, just nuke all the older ones in
there so we only ever have a single overlay RPM at a time. This does
mean that we lose caching across overlays that match builds from two or
three builds ago, but that's a pretty rare case. And building this RPM
is super cheap.