### PR TITLE
src/cmdlib: record git branch in cosa JSON

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -444,6 +444,7 @@ prepare_git_artifacts() {
     "git": {
         "commit": "${rev}",
         "origin": "${head_url}",
+        "branch": "${branch}",
         "dirty": "${is_dirty}"
     },
     "file": {


### PR DESCRIPTION
While we already record the commit that `coreos-assembler` is built
from, it would be useful to know what branch the commit was from, too.