### PR TITLE
cmdlib: Accept CAP_SYS_ADMIN in bounding set

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -40,7 +40,7 @@ has_privileges() {
         if [ -n "${FORCE_UNPRIVILEGED:-}" ]; then
             info "Detected FORCE_UNPRIVILEGED; using virt"
             _privileged=0
-        elif ! capsh --print | grep -q 'Current.*cap_sys_admin'; then
+        elif ! capsh --print | grep -q 'Bounding.*cap_sys_admin'; then
             info "Missing CAP_SYS_ADMIN; using virt"
             _privileged=0
         elif ! sudo true; then


### PR DESCRIPTION
I'm switching my devel environment to https://github.com/debarshiray/toolbox/
and I think having CAP_SYS_ADMIN in the Current set was just a bug in my
`podman` scripts.  We really want to check the bounding set.

It was a pleasant surprise that `cosa build` worked just fine here,
including the recursive containerization from `bwrap`.