### PR TITLE
[rhcos-4.2] src/cmdlib: relax RHCOS version check

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -153,7 +153,7 @@ preflight() {
 disk_ignition_version() {
     local bn
     bn=$(basename "$1")
-    if [[ ${bn} = rhcos-4[12]0.8* ]]; then
+    if [[ ${bn} = rhcos-4[12]*.8* ]]; then
         echo "2.2.0"
     else
         echo "3.0.0"


### PR DESCRIPTION
RHCOS recently changed the version string used to look like
`42.80.20190723.0` or sometimes `42devel.80.20190723.0`, so change the
version string check appropriately.

(cherry picked from commit d73f49d37c243e85cc3a1e6cab8584fac5c15fef)