### PR TITLE
Move Build class into it's own package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 src/__pycache__/*
 .gocache
 maipo/
+*.pyc
+*.pyo

--- a/src/cmd-koji-upload
+++ b/src/cmd-koji-upload
@@ -598,6 +598,7 @@ Environment variables are supported:
     if args.no_upload is False:
         upload = Upload(build, args.owner, args.tag, args.profile)
 
+    build.build_artifacts()
     upload.upload()
 
 

--- a/src/cmd-koji-upload
+++ b/src/cmd-koji-upload
@@ -2,9 +2,9 @@
 # pylint: disable=C0103
 
 """
-cmd-koji-upload performs the required steps to make COSA a Koji Content Generator.
-When running this in an automated fashion, you will need a Kerberos keytab file
-for a service account.
+cmd-koji-upload performs the required steps to make COSA a Koji Content
+Generator. When running this in an automated fashion, you will need a Kerberos
+keytab file for a service account.
 
 Python2: due to an issue with Kerberos Auth issue which returns errors like:
 [auth_gssapi:error] NO AUTH DATA Client did not send any authentication headers
@@ -29,7 +29,13 @@ import os.path
 import platform
 import shutil
 import subprocess
+import sys
 import tempfile
+
+cosa_dir = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, cosa_dir)
+
+from cosalib.build import _Build
 
 import koji
 import koji_cli.lib as klib
@@ -51,7 +57,6 @@ except IOError:
 # ARCH is the current machine architecture
 ARCH = platform.machine()
 
-# COSA_INPATH is the _in container_ path for the image build source
 COSA_INPATH = "/cosa"
 
 # Content generator types as defined in:
@@ -78,6 +83,79 @@ KOJI_CG_TYPES = {
 # These artifacts need to be renamed on upload. Koji file extension matching
 # against content types.
 RENAME_RAW = ['initramfs.img', '-kernel', "ostree-commit"]
+
+
+def md5sum_file(path):
+    """
+    Calculates the md5 sum from a path.
+    Py3 TODO: use md5sum_file in cmdlib.py, when porting to Python3.
+
+    :param path: file name to checksum
+    :returns str
+
+    Returns the hexdigest of the file.
+    """
+    h = hashlib.md5()
+    with open(path, 'rb', buffering=0) as data:
+        for b in iter(lambda: data.read(128 * 1024), b''):
+            h.update(b)
+    return h.hexdigest()
+
+
+class Build(_Build):
+    """
+    Koji implementation of Build.
+    """
+
+    def _build_artifacts(self, *args, **kwargs):
+        """
+        Implements the building of artifacts. Walk the build root and
+        prepare a list of files in it. While commitmeta.json provides
+        these artifacts, the information about the individual files is
+        not compatible with the Koji upload (e.g. SHA, type has to be
+        translated, strict filename conventions)
+
+        :param args: All non-keyword arguments
+        :type args: list
+        :param kwargs: All keyword arguments
+        :type kwargs: dict
+        """
+        # locate all the build artifacts in the build directory.
+        files = []
+        for ffile in os.listdir(self.build_root):
+            files.append(os.path.join(self.build_root, ffile))
+            if os.path.islink(ffile):
+                log.debug(" * EXCLUDING symlink '%s'", ffile)
+                log.debug(" *    target '%s'", os.path.realpath(ffile))
+                continue
+
+        # add the coreos assembler files
+        for ffile in os.listdir(COSA_INPATH):
+            files.append(os.path.join(COSA_INPATH, ffile))
+
+        # process the files that were found
+        for ffile in files:
+            log.debug("Considering file file '%s'", ffile)
+            short_path = os.path.basename(ffile)
+
+            # any file that is known as Koji archive is included.
+            if not koji_upload(short_path):
+                log.debug(" * EXCLUDING file '%s'", ffile)
+                log.debug("   File type is not supported by Koji")
+                continue
+
+            # os.path.getsize uses 1kB instead of 1KB. So we use stat instead.
+            fsize = subprocess.check_output(["stat", "--format", '%s', ffile])
+            log.debug(" * calculating checksum")
+            self._found_files[ffile] = {
+                "local_path": os.path.abspath(ffile),
+                "path": short_path,
+                "md5": md5sum_file(ffile),
+                "size": int(fsize)
+            }
+
+            log.debug(" * size is %s", self._found_files[ffile]["size"])
+            log.debug(" * md5 is %s", self._found_files[ffile]["md5"])
 
 
 def set_logger(level):
@@ -188,298 +266,6 @@ def koji_upload(fname):
     if found:
         return True
     return False
-
-
-def md5sum_file(path):
-    """
-    Calculates the md5 sum from a path.
-    Py3 TODO: use md5sum_file in cmdlib.py, when porting to Python3.
-
-    :param path: file name to checksum
-    :returns str
-
-    Returns the hexdigest of the file.
-    """
-    h = hashlib.md5()
-    with open(path, 'rb', buffering=0) as data:
-        for b in iter(lambda: data.read(128 * 1024), b''):
-            h.update(b)
-    return h.hexdigest()
-
-
-def load_json(path):
-    """
-    Shortcut for loading json from a file path.
-    Py3 TODO: use load_json in cmdlib.py when porting to Python3.
-    :param path: file name to load json from
-    :returns dict
-    :raises json.JSONDecodeError
-
-    Returns a dict of the json as read in.
-    """
-    with open(path) as data:
-        return json.load(data)
-
-
-class Build:
-    """
-    The Build Class handles the reading in and return of build JSON emitted
-    as part of the build process.
-    """
-
-    def __init__(self, build_dir, build="latest"):
-        """
-        init loads the builds.json which lists the builds, loads the relevant
-        meta-data from JSON and finally, locates the build artifacts.
-        :param build_dir: name of directory to find the builds
-        :type str
-        :param build: build id or "latest" to parse
-        :type str
-        :raises Exception
-
-        If the build meta-data fails to parse, then a generic exception is
-        raised.
-        """
-
-        log.info('Evaluating builds.json')
-        builds = load_json('%s/builds.json' % build_dir)
-        if build != "latest":
-            if build not in builds['builds']:
-                raise Exception("Build was not found in builds.json")
-        else:
-            build = builds['builds'][0]
-
-        log.info("Targeting build: %s", build)
-        self._build_root = os.path.abspath("%s/%s" % (build_dir, build))
-
-        self._build_json = {
-            "commit": None,
-            "config": None,
-            "image": None,
-            "meta": None
-        }
-        self._found_files = {}
-
-        # Check to make sure that the build and it's meta-data can be parsed.
-        emsg = "was not read in properly or is not defined"
-        if self.commit is None:
-            raise Exception("%s %s" % self.__file("commit"), emsg)
-        if self.config is None:
-            raise Exception("%s %s" % self.__file("config"), emsg)
-        if self.image is None:
-            raise Exception("%s %s" % self.__file("image"), emsg)
-        if self.meta is None:
-            raise Exception("%s %s" % self.__file("meta"), emsg)
-
-        self.build_artifacts()
-        log.info("Proccessed build for: %s (%s-%s) %s",
-                 self.summary, self.build_name.upper(), self.arch,
-                 self.build_id)
-
-    @property
-    def arch(self):
-        """ get the build arch """
-        return ARCH
-
-    @property
-    def build_id(self):
-        """ get the build id, e.g. 99.33 """
-        return self.get_meta_key("meta", "buildid")
-
-    @property
-    def build_root(self):
-        """ return the actual path for the build root """
-        return self._build_root
-
-    @property
-    def build_name(self):
-        """ get the name of the build """
-        ref = str(self.get_meta_key("meta", "ref")).split('-')
-        return ref[-1]
-
-    @property
-    def summary(self):
-        """ get the summary of the build """
-        return self.get_meta_key("meta", "summary")
-
-    @property
-    def commit(self):
-        """ get the commitmeta.json dict """
-        if self._build_json["commit"] is None:
-            self._build_json["commit"] = self.__get_json("commit")
-        return self._build_json["commit"]
-
-    @property
-    def config(self):
-        """ get the the meta-data about the config recipe """
-        if self._build_json["config"] is None:
-            self._build_json["config"] = self.__get_json("config")
-        return self._build_json["config"]
-
-    @property
-    def image(self):
-        """ get the meta-data about the COSA image """
-        if self._build_json["image"] is None:
-            self._build_json["image"] = self.__get_json("image")
-        return self._build_json["image"]
-
-    @property
-    def meta(self):
-        """ get the meta.json dict """
-        if self._build_json["meta"] is None:
-            self._build_json["meta"] = self.__get_json("meta")
-        return self._build_json["meta"]
-
-    @staticmethod
-    def ckey(var):
-        """
-        Short-hand helper to get coreos-assembler values from json.
-        :param var: postfix string to append
-        :type str
-        :return str
-        """
-        return "coreos-assembler.%s" % var
-
-    def __file(self, var):
-        """
-        Look up the file location for specific files.
-        The lookup is performed against the specific build root.
-        :param var: name of file to return
-        :type str
-        :return string
-        :raises KeyError
-        """
-        lookup = {
-            "commit": "%s/commitmeta.json" % self.build_root,
-            "config": ("%s/coreos-assembler-config-git.json" %
-                       self.build_root),
-            "image": "/cosa/coreos-assembler-git.json",
-            "meta": "%s/meta.json" % self.build_root,
-        }
-        return lookup[var]
-
-    def __get_json(self, name):
-        """
-        Read in the json file in, and decode it.
-        :param name: name of the json file to read-in
-        :type str
-        :return dict
-        """
-        file_path = self.__file(name)
-        log.debug("Reading in %s", file_path)
-        return load_json(file_path)
-
-    def get_obj(self, key):
-        """ Return the backing object
-        :param key: name of the meta-data key to return
-        :type str
-        :returns dict
-        :raises Exception
-
-        Returns the meta-data dict of the parsed JSON.
-        """
-        lookup = {
-            "commit": self.commit,
-            "config": self.config,
-            "image": self.image,
-            "meta": self.meta,
-        }
-        try:
-            return lookup[key]
-        except:
-            raise Exception("invalid key %s, valid keys are %s" %
-                            (key, lookup.keys()))
-
-    def get_meta_key(self, obj, key):
-        """
-        Look up a the key in a dict
-        :param obj: name of meta-data key to check
-        :type str
-        :param key: key to look up
-        :type str
-        :returns dict/str
-        :raises KeyError
-
-        Returns the object from the meta-data dict. For example, calling
-        get_meta_key("meta", "ref") will give you the build ref from.
-        """
-        try:
-            data = self.get_obj(obj)
-            return data[key]
-        except KeyError as err:
-            log.warning("lookup for key '%s' returned: %s", key, str(err))
-            return None
-
-    def get_sub_obj(self, obj, key, sub):
-        """
-        Return the sub-element sub of key in a nested dict, using get_meta_key.
-        This function help exploring nested dicts in meta-data.
-        :param obj: name of the meta-data object to lookup
-        :type str
-        :param key: name of nested dict to lookup
-        :type str
-        :param sub: name of the key in nested dict to lookup
-        :type str
-        :returns obj
-        """
-        if isinstance(obj, str):
-            obj = self.get_obj(obj)
-            return self.get_sub_obj(obj, key, sub)
-        try:
-            return obj[key][sub]
-        except KeyError:
-            log.warning(obj)
-
-    def build_artifacts(self):
-        """
-        Walk the build root and prepare a list of files in it. While
-        commitmeta.json provides these artifacts, the information about the
-        individual files is not compatible with the Koji upload (e.g. SHA,
-        type has to be translated, strict filename conventions)
-        """
-        log.info("Processing the build artifacts")
-
-        # locate all the build artifacts in the build directory.
-        files = []
-        for ffile in os.listdir(self.build_root):
-            files.append(os.path.join(self.build_root, ffile))
-            if os.path.islink(ffile):
-                log.debug(" * EXCLUDING symlink '%s'", ffile)
-                log.debug(" *    target '%s'", os.path.realpath(ffile))
-                continue
-
-        # add the coreos assembler files
-        for ffile in os.listdir(COSA_INPATH):
-            files.append(os.path.join(COSA_INPATH, ffile))
-
-        # process the files that were found
-        for ffile in files:
-            log.debug("Considering file file '%s'", ffile)
-            short_path = os.path.basename(ffile)
-
-            # any file that is known as Koji archive is included.
-            if not koji_upload(short_path):
-                log.debug(" * EXCLUDING file '%s'", ffile)
-                log.debug("   File type is not supported by Koji")
-                continue
-
-            # os.path.getsize uses 1kB instead of 1KB. So we use stat instead.
-            fsize = subprocess.check_output(["stat", "--format", '%s', ffile])
-            log.debug(" * calculating checksum")
-            self._found_files[ffile] = {
-                "local_path": os.path.abspath(ffile),
-                "path": short_path,
-                "md5": md5sum_file(ffile),
-                "size": int(fsize)
-            }
-
-            log.debug(" * size is %s", self._found_files[ffile]["size"])
-            log.debug(" * md5 is %s", self._found_files[ffile]["md5"])
-
-    def get_artifacts(self):
-        """ Iterator for the meta-data about artifacts in the build root """
-        for name in self._found_files:
-            yield (name, self._found_files[name])
 
 
 class Upload():
@@ -812,7 +598,7 @@ Environment variables are supported:
     if args.no_upload is False:
         upload = Upload(build, args.owner, args.tag, args.profile)
 
-    cg_info = upload.upload()
+    upload.upload()
 
 
 if __name__ == '__main__':

--- a/src/cosalib/build.py
+++ b/src/cosalib/build.py
@@ -14,6 +14,13 @@ COSA_INPATH = "/cosa"
 ARCH = platform.machine()
 
 
+class BuildError(Exception):
+    """
+    Base error for build issues.
+    """
+    pass
+
+
 def load_json(path):
     """
     Shortcut for loading json from a file path.
@@ -47,7 +54,7 @@ class _Build:
         :type build_dir: str
         :param build: build id or "latest" to parse
         :type build: str
-        :raises: Exception
+        :raises: BuildError
 
         If the build meta-data fails to parse, then a generic exception is
         raised.
@@ -56,7 +63,7 @@ class _Build:
         builds = load_json('%s/builds.json' % build_dir)
         if build != "latest":
             if build not in builds['builds']:
-                raise Exception("Build was not found in builds.json")
+                raise BuildError("Build was not found in builds.json")
         else:
             build = builds['builds'][0]
 
@@ -74,13 +81,13 @@ class _Build:
         # Check to make sure that the build and it's meta-data can be parsed.
         emsg = "was not read in properly or is not defined"
         if self.commit is None:
-            raise Exception("%s %s" % self.__file("commit"), emsg)
+            raise BuildError("%s %s" % self.__file("commit"), emsg)
         if self.config is None:
-            raise Exception("%s %s" % self.__file("config"), emsg)
+            raise BuildError("%s %s" % self.__file("config"), emsg)
         if self.image is None:
-            raise Exception("%s %s" % self.__file("image"), emsg)
+            raise BuildError("%s %s" % self.__file("image"), emsg)
         if self.meta is None:
-            raise Exception("%s %s" % self.__file("meta"), emsg)
+            raise BuildError("%s %s" % self.__file("meta"), emsg)
 
         self.build_artifacts()
         log.info("Proccessed build for: %s (%s-%s) %s",
@@ -190,7 +197,7 @@ class _Build:
         :param key: name of the meta-data key to return
         :type key: str
         :returns: dict
-        :raises: Exception
+        :raises: BuildError
 
         Returns the meta-data dict of the parsed JSON.
         """
@@ -203,7 +210,7 @@ class _Build:
         try:
             return lookup[key]
         except:
-            raise Exception(
+            raise BuildError(
                 "invalid key %s, valid keys are %s" % (key, lookup.keys()))
 
     def get_meta_key(self, obj, key):
@@ -215,7 +222,6 @@ class _Build:
         :param key: key to look up
         :type key: str
         :returns: dict or str
-        :raises: KeyError
 
         Returns the object from the meta-data dict. For example, calling
         get_meta_key("meta", "ref") will give you the build ref from.

--- a/src/cosalib/build.py
+++ b/src/cosalib/build.py
@@ -107,7 +107,6 @@ class _Build:
         if self.meta is None:
             raise BuildError("%s %s" % self.__file("meta"), emsg)
 
-        self.build_artifacts()
         log.info("Proccessed build for: %s (%s-%s) %s",
                  self.summary, self.build_name.upper(), self.arch,
                  self.build_id)

--- a/src/cosalib/build.py
+++ b/src/cosalib/build.py
@@ -1,0 +1,284 @@
+"""
+Provides a base abstration class for build reuse.
+"""
+
+import json
+import logging as log
+import os.path
+import platform
+
+# COSA_INPATH is the _in container_ path for the image build source
+COSA_INPATH = "/cosa"
+
+# ARCH is the current machine architecture
+ARCH = platform.machine()
+
+
+def load_json(path):
+    """
+    Shortcut for loading json from a file path.
+    TODO: When porting to py3, use cmdlib's load_json
+
+    :param path: The full path to the file
+    :type: path: str
+    :returns: loaded json
+    :rtype: dict
+    :raises: IOError, ValueError
+    """
+    with open(path) as f:
+        return json.load(f)
+
+
+class _Build:
+    """
+    The Build Class handles the reading in and return of build JSON emitted
+    as part of the build process.
+
+    The following must be implemented to create a valid Build class:
+      - _build_artifacts(*args, **kwargs)
+    """
+
+    def __init__(self, build_dir, build="latest"):
+        """
+        init loads the builds.json which lists the builds, loads the relevant
+        meta-data from JSON and finally, locates the build artifacts.
+
+        :param build_dir: name of directory to find the builds
+        :type build_dir: str
+        :param build: build id or "latest" to parse
+        :type build: str
+        :raises: Exception
+
+        If the build meta-data fails to parse, then a generic exception is
+        raised.
+        """
+        log.info('Evaluating builds.json')
+        builds = load_json('%s/builds.json' % build_dir)
+        if build != "latest":
+            if build not in builds['builds']:
+                raise Exception("Build was not found in builds.json")
+        else:
+            build = builds['builds'][0]
+
+        log.info("Targeting build: %s", build)
+        self._build_root = os.path.abspath("%s/%s" % (build_dir, build))
+
+        self._build_json = {
+            "commit": None,
+            "config": None,
+            "image": None,
+            "meta": None
+        }
+        self._found_files = {}
+
+        # Check to make sure that the build and it's meta-data can be parsed.
+        emsg = "was not read in properly or is not defined"
+        if self.commit is None:
+            raise Exception("%s %s" % self.__file("commit"), emsg)
+        if self.config is None:
+            raise Exception("%s %s" % self.__file("config"), emsg)
+        if self.image is None:
+            raise Exception("%s %s" % self.__file("image"), emsg)
+        if self.meta is None:
+            raise Exception("%s %s" % self.__file("meta"), emsg)
+
+        self.build_artifacts()
+        log.info("Proccessed build for: %s (%s-%s) %s",
+                 self.summary, self.build_name.upper(), self.arch,
+                 self.build_id)
+
+    @property
+    def arch(self):
+        """ get the build arch """
+        return ARCH
+
+    @property
+    def build_id(self):
+        """ get the build id, e.g. 99.33 """
+        return self.get_meta_key("meta", "buildid")
+
+    @property
+    def build_root(self):
+        """ return the actual path for the build root """
+        return self._build_root
+
+    @property
+    def build_name(self):
+        """ get the name of the build """
+        ref = str(self.get_meta_key("meta", "ref")).split('-')
+        return ref[-1]
+
+    @property
+    def summary(self):
+        """ get the summary of the build """
+        return self.get_meta_key("meta", "summary")
+
+    @property
+    def commit(self):
+        """ get the commitmeta.json dict """
+        if self._build_json["commit"] is None:
+            self._build_json["commit"] = self.__get_json("commit")
+        return self._build_json["commit"]
+
+    @property
+    def config(self):
+        """ get the the meta-data about the config recipe """
+        if self._build_json["config"] is None:
+            self._build_json["config"] = self.__get_json("config")
+        return self._build_json["config"]
+
+    @property
+    def image(self):
+        """ get the meta-data about the COSA image """
+        if self._build_json["image"] is None:
+            self._build_json["image"] = self.__get_json("image")
+        return self._build_json["image"]
+
+    @property
+    def meta(self):
+        """ get the meta.json dict """
+        if self._build_json["meta"] is None:
+            self._build_json["meta"] = self.__get_json("meta")
+        return self._build_json["meta"]
+
+    @staticmethod
+    def ckey(var):
+        """
+        Short-hand helper to get coreos-assembler values from json.
+
+        :param var: postfix string to append
+        :type var: str
+        :returns: str
+        """
+        return "coreos-assembler.%s" % var
+
+    def __file(self, var):
+        """
+        Look up the file location for specific files.
+        The lookup is performed against the specific build root.
+
+        :param var: name of file to return
+        :type var: str
+        :returns: string
+        :raises: KeyError
+        """
+        lookup = {
+            "commit": "%s/commitmeta.json" % self.build_root,
+            "config": ("%s/coreos-assembler-config-git.json" %
+                       self.build_root),
+            "image": "/cosa/coreos-assembler-git.json",
+            "meta": "%s/meta.json" % self.build_root,
+        }
+        return lookup[var]
+
+    def __get_json(self, name):
+        """
+        Read in the json file in, and decode it.
+
+        :param name: name of the json file to read-in
+        :type name: str
+        :returns: dict
+        """
+        file_path = self.__file(name)
+        log.debug("Reading in %s", file_path)
+        return load_json(file_path)
+
+    def get_obj(self, key):
+        """
+        Return the backing object
+
+        :param key: name of the meta-data key to return
+        :type key: str
+        :returns: dict
+        :raises: Exception
+
+        Returns the meta-data dict of the parsed JSON.
+        """
+        lookup = {
+            "commit": self.commit,
+            "config": self.config,
+            "image": self.image,
+            "meta": self.meta,
+        }
+        try:
+            return lookup[key]
+        except:
+            raise Exception(
+                "invalid key %s, valid keys are %s" % (key, lookup.keys()))
+
+    def get_meta_key(self, obj, key):
+        """
+        Look up a the key in a dict
+
+        :param obj: name of meta-data key to check
+        :type obj: str
+        :param key: key to look up
+        :type key: str
+        :returns: dict or str
+        :raises: KeyError
+
+        Returns the object from the meta-data dict. For example, calling
+        get_meta_key("meta", "ref") will give you the build ref from.
+        """
+        try:
+            data = self.get_obj(obj)
+            return data[key]
+        except KeyError as err:
+            log.warning("lookup for key '%s' returned: %s", key, str(err))
+            return None
+
+    def get_sub_obj(self, obj, key, sub):
+        """
+        Return the sub-element sub of key in a nested dict, using get_meta_key.
+        This function help exploring nested dicts in meta-data.
+
+        :param obj: name of the meta-data object to lookup
+        :type obj: str
+        :param key: name of nested dict to lookup
+        :type key: str
+        :param sub: name of the key in nested dict to lookup
+        :type stub: str
+        :returns: obj
+        """
+        if isinstance(obj, str):
+            obj = self.get_obj(obj)
+            return self.get_sub_obj(obj, key, sub)
+        try:
+            return obj[key][sub]
+        except KeyError:
+            log.warning(obj)
+
+    def build_artifacts(self, *args, **kwargs):
+        """
+        Wraps and executes _build_artifacts.
+
+        :param args: All non-keyword arguments
+        :type args: list
+        :param kwargs: All keyword arguments
+        :type kwargs: dict
+        :raises: NotImplementedError
+        """
+        log.info("Processing the build artifacts")
+        self._build_artifacts(*args, **kwargs)
+        log.info("Finished building artifacts")
+        if len(self._found_files.keys()) == 0:
+            log.warn("There were no files found after building")
+
+    def _build_artifacts(self, *args, **kwargs):
+        """
+        Implements the building of artifacts.
+        Must be overriden by child class and must populate the
+        _found_files dictionary.
+
+        :param args: All non-keyword arguments
+        :type args: list
+        :param kwargs: All keyword arguments
+        :type kwargs: dict
+        :raises: NotImplementedError
+        """
+        raise NotImplementedError("_build_artifacts must be overriden")
+
+    def get_artifacts(self):
+        """ Iterator for the meta-data about artifacts in the build root """
+        for name in self._found_files:
+            yield (name, self._found_files[name])


### PR DESCRIPTION
- Ignore `*.pyc` and `*.pyo` files in `git`
- Move `Build` into `cosalib`
- Use `BuildError` instead of base Exception
- Fix docstrings
- Don't execute `build_artifacts` during initialization
- Add `meta` manipulation

**TODO**:
- [x] Decouple build from koji
- [ ] Test