### PR TITLE
src/cmdlib.sh: only use RPM overrides if RPMs present

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -206,7 +206,7 @@ EOF
         mkdir tmp/overlay-build
         (cd tmp/overlay-build && "${DIR}"/build_rpm_from_dir "${configdir}/overlay" "${name}-overlay" "${workdir}/overrides/rpm")
     fi
-    if [ -d "${overridesdir}"/rpm ]; then
+    if [[ -n $(ls "${overridesdir}/rpm/"*.rpm 2> /dev/null) ]]; then
         (cd "${overridesdir}"/rpm && createrepo_c .)
         echo "Using RPM overrides from: ${overridesdir}/rpm"
         cat >> "${override_manifest}" <<EOF


### PR DESCRIPTION
Previously, we would go through the motions of creating a temporary
repo if the `overrides/rpm` directory was present, even if there were
no RPMs in the directory.  This changes the process to only create the
repo if RPMs are actually present in the directory.