### PR TITLE
Support an `ostree-remote` knob in image.yaml

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -239,8 +239,8 @@ set -x
 
 build_image() {
 	local size kargs
-	size="$(python3 -c 'import sys, yaml; print(yaml.load(sys.stdin, Loader=yaml.CLoader)["size"])' < "$configdir/image.yaml")G"
-	kargs="$(python3 -c 'import sys, yaml; args = yaml.load(sys.stdin, Loader=yaml.CLoader).get("extra-kargs", []); print(" ".join(args))' < "$configdir/image.yaml")"
+	size="$(python3 -c 'import sys, yaml; print(yaml.safe_load(sys.stdin)["size"])' < "$configdir/image.yaml")G"
+	kargs="$(python3 -c 'import sys, yaml; args = yaml.safe_load(sys.stdin).get("extra-kargs", []); print(" ".join(args))' < "$configdir/image.yaml")"
 	kargs="$kargs console=tty0 console=${VM_TERMINAL},115200n8 ignition.platform.id=qemu"
 
 	qemu-img create -f qcow2 "$1" "$size"

--- a/src/cmd-build
+++ b/src/cmd-build
@@ -238,13 +238,15 @@ imageprefix="${name}"-"${buildid}"
 set -x
 
 build_image() {
-	local size kargs
+	local size kargs ostree_remote
 	size="$(python3 -c 'import sys, yaml; print(yaml.safe_load(sys.stdin)["size"])' < "$configdir/image.yaml")G"
 	kargs="$(python3 -c 'import sys, yaml; args = yaml.safe_load(sys.stdin).get("extra-kargs", []); print(" ".join(args))' < "$configdir/image.yaml")"
+	# use NONE here instead of empty string because this has to survive through various string processing
+	ostree_remote="$(python3 -c 'import sys, yaml; print(yaml.safe_load(sys.stdin).get("ostree-remote", "NONE"))' < "$configdir/image.yaml")"
 	kargs="$kargs console=tty0 console=${VM_TERMINAL},115200n8 ignition.platform.id=qemu"
 
 	qemu-img create -f qcow2 "$1" "$size"
-	runvm_with_disk "$1" qcow2 /usr/lib/coreos-assembler/create_disk.sh /dev/vda "$tmprepo" "${ref-:${commit}}" /usr/lib/coreos-assembler/grub.cfg "$name" "\"$kargs\""
+	runvm_with_disk "$1" qcow2 /usr/lib/coreos-assembler/create_disk.sh /dev/vda "$tmprepo" "${ref-:${commit}}" "${ostree_remote}" /usr/lib/coreos-assembler/grub.cfg "$name" "\"$kargs\""
 }
 
 echo '{}' > tmp/vm-iso-checksum.json

--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -129,9 +129,10 @@ size="$(( size + 513 ))M"
 echo "Disk size estimated to $size"
 kargs="$(python3 -c 'import sys, yaml; args = yaml.safe_load(sys.stdin)["extra-kargs"]; print(" ".join(args))' < "$configdir/image.yaml")"
 kargs="$kargs console=tty0 console=${VM_TERMINAL},115200n8 ignition.platform.id=metal"
+ostree_remote="$(python3 -c 'import sys, yaml; print(yaml.safe_load(sys.stdin).get("ostree-remote", "NONE"))' < "$configdir/image.yaml")"
 
 qemu-img create -f raw "${path}.tmp" "$size"
-runvm_with_disk "${path}.tmp" raw /usr/lib/coreos-assembler/create_disk.sh /dev/vda "$ostree_repo" "${ref-:${commit}}" /usr/lib/coreos-assembler/grub.cfg "$name" "\"$kargs\""
+runvm_with_disk "${path}.tmp" raw /usr/lib/coreos-assembler/create_disk.sh /dev/vda "$ostree_repo" "${ref-:${commit}}" "${ostree_remote}" /usr/lib/coreos-assembler/grub.cfg "$name" "\"$kargs\""
 mv "${path}.tmp" "$path"
 
 # flush it out before going to the next one so we don't have to redo both if


### PR DESCRIPTION
The remote config in FCOS is provided by `fedora-repos-ostree`, which
ships under the `fedora` id. We need to be able to match this when
deploying the ref in the image so that rpm-ostree can upgrade.