### PR TITLE
virt-install: Exit with error if port is in use

### DIFF
--- a/src/virt-install
+++ b/src/virt-install
@@ -238,9 +238,14 @@ class RequestHandler(http.server.SimpleHTTPRequestHandler):
         n_requests += 1
 
 def run_webserver():
-    print(f"Listening on {ipv4}:{PORT}")
-    server = http.server.ThreadingHTTPServer((ipv4, PORT), RequestHandler)
-    server.serve_forever()
+    try:
+        print(f"Listening on {ipv4}:{PORT}")
+        server = http.server.ThreadingHTTPServer((ipv4, PORT), RequestHandler)
+        server.serve_forever()
+    except Exception as e:
+        sys.stderr.write(f"Http thread failed:\n{e}\n")
+        sys.stderr.flush()
+        os._exit(1)
 
 try:
     vinstall_args = ["virt-install", "--connect=qemu:///session",


### PR DESCRIPTION
When I installed the OpenShift extension for VS Code that started
spawning a JVM in the background which for probably terrible
reasons listens to port `8000` by default.  We should also
do dynamic ports at some point.

Then it also turned out that Python's raw thread API has
the rather unfortunate semantics that an exception thrown in a
thread just prints to stderr and continues.

I think we really want is to use the futures suggestion from
https://stackoverflow.com/questions/2829329/catch-a-threads-exception-in-the-caller-thread-in-python
but I'm not feeling it's worth trying to figure out how to rearchitect
this code to use futures right now.