### PR TITLE
gf-platformid: inject platform.id on aarch64

### DIFF
--- a/src/gf-platformid
+++ b/src/gf-platformid
@@ -80,7 +80,8 @@ coreos_gf download "${grubcfg_path}" "${tmpd}"/grub.cfg
 # Remove any platformid currently there
 sed -i -e 's, ignition.platform.id=[a-zA-Z0-9]*,,g' "${tmpd}"/grub.cfg
 # Insert our new platformid
-sed -i -e 's,^\(linux16 .*\),\1 ignition.platform.id='"${platformid}"',' "${tmpd}"/grub.cfg
+# Match both linux16 and linux since only the latter is available on aarch64
+sed -i -e 's,^\(linux\(16\)\? .*\),\1 ignition.platform.id='"${platformid}"',' "${tmpd}"/grub.cfg
 coreos_gf upload "${tmpd}"/grub.cfg "${grubcfg_path}"
 # Now the BLS version
 blscfg_path=$(coreos_gf glob-expand /boot/loader/entries/ostree-*.conf)


### PR DESCRIPTION
Since aarch64 has only EFI booting, the linux entry is just 'linux' not
'linux16'.

Fixes #458

Signed-off-by: Rafael Fonseca <r4f4rfs@gmail.com>