### PR TITLE
build.sh: Set skip_if_unavailable=False on continuous repo

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -30,8 +30,10 @@ release="30"
 
 configure_yum_repos() {
     if [ -n "${ISFEDORA}" ]; then
-        # Add continuous tag for latest build tools
-        echo -e "[f$release-coreos-continuous]\nenabled=1\nmetadata_expire=1m\nbaseurl=https://kojipkgs.fedoraproject.org/repos-dist/f$release-coreos-continuous/latest/\$basearch/\ngpgcheck=0\n" > /etc/yum.repos.d/coreos.repo
+        # Add continuous tag for latest build tools and mark as required so we
+        # can depend on those latest tools being available in all container
+        # builds.
+        echo -e "[f$release-coreos-continuous]\nenabled=1\nmetadata_expire=1m\nbaseurl=https://kojipkgs.fedoraproject.org/repos-dist/f$release-coreos-continuous/latest/\$basearch/\ngpgcheck=0\nskip_if_unavailable=False\n" > /etc/yum.repos.d/coreos.repo
 
     fi
 }


### PR DESCRIPTION
Otherwise, if it becomes inaccessible for whatever reason, any automated
process that rebuilds the container will essentially pull in older
versions of packages, which can cause regressions in pipelines.