### PR TITLE
WIP: use COSA for all meta-data operations, introduce cmd-meta

### DIFF
--- a/src/cmd-buildextend-aws
+++ b/src/cmd-buildextend-aws
@@ -9,7 +9,8 @@ import os,sys,json,yaml,shutil,argparse,subprocess,re,collections
 import tempfile,hashlib,gzip
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from cmdlib import run_verbose, write_json, sha256sum_file, Builds
+import cosalib.builds as Builds
+from cosalib.cmdlib import run_verbose, write_json, sha256sum_file
 
 # Parse args and dispatch
 parser = argparse.ArgumentParser()
@@ -24,7 +25,7 @@ parser.add_argument("--grant-user", help="Grant user launch permission",
                     nargs="*", default=[])
 args = parser.parse_args()
 
-builds = Builds()
+builds = Builds.Builds()
 builddir = builds.get_build_dir(args.build)
 buildmeta_path = os.path.join(builddir, 'meta.json')
 with open(buildmeta_path) as f:

--- a/src/cmd-buildextend-azure
+++ b/src/cmd-buildextend-azure
@@ -13,18 +13,12 @@ import shutil
 import sys
 import urllib.parse
 
-cosa_dir = os.path.dirname(os.path.abspath(__file__))
-sys.path.insert(0, cosa_dir)
-
-try:
-    from cosalib.build import _Build
-except ImportError:
-    # We're in the container and can't sense the cosa path
-    sys.path.insert(0, '/usr/lib/coreos-assembler/cosalib')
-    from cosalib.build import _Build
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from cosalib.build import _Build
+import cosalib.builds as Builds
 
 # pylint: disable=C0413
-from cmdlib import (
+from cosalib.cmdlib import (
         run_verbose,
         sha256sum_file,
         write_json)

--- a/src/cmd-buildextend-gcp
+++ b/src/cmd-buildextend-gcp
@@ -16,11 +16,11 @@ import urllib.parse
 cosa_dir = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, cosa_dir)
 # pylint: disable=C0413
-from cmdlib import (
+import cosalib.builds as Builds
+from cosalib.cmdlib import (
         run_verbose,
         sha256sum_file,
-        write_json,
-        Builds)
+        write_json)
 
 # Parse args and dispatch
 parser = argparse.ArgumentParser()
@@ -48,7 +48,7 @@ if args.project is None:
     raise Exception(arg_exp_str.format("project", "GCP_PROJECT"))
 
 # Identify the builds
-builds = Builds()
+builds = Builds.Builds()
 builddir = builds.get_build_dir(args.build)
 buildmeta_path = os.path.join(builddir, 'meta.json')
 with open(buildmeta_path) as f:

--- a/src/cmd-buildextend-installer
+++ b/src/cmd-buildextend-installer
@@ -13,8 +13,9 @@ import tarfile
 import tempfile
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from cmdlib import run_verbose, write_json, sha256sum_file
-from cmdlib import import_ostree_commit, Builds
+import cosalib.builds as Builds
+from cosalib.cmdlib import run_verbose, write_json, sha256sum_file
+from cosalib.cmdlib import import_ostree_commit
 
 # Parse args and dispatch
 parser = argparse.ArgumentParser()
@@ -23,7 +24,7 @@ parser.add_argument("--force", action='store_true', default=False,
                     help="Overwrite previously generated installer")
 args = parser.parse_args()
 
-builds = Builds()
+builds = Builds.Builds()
 
 # default to latest build if not specified
 if not args.build:

--- a/src/cmd-buildextend-openstack
+++ b/src/cmd-buildextend-openstack
@@ -11,14 +11,15 @@ import shutil
 import argparse
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from cmdlib import run_verbose, write_json, sha256sum_file, Builds
+import cosalib.builds as Builds
+from cosalib.cmdlib import run_verbose, write_json, sha256sum_file
 
 # Parse args and dispatch
 parser = argparse.ArgumentParser()
 parser.add_argument("--build", help="Build ID")
 args = parser.parse_args()
 
-builds = Builds()
+builds = Builds.Builds()
 
 # default to latest build if not specified
 if not args.build:

--- a/src/cmd-buildextend-vmware
+++ b/src/cmd-buildextend-vmware
@@ -11,14 +11,15 @@ import argparse
 import tarfile
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from cmdlib import run_verbose, load_json, write_json, sha256sum_file, Builds
+import cosalib.builds as Builds
+from cosalib.cmdlib import run_verbose, load_json, write_json, sha256sum_file
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--build", help="Build ID",
                     required=False)
 args = parser.parse_args()
 
-builds = Builds()
+builds = Builds.Builds()
 
 # default to latest build if not specified
 if not args.build:

--- a/src/cmd-buildprep
+++ b/src/cmd-buildprep
@@ -14,7 +14,8 @@ import boto3
 import shutil
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from cmdlib import load_json, rm_allow_noent, Builds  # noqa: E402
+import cosalib.builds as Builds
+from cosalib.cmdlib import load_json, rm_allow_noent  # noqa: E402
 
 
 def main():
@@ -32,7 +33,7 @@ def main():
     builds = None
     if fetcher.exists('builds.json'):
         fetcher.fetch_json('builds.json')
-        builds = Builds()
+        builds = Builds.Builds()
 
     if not builds or builds.is_empty():
         print("Remote has no builds!")

--- a/src/cmd-buildupload
+++ b/src/cmd-buildupload
@@ -11,7 +11,8 @@ import sys
 import tempfile
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from cmdlib import load_json, Builds  # noqa: E402
+import cosalib.builds as Builds
+from cosalib.cmdlib import load_json  # noqa: E402
 
 
 def main():
@@ -44,7 +45,7 @@ def parse_args():
 
 def cmd_upload_s3(args):
     if not args.freshen:
-        builds = Builds()
+        builds = Builds.Builds()
         if args.build == 'latest':
             args.build = builds.get_latest()
         print(f"Targeting build: {args.build}")

--- a/src/cmd-compress
+++ b/src/cmd-compress
@@ -13,8 +13,12 @@ import argparse
 import subprocess
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from cmdlib import run_verbose, write_json, sha256sum_file
-from cmdlib import rm_allow_noent, Builds
+import cosalib.builds as Builds
+from cosalib.cmdlib import (
+    rm_allow_noent,
+    run_verbose,
+    sha256sum_file,
+    write_json)
 
 DEFAULT_COMPRESSOR = 'gzip'
 
@@ -30,7 +34,7 @@ args = parser.parse_args()
 ext_dict = {'xz': '.xz', 'gzip': '.gz'}
 ext = ext_dict[args.compressor]
 
-builds = Builds()
+builds = Builds.Builds()
 
 # default to latest build if not specified
 if args.build:

--- a/src/cmd-meta
+++ b/src/cmd-meta
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+"""
+    cmd-meta is a helper for interacting with a builds meta.json
+"""
+
+import argparse
+import tempfile
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from cosalib.cli import BuildCli
+from cosalib.meta import GenericBuildMeta as Meta
+
+def new_cli():
+    args = BuildCli()
+    args.add_argument("--get", help="get commit id", action="store_true")
+    args.parse_args()
+
+    meta = Meta(args.buildroot, args.build)
+    print(meta.dump())
+
+if __name__ == '__main__':
+    new_cli()

--- a/src/cmd-tag
+++ b/src/cmd-tag
@@ -14,7 +14,7 @@ import os
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from cmdlib import fatal, rfc3339_time, Builds  # noqa: E402
+from cosalib.cmdlib import fatal, rfc3339_time, Builds  # noqa: E402
 
 
 def main():
@@ -62,7 +62,7 @@ def available_tags(build_data):
 def cmd_list(args):
     """List available tags in build metadata"""
 
-    builds = Builds()
+    builds = Builds.Builds()
     build_data = builds.raw()
     avail_tags = available_tags(build_data)
     if not avail_tags:
@@ -78,7 +78,7 @@ def cmd_list(args):
 def cmd_update(args):
     """Create or update a tag to new build ID"""
 
-    builds = Builds()
+    builds = Builds.Builds()
     build_data = builds.raw()
 
     avail_tags = available_tags(build_data)
@@ -114,7 +114,7 @@ def cmd_delete(args):
 
     # To delete a tag, iterate through existing tags list, and
     # drop the entry we want
-    builds = Builds()
+    builds = Builds.Builds()
     build_data = builds.raw()
     avail_tags = available_tags(build_data)
 

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
-# Shared shell script library
+# Se,red shell script library
 
 DIR=$(dirname "$0")
 RFC3339="%Y-%m-%dT%H:%M:%SZ"
@@ -634,7 +634,7 @@ get_build_dir() {
     (python3 -c "
 import sys
 sys.path.insert(0, '${DIR}')
-from cmdlib import Builds
+import cosalib.builds as Builds
 print(Builds('${workdir:-$(pwd)}').get_build_dir('${buildid}'))")
 }
 

--- a/src/cosalib/build.py
+++ b/src/cosalib/build.py
@@ -10,9 +10,6 @@ import tempfile
 import shutil
 import sys
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-from cmdlib import Builds
-
 # COSA_INPATH is the _in container_ path for the image build source
 COSA_INPATH = "/cosa"
 

--- a/src/cosalib/build.py
+++ b/src/cosalib/build.py
@@ -16,45 +16,15 @@ COSA_INPATH = "/cosa"
 # ARCH is the current machine architecture
 ARCH = platform.machine()
 
+from cosalib.cmdlib import (
+    load_json,
+    write_json)
 
 class BuildError(Exception):
     """
     Base error for build issues.
     """
     pass
-
-
-def load_json(path):
-    """
-    Shortcut for loading json from a file path.
-    TODO: When porting to py3, use cmdlib's load_json
-
-    :param path: The full path to the file
-    :type: path: str
-    :returns: loaded json
-    :rtype: dict
-    :raises: IOError, ValueError
-    """
-    with open(path) as f:
-        return json.load(f)
-
-
-def write_json(path, data):
-    """
-    Shortcut for writing a structure as json to the file system.
-    TODO: When porting to py3, use cmdlib's write_json
-
-    :param path: The full path to the file to write
-    :type: path: str
-    :param data:  structure to write out as json
-    :type data: dict or list
-    :raises: ValueError, OSError
-    """
-    dn = os.path.dirname(path)
-    f = tempfile.NamedTemporaryFile(mode='w', dir=dn, delete=False)
-    json.dump(data, f, indent=4)
-    os.fchmod(f.file.fileno(), 0o644)
-    os.rename(f.name, path)
 
 
 class _Build:

--- a/src/cosalib/builds.py
+++ b/src/cosalib/builds.py
@@ -1,0 +1,101 @@
+"""
+Builds interacts with builds.json
+"""
+
+import os
+import semver
+
+class Builds:  # pragma: nocover
+    def __init__(self, workdir=None):
+        self._workdir = workdir
+        self._fn = self._path("builds/builds.json")
+        if not os.path.isdir(self._path("builds")):
+            raise Exception("No builds/ dir found!")
+        elif os.path.isfile(self._fn):
+            self._data = load_json(self._fn)
+        else:
+            # must be a new workdir; use new schema
+            self._data = {
+                'schema-version': "1.0.0",
+                'builds': []
+            }
+            self.flush()
+        self._version = semver.parse_version_info(
+            self._data.get('schema-version', "0.0.1"))
+        # we understand < 2.0.0 only
+        if self._version._major >= 2:
+            raise Exception("Builds schema too new; please update cosa")
+        # for now, since we essentially just support "1.0.0" and "0.0.1",
+        # just dillute to a bool
+        self._legacy = (self._version._major < 1)
+
+    def _path(self, path):
+        if not self._workdir:
+            return path
+        return os.path.join(self._workdir, path)
+
+    def has(self, build_id):
+        if self._legacy:
+            return build_id in self._data['builds']
+        return any([b['id'] == build_id for b in self._data['builds']])
+
+    def is_empty(self):
+        return len(self._data['builds']) == 0
+
+    def get_latest(self):
+        # just let throw if there are none
+        if self._legacy:
+            return self._data['builds'][0]
+        return self._data['builds'][0]['id']
+
+    def get_build_arches(self, build_id):
+        assert not self._legacy
+        for build in self._data['builds']:
+            if build['id'] == build_id:
+                return build['arches']
+        assert False, "Build not found!"
+
+    def get_build_dir(self, build_id, basearch=None):
+        if build_id == 'latest':
+            build_id = self.get_latest()
+        if self._legacy:
+            return self._path(f"builds/{build_id}")
+        if not basearch:
+            # just assume caller wants build dir for current arch
+            basearch = get_basearch()
+        return self._path(f"builds/{build_id}/{basearch}")
+
+    def insert_build(self, build_id, basearch=None):
+        if self._legacy:
+            self._data['builds'].insert(0, build_id)
+        else:
+            if not basearch:
+                basearch = get_basearch()
+            # for future tooling: allow inserting in an existing build for a
+            # separate arch
+            for build in self._data['builds']:
+                if build['id'] == build_id:
+                    if basearch in build['arches']:
+                        raise "Build {build_id} for {basearch} already exists"
+                    build['arches'] += [basearch]
+                    break
+            else:
+                self._data['builds'].insert(0, {
+                    'id': build_id,
+                    'arches': [
+                        basearch
+                    ]
+                })
+
+    def bump_timestamp(self):
+        self._data['timestamp'] = rfc3339_time()
+        self.flush()
+
+    def is_legacy(self):
+        return self._legacy
+
+    def raw(self):
+        return self._data
+
+    def flush(self):
+        write_json(self._fn, self._data)

--- a/src/cosalib/cmdlib.py
+++ b/src/cosalib/cmdlib.py
@@ -10,13 +10,11 @@ import subprocess
 import sys
 import tempfile
 import gi
-import semver
 
 gi.require_version("RpmOstree", "1.0")
 from gi.repository import RpmOstree
 
 from datetime import datetime
-
 
 def run_verbose(args, **kwargs):
     """
@@ -171,100 +169,3 @@ def get_basearch():
     except AttributeError:
         get_basearch.saved = RpmOstree.get_basearch()
         return get_basearch.saved
-
-
-# FIXME: Add tests
-class Builds:  # pragma: nocover
-    def __init__(self, workdir=None):
-        self._workdir = workdir
-        self._fn = self._path("builds/builds.json")
-        if not os.path.isdir(self._path("builds")):
-            raise Exception("No builds/ dir found!")
-        elif os.path.isfile(self._fn):
-            self._data = load_json(self._fn)
-        else:
-            # must be a new workdir; use new schema
-            self._data = {
-                'schema-version': "1.0.0",
-                'builds': []
-            }
-            self.flush()
-        self._version = semver.parse_version_info(
-            self._data.get('schema-version', "0.0.1"))
-        # we understand < 2.0.0 only
-        if self._version._major >= 2:
-            raise Exception("Builds schema too new; please update cosa")
-        # for now, since we essentially just support "1.0.0" and "0.0.1",
-        # just dillute to a bool
-        self._legacy = (self._version._major < 1)
-
-    def _path(self, path):
-        if not self._workdir:
-            return path
-        return os.path.join(self._workdir, path)
-
-    def has(self, build_id):
-        if self._legacy:
-            return build_id in self._data['builds']
-        return any([b['id'] == build_id for b in self._data['builds']])
-
-    def is_empty(self):
-        return len(self._data['builds']) == 0
-
-    def get_latest(self):
-        # just let throw if there are none
-        if self._legacy:
-            return self._data['builds'][0]
-        return self._data['builds'][0]['id']
-
-    def get_build_arches(self, build_id):
-        assert not self._legacy
-        for build in self._data['builds']:
-            if build['id'] == build_id:
-                return build['arches']
-        assert False, "Build not found!"
-
-    def get_build_dir(self, build_id, basearch=None):
-        if build_id == 'latest':
-            build_id = self.get_latest()
-        if self._legacy:
-            return self._path(f"builds/{build_id}")
-        if not basearch:
-            # just assume caller wants build dir for current arch
-            basearch = get_basearch()
-        return self._path(f"builds/{build_id}/{basearch}")
-
-    def insert_build(self, build_id, basearch=None):
-        if self._legacy:
-            self._data['builds'].insert(0, build_id)
-        else:
-            if not basearch:
-                basearch = get_basearch()
-            # for future tooling: allow inserting in an existing build for a
-            # separate arch
-            for build in self._data['builds']:
-                if build['id'] == build_id:
-                    if basearch in build['arches']:
-                        raise "Build {build_id} for {basearch} already exists"
-                    build['arches'] += [basearch]
-                    break
-            else:
-                self._data['builds'].insert(0, {
-                    'id': build_id,
-                    'arches': [
-                        basearch
-                    ]
-                })
-
-    def bump_timestamp(self):
-        self._data['timestamp'] = rfc3339_time()
-        self.flush()
-
-    def is_legacy(self):
-        return self._legacy
-
-    def raw(self):
-        return self._data
-
-    def flush(self):
-        write_json(self._fn, self._data)

--- a/src/cosalib/meta.py
+++ b/src/cosalib/meta.py
@@ -1,0 +1,13 @@
+from cosalib.build import _Build
+
+class GenericBuildMeta(_Build):
+    """
+        GenericBuildMeta  interacts with a builds meta.json
+    """
+
+    def __init__(self, build_dir, build, tmpbuilddir):
+        self.tmpbuilddir = tmpbuilddir
+        _Build.__init__(self, build_dir, build)
+
+    def _build_artifacts(self, *args, **kwargs):
+        raise NotImplementedError("MetaBuild does not understand artifacts")

--- a/src/prune_builds
+++ b/src/prune_builds
@@ -16,8 +16,8 @@ import collections
 from datetime import timedelta, datetime, timezone
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from cmdlib import get_basearch, Builds
-
+import cosalib.builds as Builds
+from cosalib.cmdlib import get_basearch
 
 def parse_date_string(date_string):
     """


### PR DESCRIPTION
This is an ugly WIP. Here be dragons. I want to float the idea before getting to-far into what could be a massive refactoring.

This moves:
- cmdlib.py into `cosalib`
- introduces a `cosalib.meta` as a stub for generically handling the `meta.json` for a build. Eventually, I want to have this replace all the `jq` madness.
- introduces a generic `cmd-meta` with the idea of using it over `jq` interacting with `cosalib.meta`. 