### PR TITLE
src/cmd-koji-upload: conditionally use an explicit path for Python imports

### DIFF
--- a/src/cmd-koji-upload
+++ b/src/cmd-koji-upload
@@ -36,7 +36,12 @@ cosa_dir = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, ("%s/cosalib" % cosa_dir))
 sys.path.insert(0, cosa_dir)
 
-from cosalib.build import _Build
+try:
+   from cosalib.build import _Build
+except ImportError:
+   # We're in the container and can't sense the cosa path
+   sys.path.insert(0, '/usr/lib/coreos-assembler/cosalib')
+   from cosalib.build import _Build
 
 import koji
 import koji_cli.lib as klib


### PR DESCRIPTION
When run in the RHCOS pipeline, the `koji-upload` command has trouble
sensing the correct path to do the import of `cosalib`.  This change
allows us to catch the ImportError and try an explicit path instead.