### PR TITLE
cmd-run: Specify .bashrc file mode

### DIFF
--- a/src/cmd-run
+++ b/src/cmd-run
@@ -191,7 +191,8 @@ cat > "${f}" <<EOF
                 "path": "/home/core/.bashrc",
                 "append": [
                     { "source": "data:text/plain;base64,${rowcol}" }
-                ]
+                ],
+                "mode": 436
             }
         ]
     },


### PR DESCRIPTION
Otherwise ignition-validate will issue a warning.