### PR TITLE
cosalib/build.py: Generate file info via variable

### DIFF
--- a/src/cmd-koji-upload
+++ b/src/cmd-koji-upload
@@ -22,7 +22,6 @@ See cli() for usage information.
 """
 import argparse
 import datetime
-import hashlib
 import json
 import logging as log
 import os.path
@@ -91,22 +90,6 @@ KOJI_CG_TYPES = {
 RENAME_RAW = ['initramfs.img', '-kernel', "ostree-commit"]
 
 
-def md5sum_file(path):
-    """
-    Calculates the md5 sum from a path.
-    Py3 TODO: use md5sum_file in cmdlib.py, when porting to Python3.
-
-    :param path: file name to checksum
-    :returns str
-
-    Returns the hexdigest of the file.
-    """
-    h = hashlib.md5()
-    with open(path, 'rb', buffering=0) as data:
-        for b in iter(lambda: data.read(128 * 1024), b''):
-            h.update(b)
-    return h.hexdigest()
-
 
 class Build(_Build):
     """
@@ -126,42 +109,23 @@ class Build(_Build):
         :param kwargs: All keyword arguments
         :type kwargs: dict
         """
-        # locate all the build artifacts in the build directory.
-        files = []
-        for ffile in os.listdir(self.build_root):
-            files.append(os.path.join(self.build_root, ffile))
-            if os.path.islink(ffile):
-                log.debug(" * EXCLUDING symlink '%s'", ffile)
-                log.debug(" *    target '%s'", os.path.realpath(ffile))
-                continue
-
-        # add the coreos assembler files
-        for ffile in os.listdir(COSA_INPATH):
-            files.append(os.path.join(COSA_INPATH, ffile))
-
-        # process the files that were found
-        for ffile in files:
-            log.debug("Considering file file '%s'", ffile)
-            short_path = os.path.basename(ffile)
-
-            # any file that is known as Koji archive is included.
-            if not koji_upload(short_path):
-                log.debug(" * EXCLUDING file '%s'", ffile)
-                log.debug("   File type is not supported by Koji")
-                continue
-
-            # os.path.getsize uses 1kB instead of 1KB. So we use stat instead.
-            fsize = subprocess.check_output(["stat", "--format", '%s', ffile])
-            log.debug(" * calculating checksum")
-            self._found_files[ffile] = {
-                "local_path": os.path.abspath(ffile),
-                "path": short_path,
-                "md5": md5sum_file(ffile),
-                "size": int(fsize)
-            }
-
-            log.debug(" * size is %s", self._found_files[ffile]["size"])
-            log.debug(" * md5 is %s", self._found_files[ffile]["md5"])
+        # locate all the build artifacts in the build directory
+        # as well as locating the coreos assembler files
+        for scan_path in (self.build_root, COSA_INPATH):
+            for ffile in os.listdir(scan_path):
+                short_path = os.path.basename(ffile)
+                # Don't add symlinks
+                if os.path.islink(ffile):
+                    log.debug(" * EXCLUDING symlink '%s'", ffile)
+                    log.debug(" *    target '%s'", os.path.realpath(ffile))
+                    continue
+                # Don't add files Koji doesn't support
+                elif not koji_upload(short_path):
+                    log.debug(" * EXCLUDING file '%s'", ffile)
+                    log.debug("   File type is not supported by Koji")
+                    continue
+                # If we get here, then it's good to be used!
+                self._produced_files.append(os.path.join(scan_path, ffile))
 
 
 def set_logger(level):
@@ -604,7 +568,7 @@ Environment variables are supported:
     if args.no_upload is False:
         upload = Upload(build, args.owner, args.tag, args.profile)
 
-    build.build_artifacts()
+    build.build_artifacts(hashes=['md5'])
     upload.upload()
 
 

--- a/src/cmd-koji-upload
+++ b/src/cmd-koji-upload
@@ -36,14 +36,14 @@ sys.path.insert(0, ("%s/cosalib" % cosa_dir))
 sys.path.insert(0, cosa_dir)
 
 try:
-   from cosalib.build import _Build
+    from cosalib.build import _Build
 except ImportError:
-   # We're in the container and can't sense the cosa path
-   sys.path.insert(0, '/usr/lib/coreos-assembler/cosalib')
-   from cosalib.build import _Build
+    # We're in the container and can't sense the cosa path
+    sys.path.insert(0, '/usr/lib/coreos-assembler/cosalib')
+    from cosalib.build import _Build
 
-import koji
-import koji_cli.lib as klib
+import koji  # noqa
+import koji_cli.lib as klib  # noqa
 
 try:
     # Available in Koji v1.17, https://pagure.io/koji/issue/975
@@ -88,7 +88,6 @@ KOJI_CG_TYPES = {
 # These artifacts need to be renamed on upload. Koji file extension matching
 # against content types.
 RENAME_RAW = ['initramfs.img', '-kernel', "ostree-commit"]
-
 
 
 class Build(_Build):

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1,0 +1,50 @@
+from cosalib import build
+
+
+def _builds_return(p):
+    return {
+        "builds": ["123"],
+        "timestamp": "2019-07-12T15:58:57Z"
+    }
+
+
+def test_populate_found_files_with_hash(monkeypatch):
+    # Return mocked build.json
+    monkeypatch.setattr(build, 'load_json', _builds_return)
+    b = build._Build('mocked')
+
+    # We should have no found files
+    assert len(b._found_files) == 0
+    # Populate found files. Since we have no _produced_files ...
+    b._populate_found_files()
+    # ... we should still have 0
+    assert len(b._found_files) == 0
+
+    # Use this test file as a a _produced_file
+    this_test = 'tests/test_build.py'
+    b._produced_files.append(this_test)
+    # Populate the found_files, request md5 hashes, and expect 1
+    b._populate_found_files(hashes=['md5'])
+    assert len(b._found_files) == 1
+    # Ensure it is the file we expect
+    assert b._found_files.get(this_test) is not None
+    # And verify we have the minimal set of keys plus md5
+    for key in ('local_path', 'path', 'md5', 'size'):
+        assert key in b._found_files[this_test].keys()
+
+
+def test_populate_found_files_no_hash(monkeypatch):
+    # Return mocked build.json
+    monkeypatch.setattr(build, 'load_json', _builds_return)
+    b = build._Build('mocked')
+
+    # We should have no found files
+    assert len(b._found_files) == 0
+    # Use this test file as a a _produced_file
+    this_test = 'tests/test_build.py'
+    b._produced_files.append(this_test)
+    # Populate the found_files, request md5 hashes, and expect 1
+    b._populate_found_files()
+    # And verify we have the minimal set of keys that we must have
+    for key in ('local_path', 'path', 'size'):
+        assert key in b._found_files[this_test].keys()


### PR DESCRIPTION
Instead of making every subclass fill out `_found_files` we now make the subclass append file paths to `_produced_files`. This variable is then used to fill out `_found_files` with file information that can be used when updating metadata.

- Replaced `md5sum_file` with `hashsum_file` can hash a file with any supported algorithm.
- To calculate sums, one can provide `hashes` karg in `build_artifacts`. This is a list of all hash algorithms one wants used. Example: `hashes=['sha1', 'md5']` or `hashes=['md5']`. Not providing this kwarg means no additional hashing will occur.
- Basic testing for the functionality of this PR was also added.