### PR TITLE
 Detect rhcos for Ignition spec 2, add start of 3to2 converter

### DIFF
--- a/src/cmd-kola
+++ b/src/cmd-kola
@@ -12,18 +12,22 @@ fi
 
 # XXX: teach to kola to auto-detect based on prefix; see discussions in
 # https://github.com/coreos/coreos-assembler/pull/85
-distro=
+args=
 bn=$(basename "${latest_qcow}")
 if [[ ${bn} = fedora-coreos-* ]]; then
-    distro="-b fcos"
+    args="-b fcos"
 elif [[ ${bn} = rhcos-* ]]; then
-    distro="-b rhcos --ignition-version v2"
+    args="-b rhcos"
 else
-    echo "WARNING: Failed to detect distro, use -b to specify"
+    echo "WARNING: Failed to detect args, use -b to specify"
+fi
+ignition_version=$(disk_ignition_version "${latest_qcow}")
+if [ "${ignition_version}" = "2.2.0" ]; then
+    args="${args} --ignition-version v2"
 fi
 
 # let's print out the actual exec() call we do
 set -x
 
 # shellcheck disable=SC2086
-exec kola $distro --output-dir tmp/kola --qemu-image "${latest_qcow}" "$@"
+exec kola $args --output-dir tmp/kola --qemu-image "${latest_qcow}" "$@"

--- a/src/cmd-run
+++ b/src/cmd-run
@@ -86,10 +86,18 @@ if [ -z "${VM_DISK}" ]; then
     fi
 fi
 
-# make sure disk path is absolute
-VM_DISK=$(realpath "${VM_DISK}")
+# Make sure disk path is absolute; note we don't realpath
+# the full disk name in order to avoid canonicalizing the disk name
+# itself, since we dispatch on that to detect e.g. Ignition version,
+# and we want to support use of e.g. git-annex and tools like that.
+vmdiskdir=$(dirname "${VM_DISK}")
+VM_DISK=$(realpath "${vmdiskdir}")/$(basename "${VM_DISK}")
+
+ignition_version=$(disk_ignition_version "${VM_DISK}")
+ign_validate="ignition-validate"
 
 # Emulate the host CPU closely in both features and cores.
+# We don't care about migration for this.
 set -- -machine accel=kvm -cpu host -smp "${VM_NCPUS}" "$@"
 
 if [ -n "${VM_SRV_MNT}" ]; then
@@ -161,12 +169,19 @@ EOF
     }
 }
 EOF
+    if [ "${ignition_version}" = "2.2.0" ]; then
+        ign_validate="true"
+        spec2f=$(mktemp)
+        /usr/lib/coreos-assembler/incomplete-hack-ign-3to2 "${f}" > "${spec2f}"
+        mv "${spec2f}" "${f}"
+    fi
+
     exec 3<>"${f}"
     rm -f "${f}"
     IGNITION_CONFIG_FILE=/proc/self/fd/3
 
-    if ! ignition-validate "${IGNITION_CONFIG_FILE}"; then
-        cat "${IGNITION_CONFIG_FILE}"
+    if ! ${ign_validate} "${IGNITION_CONFIG_FILE}"; then
+        jq . < "${IGNITION_CONFIG_FILE}"
         exit 1
     fi
 fi

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -136,6 +136,22 @@ preflight() {
     fi
 }
 
+# Obviously this is a hack but...we need to know this before
+# launching, and I don't think we have structured metadata in e.g. qcow2.
+# There are other alternatives but we'll carry this hack for now.
+# But if you're reading this comment 10 years in the future, I won't be
+# too surprised either ;)  Oh and hey if you are please send me an email, it'll
+# be like a virtual time capsule!  If they still use email then...
+disk_ignition_version() {
+    local bn
+    bn=$(basename "$1")
+    if [[ ${bn} = rhcos-4[12]0.8* ]]; then
+        echo "2.2.0"
+    else
+        echo "3.0.0"
+    fi
+}
+
 prepare_build() {
     preflight
     if ! [ -d builds ]; then

--- a/src/incomplete-hack-ign-3to2
+++ b/src/incomplete-hack-ign-3to2
@@ -1,0 +1,43 @@
+#!/usr/bin/python3
+# This is a completely stupid and incomplete "downgrader"
+# from Ignition spec 3 to spec 2.  It is currently only
+# used as an implementation detail of the `run` command,
+# although part of the idea is to have a shared place
+# to maintain this tooling for other purposes, even if
+# we aren't yet ready to support it for broader uses
+# (such as targeting a spec3 Ignition config at both FCOS and CL, etc.)
+import os
+import sys
+import json
+import shutil
+import argparse
+
+# Parse args and dispatch
+parser = argparse.ArgumentParser()
+parser.add_argument("path", help="Ignition file")
+args = parser.parse_args()
+
+if args.path == '-':
+    f = sys.stdin
+else:
+    f = open(args.path)
+ign = json.load(f)
+v = ign['ignition']['version']
+vmajor = int(v.split('.', 2)[0])
+if vmajor == 2:
+    shutil.copyfileobj(sys.stdin, sys.stdout)
+    sys.exit(0)
+elif vmajor != 3:
+    raise SystemExit(f"Unsupported version {v}")
+ign['ignition']['version'] = '2.2.0'
+for f in ign['storage'].get('files', []):
+    f['filesystem'] = "root"
+    append = f.get('append')
+    if append is not None:
+        f['append'] = True
+        if len(append) != 1:
+            raise SystemExit(f"Can't handle multiple append: {f['path']}")
+        f['contents'] = append[0]
+json.dump(ign, sys.stdout)
+
+


### PR DESCRIPTION

It would be really extremely convenient for me if I could at least
`cosa run -d /path/to/rhcos.qcow2` when using cosa git master.

This prototypes out the start of a `ign-3to2` helper which
will also be extremely useful for people working on OpenShift/RHCOS
today.  If this works out we can elevate it to a toplevel command.