### PR TITLE
s390x: skip grub.cfg

### DIFF
--- a/src/gf-platformid
+++ b/src/gf-platformid
@@ -41,7 +41,8 @@ coreos_gf_run_mount "${tmp_dest}"
 # * grub config
 # * BLS config (for subsequent config regeneration)
 # First, the grub config.
-if [ "$arch" != "x86_64" ]; then
+# Set grub.cfg in case the arch uses anaconda
+if [ "$arch" == "ppc64le" ]; then
     if [ "$(coreos_gf exists '/boot/efi')" == 'true' ]; then
         grubcfg_path=$(coreos_gf glob-expand /boot/efi/EFI/*/grub.cfg)
     else


### PR DESCRIPTION
Grub is not used on s390x architecture

Signed-off-by: Alice Frosi <afrosi@de.ibm.com>