### PR TITLE
cmd-buildupload: Mark modified meta.json as JSON

### DIFF
--- a/src/cmd-buildupload
+++ b/src/cmd-buildupload
@@ -89,7 +89,8 @@ def s3_upload_build(args):
     with tempfile.NamedTemporaryFile('w') as f:
         json.dump(build, f, indent=4)
         f.flush()
-        s3_cp(args, f.name, f'{buildid}/meta.json')
+        s3_cp(args, f.name, f'{buildid}/meta.json',
+              '--content-type=application/json')
 
 
 def s3_cp(args, src, dest, *s3_args):


### PR DESCRIPTION
I think because we upload from a tempfile, the regular auto-detection
doesn't work. So explicitly set the MIME type when uploading.

This makes a difference in the FCOS Build Browser, where trying to open
the file doesn't just display it in the browser.