### PR TITLE
s390x: allow building iso image

### DIFF
--- a/src/cmd-buildextend-installer
+++ b/src/cmd-buildextend-installer
@@ -67,11 +67,6 @@ os.mkdir(tmpisoisolinux)
 
 def generate_iso():
     arch = platform.machine()
-
-    if arch in ("s390", "s390x"):
-        print(f"{arch} ISO generation is not supported at the moment")
-        sys.exit(1)
-
     tmpisofile = os.path.join(tmpdir, iso_name)
 
     # Find the directory under `/usr/lib/modules/<kver>` where the
@@ -128,6 +123,18 @@ def generate_iso():
     elif arch == "ppc64le":
         genisoargs += ['-r', '-l', '-sysid', 'PPC',
                        '-chrp-boot', '-graft-points']
+    elif arch == "s390x":
+        # combine kernel, initramfs and cmdline using lorax/mk-s390-cdboot tool
+        run_verbose(['/usr/bin/mk-s390-cdboot',
+                     '-i', os.path.join(tmpisoimages, 'vmlinuz'),
+                     '-r', os.path.join(tmpisoimages, 'initramfs.img'),
+                     '-p', os.path.join(tmpisoroot, 'zipl.prm'),
+                     '-o', os.path.join(tmpisoimages, 'fcos.img')])
+        genisoargs = ['/usr/bin/xorrisofs', '-verbose',
+                      '-volset', f"{name_version}",
+                      '-rock', '-J', '-joliet-long',
+                      '-no-emul-boot', '-eltorito-boot',
+                      os.path.join(os.path.relpath(tmpisoimages, tmpisoroot), 'fcos.img')]
 
     ### For x86_64 and aarch64 UEFI booting
     if arch in ("x86_64", "aarch64"):

--- a/src/deps-s390x.txt
+++ b/src/deps-s390x.txt
@@ -1,2 +1,2 @@
-# Place-holder for s390x arch specific dependencies
-
+# For building iso image
+lorax xorriso


### PR DESCRIPTION
This requires fedora-coreos-config/installer/zipl.prm file for kernel
parameters.
xorrisofs tool allows building iso image on s390x, genisoimage does not
support.
Blatantly copy mk-s390-cdboot tool from lorax project.

Signed-off-by: Tuan Hoang <tmhoang@linux.ibm.com>