### PR TITLE
virt-install: Add back --console=log.file

### DIFF
--- a/src/virt-install
+++ b/src/virt-install
@@ -257,6 +257,7 @@ try:
     else:
         vinstall_args.append('--nographics')
     if args.console_log_file:
+        vinstall_args.append("--console=log.file={}".format(args.console_log_file))
         tail_proc = subprocess.Popen(["setpriv", "--pdeathsig", "term", "--", "/bin/sh", "-c", f"tail -F {args.console_log_file} | grep anaconda"])
 
     # Note this is racy, we should be waiting for the webserver to be up


### PR DESCRIPTION
We lost this in 5571bca. We need it to get streaming Anaconda logs.