### PR TITLE
Support `cosa build metal`

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -18,6 +18,7 @@ Usage: coreos-assembler build --help
 
     - ostree
     - qemu
+    - metal
 
   Note that all image targets also require the "ostree" target.
 EOF
@@ -74,11 +75,12 @@ if [ $# -eq 0 ]; then
     set -- qemu
 fi
 
-build_qemu=
+build_derived=
 for target in "$@"; do
     case $target in
         ostree) ;;
-        qemu) build_qemu=1;;
+        qemu) build_derived=qemu;;
+        metal) build_derived=metal;;
         *) fatal "Unrecognized target: $target";;
     esac
 done
@@ -281,7 +283,7 @@ build_image() {
 }
 
 echo '{}' > tmp/vm-iso-checksum.json
-if [ -n "${build_qemu}" ]; then
+if [ "${build_derived}" = "qemu" ]; then
     img_qemu=${imageprefix}-qemu.qcow2
     case "$arch" in
         "x86_64"|"aarch64")
@@ -336,7 +338,7 @@ cat > tmp/meta.json <<EOF
 }
 EOF
 
-if [ -n "${build_qemu}" ]; then
+if [ "${build_derived}" = "qemu" ]; then
     cat > tmp/images.json <<EOF
 {
     "images": {
@@ -370,6 +372,13 @@ cat "${composejson}" tmp/meta.json tmp/diff.json tmp/images.json tmp/vm-iso-chec
 if [ -n "${ref_is_temp}" ]; then
     jq 'del(.ref)' < meta.json > meta.json.new
     mv meta.json{.new,}
+fi
+
+if [ "${build_derived}" = "metal" ]; then
+    # This internal_tmp_builddir is a special way to pass the `builddir` down
+    # across a separate process.  Ideally in the future both this and buildextend-metal
+    # are rewritten in a real programming language, and we can call helper functions.
+    (tmpbuilddir=$(pwd); cd "${workdir}" && env "internal_tmp_builddir=${tmpbuilddir}" cosa buildextend-metal)
 fi
 
 # Move lockfile into build dir

--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -17,6 +17,8 @@ EOF
 # Parse options
 rc=0
 build=
+# Used by cmd-build to invoke "directly"
+internal_tmp_builddir="${internal_tmp_builddir:-}"
 options=$(getopt --options h --longoptions help,build: -- "$@") || rc=$?
 [ $rc -eq 0 ] || {
     print_help
@@ -65,23 +67,32 @@ esac
 
 export LIBGUESTFS_BACKEND=direct
 
-prepare_build
+json_key() {
+    jq -r ".[\"$1\"]" < "${builddir}/meta.json"
+}
 
-if [ -z "${build}" ]; then
+if [ -z "${internal_tmp_builddir}" ]; then
+    prepare_build
+else
+    init_build_env
+    builddir="${internal_tmp_builddir}"
+    build=$(json_key buildid)
+    TMPDIR="${internal_tmp_builddir}/tmp"
+fi
+
+if [ -z "${build}" ] && [ -z "${internal_tmp_builddir}" ]; then
     build=$(get_latest_build)
     if [ -z "${build}" ]; then
         fatal "No build found."
     fi
 fi
 
-builddir=$(get_build_dir "$build")
-if [ ! -d "${builddir}" ]; then
-    fatal "Build dir ${builddir} does not exist."
+if [ -z "${internal_tmp_builddir}" ]; then
+    builddir=$(get_build_dir "$build")
+    if [ ! -d "${builddir}" ]; then
+        fatal "Build dir ${builddir} does not exist."
+    fi
 fi
-
-json_key() {
-    jq -r ".[\"$1\"]" < "${builddir}/meta.json"
-}
 
 # reread these values from the build itself rather than rely on the ones loaded
 # by prepare_build since the config might've changed since then


### PR DESCRIPTION
Some dirty hacks to allow directly building a metal image.
The value in this is that for e.g. Silverblue I don't see a good
reason to ship a `qemu` image.  Next steps here are to make
`cosa run` support this case.