### PR TITLE
buildextend-metal: --build takes an argument

### DIFF
--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -20,7 +20,7 @@ BIOS=
 UEFI=
 rc=0
 build=
-options=$(getopt --options h --longoptions help,build,bios,uefi -- "$@") || rc=$?
+options=$(getopt --options h --longoptions help,build:,bios,uefi -- "$@") || rc=$?
 [ $rc -eq 0 ] || {
     print_help
     exit 1


### PR DESCRIPTION
getopt requires a `:` in order to specify an option takes an
argument.