### PR TITLE
fix import of cosalib.build in pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ mantle:
 install:
 	install -d $(DESTDIR)$(PREFIX)/lib/coreos-assembler
 	install -D -t $(DESTDIR)$(PREFIX)/lib/coreos-assembler $$(find src/ -maxdepth 1 -type f)
+	install -d $(DESTDIR)$(PREFIX)/lib/coreos-assembler/cosalib
+	install -D -t $(DESTDIR)$(PREFIX)/lib/coreos-assembler/cosalib $$(find src/cosalib/ -maxdepth 1 -type f)
 	install -d $(DESTDIR)$(PREFIX)/bin
 	ln -sf ../lib/coreos-assembler/coreos-assembler $(DESTDIR)$(PREFIX)/bin/
 	ln -sf coreos-assembler $(DESTDIR)$(PREFIX)/bin/cosa

--- a/src/cmd-koji-upload
+++ b/src/cmd-koji-upload
@@ -33,6 +33,7 @@ import sys
 import tempfile
 
 cosa_dir = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, ("%s/cosalib" % cosa_dir))
 sys.path.insert(0, cosa_dir)
 
 from cosalib.build import _Build


### PR DESCRIPTION
In the RHCOS pipeline, we were seeing an import error when trying to
use the `koji-upload` command.  This fixes the import error for that
case.