### PR TITLE
vmdeps: Fix name of shim-x64

### DIFF
--- a/src/vmdeps.txt
+++ b/src/vmdeps.txt
@@ -18,4 +18,4 @@ selinux-policy selinux-policy-targeted policycoreutils
 # coreos-assembler
 #FEDORA python3 python3-gobject-base buildah podman skopeo iptables iptables-libs
 
-gdisk xfsprogs e2fsprogs grub2 dosfstools shim grub2-efi-x64
+gdisk xfsprogs e2fsprogs grub2 dosfstools shim-x64 grub2-efi-x64


### PR DESCRIPTION
I was missing the `chmod` on `/boot/efi` in my dev container which
broke the builds.  At first I thought it was the wrong package name,
but that wasn't it.

I guess supermin ignores nonexistent packages, but let's make the
package name correct anyways.