### PR TITLE
Add path information for GCP and Azure.

### DIFF
--- a/src/cmd-buildextend-azure
+++ b/src/cmd-buildextend-azure
@@ -11,6 +11,7 @@ import logging as log
 import os
 import shutil
 import sys
+import urllib.parse
 
 cosa_dir = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, cosa_dir)
@@ -182,7 +183,14 @@ def run_ore(args, build):
     checksum = sha256sum_file(azure_vhd_path)
     size = os.path.getsize(azure_vhd_path)
 
-    build.meta['azure'] = {'image': build.azure_vhd_name}
+    url_path = urllib.parse.quote((
+        f"{args.storage_account}.blob.core.windows.net/"
+        f"{args.container}/{build.azure_vhd_name}"
+    ))
+    build.meta['azure'] = {
+        'image': build.azure_vhd_name,
+        'url': f"https://{url_path}",
+    }
     build.meta['images'].update({
         'azure': {
             'path': build.azure_vhd_name,

--- a/src/cmd-buildextend-gcp
+++ b/src/cmd-buildextend-gcp
@@ -11,6 +11,7 @@ import json
 import os
 import shutil
 import sys
+import urllib.parse
 
 cosa_dir = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, cosa_dir)
@@ -111,7 +112,15 @@ def run_ore():
     checksum = sha256sum_file(build_tarball)
     size = os.path.getsize(build_tarball)
 
-    buildmeta['gcp'] = {'image': f"{base_name}-{args.build.replace('.', '-')}"}
+    gcp_name = f"{base_name}-{args.build.replace('.', '-')}"
+    url_path = urllib.parse.quote((
+        "storage.googleapis.com/"
+        f"{args.bucket}/{base_name}/{args.build}.tar.gz"
+    ))
+    buildmeta['gcp'] = {
+            'image': gcp_name,
+            'url': f"https://{url_path}",
+    }
     buildmeta['images'].update({
         'gcp': {
             'path': gcp_tarball_name,


### PR DESCRIPTION
The installer team would like us to include the in-cloud object paths to the meta-data. 