### PR TITLE
Unify metal and cloud builds further

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -268,15 +268,13 @@ for itype in "${IMAGE_TYPES[@]}"; do
               build_cloud_base
               /usr/lib/coreos-assembler/gf-platformid "$(pwd)"/"${img_base}" "$(pwd)"/"${img_qemu}" qemu
               ;;
-        metal-bios)
-            img_metalbios=${imageprefix}-metal-bios.raw
-            images[$itype]="${img_metalbios}"
-            run_virtinstall "$(pwd)"/"${img_metalbios}" --variant=metal
-            ;;
-        metal-uefi)
-            img_metaluefi=${imageprefix}-metal-uefi.raw
-            images[$itype]="${img_metaluefi}"
-            run_virtinstall "$(pwd)"/"${img_metaluefi}" --variant=metal-uefi
+        metal-bios|metal-uefi)
+            iname=${imageprefix}-${itype}.raw
+            images[$itype]="${iname}"
+            path="$(pwd)"/"${iname}"
+            run_virtinstall "${path}".tmp --variant="${itype}"
+            /usr/lib/coreos-assembler/gf-platformid "${path}"{.tmp,} metal
+            rm -f "${path}".tmp
             ;;
         *) fatal "Unrecognized image type: $itype"
            ;;

--- a/src/image-base.ks
+++ b/src/image-base.ks
@@ -14,6 +14,10 @@ rootpw --lock --iscrypted locked
 # We don't want Anaconda to touch the firewall
 firewall --disabled
 
+# prjquota is for quota enablement for containers: https://bugzilla.redhat.com/show_bug.cgi?id=1658386
+# rw and $ignition_firstboot are used by https://github.com/coreos/ignition-dracut/
+# Console settings are so we see output everywhere
+bootloader --timeout=1 --append="console=ttyS0,115200n8 console=tty0 rootflags=defaults,prjquota rw $ignition_firstboot"
 # Anaconda currently writes out configs for this which we don't want to persist; see below
 network --bootproto=dhcp --onboot=on
 

--- a/src/image-cloud.ks
+++ b/src/image-cloud.ks
@@ -1,4 +1,0 @@
-# no_timer_check is something we're cargo culting around
-# The other ones are for Ignition and are also in image-metal.ks;
-# change them there first.
-bootloader --timeout=1 --append="no_timer_check console=ttyS0,115200n8 console=tty0 rootflags=defaults,prjquota rw $ignition_firstboot"

--- a/src/image-metal.ks
+++ b/src/image-metal.ks
@@ -1,5 +1,0 @@
-# If you add something here, also update image-cloud.ks.
-# ignition.platform.id=metal is from https://github.com/coreos/fedora-coreos-tracker/issues/142
-# prjquota is for quota enablement for containers: https://bugzilla.redhat.com/show_bug.cgi?id=1658386
-# rw and $ignition_firstboot are used by https://github.com/coreos/ignition-dracut/
-bootloader --append="ignition.platform.id=metal console=ttyS0,115200n8 console=tty0 rootflags=defaults,prjquota rw $ignition_firstboot"

--- a/src/virt-install
+++ b/src/virt-install
@@ -30,8 +30,8 @@ parser.add_argument("--create-disk", help="Automatically create disk as qcow2, p
                     action='store_true')
 parser.add_argument("--configdir", help="coreos-assembler configdir",
                     action='store', required=True)
-parser.add_argument("--variant", help="Use an internal (kickstart) config",
-                    choices=('metal', 'metal-uefi', 'cloud'), default=None)
+parser.add_argument("--variant", help="Configure image variant",
+                    choices=('metal-bios', 'metal-uefi', 'cloud'), default=None)
 parser.add_argument("--kickstart-out", help="Save flattened kickstart",
                     action='store')
 parser.add_argument("--location", help="Installer location",
@@ -97,14 +97,6 @@ else:
     ks_tmp = tempfile.NamedTemporaryFile(mode='w', prefix="coreos-virtinstall", suffix=".ks")
 
 disk_size = None
-
-if args.variant is not None:
-    if args.variant == 'metal-uefi':
-        variant_ks = 'metal'
-    else:
-        variant_ks = args.variant
-    with open(f'/usr/lib/coreos-assembler/image-{variant_ks}.ks') as f:
-        shutil.copyfileobj(f, ks_tmp)
 
 with open('/usr/lib/coreos-assembler/image-base.ks') as basef:
     shutil.copyfileobj(basef, ks_tmp)
@@ -184,7 +176,7 @@ ostree refs --delete {args.ostree_remote}:{args.ostree_ref}
 """)
 
 if args.create_disk:
-    if args.variant in ('metal', 'metal-uefi'):
+    if args.variant.startswith('metal-'):
         fmt = 'raw'
         size_estimate_path = os.path.join(args.tmpdir, 'ostree-size.json')
         # The OSTree size is shared among disk images, so we compute it once per build


### PR DESCRIPTION
Followup to: https://github.com/coreos/coreos-assembler/pull/473
Since the only difference was `no_timer_check`, and we don't
care about that, let's just drop it.

Then switch to using `gf-platformid` for the metal images, which
as a side effect also ensures we inject `coreos.oem.id` which
will help Ignition spec2x systems.

(What is still different between metal and cloud is sizing, we
 shrink metal disks to fit)