### PR TITLE
src/cmd-buildextend-gcp: fix path for GCP tarball

### DIFF
--- a/src/cmd-buildextend-gcp
+++ b/src/cmd-buildextend-gcp
@@ -116,7 +116,7 @@ def run_ore():
     buildmeta['gcp'] = {'image': f"{base_name}-{args.build.replace('.', '-')}"}
     buildmeta['images'].update({
         'gcp': {
-            'path': build_tarball,
+            'path': gcp_tarball_name,
             'sha256': checksum,
             'size': size
         }


### PR DESCRIPTION
(cherry picked from commit 3ab57a13264f57abe67ce509099194a4842bda82)