### PR TITLE
Remove anaconda

### DIFF
--- a/bottlecap
+++ b/bottlecap
@@ -101,4 +101,4 @@ fi
 
 # we actually want work splitting here since $volumes is multiple args
 # shellcheck disable=SC2086
-$runtime run --rm -ti --privileged --userns=host $volumes --workdir /srv $entrypoint "$container" "$@"
+$runtime run --rm -ti --device '/dev/kvm' $volumes --workdir /srv $entrypoint "$container" "$@"

--- a/src/cmd-build
+++ b/src/cmd-build
@@ -242,9 +242,23 @@ img_base=tmp/${imageprefix}-base.qcow2
 # forgive me for this sin
 checksum_location=$(find /usr/lib/coreos-assembler-anaconda/ -name '*CHECKSUM' | head -1)
 
+build_image() {
+	local size kargs
+	size="$(python3 -c 'import sys, yaml; print(yaml.load(sys.stdin, Loader=yaml.CLoader)["size"])' < "$configdir/image.yaml")G"
+	kargs="$(python3 -c 'import sys, yaml; args = yaml.load(sys.stdin, Loader=yaml.CLoader).get("extra-kargs", []); print(" ".join(args))' < "$configdir/image.yaml")"
+	kargs="$kargs console=tty0 console=${VM_TERMINAL},115200n8"
+
+	qemu-img create -f qcow2 "$img_base" "$size"
+	runvm_with_disk "$img_base" /usr/lib/coreos-assembler/create_disk.sh /dev/vda "$tmprepo" "${ref-:${commit}}" /usr/lib/coreos-assembler/grub.cfg "$name" "\"$kargs\""
+}
+
 if [ -n "${build_qemu}" ]; then
     img_qemu=${imageprefix}-qemu.qcow2
-    run_virtinstall "${tmprepo}" "${ref}" "${PWD}"/"${img_base}" --variant=cloud
+    if [ "$arch" == "x86_64" ]; then
+        build_image
+    else
+        run_virtinstall "${tmprepo}" "${ref}" "${PWD}"/"${img_base}" --variant=cloud
+    fi
     /usr/lib/coreos-assembler/gf-platformid "$(pwd)"/"${img_base}" "$(pwd)"/"${img_qemu}" qemu
 fi
 

--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -59,6 +59,15 @@ grub2-install \
 	--boot-directory rootfs/boot \
 	$disk
 
+# install uefi grub
+mkdir -p rootfs/boot/efi/EFI/boot
+grub2-mkimage \
+	--format x86_64-efi \
+	--output rootfs/boot/efi/EFI/boot/bootx64.efi \
+	--prefix '(hd0,gpt1)/grub2' \
+	normal fat part_gpt gzio terminal configfile echo ext2
+cp -r /usr/lib/grub/x86_64-efi rootfs/boot/grub2/
+
 # copy the grub config and any other files we might need
 cp $grub_script rootfs/boot/grub2/grub.cfg
 touch rootfs/boot/ignition.firstboot

--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+set -euo pipefail
+
+if [ "$#" -ne 6 ]; then
+	echo 'create_disk <device> <ostree-repo> <ostree-ref> <grub-script> <os-name> <space separated kargs>'
+	exit 1
+fi
+
+export PATH=$PATH:/sbin:/usr/sbin
+
+disk="$1" && shift
+ostree="$1" && shift
+ref="$1" && shift
+grub_script="$1" && shift
+os_name="$1" && shift
+extrakargs="$1" && shift
+
+# partition and create fs
+sgdisk -Z $disk \
+	-n 1:0:+128M -c 1:boot \
+	-n 2:0:+128M -c 2:EFI-SYSTEM -t 2:C12A7328-F81F-11D2-BA4B-00A0C93EC93B \
+	-n 3:0:+128M -c 3:BIOS-BOOT  -t 3:21686148-6449-6E6F-744E-656564454649 \
+	-n 4:0:0     -c 4:root       -t 4:4F68BCE3-E8CD-4DB1-96E7-FBCAF984B709
+sgdisk -p "$disk"
+
+# HACK ALERT - wait for partition rescans
+sleep 2
+
+mkfs.ext4 "${disk}1" -L boot
+mkfs.fat "${disk}2" -n EFI-SYSTEM
+# partition 3 has no FS, its for bios grub
+mkfs.xfs "${disk}4"  -L root
+
+# mount the partitions
+rm -rf rootfs
+mkdir rootfs
+mount "${disk}4" rootfs
+mkdir rootfs/boot
+mount "${disk}1" rootfs/boot
+mkdir rootfs/boot/efi
+mount "${disk}2" rootfs/boot/efi
+
+# init the ostree
+ostree admin init-fs rootfs
+ostree pull-local "$ostree" "$ref" --repo rootfs/ostree/repo
+ostree admin os-init "$os_name" --sysroot rootfs
+allkargs='root=/dev/disk/by-label/root rootflags=defaults,prjquota rw $ignition_firstboot'
+allkargs="$allkargs $extrakargs"
+kargsargs=""
+for karg in $allkargs
+do
+	kargsargs+="--karg-append=$karg "
+done
+ostree admin deploy "$ref" --sysroot rootfs --os fedora-coreos $kargsargs
+
+# install bios grub
+grub2-install \
+	--target i386-pc \
+	--boot-directory rootfs/boot \
+	$disk
+
+# copy the grub config and any other files we might need
+cp $grub_script rootfs/boot/grub2/grub.cfg
+touch rootfs/boot/ignition.firstboot
+
+umount -R rootfs

--- a/src/gf-platformid
+++ b/src/gf-platformid
@@ -41,19 +41,21 @@ coreos_gf_run_mount "${tmp_dest}"
 # * grub config
 # * BLS config (for subsequent config regeneration)
 # First, the grub config.
-if [ "$(coreos_gf exists '/boot/efi')" == 'true' ]; then
-    grubcfg_path=$(coreos_gf glob-expand /boot/efi/EFI/*/grub.cfg)
-else
-    grubcfg_path=/boot/loader/grub.cfg
+if [ "$arch" -ne "x86_64" ] || [ "$platformid" == "metal" ]; then
+    if [ "$(coreos_gf exists '/boot/efi')" == 'true' ]; then
+        grubcfg_path=$(coreos_gf glob-expand /boot/efi/EFI/*/grub.cfg)
+    else
+        grubcfg_path=/boot/loader/grub.cfg
+    fi
+    coreos_gf download "${grubcfg_path}" "${tmpd}"/grub.cfg
+    # Remove any platformid currently there
+    sed -i -e 's, ignition.platform.id=[a-zA-Z0-9]*,,g' "${tmpd}"/grub.cfg
+    # Insert our new platformid
+    # Match linux16, linux and linuxefi since only linux is available on aarch64
+    # and linuxefi is available in grub2.cfg for UEFI
+    sed -i -e 's,^\(linux\(16\|efi\)\? .*\),\1 ignition.platform.id='"${platformid}"',' "${tmpd}"/grub.cfg
+    coreos_gf upload "${tmpd}"/grub.cfg "${grubcfg_path}"
 fi
-coreos_gf download "${grubcfg_path}" "${tmpd}"/grub.cfg
-# Remove any platformid currently there
-sed -i -e 's, ignition.platform.id=[a-zA-Z0-9]*,,g' "${tmpd}"/grub.cfg
-# Insert our new platformid
-# Match linux16, linux and linuxefi since only linux is available on aarch64
-# and linuxefi is available in grub2.cfg for UEFI
-sed -i -e 's,^\(linux\(16\|efi\)\? .*\),\1 ignition.platform.id='"${platformid}"',' "${tmpd}"/grub.cfg
-coreos_gf upload "${tmpd}"/grub.cfg "${grubcfg_path}"
 # Now the BLS version
 blscfg_path=$(coreos_gf glob-expand /boot/loader/entries/ostree-*.conf)
 coreos_gf download "${blscfg_path}" "${tmpd}"/bls.conf

--- a/src/grub.cfg
+++ b/src/grub.cfg
@@ -1,0 +1,49 @@
+set pager=1
+
+if [ -f ${config_directory}/grubenv ]; then
+  load_env -f ${config_directory}/grubenv
+elif [ -s $prefix/grubenv ]; then
+  load_env
+fi
+
+if [ x"${feature_menuentry_id}" = xy ]; then
+  menuentry_id_option="--id"
+else
+  menuentry_id_option=""
+fi
+
+function load_video {
+  if [ x$feature_all_video_module = xy ]; then
+    insmod all_video
+  else
+    insmod efi_gop
+    insmod efi_uga
+    insmod ieee1275_fb
+    insmod vbe
+    insmod vga
+    insmod video_bochs
+    insmod video_cirrus
+  fi
+}
+
+serial --speed=115200
+terminal_input serial console
+terminal_output serial console
+if [ x$feature_timeout_style = xy ] ; then
+  set timeout_style=menu
+  set timeout=1
+# Fallback normal timeout code in case the timeout_style feature is
+# unavailable.
+else
+  set timeout=1
+fi
+
+set ignition_firstboot=""
+# Determine if this is a first boot.
+if [ -f "/ignition.firstboot" ]; then
+    set ignition_firstboot="ignition.firstboot"
+fi
+
+set root='hd0,gpt1'
+set boot='hd0,gpt1'
+blscfg

--- a/src/vmdeps.txt
+++ b/src/vmdeps.txt
@@ -17,4 +17,5 @@ selinux-policy selinux-policy-targeted policycoreutils
 
 # coreos-assembler
 #FEDORA python3 python3-gobject-base buildah podman skopeo iptables iptables-libs
-gdisk xfsprogs e2fsprogs grub2 dosfstools
+
+gdisk xfsprogs e2fsprogs grub2 dosfstools grub2-efi-x64-modules

--- a/src/vmdeps.txt
+++ b/src/vmdeps.txt
@@ -17,3 +17,4 @@ selinux-policy selinux-policy-targeted policycoreutils
 
 # coreos-assembler
 #FEDORA python3 python3-gobject-base buildah podman skopeo iptables iptables-libs
+gdisk xfsprogs e2fsprogs grub2 dosfstools


### PR DESCRIPTION
* Only for qemu right now. Trying to make sense of the buildextend-metal, it looks like it's running anaconda again?
* Only tested with fcos
* We ought to not use yaml for image.yaml, it's a pain to parse
* Doesn't actually remove anaconda, just switches to not using it

