### PR TITLE
cmd-build: Fix ostree-only builds

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -64,6 +64,15 @@ if [ $# -eq 0 ]; then
     set -- qemu
 fi
 
+build_qemu=
+for target in "$@"; do
+    case $target in
+        ostree) ;;
+        qemu) build_qemu=1;;
+        *) fatal "Unrecognized target: $target";;
+    esac
+done
+
 export LIBGUESTFS_BACKEND=direct
 
 prepare_build
@@ -219,9 +228,11 @@ img_base=tmp/${imageprefix}-base.qcow2
 # forgive me for this sin
 checksum_location=$(find /usr/lib/coreos-assembler-anaconda/ -name '*CHECKSUM' | head -1)
 
-img_qemu=${imageprefix}-qemu.qcow2
-run_virtinstall "${tmprepo}" "${ref}" "${PWD}"/"${img_base}" --variant=cloud
-/usr/lib/coreos-assembler/gf-platformid "$(pwd)"/"${img_base}" "$(pwd)"/"${img_qemu}" qemu
+if [ -n "${build_qemu}" ]; then
+    img_qemu=${imageprefix}-qemu.qcow2
+    run_virtinstall "${tmprepo}" "${ref}" "${PWD}"/"${img_base}" --variant=cloud
+    /usr/lib/coreos-assembler/gf-platformid "$(pwd)"/"${img_base}" "$(pwd)"/"${img_qemu}" qemu
+fi
 
 "${dn}"/write-commit-object "${tmprepo}" "${commit}" "$(pwd)"
 
@@ -257,7 +268,8 @@ cat > tmp/meta.json <<EOF
 }
 EOF
 
-cat > tmp/images.json <<EOF
+if [ -n "${build_qemu}" ]; then
+    cat > tmp/images.json <<EOF
 {
     "images": {
         "qemu": {
@@ -268,6 +280,9 @@ cat > tmp/images.json <<EOF
     }
 }
 EOF
+else
+    echo '{ "images": {} }' > tmp/images.json
+fi
 
 # And the build information about our container, if we are executing
 # from a container.


### PR DESCRIPTION
And also sanity check that we're not passed unsupported targets.

Minor regression from #510. I think my thinking there was that we'd have
a `buildextend-qemu` so that an OSTree-only build could still later on
be extended if one wants. Though I didn't actually get around to
splitting it out.