### PR TITLE
cmdlib.sh: fix GIC version on aarch64

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -244,9 +244,9 @@ if [ -x /usr/libexec/qemu-kvm ]; then
 else
     # Enable arch-specific options for qemu
     case "$(arch)" in
-        "x86_64")  QEMU_KVM="qemu-system-$(arch) -accel kvm"         ;;
-        "aarch64") QEMU_KVM="qemu-system-$(arch) -accel kvm -M virt" ;;
-        "ppc64le") QEMU_KVM="qemu-system-ppc64 -accel kvm"           ;;
+        "x86_64")  QEMU_KVM="qemu-system-$(arch) -accel kvm"                          ;;
+        "aarch64") QEMU_KVM="qemu-system-$(arch) -accel kvm -M virt,gic-version=host" ;;
+        "ppc64le") QEMU_KVM="qemu-system-ppc64 -accel kvm"                            ;;
         *)         fatal "Architecture $(arch) not supported"
     esac
 fi


### PR DESCRIPTION
Some newer aarch64 HW (e.g. osprey) doesn't support the default GICv2
used by qemu. So explicitly pass in the GIC version depending on the
host.

This fixes the following error message:
qemu-kvm: PMU: KVM_SET_DEVICE_ATTR: Invalid argument
qemu-kvm: failed to set irq for PMU

Reference: https://bugzilla.redhat.com/show_bug.cgi?id=1661976

Signed-off-by: Rafael Fonseca <r4f4rfs@gmail.com>