### PR TITLE
Rebase tree to f30

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:29
+FROM registry.fedoraproject.org/fedora:30
 WORKDIR /root/containerbuild
 
 # Only need a few of our scripts for the first few steps

--- a/build.sh
+++ b/build.sh
@@ -26,11 +26,11 @@ fi
 set -x
 srcdir=$(pwd)
 
-release="29"
+release="30"
 
 configure_yum_repos() {
     if [ -n "${ISFEDORA}" ]; then
-        # Add f29-coreos-continuous tag for latest build tools
+        # Add continuous tag for latest build tools
         echo -e "[f$release-coreos-continuous]\nenabled=1\nmetadata_expire=1m\nbaseurl=https://kojipkgs.fedoraproject.org/repos-dist/f$release-coreos-continuous/latest/\$basearch/\ngpgcheck=0\n" > /etc/yum.repos.d/coreos.repo
 
     fi
@@ -100,6 +100,10 @@ _prep_make_and_make_install() {
     fi
 }
 
+# For now keep using the f29 anaconda. There's no golden f30 image yet and it
+# doesn't support the installclass stuff and hopefully we'll stop using it soon.
+installer_release=29
+
 arch=$(uname -m)
 # Download url is different for primary and secondary fedora
 # Primary Fedora - https://download.fedoraproject.org/pub/fedora/linux/releases/
@@ -113,8 +117,8 @@ repository_dirs[ppc64le]=fedora-secondary
 repository_dirs[s390x]=fedora-secondary
 
 repository_dir=${repository_dirs[$arch]}
-INSTALLER=https://download.fedoraproject.org/pub/$repository_dir/releases/$release/Everything/$arch/iso/Fedora-Everything-netinst-$arch-$release-1.2.iso
-INSTALLER_CHECKSUM=https://download.fedoraproject.org/pub/$repository_dir/releases/$release/Everything/$arch/iso/Fedora-Everything-$release-1.2-$arch-CHECKSUM
+INSTALLER=https://download.fedoraproject.org/pub/$repository_dir/releases/$installer_release/Everything/$arch/iso/Fedora-Everything-netinst-$arch-$installer_release-1.2.iso
+INSTALLER_CHECKSUM=https://download.fedoraproject.org/pub/$repository_dir/releases/$installer_release/Everything/$arch/iso/Fedora-Everything-$installer_release-1.2-$arch-CHECKSUM
 
 install_anaconda() {
     # Overriding install URL


### PR DESCRIPTION
This will allow us to match the content we're now composing. It also
means that from this point on, f29 is strictly about Fedora Atomic Host,
while f30 is strictly about Fedora CoreOS. This means more flexibility
wrt backwards compatibility.

The odd one is Anaconda; we're still using the f29 one for now. See
comment in patch for details.