### PR TITLE
Add support for lockfile overrides

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -154,7 +154,12 @@ prepare_git_artifacts "${configdir_gitrepo}" "${PWD}/coreos-assembler-config.tar
 lock_arg=
 if [ -f "${manifest_lock}" ]; then
     lock_arg="--ex-lockfile=${manifest_lock}"
-    echo "Building from lockfile ${manifest_lock}"
+    echo -n "Building from lockfile ${manifest_lock}"
+    if [ -f "${manifest_lock_overrides}" ]; then
+        lock_arg="${lock_arg} --ex-lockfile=${manifest_lock_overrides}"
+        echo -n " and overrides ${manifest_lock_overrides}"
+    fi
+    echo
     sleep 1
 fi
 

--- a/src/cmd-fetch
+++ b/src/cmd-fetch
@@ -55,9 +55,18 @@ lock_arg=
 if [ -n "${UPDATE_LOCKFILE}" ]; then
     # Put this under tmprepo so it gets automatically chown'ed if needed
     lock_arg="--ex-write-lockfile-to=${tmprepo}/tmp/manifest-lock.json"
+    if [ -f "${manifest_lock_overrides}" ]; then
+        echo "NB: ignoring overrides ${manifest_lock_overrides}"
+        sleep 1
+    fi
 elif [ -f "${manifest_lock}" ]; then
     lock_arg="--ex-lockfile=${manifest_lock}"
-    echo "Fetching RPMs from lockfile ${manifest_lock}"
+    echo -n "Fetching RPMs from lockfile ${manifest_lock}"
+    if [ -f "${manifest_lock_overrides}" ]; then
+        lock_arg="${lock_arg} --ex-lockfile=${manifest_lock_overrides}"
+        echo -n " and overrides ${manifest_lock_overrides}"
+    fi
+    echo
     sleep 1
 fi
 

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -179,7 +179,8 @@ prepare_build() {
     configdir=${workdir}/src/config
     manifest=${configdir}/manifest.yaml
     manifest_lock=${configdir}/manifest-lock.${basearch}.json
-    export workdir configdir manifest manifest_lock
+    manifest_lock_overrides=${configdir}/manifest-lock.overrides.${basearch}.json
+    export workdir configdir manifest manifest_lock manifest_lock_overrides
 
     if ! [ -f "${manifest}" ]; then
         fatal "Failed to find ${manifest}"


### PR DESCRIPTION
This is needed in FCOS, where we'll have a shared base lockfile, and a
curated overrides file. For more info, see the stream tooling doc[1].

For now, we just keep separate overrides per basearch to keep things
simple (instead of having a single override as per the stream tooling
doc). We can add more enhancements in rpm-ostree to enable this, but
let's get the basics working first.

[1] https://github.com/coreos/fedora-coreos-tracker/blob/master/stream-tooling.md