### PR TITLE
Also connect to consoles for bare metal

### DIFF
--- a/src/image-cloud.ks
+++ b/src/image-cloud.ks
@@ -1,5 +1,4 @@
 # no_timer_check is something we're cargo culting around
-# console= args are also for clouds
 # The other ones are for Ignition and are also in image-metal.ks;
 # change them there first.
 bootloader --timeout=1 --append="no_timer_check console=ttyS0,115200n8 console=tty0 rootflags=defaults,prjquota rw $ignition_firstboot"

--- a/src/image-metal.ks
+++ b/src/image-metal.ks
@@ -2,4 +2,4 @@
 # ignition.platform.id=metal is from https://github.com/coreos/fedora-coreos-tracker/issues/142
 # prjquota is for quota enablement for containers: https://bugzilla.redhat.com/show_bug.cgi?id=1658386
 # rw and $ignition_firstboot are used by https://github.com/coreos/ignition-dracut/
-bootloader --append="ignition.platform.id=metal rootflags=defaults,prjquota rw $ignition_firstboot"
+bootloader --append="ignition.platform.id=metal console=ttyS0,115200n8 console=tty0 rootflags=defaults,prjquota rw $ignition_firstboot"


### PR DESCRIPTION
Being able to see bootup progress and log in through the serial console
is also relevant for bare metal nodes.