### PR TITLE
image-cloud: Use persistent NIC naming, drop eth0

### DIFF
--- a/src/image-cloud.ks
+++ b/src/image-cloud.ks
@@ -1,23 +1,5 @@
-# We use net.ifnames in cloud environments
 # no_timer_check is something we're cargo culting around
 # console= args are also for clouds
 # The other ones are for Ignition and are also in image-metal.ks;
 # change them there first.
-bootloader --timeout=1 --append="no_timer_check console=ttyS0,115200n8 console=tty0 net.ifnames=0 biosdevname=0 rootflags=defaults,prjquota rw $ignition_firstboot"
-
-%post --erroronfail
-# By default, we do DHCP.  Also, due to the above disabling
-# of biosdevname/net.ifnames, this uses eth0.
-# The DHCP_CLIENT_ID="mac" bit is so that we match what dhclient
-# does in the initrd, and the DHCP server gives us the same lease
-# if possible. See https://github.com/coreos/fedora-coreos-config/issues/58.
-cat <<EOF > /etc/sysconfig/network-scripts/ifcfg-eth0
-DEVICE="eth0"
-BOOTPROTO="dhcp"
-ONBOOT="yes"
-TYPE="Ethernet"
-PERSISTENT_DHCLIENT="yes"
-NM_CONTROLLED="yes"
-DHCP_CLIENT_ID="mac"
-EOF
-%end
+bootloader --timeout=1 --append="no_timer_check console=ttyS0,115200n8 console=tty0 rootflags=defaults,prjquota rw $ignition_firstboot"


### PR DESCRIPTION
With this I'll have to find a way to remove my "eth0 FOR LIFE" tattoo.

This came up in a bigger discussion with OpenStack:
https://github.com/coreos/ignition/issues/769#issuecomment-475825814

The history behind disabling persistent NIC naming in Fedora/RHEL
is...long.

I think we have an opportunity now to do a clean break with that
history.  Let's use persistent NIC naming even for cloud environments
like AWS.

This massively reduces the delta between our "metal" and "openstack"
images.  We just have console tweaks and `no_timer_check`.

Note that with https://github.com/coreos/ignition-dracut/pull/57
we actually do do DHCP on all interfaces anyways, so the hardcoded
`eth0` here made even less sense.