### PR TITLE
cmd-build: Rename OSTree commit object

### DIFF
--- a/src/write-commit-object
+++ b/src/write-commit-object
@@ -22,5 +22,5 @@ r.open(None)
 
 [_, rev] = r.resolve_rev(args.rev, True)
 [_, commit, _] = r.load_commit(rev)
-with open(args.builddir + '/ostree-commit', 'wb') as f:
+with open(args.builddir + '/ostree-commit-object', 'wb') as f:
     f.write(commit.get_data_as_bytes().get_data())


### PR DESCRIPTION
Rename the OSTree commit object to `ostree-commit-object` to be more
explicit. I'd like the term "OSTree commit" to refer to the whole tree.

Split out of #515.