### PR TITLE
deps.txt: add grub efi modules

### DIFF
--- a/src/deps.txt
+++ b/src/deps.txt
@@ -50,7 +50,7 @@ awscli python3-boto3 python3-requests
 ShellCheck
 
 # for grub install when creating images without anaconda
-grub2
+grub2 grub2-efi-x64-modules
 
 # Support for Koji uploads.
 krb5-libs krb5-workstation python2-koji python2-krbv


### PR DESCRIPTION
This is needed for installing efi grub without anaconda