### PR TITLE
cmd-run: Add --persist-to-img IMG

### DIFF
--- a/src/cmd-run
+++ b/src/cmd-run
@@ -113,6 +113,13 @@ kernel.printk = 3 4 1 7
 EOF
     )
 
+    coreos_assembler_motd=$(cat << 'EOF' | base64 --wrap 0
+ICMP traffic (ping) does not work with QEMU and user mode networking.
+To exit, press Ctrl-A and then X.
+
+EOF
+    )
+
     f=$(mktemp)
     cat > "${f}" <<EOF
 {
@@ -124,6 +131,13 @@ EOF
             {
                 "path": "/etc/sysctl.d/10-coreos-assembler.conf",
                 "contents": { "source": "data:text/plain;base64,${coreos_assembler_sysctl}" },
+                "mode": 420
+            },
+            {
+                "path": "/etc/motd",
+                "append": [
+                    { "source": "data:text/plain;base64,${coreos_assembler_motd}" }
+                ],
                 "mode": 420
             }
         ]
@@ -138,11 +152,6 @@ EOF
                         "contents": "[Service]\\nTTYVTDisallocate=no\\nExecStart=\\nExecStart=-/usr/sbin/agetty --autologin core --noclear %I \$TERM\\n"
                     }
                 ]
-            },
-            {
-                "name": "serial-getty-motd.service",
-                "enabled": true,
-                "contents": "[Unit]\\nDescription=Helper message to exit QEMU monitor to /etc/motd\\nBefore=getty.target\\n[Service]\\nType=oneshot\\nExecStart=/bin/sh -c '/usr/bin/echo \\"ICMP traffic (ping) does not work with QEMU and user mode networking.\\\\nTo exit, press Ctrl-A and then X.\\\\n\\" >> /etc/motd'\\n[Install]\\nWantedBy=getty.target\\n"
             }
             ${ign_var_srv_mount}
         ]

--- a/src/cmd-run
+++ b/src/cmd-run
@@ -13,19 +13,19 @@ dn=$(dirname "$0")
 
 VM_DISK=
 VM_MEMORY=2048
-VM_PERSIST=0
+VM_PERSIST_IMG=
 VM_NCPUS="${VM_NCPUS:-$(nproc)}"
 VM_SRV_MNT=
 SSH_PORT=${SSH_PORT:-}
 USAGE="Usage: $0 [-d /path/to/disk.qcow2] [--] [qemu options...]
 Options:
-    -d DISK     Root disk drive (won't be changed by default)
-    --persist   Don't create a temporary snapshot
-    -i FILE     File containing an Ignition config
-    --srv src   Mount (via 9p) src on the host as /var/srv in guest
-    -m MB       RAM size in MB (2048)
-    -p PORT     The port on localhost to map to the VM's sshd. [2222]
-    -h          this ;-)
+    -d DISK               Root disk drive (won't be changed by default)
+    --persist-to-img IMG  Persist changes to a separate image
+    -i FILE               File containing an Ignition config
+    --srv src             Mount (via 9p) src on the host as /var/srv in guest
+    -m MB                 RAM size in MB (2048)
+    -p PORT               The port on localhost to map to the VM's sshd. [2222]
+    -h                    this ;-)
 
 This script is a wrapper around qemu for starting CoreOS virtual machines,
 it will auto-log you into the console, and by default for read-only disk
@@ -46,9 +46,9 @@ while [ $# -ge 1 ]; do
         -d)
             VM_DISK="$2"
             shift 2 ;;
-        --persist)
-            VM_PERSIST=1
-            shift 1 ;;
+        --persist-to-img)
+            VM_PERSIST_IMG="$2"
+            shift 2 ;;
         -i|--ignition-config)
             IGNITION_CONFIG_FILE="$2"
             shift 2 ;;
@@ -84,6 +84,23 @@ if [ -z "${VM_DISK}" ]; then
     else
         die "No builds/latest, and no -d argument provided"
     fi
+fi
+
+# make sure disk path is absolute
+VM_DISK=$(realpath "${VM_DISK}")
+
+if [ -z "${VM_PERSIST_IMG}" ]; then
+    f=$(mktemp -p "${TMPDIR:-/var/tmp}")
+    exec 4<> "${f}"
+    rm -f "${f}"
+    VM_PERSIST_IMG=/proc/self/fd/4
+fi
+
+if [ ! -s "${VM_PERSIST_IMG}" ]; then
+    echo "Creating temporary image"
+    qemu-img create -q -f qcow2 -b "${VM_DISK}" "${VM_PERSIST_IMG}"
+else
+    echo "Re-using existing ${VM_PERSIST_IMG}"
 fi
 
 # Emulate the host CPU closely in both features and cores.
@@ -173,12 +190,7 @@ if [ -n "${SSH_PORT}" ]; then
    hostfwd=",hostfwd=tcp::${SSH_PORT}-:22"
 fi
 
-if [ "${VM_PERSIST}" = 0 ]; then
-    set -- -snapshot "$@"
-    vm_drive_args=",cache=unsafe"
-fi
-
-set -- -drive if=virtio"${vm_drive_args:-}",file="${VM_DISK}" "$@"
+set -- -drive if=virtio,file="${VM_PERSIST_IMG}" "$@"
 
 # There is no BIOS on aarch64, so we need a firmware to boot the system
 if [ "$(arch)" == "aarch64" ]; then

--- a/src/cmd-run
+++ b/src/cmd-run
@@ -101,8 +101,9 @@ else
     ign_var_srv_mount=""
 fi
 
+if [ -z "${IGNITION_CONFIG_FILE:-}" ]; then
 
-coreos_assembler_sysctl=$(cat << 'EOF' | base64 --wrap 0
+    coreos_assembler_sysctl=$(cat << 'EOF' | base64 --wrap 0
 # Written during `coreos-assembler run`.
 
 # Right now, we're running at the default log level, which is DEBUG (7).
@@ -110,9 +111,8 @@ coreos_assembler_sysctl=$(cat << 'EOF' | base64 --wrap 0
 # Bump the default to ERROR (3).
 kernel.printk = 3 4 1 7
 EOF
-)
+    )
 
-if [ -z "${IGNITION_CONFIG_FILE:-}" ]; then
     f=$(mktemp)
     cat > "${f}" <<EOF
 {

--- a/src/cmd-run
+++ b/src/cmd-run
@@ -75,7 +75,6 @@ while [ $# -ge 1 ]; do
     esac
 done
 
-set -x
 preflight
 
 if [ -z "${VM_DISK}" ]; then


### PR DESCRIPTION
This is useful when we want to be able to hack on a VM that has a bit
more persistence, but not necessarily go the full `virt-install` path
(or if you can't use libvirt for whatever reason). Basically make using
`cosa run` as a glorified `qemu-kvm` easier.