### PR TITLE
build: Remove unversioned qemu link

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -267,9 +267,6 @@ for itype in "${IMAGE_TYPES[@]}"; do
               images[$itype]="${img_qemu}"
               build_cloud_base
               /usr/lib/coreos-assembler/gf-platformid "$(pwd)"/"${img_base}" "$(pwd)"/"${img_qemu}" qemu
-              # make a version-less symlink to have a stable path
-              # TODO: Remove this, things should be parsing the metadata
-              ln -s "${img_qemu}" "${name}"-qemu.qcow2
               ;;
         metal-bios)
             img_metalbios=${imageprefix}-metal-bios.raw


### PR DESCRIPTION
I mistakenly thought this had already been backported, this should have been part of https://github.com/coreos/coreos-assembler/pull/475

Things should be parsing the build metadata now.

(cherry picked from commit 1b12aa584342de12d98a96257fbced62a90968e6)