### PR TITLE
Split out metal-{bios,uefi} into buildextend-metal

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -18,8 +18,6 @@ Usage: coreos-assembler build --help
 
     - ostree
     - qemu
-    - metal-bios
-    - metal-uefi
 
   Note that all image targets also require the "ostree" target.
 EOF
@@ -64,18 +62,6 @@ done
 
 if [ $# -eq 0 ]; then
     set -- qemu
-fi
-
-declare -a IMAGE_TYPES
-IMAGE_TYPES=()
-# shellcheck disable=SC2068
-for target in $@; do
-    if [[ $target != ostree ]]; then
-        IMAGE_TYPES+=("$target")
-    fi
-done
-if [ "${#IMAGE_TYPES[@]}" != 0 ]; then
-    echo "Image types: ${IMAGE_TYPES[*]}"
 fi
 
 export LIBGUESTFS_BACKEND=direct
@@ -205,36 +191,9 @@ img_base=tmp/${imageprefix}-base.qcow2
 # forgive me for this sin
 checksum_location=$(find /usr/lib/coreos-assembler-anaconda/ -name '*CHECKSUM' | head -1)
 
-build_cloud_base() {
-    if [ -f "${PWD}/${img_base}" ]; then
-        return
-    fi
-    local args=""
-    args="$args --variant=cloud"
-    # shellcheck disable=SC2046 disable=SC2086
-    run_virtinstall "${ref:-${commit}}" "${PWD}"/"${img_base}" $args
-}
-
-declare -A images
-for itype in "${IMAGE_TYPES[@]}"; do
-    case $itype in
-        qemu) img_qemu=${imageprefix}-qemu.qcow2
-              images[$itype]="${img_qemu}"
-              build_cloud_base
-              /usr/lib/coreos-assembler/gf-platformid "$(pwd)"/"${img_base}" "$(pwd)"/"${img_qemu}" qemu
-              ;;
-        metal-bios|metal-uefi)
-            iname=${imageprefix}-${itype}.raw
-            images[$itype]="${iname}"
-            path="$(pwd)"/"${iname}"
-            run_virtinstall "${ref:-${commit}}" "${path}".tmp --variant="${itype}"
-            /usr/lib/coreos-assembler/gf-platformid "${path}"{.tmp,} metal
-            rm -f "${path}".tmp
-            ;;
-        *) fatal "Unrecognized image type: $itype"
-           ;;
-    esac
-done
+img_qemu=${imageprefix}-qemu.qcow2
+run_virtinstall "${ref:-${commit}}" "${PWD}"/"${img_base}" --variant=cloud
+/usr/lib/coreos-assembler/gf-platformid "$(pwd)"/"${img_base}" "$(pwd)"/"${img_qemu}" qemu
 
 "${dn}"/write-commit-object "${workdir}/repo" "${commit}" "$(pwd)"
 
@@ -270,18 +229,17 @@ cat > tmp/meta.json <<EOF
 }
 EOF
 
-# The `images:` section
-first=true
-(echo '{ "images": {'
- for image in "${!images[@]}"; do
-     path=${images[${image}]}
-     checksum=$(sha256sum "${path}" | cut -f 1 -d ' ')
-     size=$(stat -c '%s' "${path}")
-     if ${first}; then first=false; else echo ','; fi
-     echo '"'"${image}"'": {"path": "'"${path}"'", "sha256": "'"${checksum}"'", "size": '"${size}"'}'
- done
- echo "}}"
-) > tmp/images.json
+cat > tmp/images.json <<EOF
+{
+    "images": {
+        "qemu": {
+            "path": "${img_qemu}",
+            "sha256": "$(sha256sum_str < "${img_qemu}")",
+            "size": $(stat -c '%s' "${img_qemu}")
+        }
+    }
+}
+EOF
 
 # And the build information about our container, if we are executing
 # from a container.

--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+dn=$(dirname "$0")
+# shellcheck source=src/cmdlib.sh
+. "${dn}"/cmdlib.sh
+
+print_help() {
+    cat 1>&2 <<'EOF'
+Usage: coreos-assembler buildextend-metal --help
+       coreos-assembler buildextend-metal [--build ID] [--bios] [--uefi]
+
+  Build raw metal images for bios or metal. If neither switches are provided,
+  both targets are built.
+EOF
+}
+
+# Parse options
+BIOS=
+UEFI=
+rc=0
+build=
+options=$(getopt --options h --longoptions help,build,bios,uefi -- "$@") || rc=$?
+[ $rc -eq 0 ] || {
+    print_help
+    exit 1
+}
+eval set -- "$options"
+while true; do
+    case "$1" in
+        -h | --help)
+            print_help
+            exit 0
+            ;;
+        --bios)
+            BIOS=1
+            ;;
+        --uefi)
+            UEFI=1
+            ;;
+        --build)
+            build=$2
+            shift
+            ;;
+        --)
+            shift
+            break
+            ;;
+        -*)
+            fatal "$0: unrecognized option: $1"
+            exit 1
+            ;;
+        *)
+            break
+            ;;
+    esac
+    shift
+done
+
+if [ $# -ne 0 ]; then
+    print_help
+    fatal "Too many arguments passed"
+fi
+
+# default to both of them
+if [ -z "${BIOS}" ] && [ -z "${UEFI}" ]; then
+    BIOS=1
+    UEFI=1
+fi
+
+export LIBGUESTFS_BACKEND=direct
+
+prepare_build
+
+if [ -z "${build}" ]; then
+    if [ -L "${workdir}"/builds/latest ]; then
+        build=$(readlink "${workdir}"/builds/latest)
+    else
+        fatal "No build found."
+    fi
+fi
+
+builddir="${workdir}/builds/${build}"
+if [ ! -d "${builddir}" ]; then
+    fatal "Build dir ${builddir} does not exist."
+fi
+
+json_key() {
+    jq -r ".[\"$1\"]" < "${builddir}/meta.json"
+}
+
+# reread these values from the build itself rather than rely on the ones loaded
+# by prepare_build since the config might've changed since then
+name=$(json_key name)
+ref=$(json_key ref)
+ref_is_temp=""
+if [ "${ref}" = "null" ]; then
+    ref="tmpref-${name}"
+    ref_is_temp=1
+fi
+commit=$(json_key ostree-commit)
+
+# for anaconda logs
+mkdir -p tmp/anaconda
+
+for itype in ${BIOS:+metal-bios} ${UEFI:+metal-uefi}; do
+    img=${name}-${build}-${itype}.raw
+    if [ -f "${builddir}/${img}" ]; then
+        echo "Image $itype already exists"
+        continue
+    fi
+
+    path=${PWD}/${img}
+    run_virtinstall "${commit}" "${path}.tmp" --variant="${itype}"
+    /usr/lib/coreos-assembler/gf-platformid "${path}"{.tmp,} metal
+    rm -f "${path}".tmp
+
+    # flush it out before going to the next one so we don't have to redo both if
+    # the next one fails
+
+    # there's probably a jq one-liner for this...
+    python3 -c "
+import sys, json
+j = json.load(sys.stdin)
+j['images']['$itype'] = {
+    'path': '${img}',
+    'sha256': '$(sha256sum_str < "${img}")',
+    'size': $(stat -c '%s' "${img}")
+}
+json.dump(j, sys.stdout, indent=4)
+" < "${builddir}/meta.json" > meta.json.new
+
+    # and now the crucial bit
+    mv -T meta.json.new "${builddir}/meta.json"
+    mv -T "${img}" "${builddir}/${img}"
+done

--- a/src/coreos-assembler
+++ b/src/coreos-assembler
@@ -38,7 +38,7 @@ cmd=${1:-}
 build_commands="init fetch build run prune clean"
 # commands more likely to be used in a prod pipeline only
 advanced_build_commands="buildprep oscontainer"
-buildextend_commands="aws openstack installer vmware"
+buildextend_commands="aws openstack installer vmware metal"
 utility_commands="tag compress bump-timestamp"
 other_commands="shell"
 if [ -z "${cmd}" ]; then


### PR DESCRIPTION
We don't want to have to create metal images upfront if the qcow2 is
rubbish.

Addresses the major part of #405 (but not the part about making `build`
and `buildextend` work better together yet...).