### PR TITLE
gf-platformid: used glob for EFI grub.cfg location

### DIFF
--- a/src/gf-platformid
+++ b/src/gf-platformid
@@ -72,7 +72,7 @@ coreos_gf_run_mount "${tmp_dest}"
 # * BLS config (for subsequent config regeneration)
 # First, the grub config.
 if [ "$(coreos_gf exists '/boot/efi')" == 'true' ]; then
-    grubcfg_path=/boot/efi/EFI/fedora/grub.cfg
+    grubcfg_path=$(coreos_gf glob-expand /boot/efi/EFI/*/grub.cfg)
 else
     grubcfg_path=/boot/loader/grub.cfg
 fi


### PR DESCRIPTION
Solves #361

Solution provided by Ben Howard

Signed-off-by: Rafael Fonseca <r4f4rfs@gmail.com>