### PR TITLE
vmdeps: Make EFI deps architecture independent, use meta provides

### DIFF
--- a/src/vmdeps.txt
+++ b/src/vmdeps.txt
@@ -18,4 +18,4 @@ selinux-policy selinux-policy-targeted policycoreutils
 # coreos-assembler
 #FEDORA python3 python3-gobject-base buildah podman skopeo iptables iptables-libs
 
-gdisk xfsprogs e2fsprogs grub2 dosfstools shim-x64 grub2-efi-x64
+gdisk xfsprogs e2fsprogs grub2 dosfstools shim grub2-efi


### PR DESCRIPTION
The `Provides:` here are sufficient to pull in what we need.

Closes: #660