### PR TITLE
virt-install: allow ostre-remote in image.yaml verification

### DIFF
--- a/src/virt-install
+++ b/src/virt-install
@@ -28,7 +28,7 @@ def fatal(msg):
 
 # Set of valid keys in image.yaml
 IMAGE_CONF_KEYS = ['size', 'postprocess-script', 'extra-kargs',
-                   'save-var-subdirs-for-selabel-workaround']
+                   'save-var-subdirs-for-selabel-workaround', 'ostree-remote']
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--dest", help="Destination disk",


### PR DESCRIPTION
https://github.com/coreos/fedora-coreos-config/commit/1842e9e309c2dfc89863705917c19f8eb85be245#diff-b56ad46b43eb108be045b7ad559c32b6 introduced the ostree-remote in to the image.yaml Add it in to the allowed keys in virt-install. This resolves issue on ppc64le.