### PR TITLE
[backport] gf-anaconda-cleanup: Remove cruft in /etc

### DIFF
--- a/src/gf-anaconda-cleanup
+++ b/src/gf-anaconda-cleanup
@@ -18,11 +18,23 @@ coreos_gf_run "${src}"
 coreos_gf set-label /dev/sda2 boot
 coreos_gf_run_mount "${src}"
 
-# Remove some things written by anaconda; eventually
-# we want to reset /etc except we also need /etc/fstab right now e.g.
-for x in "/etc/sysconfig/anaconda" "/etc/resolv.conf" "/etc/systemd/system/default.target"; do
-    coreos_gf rm-rf "${deploydir}${x}"
+# Remove most things written by anaconda in /etc, except
+# for /etc/fstab mainly.  We also keep /etc/hostname and /etc/locale.conf as otherwise
+# systemd-firstboot triggers.
+for x in "sysconfig/anaconda" "sysconfig/network" "crypttab" "resolv.conf" "X11" "systemd/system/default.target" "shadow-"; do
+    coreos_gf rm-rf "${deploydir}/etc/${x}"
 done
+for x in $(coreos_gf glob-expand "${deploydir}/etc/sysconfig/network-scripts/"'*'); do
+    coreos_gf rm-rf "${x}"
+done
+for x in $(coreos_gf find "${deploydir}/etc/ostree/remotes.d/"); do
+    e=$(coreos_gf exists "${deploydir}/usr/etc/${x}")
+    if [ "${e}" = "true" ]; then
+        continue
+    fi
+    coreos_gf rm "${deploydir}/etc/ostree/remotes.d/${x}"
+done
+
 # And blow away all of /var - we want systemd-tmpfiles to be
 # canonical
 coreos_gf rm-rf "${stateroot}/var/*"


### PR DESCRIPTION
In particular @bgilbert pointed out that we had
`/etc/sysconfig/network-scripts/ifcfg-enp2s0` which is horrifying.

Though it turns out we need `/etc/hostname` and `/etc/vconsole.conf`,
otherwise `systemd-firstboot.service` kicks in.  We should probably figure
out having Ignition default to doing everything systemd-firstboot
does.

(cherry picked from commit 516de82c77f2cb903b061ada2d6f0d25dd34b9ee)