### PR TITLE
cmd-*: store JSON sizes as numbers rather than strings

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -325,7 +325,7 @@ first=true
      checksum=$(sha256sum "${path}" | cut -f 1 -d ' ')
      size=$(stat -c '%s' "${path}")
      if ${first}; then first=false; else echo ','; fi
-     echo '"'"${image}"'": {"path": "'"${path}"'", "sha256": "'"${checksum}"'", "size": "'"${size}"'"}'
+     echo '"'"${image}"'": {"path": "'"${path}"'", "sha256": "'"${checksum}"'", "size": '"${size}"'}'
  done
  echo "}}"
 ) > tmp/images.json

--- a/src/cmd-buildextend-openstack
+++ b/src/cmd-buildextend-openstack
@@ -52,7 +52,7 @@ def generate_openstack():
     buildmeta_images['openstack'] = {
         'path': openstack_name,
         'sha256': checksum,
-        'size': str(size)
+        'size': size
     }
     os.rename(tmp_img_openstack, f"{builddir}/{openstack_name}")
     write_json(buildmeta_path, buildmeta)

--- a/src/cmd-buildextend-vmware
+++ b/src/cmd-buildextend-vmware
@@ -118,7 +118,7 @@ def generate_ova_from_template():
     buildmeta_images['vmware'] = {
         'path': ova_name,
         'sha256': checksum,
-        'size': str(size)
+        'size': size
     }
 
     write_json(buildmeta_path, buildmeta)

--- a/src/cmd-compress
+++ b/src/cmd-compress
@@ -67,7 +67,7 @@ for img_format in buildmeta['images']:
         compressed_size = os.path.getsize(tmpfile)
         img['path'] = file_gz
         img['sha256'] = sha256sum_file(tmpfile)
-        img['size'] = str(compressed_size)
+        img['size'] = compressed_size
 
         # just flush out after every image type, but unlink after writing.
         # Then, we should be able to interrupt and restart from the last type.

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -451,7 +451,7 @@ prepare_git_artifacts() {
         "checksum_type": "sha256",
         "format": "tar.gz",
         "name": "$(basename ${tarball})",
-        "size": "$(stat --format=%s ${tarball})"
+        "size": $(stat --format=%s ${tarball})
     }
 }
 EOC


### PR DESCRIPTION
See discussion at https://github.com/coreos/coreos-assembler/pull/450#discussion_r270260281.