### PR TITLE
src/libguestfish: unset GUESTFISH* vars during shutdown

### DIFF
--- a/src/libguestfish.sh
+++ b/src/libguestfish.sh
@@ -78,4 +78,6 @@ coreos_gf_run_mount() {
 coreos_gf_shutdown() {
     coreos_gf umount-all
     coreos_gf exit
+    GUESTFISH_RUNNING=
+    GUESTFISH_PID=
 }


### PR DESCRIPTION
If you are using multiple invocations of the `coreos_gf_run` and
`coreos_gf_shutdown` in the same script, it would fail because the
`GUESTFISH_RUNNING` and `GUESTFISH_PID` would remain set.  This unsets
them as part of `coreos_gf_shutdown`