### PR TITLE
cmd-compress: Rename --algorithm to --compressor

### DIFF
--- a/src/cmd-compress
+++ b/src/cmd-compress
@@ -12,19 +12,19 @@ import argparse
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from cmdlib import run_verbose, write_json, sha256sum_file, rm_allow_noent
 
-DEFAULT_COMPRESSION_ALGO = 'gzip'
+DEFAULT_COMPRESSOR = 'gzip'
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--build", help="Build ID")
-parser.add_argument("--algorithm",
+parser.add_argument("--compressor",
                     choices=['xz', 'gzip'],
-                    default=DEFAULT_COMPRESSION_ALGO,
-                    help="Compression algorithm to use, default is gzip")
+                    default=DEFAULT_COMPRESSOR,
+                    help=f"Compressor to use, default is {DEFAULT_COMPRESSOR}")
 args = parser.parse_args()
 
-# find extension for --algorithm
+# find extension for --compressor
 ext_dict = {'xz': '.xz', 'gzip': '.gz'}
-ext = ext_dict[args.algorithm]
+ext = ext_dict[args.compressor]
 
 # default to latest build if not specified
 if args.build:
@@ -71,7 +71,7 @@ for img_format in buildmeta['images']:
         img['uncompressed-sha256'] = img['sha256']
         img['uncompressed-size'] = img['size']
         with open(tmpfile, 'wb') as f:
-            if ext == '.xz':
+            if args.compressor == 'xz':
                 run_verbose(['xz', '-c9', filepath], stdout=f)
             else:
                 run_verbose(['gzip', '-c', filepath], stdout=f)


### PR DESCRIPTION
As mentioned in #558, `--compressor` is more accurate than
`--algorithm`. Since the command is still fresh, let's just change it
now while nothing depends on it yet.