### PR TITLE
s390x: correct qemu, tty, pci device types

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -275,7 +275,10 @@ build_image() {
 	# use NONE here instead of empty string because this has to survive through various string processing
 	ostree_remote="$(python3 -c 'import sys, yaml; print(yaml.safe_load(sys.stdin).get("ostree-remote", "NONE"))' < "$configdir/image.yaml")"
 	save_var_subdirs="$(python3 -c 'import sys, yaml; print(yaml.safe_load(sys.stdin).get("save-var-subdirs-for-selabel-workaround", "NONE"))' < "$configdir/image.yaml")"
-	kargs="$kargs console=tty0 console=${VM_TERMINAL},115200n8 ignition.platform.id=qemu"
+	tty="console=tty0 console=${VM_TERMINAL},115200n8"
+	# tty0 does not exist on s390x
+	[ "$arch" = "s390x" ] && tty="console=${VM_TERMINAL}"
+	kargs="$kargs $tty ignition.platform.id=qemu"
 
 	qemu-img create -f qcow2 "$1" "$size"
 	runvm_with_disk "$1" qcow2 /usr/lib/coreos-assembler/create_disk.sh /dev/vda "$tmprepo" "${ref-:${commit}}" "${ostree_remote}" /usr/lib/coreos-assembler/grub.cfg "$name" "${save_var_subdirs}" "\"$kargs\""

--- a/src/cmd-run
+++ b/src/cmd-run
@@ -121,7 +121,7 @@ set -- -machine accel=kvm -cpu host -smp "${VM_NCPUS}" "$@"
 
 if [ -n "${VM_SRV_MNT}" ]; then
     set -- --fsdev local,id=var-srv,path="${VM_SRV_MNT}",security_model=mapped,readonly \
-        -device virtio-9p-pci,fsdev=var-srv,mount_tag=/var/srv "$@"
+        -device virtio-9p-"${devtype}",fsdev=var-srv,mount_tag=/var/srv "$@"
     # The dependency changes are hacks around https://github.com/coreos/fedora-coreos-tracker/issues/223
     ign_var_srv_mount=',{
 "name": "var-srv.mount",
@@ -285,6 +285,6 @@ fi
 # shellcheck disable=SC2086
 exec ${QEMU_KVM} -name coreos -m "${VM_MEMORY}" -nographic \
               -netdev user,id=eth0,hostname=coreos"${hostfwd:-}" \
-              -device virtio-net-pci,netdev=eth0 \
-              -object rng-random,filename=/dev/urandom,id=rng0 -device virtio-rng-pci,rng=rng0 \
+              -device virtio-net-"${devtype}",netdev=eth0 \
+              -object rng-random,filename=/dev/urandom,id=rng0 -device virtio-rng-"${devtype}",rng=rng0 \
               "$@"


### PR DESCRIPTION
- use ccw as device type instead of pci
- specify s390x KVM machine type

Signed-off-by: Tuan Hoang <tmhoang@linux.ibm.com>