### PR TITLE
src/create_disk: use more reasonable sizes

### DIFF
--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -17,9 +17,9 @@ extrakargs="$1" && shift
 
 # partition and create fs
 sgdisk -Z $disk \
-	-n 1:0:+128M -c 1:boot \
-	-n 2:0:+128M -c 2:EFI-SYSTEM -t 2:C12A7328-F81F-11D2-BA4B-00A0C93EC93B \
-	-n 3:0:+128M -c 3:BIOS-BOOT  -t 3:21686148-6449-6E6F-744E-656564454649 \
+	-n 1:0:+384M -c 1:boot \
+	-n 2:0:+127M -c 2:EFI-SYSTEM -t 2:C12A7328-F81F-11D2-BA4B-00A0C93EC93B \
+	-n 3:0:+1M   -c 3:BIOS-BOOT  -t 3:21686148-6449-6E6F-744E-656564454649 \
 	-n 4:0:0     -c 4:root       -t 4:4F68BCE3-E8CD-4DB1-96E7-FBCAF984B709
 sgdisk -p "$disk"
 


### PR DESCRIPTION
Use 256M for /boot since it may have up to three (two?) kernels +
initramfs's. With Container Linux we could get away with 128M since our
kernels and initramfs's were smaller, but we'd likely hit issues with
the fedora ones.

Dramatically shrink BIOS-BOOT. 4M should be plenty. The grub docs refer
to 1M as being enough[1] so this should be more than adequate.

Shrink the ESP by 4M. We hardly put anything in it. Could probably stand
to be smaller but I'm not sure the ramifications right now. All that's
in it is the shim, grub efi program, and a tiny stub config.

[1] https://www.gnu.org/software/grub/manual/grub/html_node/BIOS-installation.html#BIOS-installation

cc @martinezjavier especially about esp sizing