### PR TITLE
cmd-buildupload: Add --skip-builds-json

### DIFF
--- a/src/cmd-buildupload
+++ b/src/cmd-buildupload
@@ -31,8 +31,11 @@ def parse_args():
     parser.add_argument("--build", help="Build ID", default='latest')
     parser.add_argument("--dry-run", help="Just print and exit",
                         action='store_true')
-    parser.add_argument("--freshen", help="Only push builds.json",
-                        action='store_true')
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--freshen", help="Only push builds.json",
+                       action='store_true')
+    group.add_argument("--skip-builds-json", help="Don't push builds.json",
+                       action='store_true')
 
     subparsers = parser.add_subparsers(dest='cmd', title='subcommands')
     subparsers.required = True
@@ -70,7 +73,9 @@ def cmd_upload_s3(args):
                 # assume it's metadata
                 s3_cp(args, CACHE_MAX_AGE_METADATA,
                       f'builds/{args.build}/{f}', f'{args.build}/{f}')
-    s3_cp(args, CACHE_MAX_AGE_METADATA, 'builds/builds.json', 'builds.json')
+    if not args.skip_builds_json:
+        s3_cp(args, CACHE_MAX_AGE_METADATA,
+              'builds/builds.json', 'builds.json')
 
 
 def s3_upload_build(args, builddir, dest):


### PR DESCRIPTION
We want to be able to upload only the build itself, without also
uploading `builds.json`. The use case for this in a pipeline context is
uploading new or modified files in existing build directories but still
categorically rule out racing with another job also adding a new build.