### PR TITLE
cosalib: fix name reference

### DIFF
--- a/src/cosalib/build.py
+++ b/src/cosalib/build.py
@@ -129,7 +129,7 @@ class _Build:
     @property
     def build_name(self):
         """ get the name of the build """
-        return str(self.get_meta_key("meta", "name")
+        return str(self.get_meta_key("meta", "name"))
 
     @property
     def summary(self):

--- a/src/cosalib/build.py
+++ b/src/cosalib/build.py
@@ -129,8 +129,7 @@ class _Build:
     @property
     def build_name(self):
         """ get the name of the build """
-        ref = str(self.get_meta_key("meta", "ref")).split('-')
-        return ref[-1]
+        return str(self.get_meta_key("meta", "name")
 
     @property
     def summary(self):


### PR DESCRIPTION
Our Koji uploads are getting "none" as their name. The meta-data format has changed to use "name" instead of "ref".

(cherry picked from commit e04f66248c8bb824af4bdf7dc8f1e7f29fea8c54)