### PR TITLE
4.2 backport build root to dir change

### DIFF
--- a/src/cmd-buildextend-azure
+++ b/src/cmd-buildextend-azure
@@ -64,7 +64,7 @@ class Build(_Build):
 
         # Generate path locations
         img_qemu = os.path.join(
-            self.build_root, self.meta['images']['qemu']['path'])
+            self.build_dir, self.meta['images']['qemu']['path'])
 
         tmp_img_azure = os.path.join(self.tmpbuilddir, (azure_nv + '.qcow2'))
         tmp_img_azure_vhd = os.path.join(self.tmpbuilddir, self.azure_vhd_name)
@@ -79,7 +79,7 @@ class Build(_Build):
 
         # place the VHD into is final place
         final_vhd = os.path.basename(tmp_img_azure_vhd)
-        final_vhd_path = f"{self.build_root}/{final_vhd}"
+        final_vhd_path = f"{self.build_dir}/{final_vhd}"
         os.rename(tmp_img_azure_vhd, final_vhd_path)
 
         # TODO: This can be pulled out into a _Build method.
@@ -164,7 +164,7 @@ def run_ore(args, build):
     :param build: Build instance to use
     :type build: Build
     """
-    azure_vhd_path = os.path.join(build.build_root, build.azure_vhd_name)
+    azure_vhd_path = os.path.join(build.build_dir, build.azure_vhd_name)
     ore_upload_args = [
         'ore', 'azure', 'upload-blob-arm',
         '--azure-auth', args.auth,

--- a/src/cmd-koji-upload
+++ b/src/cmd-koji-upload
@@ -128,8 +128,8 @@ class Build(_Build):
         """
         # locate all the build artifacts in the build directory.
         files = []
-        for ffile in os.listdir(self.build_root):
-            files.append(os.path.join(self.build_root, ffile))
+        for ffile in os.listdir(self.build_dir):
+            files.append(os.path.join(self.build_dir, ffile))
             if os.path.islink(ffile):
                 log.debug(" * EXCLUDING symlink '%s'", ffile)
                 log.debug(" *    target '%s'", os.path.realpath(ffile))

--- a/src/cosalib/build.py
+++ b/src/cosalib/build.py
@@ -65,13 +65,13 @@ class _Build:
       - _build_artifacts(*args, **kwargs)
     """
 
-    def __init__(self, build_dir, build="latest", workdir=None):
+    def __init__(self, builds_dir, build="latest", workdir=None):
         """
         init loads the builds.json which lists the builds, loads the relevant
         meta-data from JSON and finally, locates the build artifacts.
 
-        :param build_dir: name of directory to find the builds
-        :type build_dir: str
+        :param builds_dir: name of directory to find the builds
+        :type builds_dir: str
         :param build: build id or "latest" to parse
         :type build: str
         :param workdir: Temporary directory to ensure exists and is clean
@@ -84,7 +84,7 @@ class _Build:
         If workdir is None then no temporary work directory is created.
         """
         log.info('Evaluating builds.json')
-        builds = load_json('%s/builds.json' % build_dir)
+        builds = load_json('%s/builds.json' % builds_dir)
         if build != "latest":
             if build not in builds['builds']:
                 raise BuildError("Build was not found in builds.json")
@@ -92,7 +92,7 @@ class _Build:
             build = builds['builds'][0]
 
         log.info("Targeting build: %s", build)
-        self._build_root = os.path.abspath("%s/%s" % (build_dir, build))
+        self._build_dir = os.path.abspath("%s/%s" % (builds_dir, build))
 
         self._build_json = {
             "commit": None,
@@ -156,9 +156,9 @@ class _Build:
         return self.get_meta_key("meta", "buildid")
 
     @property
-    def build_root(self):
+    def build_dir(self):
         """ return the actual path for the build root """
-        return self._build_root
+        return self._build_dir
 
     @property
     def build_name(self):
@@ -220,11 +220,10 @@ class _Build:
         :raises: KeyError
         """
         lookup = {
-            "commit": "%s/commitmeta.json" % self.build_root,
-            "config": ("%s/coreos-assembler-config-git.json" %
-                       self.build_root),
+            "commit": "%s/commitmeta.json" % self.build_dir,
+            "config": ("%s/coreos-assembler-config-git.json" % self.build_dir),
             "image": "/cosa/coreos-assembler-git.json",
-            "meta": "%s/meta.json" % self.build_root,
+            "meta": "%s/meta.json" % self.build_dir,
         }
         return lookup[var]
 


### PR DESCRIPTION
Backports to make `build_root` :arrow_right: `build_dir` valid in rhcos-4.2 as well.

See:
- https://github.com/coreos/coreos-assembler/pull/646
- https://github.com/coreos/coreos-assembler/commit/f583a0d58796d9e4ef57c859ec726ede6a07091f