### PR TITLE
build: Ignore non-directories in overlay.d

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -293,6 +293,9 @@ EOF
     fi
     if [ -d "${ovld}" ]; then
         for n in "${ovld}"/*; do
+            if ! [ -d "${n}" ]; then
+                continue
+            fi
             local bn ovlname
             bn=$(basename "${n}")
             ovlname="${name}-config-overlay-${bn}"


### PR DESCRIPTION
So we can add a `README.md` for example to help people understand
different ones.