### PR TITLE
gf-platformid: set legacy coreos.oem.id properly

### DIFF
--- a/src/cmd-buildextend-aws
+++ b/src/cmd-buildextend-aws
@@ -46,7 +46,7 @@ def generate_aws_vmdk():
     tmp_img_aws = os.path.join(tmpdir, (ami_name_version + '.qcow2'))
     tmp_img_aws_vmdk = os.path.join(tmpdir, (ami_name_version + '.vmdk'))
     run_verbose(['/usr/lib/coreos-assembler/gf-platformid',
-                 img_qemu, tmp_img_aws, 'aws'])
+                 img_qemu, tmp_img_aws, 'ec2'])
     run_verbose(['qemu-img', 'convert', '-f', 'qcow2', '-O', 'vmdk',
                  tmp_img_aws,
                  '-o', 'adapter_type=lsilogic,subformat=streamOptimized,compat6',

--- a/src/gf-platformid
+++ b/src/gf-platformid
@@ -52,14 +52,14 @@ sed -i -e 's, ignition.platform.id=[a-zA-Z0-9]*,,g' "${tmpd}"/grub.cfg
 # Insert our new platformid
 # Match linux16, linux and linuxefi since only linux is available on aarch64
 # and linuxefi is available in grub2.cfg for UEFI
-sed -i -e 's,^\(linux\(16\|efi\)\? .*\),\1 ignition.platform.id='"${platformid}"',' "${tmpd}"/grub.cfg
+sed -i -e 's,^\(linux\(16\|efi\)\? .*\),\1 coreos.oem.id='"${platformid}"' ignition.platform.id='"${platformid}"',' "${tmpd}"/grub.cfg
 coreos_gf upload "${tmpd}"/grub.cfg "${grubcfg_path}"
 # Now the BLS version
 blscfg_path=$(coreos_gf glob-expand /boot/loader/entries/ostree-*.conf)
 coreos_gf download "${blscfg_path}" "${tmpd}"/bls.conf
 # Remove any platformid currently there
 sed -i -e 's, ignition.platform.id=[a-zA-Z0-9]*,,g' "${tmpd}"/bls.conf
-sed -i -e 's,^\(options .*\),\1 ignition.platform.id='"${platformid}"',' "${tmpd}"/bls.conf
+sed -i -e 's,^\(options .*\),\1 coreos.oem.id='"${platformid}"' ignition.platform.id='"${platformid}"',' "${tmpd}"/bls.conf
 coreos_gf upload "${tmpd}"/bls.conf "${blscfg_path}"
 
 coreos_gf_shutdown


### PR DESCRIPTION
Fix coreos.oem.id not being set on RHCOS 4.2