### PR TITLE
cmd-run: Make --srv work again via dependency hacking

### DIFF
--- a/src/cmd-run
+++ b/src/cmd-run
@@ -117,10 +117,11 @@ set -- -machine accel=kvm -cpu host -smp "${VM_NCPUS}" "$@"
 if [ -n "${VM_SRV_MNT}" ]; then
     set -- --fsdev local,id=var-srv,path="${VM_SRV_MNT}",security_model=mapped,readonly \
         -device virtio-9p-pci,fsdev=var-srv,mount_tag=/var/srv "$@"
+    # The dependency changes are hacks around https://github.com/coreos/fedora-coreos-tracker/issues/223
     ign_var_srv_mount=',{
 "name": "var-srv.mount",
 "enabled": true,
-"contents": "[Mount]\nWhat=/var/srv\nWhere=/var/srv\nType=9p\nOptions=ro,trans=virtio,version=9p2000.L\n[Install]\nWantedBy=multi-user.target\n"
+"contents": "[Unit]\nDefaultDependencies=no\nAfter=systemd-tmpfiles-setup.service\nBefore=basic.target\n[Mount]\nWhat=/var/srv\nWhere=/var/srv\nType=9p\nOptions=ro,trans=virtio,version=9p2000.L\n[Install]\nWantedBy=multi-user.target\n"
 }'
 else
     ign_var_srv_mount=""


### PR DESCRIPTION
This is an awful hack-around
https://github.com/coreos/fedora-coreos-tracker/issues/223

But I use `--srv` for developing a lot as it's an easy
way to get data into the VM (e.g. test RPMs), so let's
make it work so I and others can use it to develop FCOS
and even test fixes to things like this.