### PR TITLE
s390x: allow cosa build and run without anaconda

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -285,7 +285,7 @@ echo '{}' > tmp/vm-iso-checksum.json
 if [ -n "${build_qemu}" ]; then
     img_qemu=${imageprefix}-qemu.qcow2
     case "$arch" in
-        "x86_64"|"aarch64")
+        "x86_64"|"aarch64"|"s390x")
             build_image "$img_qemu"
             ;;
         *)


### PR DESCRIPTION
- add zipl code in create_disk.sh. We need to implement removal of
ignition.firstboot and re-run zipl in ignition-dracut hooks.
See https://github.com/coreos/ignition-dracut/issues/84.

Signed-off-by: Tuan Hoang <tmhoang@linux.ibm.com>