### PR TITLE
kola: Automatically use qemu-unpriv if non-root

### DIFF
--- a/src/cmd-kola
+++ b/src/cmd-kola
@@ -26,6 +26,10 @@ if [ "${ignition_version}" = "2.2.0" ]; then
     args="${args} --ignition-version v2"
 fi
 
+if [ "$(id -u)" != "0" ]; then
+    args="${args} -p qemu-unpriv"
+fi
+
 # let's print out the actual exec() call we do
 set -x
 


### PR DESCRIPTION
Since it's way friendlier; if I can `cosa run` as non-root I should
be able to use `kola` too.