### PR TITLE
ign-3to2: Don't crash if there's nothing to merge

### DIFF
--- a/src/incomplete-hack-ign-3to2
+++ b/src/incomplete-hack-ign-3to2
@@ -40,7 +40,7 @@ for f in ign['storage'].get('files', []):
         f['contents'] = append[0]
 
 # replace the merge keyword with append
-merge = ign['ignition'].pop('merge')
+merge = ign['ignition'].pop('merge', None)
 if merge is not None:
     ign['ignition']['append'] = merge
 


### PR DESCRIPTION
The previous change here broke the basic `cosa run` targeting RHCOS.