### PR TITLE
cosalib/cli.py: Cli/BuildCli class for reusability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ maipo/
 *.pyc
 *.pyo
 *.shellchecked
+.coverage

--- a/README-devel.md
+++ b/README-devel.md
@@ -34,3 +34,36 @@ $ git push origin $YOURBRANCH
 ```
 
 You can test the results by doing a build. See `Building the cosa container image locally` in [README.md](README.md#building-the-cosa-container-image-locally)
+
+# Running Unit Tests
+
+1. Ensure that `pytest` and `pytest-cov` are installed:
+
+```
+$ pip3 install --user -r test-requirements.txt
+```
+
+2. Run `pytest` on the `tests` directory
+
+```
+$ pytest tests/
+============================= test session starts ==============================
+platform linux -- Python 3.7.3, pytest-4.6.3, py-1.8.0, pluggy-0.12.0
+rootdir: /var/home/steve/Tech/GITHUB/coreos-assembler, inifile: pytest.ini
+plugins: cov-2.7.1
+collected 3 items
+
+tests/test_cli.py ...                                                    [100%]
+
+----------- coverage: platform linux, python 3.7.3-final-0 -----------
+Name                      Stmts   Miss  Cover
+---------------------------------------------
+src/cosalib/__init__.py       0      0   100%
+src/cosalib/build.py        127    127     0%
+src/cosalib/cli.py           28      0   100%
+---------------------------------------------
+TOTAL                       155    127    18%
+
+
+=========================== 3 passed in 0.05 seconds ===========================
+```

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --cov=cosalib --cov-report term

--- a/src/cosalib/cli.py
+++ b/src/cosalib/cli.py
@@ -1,0 +1,93 @@
+# NOTE: PYTHONUNBUFFERED is set in cmdlib.sh for unbuffered output
+# pylint: disable=C0103
+
+import argparse
+import logging as log
+import os
+
+
+class Cli(argparse.ArgumentParser):
+    """
+    Abstraction for executing commands from the cli.
+    """
+
+    def __init__(self, *args, **kwargs):
+        """
+        Initializes the Cli instance.
+
+        :param kwargs: All keyword arguments which will pass to ArgumentParser
+        :type kwargs: dict
+        """
+        argparse.ArgumentParser.__init__(self, *args, **kwargs)
+        self.add_argument(
+            '--log-level', env_var='COSA_LOG_LEVEL', default='info',
+            choices=log._nameToLevel.keys(), help='Set the log level')
+
+    def add_argument(self, *args, **kwargs):
+        """
+        Overloads the add_argument to be able to also read from
+        the environment. To read from the environment provide
+        the keyword arugment env_var.
+
+        :param args: Non keyword arguments to pass to add_argument
+        :type args: list
+        :param kwargs: Keyword arguments to pass to add_argument
+        :type kwargs: dict
+        """
+        env_var = kwargs.pop('env_var', None)
+        if env_var is not None:
+            if kwargs.get('help') is None:
+                kwargs['help'] = ''
+            kwargs['help'] = kwargs['help'] + ' (Env: {})'.format(env_var)
+            default = kwargs.pop('default', None)
+            super().add_argument(
+                *args, default=os.environ.get(env_var, default), **kwargs)
+        else:
+            super().add_argument(*args, **kwargs)
+
+    def parse_args(self):
+        """
+        Parses the arguments passed in, verifies inputs, sets the logger,
+        and returns the arguments.
+
+        :returns: The parsed arguments
+        :rtype: argparse.Namepsace
+        """
+        args = super().parse_args()
+        self._set_logger(args.log_level)
+        return args
+
+    def _set_logger(self, level):
+        """
+        Set the log level
+
+        :param level: set the log level
+        :type level: str
+        """
+        log.basicConfig(
+            format='[%(asctime)s  %(levelname)s]: %(message)s',
+            level=log._nameToLevel.get(level.upper(), log.DEBUG))
+
+
+class BuildCli(Cli):
+    """
+    Cli class that adds in reusable build specific arguments.
+    """
+
+    def __init__(self, *args, **kwargs):
+        """
+        Initializes the BuildCli instance.
+
+        :param kwargs: All keyword arguments which will pass to ArgumentParser
+        :type kwargs: dict
+        """
+        Cli.__init__(self, *args, **kwargs)
+        # Set common arguments
+        self.add_argument(
+            '--build', default='latest',
+            help='Override build id, defaults to latest')
+        self.add_argument(
+            '--buildroot', default='builds', help='Build diretory')
+        self.add_argument(
+            '--dump', default=False, action='store_true',
+            help='Dump the manfiest and exit')

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,2 @@
+pytest
+pytest-cov

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,48 @@
+import os
+import sys
+import uuid
+
+import pytest
+
+from cosalib.cli import Cli, BuildCli
+
+
+def test_cli_add_argument():
+    """
+    Ensure add_argument works normally
+    """
+    parser = Cli()
+    parser.add_argument('-t', '--test', action='store_true')
+    sys.argv = ['', '-t']
+    args = parser.parse_args()
+    assert args.test is True
+
+
+def test_cli_add_argument_with_env_var():
+    """
+    Ensure add_argument works with environment variables
+    """
+    sys.argv = ['']
+    expected = str(uuid.uuid4())
+    os.environ['ENVIRON_TEST'] = expected
+    parser = Cli()
+    parser.add_argument(
+        '-e', '--environ', env_var='ENVIRON_TEST')
+    args = parser.parse_args()
+    assert args.environ == expected
+
+
+def test_build_cli_additional_args():
+    """
+    Ensure that BuildCli contains the expected additional default args
+    """
+    parser = BuildCli()
+    expected = ['--build', '--buildroot', '--dump']
+    for action in parser._actions:
+        for expect in expected:
+            if expect in action.option_strings:
+                expected.pop(expected.index(expect))
+    if len(expected) != 0:
+        pytest.fail(
+            'The following actions were missing: {}'.format(
+                ', '.join(expected)))


### PR DESCRIPTION
## Cli
- Base class which can be used by other Cli classes
- Sets up the logger
- Provides an environment variable driven argument method
- Appends env variables to env args help text

## BuildCli
- Provides common arguments for build commands

## Tests
This PR also provides > 80% test coverage for the code in this PR :smile: 

```
$ pytest tests/
============================= test session starts ==============================
platform linux -- Python 3.7.3, pytest-4.6.3, py-1.8.0, pluggy-0.12.0
rootdir: /var/home/steve/Tech/GITHUB/coreos-assembler, inifile: pytest.ini
plugins: cov-2.7.1
collected 3 items                                                              

tests/test_cli.py ...                                                    [100%]

----------- coverage: platform linux, python 3.7.3-final-0 -----------
Name                      Stmts   Miss  Cover
---------------------------------------------
src/cosalib/__init__.py       0      0   100%
src/cosalib/build.py        127    127     0%
src/cosalib/cli.py           28      0   100%
---------------------------------------------
TOTAL                       155    127    18%


=========================== 3 passed in 0.04 seconds ===========================

```

## Code
```python3
from cosalib.cli import BuildCli

b = BuildCli(usage='test')
b.add_argument('-t', '--test', help='test')
b.add_argument('-e', '--env-test', env_var='ENV_VAR', default='default')
print(b.parse_args())
b.print_help()
```
## Output
```
usage: test

optional arguments:
  -h, --help            show this help message and exit
  --log-level {CRITICAL,FATAL,ERROR,WARN,WARNING,INFO,DEBUG,NOTSET}
                        Set the log level (Env: COSA_LOG_LEVEL)
  --build BUILD         Override build id, defaults to latest
  --buildroot BUILDROOT
                        Build diretory
  --dump                Dump the manfiest and exit
  -t TEST, --test TEST  test
  -e ENV_TEST, --env-test ENV_TEST
                        (Env: ENV_VAR)
```