### PR TITLE
Add COSA_RPMOSTREE_GDB env, change to COSA_RPMOSTREE_ARGS

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -224,9 +224,9 @@ EOF
     rm -f "${changed_stamp}"
 
     # shellcheck disable=SC2086
-    set - rpm-ostree compose tree --repo="${workdir}"/repo \
+    set - ${COSA_RPMOSTREE_GDB:-} rpm-ostree compose tree --repo="${workdir}"/repo \
             --cachedir="${workdir}"/cache --touch-if-changed "${changed_stamp}" \
-            --unified-core "${manifest}" ${RPMOSTREE_EXTRA_ARGS:-} "$@"
+            --unified-core "${manifest}" ${COSA_RPMOSTREE_ARGS:-} "$@"
 
     echo "Running: $*"
 


### PR DESCRIPTION
The first is useful for `env COSA_RPMOSTREE_GDB="gdb --args"`.  Make
the name of the second consistent.