### PR TITLE
create_disk: Set up SELinux labeling fully

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -67,6 +67,8 @@ install_rpms() {
     if [ -e /boot/efi ]; then
         chmod -R a+rX /boot/efi
     fi
+    # Similarly for kernel data and SELinux policy, which we want to inject into supermin
+    chmod -R a+rX /usr/lib/modules /usr/share/selinux/targeted
     # Further cleanup
     yum clean all
 

--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -52,13 +52,23 @@ mkfs.xfs "${disk}4"  -L root -m reflink=1
 rm -rf rootfs
 mkdir rootfs
 mount "${disk}4" rootfs
+chcon $(matchpathcon -n /) rootfs
 mkdir rootfs/boot
+chcon $(matchpathcon -n /boot) rootfs/boot
 mount "${disk}1" rootfs/boot
+chcon $(matchpathcon -n /boot) rootfs/boot
 mkdir rootfs/boot/efi
+# FAT doesn't support SELinux labeling, it uses "genfscon", so we
+# don't need to give it a label manually.
 mount "${disk}2" rootfs/boot/efi
 
-# init the ostree
-ostree admin init-fs rootfs
+# Initialize the ostree setup; TODO replace this with
+# https://github.com/ostreedev/ostree/pull/1894
+# `ostree admin init-fs --modern`
+mkdir -p rootfs/ostree
+chcon $(matchpathcon -n /ostree) rootfs/ostree
+mkdir -p rootfs/ostree/{repo,deploy}
+ostree --repo=rootfs/ostree/repo init --mode=bare
 remote_arg=
 deploy_ref="${ref}"
 if [ "${remote_name}" != NONE ]; then


### PR DESCRIPTION
Booting current FCOS, one can see that stuff under
e.g. `/sysroot/ostree/` is mostly `unlabeled_t`.

Also, there's junk in `/sysroot` that isn't necessary; I think
when I was writing `ostree admin init-fs` I was thinking of dracut
requirements at the time that the target root (before ostree pivot)
had e.g. `/dev` - that's no longer true (if it ever was).

For each mount point, add an initial hardcoded label; the physical
root is `root_t` for example.  This ensures that at least anything
created under that will have *a* label, and usually via
path transitions, the correct one.

Combining the above, we inline the bits of `init-fs` we need, namely
creating the repo and `deploy` directory.  We add the `usr_t`
label to the ostree repo, and let SELinux policy handle the rest.

Then the result is that the full disk we create should have
SELinux labels on all files.

This is just a good fix in general, but I'm writing this specifically
as prep for having `/var/home` pre-created to aid RHCOS, which has
an older SELinux policy that doesn't allow Ignition to operate
on unlabeled data.