### PR TITLE
src/cmdlib.sh: let runvm_with_disk accept a format

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -245,7 +245,7 @@ build_image() {
 	kargs="$kargs console=tty0 console=${VM_TERMINAL},115200n8 ignition.platform.id=qemu"
 
 	qemu-img create -f qcow2 "$1" "$size"
-	runvm_with_disk "$1" /usr/lib/coreos-assembler/create_disk.sh /dev/vda "$tmprepo" "${ref-:${commit}}" /usr/lib/coreos-assembler/grub.cfg "$name" "\"$kargs\""
+	runvm_with_disk "$1" qcow2 /usr/lib/coreos-assembler/create_disk.sh /dev/vda "$tmprepo" "${ref-:${commit}}" /usr/lib/coreos-assembler/grub.cfg "$name" "\"$kargs\""
 }
 
 if [ -n "${build_qemu}" ]; then

--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -131,10 +131,9 @@ echo "Disk size estimated to $size"
 kargs="$(python3 -c 'import sys, yaml; args = yaml.safe_load(sys.stdin)["extra-kargs"]; print(" ".join(args))' < "$configdir/image.yaml")"
 kargs="$kargs console=tty0 console=${VM_TERMINAL},115200n8 ignition.platform.id=metal"
 
-qemu-img create -f qcow2 "${path}.qcow2" "$size"
-runvm_with_disk "${path}.qcow2" /usr/lib/coreos-assembler/create_disk.sh /dev/vda "$ostree_repo" "${ref-:${commit}}" /usr/lib/coreos-assembler/grub.cfg "$name" "\"$kargs\""
-qemu-img convert "${path}.qcow2" "$path"
-rm "${path}.qcow2"
+qemu-img create -f raw "${path}.tmp" "$size"
+runvm_with_disk "${path}.tmp" raw /usr/lib/coreos-assembler/create_disk.sh /dev/vda "$ostree_repo" "${ref-:${commit}}" /usr/lib/coreos-assembler/grub.cfg "$name" "\"$kargs\""
+mv "${path}.tmp" "$path"
 
 # flush it out before going to the next one so we don't have to redo both if
 # the next one fails

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -326,11 +326,13 @@ EOF
 }
 
 runvm() {
-    runvm_with_disk "" "$@"
+    runvm_with_disk "" "" "$@"
 }
 
 runvm_with_disk() {
     local disk="$1"
+    shift
+    local disk_fmt="$1"
     shift
     local vmpreparedir=${workdir}/tmp/supermin.prepare
     local vmbuilddir=${workdir}/tmp/supermin.build
@@ -401,7 +403,7 @@ EOF
     # if a disk image exists, attach it too
     extradisk=()
     if [ -n "$disk" ]; then
-        extradisk=("-drive" "if=virtio,id=target,format=qcow2,file=$disk")
+        extradisk=("-drive" "if=virtio,id=target,format=$disk_fmt,file=$disk")
     fi
 
     #shellcheck disable=SC2086


### PR DESCRIPTION
Pass the disk format to runvm_with_disk instead of assuming qcow2. This
allows building raw disks without having to convert. As a bonus, raw
disks can have better performance as well.