### PR TITLE
[rhcos-4.2] deps: add arch dependent deps files for the vm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM registry.fedoraproject.org/fedora:30
 WORKDIR /root/containerbuild
 
 # Only need a few of our scripts for the first few steps
-COPY ./src/cmdlib.sh ./build.sh ./deps*.txt ./vmdeps.txt ./build-deps.txt /root/containerbuild/
+COPY ./src/cmdlib.sh ./build.sh ./deps*.txt ./vmdeps*.txt ./build-deps.txt /root/containerbuild/
 RUN ./build.sh configure_yum_repos
 RUN ./build.sh install_rpms
 

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -2,7 +2,7 @@ FROM registry.redhat.io/rhel7:latest
 WORKDIR /root/containerbuild
 
 # Only need a few of our scripts for the first few steps
-COPY ./src/cmdlib.sh ./build.sh ./deps*.txt ./vmdeps.txt ./build-deps.txt /root/containerbuild/
+COPY ./src/cmdlib.sh ./build.sh ./deps*.txt ./vmdeps*.txt ./build-deps.txt /root/containerbuild/
 COPY ./maipo/maipo.repo /etc/yum.repos.d/
 RUN ./build.sh configure_yum_repos
 # ostree-packages are on another line because all repos get configured to exclude

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -334,8 +334,9 @@ runvm() {
     [ -n "${ISFEDORA}" ] && filter='^#FEDORA '
     [ -n "${ISEL}" ]     && filter='^#EL7 '
     rpms=$(sed "s/${filter}//" "${DIR}"/vmdeps.txt | grep -v '^#')
+    archrpms=$(sed "s/${filter}//" "${DIR}"/vmdeps-"$(arch)".txt | grep -v '^#')
     # shellcheck disable=SC2086
-    supermin --prepare --use-installed -o "${vmpreparedir}" $rpms
+    supermin --prepare --use-installed -o "${vmpreparedir}" $rpms $archrpms
 
     # include COSA in the image
     find /usr/lib/coreos-assembler/ -type f > "${vmpreparedir}/hostfiles"

--- a/src/vmdeps-aarch64.txt
+++ b/src/vmdeps-aarch64.txt
@@ -1,0 +1,3 @@
+# Place-holder for aarch64 arch specific dependencies for the guest
+
+grub2 grub2-efi

--- a/src/vmdeps-ppc64le.txt
+++ b/src/vmdeps-ppc64le.txt
@@ -1,0 +1,3 @@
+# Place-holder for ppc64le arch specific dependencies for the guest
+
+grub2 grub2-efi

--- a/src/vmdeps-s390x.txt
+++ b/src/vmdeps-s390x.txt
@@ -1,0 +1,3 @@
+# Place-holder for s390x arch specific dependencies for the guest
+
+s390utils-base haveged

--- a/src/vmdeps-x86_64.txt
+++ b/src/vmdeps-x86_64.txt
@@ -1,0 +1,3 @@
+# Place-holder for x86_64 arch specific dependencies for the guest
+
+grub2 grub2-efi

--- a/vmdeps-aarch64.txt
+++ b/vmdeps-aarch64.txt
@@ -1,0 +1,1 @@
+src/vmdeps-aarch64.txt

--- a/vmdeps-ppc64le.txt
+++ b/vmdeps-ppc64le.txt
@@ -1,0 +1,1 @@
+src/vmdeps-ppc64le.txt

--- a/vmdeps-s390x.txt
+++ b/vmdeps-s390x.txt
@@ -1,0 +1,1 @@
+src/vmdeps-s390x.txt

--- a/vmdeps-x86_64.txt
+++ b/vmdeps-x86_64.txt
@@ -1,0 +1,1 @@
+src/vmdeps-x86_64.txt


### PR DESCRIPTION
Add additional files that specify the dependecies for each architecture.
It has the same structure as deps-arch.txt. This is needed to install
different packages for s390x. For example for s390x, grub is not needed

Backport of: #694

Signed-off-by: Alice Frosi <afrosi@de.ibm.com>