### PR TITLE
vmdeps: Use correct grub-efi packages on each arch

### DIFF
--- a/src/vmdeps-aarch64.txt
+++ b/src/vmdeps-aarch64.txt
@@ -1,3 +1,1 @@
-# Place-holder for aarch64 arch specific dependencies for the guest
-
-grub2 grub2-efi
+grub2 grub2-efi-aa64

--- a/src/vmdeps-ppc64le.txt
+++ b/src/vmdeps-ppc64le.txt
@@ -1,3 +1,1 @@
-# Place-holder for ppc64le arch specific dependencies for the guest
-
-grub2 grub2-efi
+grub2

--- a/src/vmdeps-s390x.txt
+++ b/src/vmdeps-s390x.txt
@@ -1,3 +1,1 @@
-# Place-holder for s390x arch specific dependencies for the guest
-
 s390utils-base haveged

--- a/src/vmdeps-x86_64.txt
+++ b/src/vmdeps-x86_64.txt
@@ -1,3 +1,1 @@
-# Place-holder for x86_64 arch specific dependencies for the guest
-
-grub2 grub2-efi
+grub2 grub2-efi-x64


### PR DESCRIPTION
Fix: #660
Tested on x86_64 and ppc64le via ```cosa run```.