### PR TITLE
build: Fix relative links for `src/config` with supermin

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -176,7 +176,7 @@ prepare_build() {
     fi
 
     workdir="$(pwd)"
-    configdir=${workdir}/src/config
+    configdir=${COSA_CONFIG_GIT:-${workdir}/src/config}
     manifest=${configdir}/manifest.yaml
     manifest_lock=${configdir}/manifest-lock.${basearch}.json
     export workdir configdir manifest manifest_lock

--- a/src/supermin-init-prelude.sh
+++ b/src/supermin-init-prelude.sh
@@ -26,8 +26,9 @@ umask 002
 mkdir -p "${workdir:?}"
 mount -t 9p -o rw,trans=virtio,version=9p2000.L workdir "${workdir}"
 if [ -L "${workdir}"/src/config ]; then
-    mkdir -p "$(readlink "${workdir}"/src/config)"
-    mount -t 9p -o rw,trans=virtio,version=9p2000.L source "${workdir}"/src/config
+    tmpd=$(mktemp -d)
+    mount -t 9p -o rw,trans=virtio,version=9p2000.L source "${tmpd}"
+    export COSA_CONFIG_GIT="${tmpd}"
 fi
 mkdir -p "${workdir}"/cache /host/container-work
 if [ -b /dev/sdb1 ]; then


### PR DESCRIPTION
I use `ln -sr ~walters/src/redhat-coreos src/config` and the `-r`
makes a relative link which breaks this code as it tries to `mkdir -p`
on a relative path inside the supermin VM.

Rather than trying to make the path the same on the host and the VM,
add a `COSA_CONFIG_GIT` environment variable that overrides `src/config`,
and use that in the supermin path if we detect that `src/config` is
a symlink.  This way there doesn't need to be a fixed correspondence
between the host filesystem and VM (other than the rest of `workdir`
which should have all relative links contained inside it).