### PR TITLE
tweak system and os_type for OVA

### DIFF
--- a/src/cmd-buildextend-vmware
+++ b/src/cmd-buildextend-vmware
@@ -43,8 +43,8 @@ os.mkdir(tmpdir)
 
 
 def generate_ovf_parameters(qemu, vmdk, cpu=2,
-                            memory=4096, system_type="vmx-07 vmx-08",
-                            os_type="other26xLinux64Guest", scsi="VirtualSCSI",
+                            memory=4096, system_type="vmx-13",
+                            os_type="rhel7_64Guest", scsi="VirtualSCSI",
                             network="VmxNet3"):
     """
     Returns a dictionary with the parameters needed to create an OVF file based


### PR DESCRIPTION
These were both suggested by contacts at VMWare.

The change here to the "vmx" value will prevent the OVA from being used on ESX versions that are older than what we are prepared to support, and is thus a desirable change from a customer experience perspective.

The OS change may be more cosmetic.  Eventually there will also be a "rhel8" equivalent, which we may want to switch to.