### PR TITLE
WIP: buildextend-metal: Add boot partition sizes to estimate

### DIFF
--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -122,7 +122,8 @@ fi
 path=${PWD}/${img}
 
 echo "Estimating disk size..."
-/usr/lib/coreos-assembler/estimate-commit-disk-size --repo "$ostree_repo" "$ref" --add-percent 20 > "$PWD/tmp/ostree-size.json"
+# Keep this number 512 in sync with create_disk.sh
+/usr/lib/coreos-assembler/estimate-commit-disk-size --add-mb 512 --repo "$ostree_repo" "$ref" > "$PWD/tmp/ostree-size.json"
 size="$(jq '."estimate-mb".final' "$PWD/tmp/ostree-size.json")"
 # extra size is the non-ostree partitions, see create_disk.sh
 size="$(( size + 513 ))M"

--- a/src/estimate-commit-disk-size
+++ b/src/estimate-commit-disk-size
@@ -20,7 +20,8 @@ parser.add_argument("--blksize", type=int, default=4096)
 parser.add_argument("--metadata-overhead-percent", type=int, default=5)
 # This is an arbitrary number of course.  We need enough to not trip e.g. ostree's min-free-space-percent
 # checks etc.
-parser.add_argument("--add-percent", help="Additional space (integer percentage) to reserve", type=int, default=15)
+parser.add_argument("--add-percent", help="Additional space (integer percentage) to reserve", type=int, default=20)
+parser.add_argument("--add-mb", help="Additional space in MB to reserve", type=int, default=0)
 parser.add_argument("--repo", help="Repository", required=True)
 parser.add_argument("ref", help="Ref")
 args = parser.parse_args()
@@ -58,7 +59,7 @@ blks_per_mb = (1024*1024) // args.blksize
 total_data_mb = (blks_meta + blks_regfiles + blks_symlinks) // blks_per_mb
 add_percent = args.metadata_overhead_percent + args.add_percent
 add_percent_modifier = (100.0+add_percent)/100.0
-estimate_mb = int(total_data_mb * add_percent_modifier) + 1
+estimate_mb = int(total_data_mb * add_percent_modifier) + args.add_mb + 1
 res = {
     'meta': {'count': n_meta,
              'blocks': blks_meta,},


### PR DESCRIPTION
Similar to what we were doing with the virt-install/Anaconda path,
which adds the size of the boot partition (1GB) to the estimate.

`cosa buildextend-metal` was hitting `ENOSPC` for me building
Silverblue.

(In the future when this isn't shell script we should obviously
 only have the ~512 MB in one place, but for now this is better)

While I have the patient open, change the metadata percent estimate
default to 20 to match what we were passing anyways.