### PR TITLE
Patch set that enables build of the coreos-assembler container on s390x

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -13,6 +13,8 @@ else
     exit 1
 fi
 
+arch=$(uname -m)
+
 if [ $# -eq 0 ]; then
   echo Usage: "build.sh CMD"
   echo "Supported commands:"
@@ -76,10 +78,11 @@ install_rpms() {
     sed -e "s/^.*default_ccache_name/#    default_ccache_name/g" -i /etc/krb5.conf
 
     # Open up permissions on /boot/efi files so we can copy them
-    # for our ISO installer image
-    find /boot/efi -type f -print0 | xargs -r -0 chmod +r
-    find /boot/efi -type d -print0 | xargs -r -0 chmod +rx
-
+    # for our ISO installer image, skip if not present
+    if [ -e /boot/efi ]; then
+        find /boot/efi -type f -print0 | xargs -r -0 chmod +r
+        find /boot/efi -type d -print0 | xargs -r -0 chmod +rx
+    fi
     # Further cleanup
     yum clean all
 
@@ -110,7 +113,6 @@ _prep_make_and_make_install() {
 # doesn't support the installclass stuff and hopefully we'll stop using it soon.
 installer_release=29
 
-arch=$(uname -m)
 # Download url is different for primary and secondary fedora
 # Primary Fedora - https://download.fedoraproject.org/pub/fedora/linux/releases/
 # Secondary Fedora - https://download.fedoraproject.org/pub/fedora-secondary/releases/

--- a/deps-s390x.txt
+++ b/deps-s390x.txt
@@ -1,0 +1,1 @@
+src/deps-s390x.txt

--- a/src/deps-aarch64.txt
+++ b/src/deps-aarch64.txt
@@ -1,2 +1,5 @@
+# For grub install when creating images without anaconda
+grub2
+
 # For creating bootable UEFI media on aarch64
 shim-aa64 grub2-efi-aa64

--- a/src/deps-s390x.txt
+++ b/src/deps-s390x.txt
@@ -1,0 +1,2 @@
+# Place-holder for s390x arch specific dependencies
+

--- a/src/deps-x86_64.txt
+++ b/src/deps-x86_64.txt
@@ -1,3 +1,6 @@
+# For grub install when creating images without anaconda
+grub2
+
 # For generating ISO images
 syslinux-nonlinux
 

--- a/src/deps.txt
+++ b/src/deps.txt
@@ -49,8 +49,5 @@ awscli python3-boto3 python3-requests
 # shellcheck for test
 ShellCheck
 
-# for grub install when creating images without anaconda
-grub2
-
 # Support for Koji uploads.
 krb5-libs krb5-workstation python2-koji python2-krbv


### PR DESCRIPTION
Rather minimal changes that enable the build of the assembler container on s390x. Testing on ppc64le and x86_64 I haven't seen any breakage.