### PR TITLE
build: Remove unversioned qemu link

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -267,9 +267,6 @@ for itype in "${IMAGE_TYPES[@]}"; do
               images[$itype]="${img_qemu}"
               build_cloud_base
               /usr/lib/coreos-assembler/gf-platformid "$(pwd)"/"${img_base}" "$(pwd)"/"${img_qemu}" qemu
-              # make a version-less symlink to have a stable path
-              # TODO: Remove this, things should be parsing the metadata
-              ln -s "${img_qemu}" "${name}"-qemu.qcow2
               ;;
         metal-bios)
             img_metalbios=${imageprefix}-metal-bios.raw


### PR DESCRIPTION
Things should be parsing the build metadata now.