### PR TITLE
cmd-run: Add permissions to bashrc file

### DIFF
--- a/src/cmd-run
+++ b/src/cmd-run
@@ -191,7 +191,8 @@ cat > "${f}" <<EOF
                 "path": "/home/core/.bashrc",
                 "append": [
                     { "source": "data:text/plain;base64,${rowcol}" }
-                ]
+                ],
+                "mode": 420
             }
         ]
     },


### PR DESCRIPTION
Otherwise ignition complains about it being missing:

```
warning at $.storage.files.2.mode, line 19 col 14: permissions unset, defaulting to 0644
warning at $.storage.files.2.mode: permissions unset, defaulting to 0644
```