### PR TITLE
buildextend-aws: Record snapshot ID too

### DIFF
--- a/src/cmd-buildextend-aws
+++ b/src/cmd-buildextend-aws
@@ -77,7 +77,8 @@ def run_ore():
     # This matches the Container Linux schema:
     # https://stable.release.core-os.net/amd64-usr/current/coreos_production_ami_all.json
     ami_data = {'name': args.region,
-                'hvm': ore_data['HVM']}
+                'hvm': ore_data['HVM'],
+                'snapshot': ore_data['SnapshotID']}
     buildmeta['amis'] = [ami_data]
     buildmeta['images'].update({
         'aws': {


### PR DESCRIPTION
Per discussion in https://github.com/coreos/mantle/pull/1039
around garbage collection.  This way even if the AMI is deleted
we know what the underlying snapshot was.