### PR TITLE
src/cmd-aws-replicate: Add command to replicate AWS AMI to regions

### DIFF
--- a/src/cmd-aws-replicate
+++ b/src/cmd-aws-replicate
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+# NOTE: PYTHONUNBUFFERED is set in cmdlib.sh for unbuffered output
+#
+# An operation that mutates a build by replicating an existing
+# EC2 AMI to additional regions, extending the meta.json with
+# AMI information about each region replicated to.
+#
+# Intended to be used in conjunction with buildextend-aws
+# to allow the initial upload to a single region for testing
+# purposes before replication to a list of regions.
+
+import os,sys,json,argparse,subprocess
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from cmdlib import write_json, Builds
+
+# default region list
+default_all_regions = [
+        "us-east-1", "us-east-2", "us-west-1", "us-west-2", "eu-west-1",
+        "eu-west-2", "eu-west-3", "eu-central-1", "eu-north-1",
+        "ap-south-1", "ap-southeast-1", "ap-southeast-2", "ap-northeast-1",
+        "ap-northeast-2", "sa-east-1", "ca-central-1"]
+
+# Parse args and dispatch
+parser = argparse.ArgumentParser()
+parser.add_argument("--build", help="Build ID",
+                    required=True)
+parser.add_argument("--name-suffix", help="Suffix for name")
+parser.add_argument("--regions", help="EC2 regions",
+                    default=default_all_regions, nargs='+')
+args = parser.parse_args()
+
+builds = Builds()
+builddir = builds.get_build_dir(args.build)
+buildmeta_path = os.path.join(builddir, 'meta.json')
+with open(buildmeta_path) as f:
+    buildmeta = json.load(f)
+
+base_name = buildmeta['name']
+if args.name_suffix:
+    ami_name_version = f'{base_name}-{args.name_suffix}-{args.build}'
+else:
+    ami_name_version = f'{base_name}-{args.build}'
+
+def run_ore():
+    if len(buildmeta['amis']) < 1:
+        raise SystemExit("buildmeta doesn't contain source AMIs. Run buildextend-aws first")
+    # only replicate to regions that don't already exist
+    existing_regions = [item['name'] for item in buildmeta['amis']]
+    duplicates = list(set(args.regions).intersection(existing_regions))
+    if len(duplicates) > 0:
+        print(f"AMIs already exist in {duplicates} region(s), skipping listed region(s)...")
+    region_list = list(set(args.regions) - set(duplicates))
+    if len(region_list) == 0:
+        print("no new regions detected")
+        sys.exit(0)
+
+    source_image = buildmeta['amis'][0]['hvm']
+    source_region = buildmeta['amis'][0]['name']
+    ore_args = ['ore', 'aws', 'copy-image',
+                '--image', source_image, '--region', source_region]
+    ore_args.extend(region_list)
+    print("+ {}".format(subprocess.list2cmdline(ore_args)))
+    ore_data = json.loads(subprocess.check_output(ore_args))
+    # This matches the Container Linux schema:
+    # https://stable.release.core-os.net/amd64-usr/current/coreos_production_ami_all.json
+    ami_data = [{'name': region,
+                 'hvm': vals['ami'],
+                 'snapshot': vals['snapshot']}
+                for region, vals in ore_data.items()]
+    buildmeta['amis'].extend(ami_data)
+    write_json(buildmeta_path, buildmeta)
+    print(f"Updated: {buildmeta_path}")
+
+# Do it!
+run_ore()

--- a/src/coreos-assembler
+++ b/src/coreos-assembler
@@ -39,7 +39,7 @@ build_commands="init fetch build run prune clean"
 # commands more likely to be used in a prod pipeline only
 advanced_build_commands="buildprep buildupload oscontainer"
 buildextend_commands="aws azure gcp openstack installer vmware metal"
-utility_commands="tag compress bump-timestamp koji-upload kola"
+utility_commands="tag compress bump-timestamp koji-upload kola aws-replicate"
 other_commands="shell"
 if [ -z "${cmd}" ]; then
     echo Usage: "coreos-assembler CMD ..."


### PR DESCRIPTION
Adds a new command `aws-replicate` which will replicate the AMI of a
given build to a list of regions. It utilizes the `ore aws copy-image`
command to do the actual copying, searches for the initial AMI from the
buildmeta, skips any given regions that already exist in buildmeta, and
finally updates the buildmeta with the new values.

Requires https://github.com/coreos/mantle/pull/1040