### PR TITLE
cmdlib.sh: Use terminal according to arch in vmrun

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -355,7 +355,7 @@ EOF
         -drive if=none,id=drive-scsi0-0-0-1,discard=unmap,file="${workdir}/cache/cache.qcow2" \
         -device scsi-hd,bus=scsi0.0,channel=0,scsi-id=0,lun=1,drive=drive-scsi0-0-0-1,id=scsi0-0-0-1 \
         -virtfs local,id=workdir,path="${workdir}",security_model=none,mount_tag=workdir \
-        "${srcvirtfs[@]}" -serial stdio -append "root=/dev/sda console=ttyS0 selinux=1 enforcing=0 autorelabel=1"
+        "${srcvirtfs[@]}" -serial stdio -append "root=/dev/sda console=${VM_TERMINAL} selinux=1 enforcing=0 autorelabel=1"
 
     if [ ! -f "${workdir}"/tmp/rc ]; then
         fatal "Couldn't find rc file, something went terribly wrong!"


### PR DESCRIPTION
Using ttyS0 on ppc64le leads to crash in supermin init in not privileged mode(coreos-assembler fetch/...).
```
.
.
.
.
[    0.312625] sd 0:0:0:0: [sda] Write cache: enabled, read cache: enabled, doesn't support DPO or FUA
[    0.313933]  sdb: sdb1
[    0.314762] sd 0:0:0:1: [sdb] Attached SCSI disk
[    0.315320] sd 0:0:0:0: [sda] Attached SCSI disk
[    0.323285] EXT4-fs (sda): mounting ext2 file system using the ext4 subsystem
[    0.325867] EXT4-fs (sda): mounted filesystem without journal. Opts: 
[    0.771603] SELinux:  policy capability network_peer_controls=1
[    0.844211] SELinux:  policy capability open_perms=1
[    0.844625] SELinux:  policy capability extended_socket_class=1
[    0.845144] SELinux:  policy capability always_check_network=0
[    0.845656] SELinux:  policy capability cgroup_seclabel=1
[    0.846132] SELinux:  policy capability nnp_nosuid_transition=1
[    0.856079] audit: type=1403 audit(1559287806.090:2): auid=4294967295 ses=4294967295 lsm=selinux res=1
[    0.881682] 9pnet: Installing 9P2000 support
[    0.898092] fuse init (API version 7.28)
[    1.292473] IPv6: ADDRCONF(NETDEV_CHANGE): eth0: link becomes ready
[    3.109229] FS-Cache: Loaded
[    3.117372] 9p: Installing v9fs 9p2000 file system support
[    3.117901] FS-Cache: Netfs '9p' registered for caching
[    3.268629] SGI XFS with ACLs, security attributes, scrub, no debug enabled
[    3.273515] XFS (sdb1): Mounting V5 Filesystem
[    3.298993] XFS (sdb1): Ending clean mount
[    3.909198] Kernel panic - not syncing: Attempted to kill init! exitcode=0x00000100
[    3.909987] CPU: 0 PID: 1 Comm: init Not tainted 5.0.17-300.fc30.ppc64le #1
[    3.910728] Call Trace:
[    3.910995] [c00000007e70fc30] [c000000000c49628] dump_stack+0xac/0xf4 (unreliable)
[    3.911808] [c00000007e70fc70] [c00000000011d2d8] panic+0x168/0x3b0
[    3.912427] [c00000007e70fd00] [c000000000124840] do_exit+0xd00/0xdb0
[    3.913111] [c00000007e70fdc0] [c0000000001249c0] do_group_exit+0x60/0x100
[    3.913836] [c00000007e70fe00] [c000000000124a84] sys_exit_group+0x24/0x30
[    3.914572] [c00000007e70fe20] [c00000000000b9e4] system_call+0x5c/0x70
+ rc=1
+ set +x
```
Not yet tested on x86_64.