### PR TITLE
Add a `basearch` command

### DIFF
--- a/src/cmd-basearch
+++ b/src/cmd-basearch
@@ -1,0 +1,7 @@
+#!/usr/bin/python3
+# Convenient wrapper for getting the base architecture; will
+# likely be used by the FCOS pipeline at least.
+import gi
+gi.require_version("RpmOstree", "1.0")
+from gi.repository import RpmOstree
+print(RpmOstree.get_basearch())


### PR DESCRIPTION
The FCOS pipeline at least wants access to this, let's make it easier.
(There were at one point Java GI bindings and in theory we could use
 that from Groovy maybe but...let's not go there)
See e.g. https://github.com/coreos/fedora-coreos-pipeline/pull/107/commits/6191937a53a64ce122e26166bf6d3c6145b020f3#diff-67e4a5e30b926dea6c478806ed55fe54R38