### PR TITLE
cmd-buildprep: Handle 404 for builds.json gracefully

### DIFF
--- a/src/cmd-buildprep
+++ b/src/cmd-buildprep
@@ -9,6 +9,8 @@ import os
 import subprocess
 import sys
 import requests
+import botocore
+import boto3
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from cmdlib import load_json, rm_allow_noent  # noqa: E402
@@ -24,7 +26,10 @@ def main():
     else:
         raise Exception("Invalid scheme: only s3:// and http(s):// supported")
 
-    builds = fetcher.fetch_json('builds.json')['builds']
+    builds = []
+    if fetcher.exists('builds.json'):
+        builds = fetcher.fetch_json('builds.json')['builds']
+
     if len(builds) == 0:
         print("Remote has no builds!")
         return
@@ -74,6 +79,10 @@ class Fetcher(object):
     def fetch_json(self, path):
         return load_json(self.fetch(path))
 
+    def exists(self, path):
+        url = os.path.join(self.url_base, path)
+        return self.exists_impl(url)
+
 
 class HTTPFetcher(Fetcher):
 
@@ -88,6 +97,14 @@ class HTTPFetcher(Fetcher):
             with open(dest, mode='wb') as f:
                 f.write(r.content)
 
+    def exists_impl(self, url):
+        with requests.head(url) as r:
+            if r.status_code == 200:
+                return True
+            if r.status_code == 404:
+                return False
+            raise Exception(f"Received rc {r.status_code} for {url}")
+
 
 class S3Fetcher(Fetcher):
 
@@ -97,6 +114,18 @@ class S3Fetcher(Fetcher):
     def fetch_impl(self, url, dest):
         subprocess.check_call(['aws', 's3', 'cp', url, dest],
                               stdout=subprocess.DEVNULL)
+
+    def exists_impl(self, url):
+        assert url.startswith("s3://")
+        bucket, key = url[len("s3://"):].split('/', 1)
+        s3 = boto3.client('s3')
+        try:
+            s3.head_object(Bucket=bucket, Key=key)
+        except botocore.exceptions.ClientError as e:
+            if e.response['Error']['Code'] == '404':
+                return False
+            raise e
+        return True
 
 
 if __name__ == '__main__':

--- a/src/cmd-buildprep
+++ b/src/cmd-buildprep
@@ -25,12 +25,12 @@ def main():
     else:
         raise Exception("Invalid scheme: only s3:// and http(s):// supported")
 
-    builds = fetcher.fetch_json('builds.json')
+    builds = fetcher.fetch_json('builds.json')['builds']
     if len(builds) == 0:
         print("Remote has no builds!")
         return
 
-    buildid = builds['builds'][0]
+    buildid = builds[0]
     os.makedirs(f'builds/{buildid}', exist_ok=True)
     for f in ['meta.json', 'ostree-commit-object']:
         fetcher.fetch(f'{buildid}/{f}')

--- a/src/cmd-buildprep
+++ b/src/cmd-buildprep
@@ -8,8 +8,7 @@ import argparse
 import os
 import subprocess
 import sys
-import urllib
-import urllib.request
+import requests
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from cmdlib import load_json, rm_allow_noent  # noqa: E402
@@ -82,12 +81,12 @@ class HTTPFetcher(Fetcher):
         super().__init__(url_base)
 
     def fetch_impl(self, url, dest):
-        with urllib.request.urlopen(url) as response:
-            rc = response.getcode()
-            if rc != 200:
-                raise Exception(f"Received rc {rc} for {url}")
+        # notice we don't use `stream=True` here; the stuff we're fetching for
+        # now is super small
+        with requests.get(url) as r:
+            r.raise_for_status()
             with open(dest, mode='wb') as f:
-                f.write(response.read())
+                f.write(r.content)
 
 
 class S3Fetcher(Fetcher):

--- a/src/deps.txt
+++ b/src/deps.txt
@@ -40,6 +40,9 @@ podman buildah skopeo
 # Miscellaneous tools
 jq awscli
 
+# For interacting with HTTP
+python3-requests
+
 # For ignition file validation in cmd-run
 /usr/bin/ignition-validate
 

--- a/src/deps.txt
+++ b/src/deps.txt
@@ -38,10 +38,10 @@ python2-gobject-base python3-gobject-base
 podman buildah skopeo
 
 # Miscellaneous tools
-jq awscli
+jq
 
-# For interacting with HTTP
-python3-requests
+# For interacting with AWS/HTTP
+awscli python3-boto3 python3-requests
 
 # For ignition file validation in cmd-run
 /usr/bin/ignition-validate


### PR DESCRIPTION
If we're trying to `buildprep` from a remote which doesn't have any
builds yet, don't error out. To do this, just use HEAD/HeadObject and
check for a 404 response code. E.g. for AWS, we still error out if the
issue is missing credentials.

Closes: #543