### PR TITLE
deps.txt: just specify /usr/bin/ignition-validate

### DIFF
--- a/src/deps.txt
+++ b/src/deps.txt
@@ -41,7 +41,7 @@ podman buildah skopeo
 jq awscli
 
 # For ignition file validation in cmd-run
-ignition
+/usr/bin/ignition-validate
 
 # shellcheck for test
 ShellCheck


### PR DESCRIPTION
This was broken out in https://src.fedoraproject.org/rpms/ignition/pull-request/26