### PR TITLE
grub: Read ignition platform id from separate file

### DIFF
--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -64,7 +64,7 @@ if [ "${remote_name}" != NONE ]; then
 fi
 ostree pull-local "$ostree" "$ref" --repo rootfs/ostree/repo $remote_arg
 ostree admin os-init "$os_name" --sysroot rootfs
-allkargs='root=/dev/disk/by-label/root rootflags=defaults,prjquota rw $ignition_firstboot'
+allkargs='root=/dev/disk/by-label/root rootflags=defaults,prjquota rw $ignition_firstboot $ignition_platform_id'
 allkargs="$allkargs $extrakargs"
 kargsargs=""
 for karg in $allkargs

--- a/src/grub.cfg
+++ b/src/grub.cfg
@@ -58,12 +58,10 @@ if [ -f "/ignition.firstboot" ]; then
 fi
 
 # Read ignition platform id from /ignition_platform_id
-set ignition_platform_id=""
 if [ -f "/ignition_platform_id" ]; then
-    set ignition.platform.id=''
 
-    # source in the `ignition_platform_id` file which could override the
-    # above $ignition.platform.id with ignition platform id.
+    # source in the `ignition_platform_id` file which contains
+    # ignition platform id, for example "set ignition.platform.id=qemu"
     source "/ignition_platform_id"
 
     set ignition_platform_id="${ignition.platform.id}"

--- a/src/grub.cfg
+++ b/src/grub.cfg
@@ -57,4 +57,16 @@ if [ -f "/ignition.firstboot" ]; then
     set ignition_firstboot="ignition.firstboot ${ignition_network_kcmdline}"
 fi
 
+# Read ignition platform id from /ignition_platform_id
+set ignition_platform_id=""
+if [ -f "/ignition_platform_id" ]; then
+    set ignition.platform.id=''
+
+    # source in the `ignition_platform_id` file which could override the
+    # above $ignition.platform.id with ignition platform id.
+    source "/ignition_platform_id"
+
+    set ignition_platform_id="${ignition.platform.id}"
+fi
+
 blscfg


### PR DESCRIPTION
Changes to let grub read ignition platform id from a separate file
`ignition_platform_id`.

Related issue: 
 - Original issue: https://github.com/coreos/fedora-coreos-tracker/issues/191#issuecomment-499656531
 - PR on coreos-installer writing platform id to separate file: https://github.com/coreos/coreos-installer/pull/52
 - PR on removing default ignition platform id from `cosa` : https://github.com/coreos/coreos-assembler/pull/645