### PR TITLE
lockfile: Add basearch to lockfile name

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -162,7 +162,7 @@ fi
 # These need to be absolute paths right now for rpm-ostree
 composejson=${PWD}/tmp/compose.json
 # Put this under tmprepo so it gets automatically chown'ed if needed
-lockfile_out=${tmprepo}/tmp/manifest-lock.generated.json
+lockfile_out=${tmprepo}/tmp/manifest-lock.generated.${basearch}.json
 # --cache-only is here since `fetch` is a separate verb.
 # shellcheck disable=SC2086
 runcompose --cache-only ${FORCE} --add-metadata-from-json "${commitmeta_input_json}" \

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -178,7 +178,7 @@ prepare_build() {
     workdir="$(pwd)"
     configdir=${workdir}/src/config
     manifest=${configdir}/manifest.yaml
-    manifest_lock=${configdir}/manifest-lock.json
+    manifest_lock=${configdir}/manifest-lock.${basearch}.json
     export workdir configdir manifest manifest_lock
 
     if ! [ -f "${manifest}" ]; then


### PR DESCRIPTION
This is prep for multi-arch. We'll be storing the lockfiles for all the
archs in the config repo alongside each other. So tag on the basearch
to the lockfile we actually look for and the one we generate.