### PR TITLE
cmd-build: Check if previous OSTree tarfile exists before copying

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -340,7 +340,8 @@ mv "${lockfile_out}" .
 "${dn}"/commitmeta_to_json "${tmprepo}" "${commit}" > commitmeta.json
 
 # And create the ostree repo tarball containing the commit
-if [ "${commit}" == "${previous_commit}" ]; then
+if [ "${commit}" == "${previous_commit}" ] && \
+    [ -f "${previous_builddir}/ostree-commit.tar" ]; then
     cp -a --reflink=auto "${previous_builddir}/ostree-commit.tar" .
 else
     ostree init --repo=repo --mode=archive


### PR DESCRIPTION
If we initialized with `buildprep`, we won't have `ostree-commit.tar`.
If `cosa build` then detects no changes to the OSTree, but only to the
image it will try to avoid tarring by copying the previous build's
OSTree tarfile, which will fail. Just add a check for the file before
enabling that optimization.