### PR TITLE
cmd-kola: Port to Python

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,9 @@ DESTDIR ?=
 # E722 do not use bare 'except'
 PYIGNORE ?= E402,E722
 
-.PHONY: all check flake8 unittest clean mantle install 
+pysources = src/cosalib src/oscontainer.py src/cmd-kola
+
+.PHONY: all check flake8 unittest clean mantle install
 
 all: mantle
 
@@ -22,7 +24,7 @@ check: ${src_checked} ${tests_checked} ${cwd_checked} flake8
 	echo OK
 
 flake8:
-	python3 -m flake8 --ignore=$(PYIGNORE) src/cosalib src/oscontainer.py
+	python3 -m flake8 --ignore=$(PYIGNORE) $(pysources)
 	# The following lines will verify python files that are not modules
 	# but are commented out as the files are not ready for checking yet
 	# grep -r "^\#\!/usr/bin/py" src/ | cut -d : -f 1 | xargs flake8 --ignore=$(PYIGNORE)

--- a/src/cmd-kola
+++ b/src/cmd-kola
@@ -1,37 +1,57 @@
-#!/usr/bin/env bash
-set -euo pipefail
+#!/usr/bin/env python3
 
-dn=$(dirname "$0")
-# shellcheck source=src/cmdlib.sh
-. "${dn}"/cmdlib.sh
+import argparse
+import subprocess
+import json
+import os
+import sys
 
-latest_qcow=$(get_latest_qemu)
-if [ -z "${latest_qcow}" ]; then
-    fatal "No latest build"
-fi
+cosa_dir = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, cosa_dir)
+
+import cmdlib
+
+# Parse args and dispatch
+parser = argparse.ArgumentParser()
+parser.add_argument("--build", help="Build ID")
+parser.add_argument("--output-dir", help="Output directory")
+parser.add_argument("subargs", help="Remaining arguments for kola", nargs='*',
+                    default=['run'])
+args = parser.parse_args()
+
+builds = cmdlib.Builds()
+if args.build is None:
+    args.build = builds.get_latest()
+builddir = builds.get_build_dir(args.build)
+with open(os.path.join(builddir, "meta.json")) as f:
+    buildmeta = json.load(f)
+
+qemuimg = buildmeta['images'].get('qemu')
+if qemuimg is None:
+    raise SystemExit(f"No qemu image in build: {args.build}")
+qemupath = os.path.join(builddir, qemuimg['path'])
 
 # XXX: teach to kola to auto-detect based on prefix; see discussions in
 # https://github.com/coreos/coreos-assembler/pull/85
-args=
-bn=$(basename "${latest_qcow}")
-if [[ ${bn} = fedora-coreos-* ]]; then
-    args="-b fcos"
-elif [[ ${bn} = rhcos-* ]]; then
-    args="-b rhcos"
-else
-    echo "WARNING: Failed to detect args, use -b to specify"
-fi
-ignition_version=$(disk_ignition_version "${latest_qcow}")
-if [ "${ignition_version}" = "2.2.0" ]; then
-    args="${args} --ignition-version v2"
-fi
+kolaargs = ['kola']
+bn = os.path.basename(qemupath)
+if not any([x in args.subargs for x in ["-b", "--distro"]]):
+    if bn.startswith("rhcos-"):
+        kolaargs.extend(['-b', 'rhcos'])
+    else:
+        kolaargs.extend(['-b', 'fcos'])
 
-if [ "$(id -u)" != "0" ]; then
-    args="${args} -p qemu-unpriv"
-fi
+ignition_version = cmdlib.disk_ignition_version(qemupath)
 
-# let's print out the actual exec() call we do
-set -x
+if ignition_version == "2.2.0":
+    kolaargs.extend(["--ignition-version", "v2"])
+
+if os.getuid() != 0 and not ('-p' in args.subargs):
+    kolaargs.extend(['-p', 'qemu-unpriv'])
 
 # shellcheck disable=SC2086
-exec kola $args --output-dir tmp/kola --qemu-image "${latest_qcow}" "$@"
+kolaargs.extend(['--qemu-image', qemupath])
+outputdir = args.output_dir or "tmp/kola"
+kolaargs.extend(args.subargs)
+print(subprocess.list2cmdline(kolaargs))
+os.execvp('kola', kolaargs)

--- a/src/cmdlib.py
+++ b/src/cmdlib.py
@@ -146,6 +146,20 @@ def rm_allow_noent(path):
         pass
 
 
+# Obviously this is a hack but...we need to know this before
+# launching, and I don't think we have structured metadata in e.g. qcow2.
+# There are other alternatives but we'll carry this hack for now.
+# But if you're reading this comment 10 years in the future, I won't be
+# too surprised either ;)  Oh and hey if you are please send me an email, it'll
+# be like a virtual time capsule!  If they still use email then...
+def disk_ignition_version(path):
+    bn = os.path.basename(path)
+    if bn.startswith(("rhcos-41", "rhcos-42")):
+        return "2.2.0"
+    else:
+        return "3.0.0"
+
+
 def import_ostree_commit(repo, commit, tarfile):
     # create repo in case e.g. tmp/ was cleared out; idempotent
     subprocess.check_call(['ostree', 'init', '--repo', repo, '--mode=archive'])

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -148,20 +148,16 @@ preflight() {
     fi
 }
 
-# Obviously this is a hack but...we need to know this before
-# launching, and I don't think we have structured metadata in e.g. qcow2.
-# There are other alternatives but we'll carry this hack for now.
-# But if you're reading this comment 10 years in the future, I won't be
-# too surprised either ;)  Oh and hey if you are please send me an email, it'll
-# be like a virtual time capsule!  If they still use email then...
+
 disk_ignition_version() {
-    local bn
-    bn=$(basename "$1")
-    if [[ ${bn} = rhcos-4[12]*.8* ]]; then
-        echo "2.2.0"
-    else
-        echo "3.0.0"
-    fi
+    local path
+    path=$1
+    # yup, this is happening *again* (see below too)
+    python3 -c "
+import sys
+sys.path.insert(0, '${DIR}')
+from cmdlib import disk_ignition_version
+print(disk_ignition_version('${path}}'))"
 }
 
 prepare_build() {


### PR DESCRIPTION
Prep for more work; such as supporting `-p aws` to read the `builds.json`
and find the AMIs there.

(Bigger picture of course the separation between cosa and mantle is increasingly
 weird and awkward...)