### PR TITLE
grub.cfg: Fix ignition.firstboot semantics

### DIFF
--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -85,6 +85,9 @@ else
 	ext="AA64"
 fi
 
+# we use pure BLS, so don't need grub2-mkconfig
+ostree config --repo rootfs/ostree/repo set sysroot.bootloader none
+
 # install uefi grub
 mkdir -p rootfs/boot/efi/EFI/{BOOT,fedora}
 cp "/boot/efi/EFI/BOOT/BOOT${ext}.EFI" "rootfs/boot/efi/EFI/BOOT/BOOT${ext}.EFI"

--- a/src/grub.cfg
+++ b/src/grub.cfg
@@ -40,10 +40,21 @@ else
   set timeout=1
 fi
 
+# Determine if this is a first boot and set the ${ignition_firstboot} variable
+# which is used in the kernel command line.
 set ignition_firstboot=""
-# Determine if this is a first boot.
 if [ -f "/ignition.firstboot" ]; then
-    set ignition_firstboot="ignition.firstboot"
+    # default to dhcp networking parameters to be used with ignition
+    set ignition_network_kcmdline='rd.neednet=1 ip=dhcp'
+
+    # source in the `ignition.firstboot` file which could override the
+    # above $ignition_network_kcmdline with static networking config.
+    # This override feature is primarily used by coreos-installer to
+    # persist static networking config provided during install to the
+    # first boot of the machine.
+    source "/ignition.firstboot"
+
+    set ignition_firstboot="ignition.firstboot ${ignition_network_kcmdline}"
 fi
 
 blscfg


### PR DESCRIPTION
A very important piece we lost moving towards a static GRUB2 config is
the `rd.neednet=1 ip=dhcp` args which normally comes from
ignition-dracut[1].

It also included some subtle semantics which interact with
coreos-installer through the `ignition.firstboot` file so that
networking args are carried over.

Not sure if there were plans to deal with this differently, though we
need something for right now at least for FCOS preview. (And we'll want
to drop `02_ignition_firstboot` from ignition-dracut, but it's not a
hard requirement).

[1] https://github.com/coreos/ignition-dracut/blob/8551bc7fd89a80200d94d009ad3d17131fc11dcf/grub/02_ignition_firstboot