### PR TITLE
Fix running cosa in unprivileged mode on aarch64

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -320,6 +320,7 @@ EOF
         -netdev user,id=eth0,hostname=supermin \
         -device virtio-net-pci,netdev=eth0 \
         -device virtio-scsi-pci,id=scsi0,bus=${pcibus},addr=0x3 \
+        -object rng-random,filename=/dev/urandom,id=rng0 -device virtio-rng-pci,rng=rng0 \
         -drive if=none,id=drive-scsi0-0-0-0,snapshot=on,file="${vmbuilddir}/root" \
         -device scsi-hd,bus=scsi0.0,channel=0,scsi-id=0,lun=0,drive=drive-scsi0-0-0-0,id=scsi0-0-0-0,bootindex=1 \
         -drive if=none,id=drive-scsi0-0-0-1,discard=unmap,file="${workdir}/cache/cache.qcow2" \

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -305,10 +305,13 @@ EOF
         srcvirtfs=("-virtfs" "local,id=source,path=${workdir}/src/config,security_model=none,mount_tag=source")
     fi
 
-    # 'pci' bus doesn't work on aarch64
     pcibus=pci.0
+    arch_args=''
     if [ "$(arch)" = "aarch64" ]; then
+        # 'pci' bus doesn't work on aarch64
         pcibus=pcie.0
+
+        arch_args='-bios /usr/share/AAVMF/AAVMF_CODE.fd'
     fi
 
     ${QEMU_KVM} -nodefaults -nographic -m 2048 -no-reboot -cpu host \
@@ -322,7 +325,8 @@ EOF
         -drive if=none,id=drive-scsi0-0-0-1,discard=unmap,file="${workdir}/cache/cache.qcow2" \
         -device scsi-hd,bus=scsi0.0,channel=0,scsi-id=0,lun=1,drive=drive-scsi0-0-0-1,id=scsi0-0-0-1 \
         -virtfs local,id=workdir,path="${workdir}",security_model=none,mount_tag=workdir \
-        "${srcvirtfs[@]}" -serial stdio -append "root=/dev/sda console=ttyS0 selinux=1 enforcing=0 autorelabel=1"
+        "${srcvirtfs[@]}" -serial stdio -append "root=/dev/sda console=ttyS0 selinux=1 enforcing=0 autorelabel=1" \
+        "${arch_args}"
 
     if [ ! -f "${workdir}"/tmp/rc ]; then
         fatal "Couldn't find rc file, something went terribly wrong!"


### PR DESCRIPTION
This patchset fixes #410 and make it possible to build FCOS images on aarch64 using unprivileged containers. The only thing remaining to successfully run the built image is #425: using newer `ignition` package with overrides and making sure autologin is at `ttyAMA0`.