### PR TITLE
[rhcos-4.1] Revert "Fix nuking everything in /var"

### DIFF
--- a/src/gf-anaconda-cleanup
+++ b/src/gf-anaconda-cleanup
@@ -25,7 +25,7 @@ for x in "/etc/sysconfig/anaconda" "/etc/resolv.conf" "/etc/systemd/system/defau
 done
 # And blow away all of /var - we want systemd-tmpfiles to be
 # canonical
-coreos_gf glob rm-rf "${stateroot}/var/*"
+coreos_gf rm-rf "${stateroot}/var/*"
 # And finally, remove cruft from the *physical* root as nothing should be
 # using those; Anaconda is creating them today.
 for x in $(coreos_gf glob-expand '/*'); do


### PR DESCRIPTION
This reverts commit 1a005c024b55f80a1e520ff91a640e277b375bbc.

See https://github.com/coreos/coreos-assembler/issues/500.