### PR TITLE
Add `save-var-subdirs-for-selabel-workaround` key in image.yaml 

### DIFF
--- a/src/gf-anaconda-cleanup
+++ b/src/gf-anaconda-cleanup
@@ -46,6 +46,17 @@ for x in $(coreos_gf find "${deploydir}/etc/ostree/remotes.d/"); do
     coreos_gf rm "${deploydir}/etc/ostree/remotes.d/${x}"
 done
 
+# Next remove cruft from the *physical* root as nothing should be using those;
+# Anaconda is creating them today.
+for x in $(coreos_gf glob-expand '/*'); do
+  case $x in
+    /ostree/|/boot/) continue;;
+    *) coreos_gf rm-rf "${x}"
+  esac
+done
+
+var="${stateroot}/var"
+
 # We'd like to remove all of /var, but SELinux issues prevent that.
 # see https://github.com/coreos/ignition-dracut/pull/79#issuecomment-488446949
 # For now we retain just /var/lib/systemd (for the random seed) and /var/log
@@ -67,14 +78,6 @@ coreos_gf ls "${var}/lib" | while read -r x; do
 done
 for x in "lib/systemd" "log"; do
   coreos_gf glob rm-rf "${var}/${x}/*"
-done
-# And finally, remove cruft from the *physical* root as nothing should be
-# using those; Anaconda is creating them today.
-for x in $(coreos_gf glob-expand '/*'); do
-  case $x in
-    /ostree/|/boot/) continue;;
-    *) coreos_gf rm-rf "${x}"
-  esac
 done
 
 coreos_gf_shutdown

--- a/src/gf-anaconda-cleanup
+++ b/src/gf-anaconda-cleanup
@@ -50,10 +50,14 @@ done
 # see https://github.com/coreos/ignition-dracut/pull/79#issuecomment-488446949
 # For now we retain just /var/lib/systemd (for the random seed) and /var/log
 # for the journal, which init before systemd-tmpfiles.
+# Also just leave /var/home and /var/roothome; this allows early Ignition in
+# RHCOS to add users and drop files in /root.  (On FCOS, we don't strictly
+# *need* this because we run systemd-tmpfiles).
 var="${stateroot}/var"
 coreos_gf ls "${var}" | while read -r x; do
   case "$x" in 
     log|lib) continue;;
+    home|roothome) coreos_gf glob rm-rf "${var}/${x}/*";;
     *) coreos_gf rm-rf "${var}/${x}"
   esac
 done

--- a/src/gf-anaconda-cleanup
+++ b/src/gf-anaconda-cleanup
@@ -8,6 +8,17 @@ dn=$(dirname "$0")
 # shellcheck source=src/libguestfish.sh
 . "${dn}"/libguestfish.sh
 
+SAVE_VAR=
+options=$(getopt --options '' --longoptions save-var-subdirs-for-selabel-workaround -- "$@")
+eval set -- "$options"
+while true; do
+    case "$1" in
+        --save-var-subdirs-for-selabel-workaround) SAVE_VAR=1;;
+        --) shift; break;;
+    esac
+    shift
+done
+
 src="$1"
 shift
 
@@ -57,14 +68,22 @@ done
 
 var="${stateroot}/var"
 
-# We'd like to remove all of /var, but SELinux issues prevent that.
+# By default, we nuke all of /var unless explicitly requested not to. Anaconda
+# creates stuff in there, but we want the canonical source to be
+# systemd-tmpfiles and Ignition.
+if [ -z "${SAVE_VAR}" ]; then
+    coreos_gf glob rm-rf "${var}/*"
+    coreos_gf_shutdown
+    exit 0
+fi
+
+# /var hack: we'd like to remove all of /var, but SELinux issues prevent that.
 # see https://github.com/coreos/ignition-dracut/pull/79#issuecomment-488446949
 # For now we retain just /var/lib/systemd (for the random seed) and /var/log
 # for the journal, which init before systemd-tmpfiles.
 # Also just leave /var/home and /var/roothome; this allows early Ignition in
 # RHCOS to add users and drop files in /root.  (On FCOS, we don't strictly
 # *need* this because we run systemd-tmpfiles).
-var="${stateroot}/var"
 coreos_gf ls "${var}" | while read -r x; do
   case "$x" in 
     log|lib) continue;;

--- a/src/virt-install
+++ b/src/virt-install
@@ -27,7 +27,8 @@ def fatal(msg):
     raise SystemExit(1)
 
 # Set of valid keys in image.yaml
-IMAGE_CONF_KEYS = ['size', 'postprocess-script', 'extra-kargs']
+IMAGE_CONF_KEYS = ['size', 'postprocess-script', 'extra-kargs',
+                   'save-var-subdirs-for-selabel-workaround']
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--dest", help="Destination disk",
@@ -309,6 +310,8 @@ try:
     # And strip out all of the Anaconda stuff in /var; this uses libguestfs
     # to ensure we fully control the code.
     cleanup_argv = ['/usr/lib/coreos-assembler/gf-anaconda-cleanup', args.dest]
+    if image_conf.get('save-var-subdirs-for-selabel-workaround'):
+        cleanup_argv += ['--save-var-subdirs-for-selabel-workaround']
     run_sync_verbose(cleanup_argv)
 
     # This one is part of the "API" we provide to config repositories.  At least


### PR DESCRIPTION
A lot of backstory here, but essentially, we want Ignition to be able to
add users in RHCOS. This requires `/var/home` existing. To do this,
we either need to run systemd-tmpfiles, like FCOS, or just leave it
hanging around after Anaconda.

Since we're already doing the latter for `/var/lib` and `/var/log`, this
patch just extends it for `/var/home`. It's just easier to do this for
now rather than more involved fixes. This will be fixed the proper way
once RHCOS is bumped to spec 3 and inherits all the work that happened
in FCOS to support it.

Some more information about this in:
https://github.com/coreos/ignition-dracut/pull/79