### PR TITLE
Add overrides/rootfs

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -239,7 +239,7 @@ runcompose() {
     local overridesdir=${workdir}/overrides
     local tmp_overridesdir=${TMPDIR}/override
     local override_manifest="${tmp_overridesdir}"/coreos-assembler-override-manifest.yaml
-    if [ -d "${overridesdir}"/rpm ] || [ -n "${ref_is_temp}" ] || [ -d "${configdir}/overlay" ]; then
+    if [ -d "${overridesdir}" ] || [ -n "${ref_is_temp}" ] || [ -d "${configdir}/overlay" ]; then
         mkdir "${tmp_overridesdir}"
         cat > "${override_manifest}" <<EOF
 include: ${workdir}/src/config/manifest.yaml
@@ -274,6 +274,16 @@ EOF
 name=coreos-assembler-local-overrides
 baseurl=file://${workdir}/overrides/rpm
 gpgcheck=0
+EOF
+    fi
+    rootfs_overlay="${overridesdir}/rootfs"
+    if [ -d "${rootfs_overlay}" ]; then
+        echo "Committing ${rootfs_overlay}"
+        sudo ostree commit --repo="${workdir}/tmp/repo" --tree=dir="${rootfs_overlay}" -b cosa-bin-overlay \
+          --owner-uid 0 --owner-gid 0 --no-xattrs --no-bindings --parent=none
+          cat >> "${override_manifest}" << EOF
+ostree-override-layers:
+  - cosa-bin-overlay
 EOF
     fi
 


### PR DESCRIPTION
This is strongly related to https://github.com/coreos/fedora-coreos-config/pull/66

For development iteration, we want the ability to directly overlay
binaries.  This depends on
https://github.com/projectatomic/rpm-ostree/pull/1830
which adds rpm-ostree ability to inject ostree refs into the build.

We could implement this in cosa by building an RPM but I think that's
silly - we end up compressing the data only to immediately decompress it.
Plus, while there are advantages to having entries for files in the RPM
database, in practice we're lying about having these files built by RPM.
So let's just directly generate an OSTree commit from them and inject
that.

(In practice for *this* use case rpm-ostree could actually learn
 a way to directly consume a directory, but indirecting via OSTree
 means it's equally easy to manage pre-generated ostree branches too
 in an efficient way rather than re-committing each time)