### PR TITLE
oscontainer: Sort NEVRAs before dumping pkglist.txt

### DIFF
--- a/src/oscontainer.py
+++ b/src/oscontainer.py
@@ -121,9 +121,11 @@ def oscontainer_build(containers_storage, src, ref, image_name_and_tag,
         # Generate pkglist.txt in to the oscontainer at /
         pkg_list_dest = os.path.join(mnt, 'pkglist.txt')
         pkgs = RpmOstree.db_query_all(r, rev, None)
+        # should already be sorted, but just re-sort to be sure
+        nevras = sorted([pkg.get_nevra() for pkg in pkgs])
         with open(pkg_list_dest, 'w') as f:
-            for pkg in sorted(pkgs):
-                f.write(pkg.get_nevra())
+            for nevra in nevras:
+                f.write(nevra)
                 f.write('\n')
 
         # We use /noentry to trick `podman create` into not erroring out


### PR DESCRIPTION
Before we were sorting the RpmOstreePackage objects themselves, which
don't really have an implemented ordering through the GI bindings. Just
coalesce the NEVRAs directly and sort those instead.