### PR TITLE
run: Remove "Creating temporary image" message

### DIFF
--- a/src/cmd-run
+++ b/src/cmd-run
@@ -172,7 +172,6 @@ EOF
 fi
 
 if [ -z "${VM_PERSIST_IMG}" ]; then
-    echo "Creating temporary image"
     VM_IMG=$(mktemp -p "${TMPDIR:-/var/tmp}")
     qemu-img create -q -f qcow2 -b "${VM_DISK}" "${VM_IMG}"
 else


### PR DESCRIPTION
No reason to print this, we didn't do so before;
I found it confusing.