### PR TITLE
add 'uncompressed-size' and 'size' for images to meta.json

### DIFF
--- a/src/cmd-buildextend-openstack
+++ b/src/cmd-buildextend-openstack
@@ -48,9 +48,11 @@ def generate_openstack():
     run_verbose(['/usr/lib/coreos-assembler/gf-oemid',
                  img_qemu, tmp_img_openstack, 'openstack'])
     checksum = sha256sum_file(tmp_img_openstack)
+    size = os.path.getsize(tmp_img_openstack)
     buildmeta_images['openstack'] = {
         'path': openstack_name,
-        'sha256': checksum
+        'sha256': checksum,
+        'size': str(size)
     }
     os.rename(tmp_img_openstack, f"{builddir}/{openstack_name}")
     write_json(buildmeta_path, buildmeta)

--- a/src/cmd-buildextend-vmware
+++ b/src/cmd-buildextend-vmware
@@ -113,10 +113,12 @@ def generate_ova_from_template():
 
     # update the build meta.json with info about the ova
     checksum = sha256sum_file(ova_file)
+    size = os.path.getsize(ova_file)
     buildmeta_images = buildmeta['images']
     buildmeta_images['vmware'] = {
         'path': ova_name,
-        'sha256': checksum
+        'sha256': checksum,
+        'size': str(size)
     }
 
     write_json(buildmeta_path, buildmeta)

--- a/src/cmd-compress
+++ b/src/cmd-compress
@@ -54,14 +54,17 @@ for img_format in buildmeta['images']:
     filepath = os.path.join('builds', build, file)
     if not file.endswith('.gz'):
         tmpfile = os.path.join(tmpdir, (file + '.gz'))
-        # SHA256 for uncompressed image was already calculated during 'build'
+        # SHA256 + size for uncompressed image was already calculated during 'build'
         img['uncompressed-sha256'] = img['sha256']
+        img['uncompressed-size'] = img['size']
         with open(tmpfile, 'wb') as f:
             run_verbose(['gzip', '-c', filepath], stdout=f)
         file_gz = file + '.gz'
         filepath_gz = filepath + '.gz'
+        compressed_size = os.path.getsize(tmpfile)
         img['path'] = file_gz
         img['sha256'] = sha256sum_file(tmpfile)
+        img['size'] = str(compressed_size)
 
         # just flush out after every image type, but unlink after writing.
         # Then, we should be able to interrupt and restart from the last type.


### PR DESCRIPTION
This unifies all the images (qemu, metal, openstack, vmware) to
provide an uncompressed size and compressed size in the `meta.json`.
This follows the same pattern of providing a SHA256 for the
uncompressed and compressed versions of the images.