### PR TITLE
gf-anaconda-cleanup: Remove cruft in /

### DIFF
--- a/src/gf-anaconda-cleanup
+++ b/src/gf-anaconda-cleanup
@@ -38,5 +38,13 @@ done
 # And blow away all of /var - we want systemd-tmpfiles to be
 # canonical
 coreos_gf rm-rf "${stateroot}/var/*"
+# And finally, remove cruft from the *physical* root as nothing should be
+# using those; Anaconda is creating them today.
+for x in $(coreos_gf glob-expand '/*'); do
+  case $x in
+    /ostree/|/boot/) continue;;
+    *) coreos_gf rm-rf "${x}"
+  esac
+done
 
 coreos_gf_shutdown


### PR DESCRIPTION
In particular the presence of `/etc/resolv.conf` was confusing,
even though it wasn't used.

Delete everything except `/boot` and `/ostree`.