### PR TITLE
src/cmdlib: relax RHCOS version check

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -157,7 +157,7 @@ preflight() {
 disk_ignition_version() {
     local bn
     bn=$(basename "$1")
-    if [[ ${bn} = rhcos-4[12]0*.8* ]]; then
+    if [[ ${bn} = rhcos-4[12]*.8* ]]; then
         echo "2.2.0"
     else
         echo "3.0.0"


### PR DESCRIPTION
RHCOS recently changed the version string used to look like
`42.80.20190723.0` or sometimes `42devel.80.20190723.0`, so change the
version string check appropriately.