### PR TITLE
cmd-build: Remove default ignition platform id kernel argument

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -274,7 +274,7 @@ build_image() {
 	kargs="$(python3 -c 'import sys, yaml; args = yaml.safe_load(sys.stdin).get("extra-kargs", []); print(" ".join(args))' < "$configdir/image.yaml")"
 	# use NONE here instead of empty string because this has to survive through various string processing
 	ostree_remote="$(python3 -c 'import sys, yaml; print(yaml.safe_load(sys.stdin).get("ostree-remote", "NONE"))' < "$configdir/image.yaml")"
-	kargs="$kargs console=tty0 console=${VM_TERMINAL},115200n8 ignition.platform.id=qemu"
+	kargs="$kargs console=tty0 console=${VM_TERMINAL},115200n8"
 
 	qemu-img create -f qcow2 "$1" "$size"
 	runvm_with_disk "$1" qcow2 /usr/lib/coreos-assembler/create_disk.sh /dev/vda "$tmprepo" "${ref-:${commit}}" "${ostree_remote}" /usr/lib/coreos-assembler/grub.cfg "$name" "\"$kargs\""

--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -128,7 +128,7 @@ size="$(jq '."estimate-mb".final' "$PWD/tmp/ostree-size.json")"
 size="$(( size + 513 ))M"
 echo "Disk size estimated to $size"
 kargs="$(python3 -c 'import sys, yaml; args = yaml.safe_load(sys.stdin).get("extra-kargs", []); print(" ".join(args))' < "$configdir/image.yaml")"
-kargs="$kargs console=tty0 console=${VM_TERMINAL},115200n8 ignition.platform.id=metal"
+kargs="$kargs console=tty0 console=${VM_TERMINAL},115200n8"
 ostree_remote="$(python3 -c 'import sys, yaml; print(yaml.safe_load(sys.stdin).get("ostree-remote", "NONE"))' < "$configdir/image.yaml")"
 
 qemu-img create -f raw "${path}.tmp" "$size"


### PR DESCRIPTION
Related issues:
 - Original issue: https://github.com/coreos/fedora-coreos-tracker/issues/191#issuecomment-499656531
 - PR on coreos-installer writing platform id to separate file: https://github.com/coreos/coreos-installer/pull/52
 - PR on `cosa` reading platform id from the file: https://github.com/coreos/coreos-assembler/pull/644