### PR TITLE
gcp: Always --force

### DIFF
--- a/src/cmd-buildextend-gcp
+++ b/src/cmd-buildextend-gcp
@@ -28,9 +28,6 @@ parser.add_argument("--bucket", help="Storage account to write image to",
 parser.add_argument("--gce", help="Use GCE as the platform ID instead of GCP",
                     action="store_true",
                     default=bool(os.environ.get("GCP_GCE_PLATFORM_ID", False)))
-parser.add_argument("--force", help="Replace existing images and upload",
-                    action="store_true",
-                    default=bool(os.environ.get("GCP_FORCE", False)))
 parser.add_argument("--json-key", help="GCP Service Account JSON Auth",
                     default=os.environ.get("GCP_JSON_AUTH"))
 parser.add_argument("--name-suffix", help="Append suffix to name",
@@ -99,6 +96,7 @@ def run_ore():
                 '--project', args.project,
                 '--basename', base_name,
                 'upload',
+                '--force',  # We want to support restarting the pipeline
                 '--board=""',
                 '--bucket', f'gs://{args.bucket}/{base_name}',
                 '--json-key', args.json_key,


### PR DESCRIPTION
Our model is built on "immutable" version numbers, however it
can happen that e.g. a GCP build completes but a later stage fails.
If that happens, we may reassign the version number, and the correct
thing is to overwrite the build.

So always pass `--force`, and rely on the higher level pipeline
logic not overwriting builds that were successful.