### PR TITLE
buildextend: create initramfs and kernel artifacts

### DIFF
--- a/src/cmd-buildextend-installer
+++ b/src/cmd-buildextend-installer
@@ -155,11 +155,32 @@ def generate_iso():
     genisoargs += ['-o', tmpisofile, tmpisoroot]
 
     run_verbose(genisoargs)
+
+    kernel_name = f'{base_name}-{args.build}-installer-kernel'
+    initramfs_name = f'{base_name}-{args.build}-installer-initramfs.img'
+    kernel_file = os.path.join(builddir, kernel_name)
+    initramfs_file = os.path.join(builddir, initramfs_name)
+    shutil.copyfile(os.path.join(tmpisoimages, "vmlinuz"), kernel_file)
+    shutil.copyfile(os.path.join(tmpisoimages, "initramfs.img"), initramfs_file)
+
+    kernel_checksum = sha256sum_file(kernel_file)
+    initramfs_checksum = sha256sum_file(initramfs_file)
     checksum = sha256sum_file(tmpisofile)
-    buildmeta['images']['iso'] = {
-        'path': iso_name,
-        'sha256': checksum
-    }
+
+    buildmeta['images'].update({
+        'iso': {
+            'path': iso_name,
+            'sha256': checksum
+        },
+        'kernel': {
+            'path': kernel_name,
+            'sha256': kernel_checksum
+        },
+        'initramfs': {
+            'path': initramfs_name,
+            'sha256': initramfs_checksum
+        }
+    })
     os.rename(tmpisofile, f"{builddir}/{iso_name}")
     write_json(buildmeta_path, buildmeta)
     print(f"Updated: {buildmeta_path}")

--- a/src/cmd-compress
+++ b/src/cmd-compress
@@ -43,12 +43,13 @@ os.mkdir(tmpdir)
 
 at_least_one = False
 imgs_to_compress = []
-imgs_to_skip = ["iso", "vmware"]
+imgs_to_skip = ["iso", "vmware", "initramfs", "kernel"]
 
 for img_format in buildmeta['images']:
 
-    # Don't try to compress ISO images
+    # Don't compress certain images
     if img_format in imgs_to_skip:
+        print(f"Skipping {img_format}")
         continue
 
     img = buildmeta['images'][img_format]


### PR DESCRIPTION
The installer ISO generation already pulls the initramfs and kernel
from the ostree repo so this just piggybacks off that and copies the
artifacts to the build directory.  Having the initramfs and kernel is
useful for tools like virt-install and OZ to look at a tree and boot
the kernel with fine grain control over the kernel command line.