### PR TITLE
Nuke anaconda leftover bits from /var

### DIFF
--- a/src/gf-anaconda-cleanup
+++ b/src/gf-anaconda-cleanup
@@ -35,9 +35,9 @@ for x in $(coreos_gf find "${deploydir}/etc/ostree/remotes.d/"); do
     coreos_gf rm "${deploydir}/etc/ostree/remotes.d/${x}"
 done
 
-# And blow away all of /var - we want systemd-tmpfiles to be
-# canonical
-coreos_gf rm-rf "${stateroot}/var/*"
+# And blow away things from /var we don't want.
+coreos_gf rm-rf "${stateroot}/var/log/anaconda"    # anaconda logs
+coreos_gf glob rm-rf "${stateroot}/var/roothome/*" # kickstarts
 # And finally, remove cruft from the *physical* root as nothing should be
 # using those; Anaconda is creating them today.
 for x in $(coreos_gf glob-expand '/*'); do


### PR DESCRIPTION
Don't nuke all of `/var`; there are some interdependencies there with
mountpoints (see discussions in [1]). For now, just nuke Anaconda
specific things we don't want.

[1] https://github.com/coreos/ignition-dracut/pull/79