### PR TITLE
build: Readd support for save-var-subdirs-for-selabel-workaround

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -274,10 +274,11 @@ build_image() {
 	kargs="$(python3 -c 'import sys, yaml; args = yaml.safe_load(sys.stdin).get("extra-kargs", []); print(" ".join(args))' < "$configdir/image.yaml")"
 	# use NONE here instead of empty string because this has to survive through various string processing
 	ostree_remote="$(python3 -c 'import sys, yaml; print(yaml.safe_load(sys.stdin).get("ostree-remote", "NONE"))' < "$configdir/image.yaml")"
+	save_var_subdirs="$(python3 -c 'import sys, yaml; print(yaml.safe_load(sys.stdin).get("save-var-subdirs-for-selabel-workaround", "NONE"))' < "$configdir/image.yaml")"
 	kargs="$kargs console=tty0 console=${VM_TERMINAL},115200n8 ignition.platform.id=qemu"
 
 	qemu-img create -f qcow2 "$1" "$size"
-	runvm_with_disk "$1" qcow2 /usr/lib/coreos-assembler/create_disk.sh /dev/vda "$tmprepo" "${ref-:${commit}}" "${ostree_remote}" /usr/lib/coreos-assembler/grub.cfg "$name" "\"$kargs\""
+	runvm_with_disk "$1" qcow2 /usr/lib/coreos-assembler/create_disk.sh /dev/vda "$tmprepo" "${ref-:${commit}}" "${ostree_remote}" /usr/lib/coreos-assembler/grub.cfg "$name" "${save_var_subdirs}" "\"$kargs\""
 }
 
 echo '{}' > tmp/vm-iso-checksum.json

--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -130,9 +130,10 @@ echo "Disk size estimated to $size"
 kargs="$(python3 -c 'import sys, yaml; args = yaml.safe_load(sys.stdin).get("extra-kargs", []); print(" ".join(args))' < "$configdir/image.yaml")"
 kargs="$kargs console=tty0 console=${VM_TERMINAL},115200n8 ignition.platform.id=metal"
 ostree_remote="$(python3 -c 'import sys, yaml; print(yaml.safe_load(sys.stdin).get("ostree-remote", "NONE"))' < "$configdir/image.yaml")"
+save_var_subdirs="$(python3 -c 'import sys, yaml; print(yaml.safe_load(sys.stdin).get("save-var-subdirs-for-selabel-workaround", "NONE"))' < "$configdir/image.yaml")"
 
 qemu-img create -f raw "${path}.tmp" "$size"
-runvm_with_disk "${path}.tmp" raw /usr/lib/coreos-assembler/create_disk.sh /dev/vda "$ostree_repo" "${ref-:${commit}}" "${ostree_remote}" /usr/lib/coreos-assembler/grub.cfg "$name" "\"$kargs\""
+runvm_with_disk "${path}.tmp" raw /usr/lib/coreos-assembler/create_disk.sh /dev/vda "$ostree_repo" "${ref-:${commit}}" "${ostree_remote}" /usr/lib/coreos-assembler/grub.cfg "$name" "${save_var_subdirs}" "\"$kargs\""
 mv "${path}.tmp" "$path"
 
 # flush it out before going to the next one so we don't have to redo both if

--- a/src/gf-anaconda-cleanup
+++ b/src/gf-anaconda-cleanup
@@ -77,6 +77,7 @@ if [ -z "${SAVE_VAR}" ]; then
     exit 0
 fi
 
+# See the equivalent code in create_disk.sh
 # /var hack: we'd like to remove all of /var, but SELinux issues prevent that.
 # see https://github.com/coreos/ignition-dracut/pull/79#issuecomment-488446949
 # For now we retain just /var/lib/systemd (for the random seed) and /var/log
@@ -85,7 +86,7 @@ fi
 # RHCOS to add users and drop files in /root.  (On FCOS, we don't strictly
 # *need* this because we run systemd-tmpfiles).
 coreos_gf ls "${var}" | while read -r x; do
-  case "$x" in 
+  case "$x" in
     log|lib) continue;;
     home|roothome) coreos_gf glob rm-rf "${var}/${x}/*";;
     *) coreos_gf rm-rf "${var}/${x}"


### PR DESCRIPTION
Currently the SELinux policy in RHCOS doesn't allow systemd
to operate on `unlabeled_t`.  General agreement was
that the real fix is to do some "bootstrap" labeling in
Ignition, but the problem is the kernel doesn't currently
allow it.

For more information, see:
https://github.com/coreos/ignition-dracut/pull/79#issuecomment-488446949

For now, we just carry forward this (opt-in) workaround which already
exists in the `virt-install` path.

Closes: https://github.com/coreos/coreos-assembler/issues/581