### PR TITLE
cmd-koji-upload: add compressed qcow2 and xz compression for Koji

### DIFF
--- a/src/cmd-koji-upload
+++ b/src/cmd-koji-upload
@@ -76,8 +76,14 @@ KOJI_CG_TYPES = {
     "ova": ("Open Virtualization Archive", "ova", ARCH, "image"),
     "qcow": ("QCOW image", "qcow", ARCH, "image"),
     "qcow2": ("QCOW2 image", "qcow2", ARCH, "image"),
+    "qcow2.gz": ("Compressed QCOW2", "qcow2.gz", ARCH, "image"),
+    "qcow2.xz": ("Compressed QCOW2", "qcow2.gz", ARCH, "image"),
     "raw": ("Raw disk image", "raw", ARCH, "image"),
+    "raw.gz": ("Compressed Raw", "raw.gz", ARCH, "image"),
+    "raw.xz": ("Compressed Raw", "raw.xz", ARCH, "image"),
     "tar": ("Tar file", "tar", "noarch", "source"),
+    "tar.gz": ("Tar file", "tar.gz", "noarch", "source"),
+    "tar.xz": ("Tar file", "tar.xz", "noarch", "source"),
     "vdi": ("VirtualBox Virtual Disk Image", "vdi", ARCH, "image"),
     "vhd": ("Hyper-V image", "vhd", ARCH, "image"),
     "vhdx": ("Hyper-V Virtual Hard Disk v2 image", "vhdx", ARCH, "image"),
@@ -244,13 +250,6 @@ def special_name(fname):
         New name of the file
         The Koji type that the file if renamed
     """
-
-    # koji doesn't understand raw.gz, so swap 'em
-    # request filed with Koji maintainers to fix this.
-    if fname.endswith("raw.gz"):
-        return fname.replace("raw.gz", "gz.raw"), "raw"
-
-    # handle special files such as installers kernels.
     for ending in RENAME_RAW:
         if fname.endswith(ending):
             return "%s.raw" % fname, "raw"

--- a/src/cmd-koji-upload
+++ b/src/cmd-koji-upload
@@ -24,6 +24,8 @@ import argparse
 import datetime
 import hashlib
 import json
+import koji
+import koji_cli.lib as klib
 import logging as log
 import os.path
 import platform
@@ -37,14 +39,11 @@ sys.path.insert(0, ("%s/cosalib" % cosa_dir))
 sys.path.insert(0, cosa_dir)
 
 try:
-   from cosalib.build import _Build
+    from cosalib.build import _Build
 except ImportError:
-   # We're in the container and can't sense the cosa path
-   sys.path.insert(0, '/usr/lib/coreos-assembler/cosalib')
-   from cosalib.build import _Build
-
-import koji
-import koji_cli.lib as klib
+    # We're in the container and can't sense the cosa path
+    sys.path.insert(0, '/usr/lib/coreos-assembler/cosalib')
+    from cosalib.build import _Build
 
 try:
     # Available in Koji v1.17, https://pagure.io/koji/issue/975


### PR DESCRIPTION
With [1], Koji now supports compressed `qcow2` and `raw` disk images. This uploading these compressed artifacts.
[1] https://pagure.io/koji/c/fac81bd7bec410cbacce649ba8006704486a2f57?branch=master 