### PR TITLE
s390x: multiarch support for kolet/kola installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,12 @@ tests:=$(shell find tests -maxdepth 1 -type f -executable -print)
 tests_checked:=$(patsubst tests/%,tests/.%.shellchecked,${tests})
 cwd:=$(shell find . -maxdepth 1 -type f -executable -print)
 cwd_checked:=$(patsubst ./%,.%.shellchecked,${cwd})
+GOARCH:=$(shell uname -m)
+ifeq ($(GOARCH),x86_64)
+        GOARCH="amd64"
+else ifeq ($(GOARCH),aarch64)
+        GOARCH="arm64"
+endif
 
 .%.shellchecked: %
 	./tests/check_one.sh $< $@
@@ -50,5 +56,5 @@ install:
 	ln -sf ../lib/coreos-assembler/coreos-assembler $(DESTDIR)$(PREFIX)/bin/
 	ln -sf coreos-assembler $(DESTDIR)$(PREFIX)/bin/cosa
 	install -D -t $(DESTDIR)$(PREFIX)/bin mantle/bin/{ore,kola,plume}
-	install -d $(DESTDIR)$(PREFIX)/lib/kola/amd64
-	install -D -m 0755 -t $(DESTDIR)$(PREFIX)/lib/kola/amd64 mantle/bin/amd64/kolet
+	install -d $(DESTDIR)$(PREFIX)/lib/kola/$(GOARCH)
+	install -D -m 0755 -t $(DESTDIR)$(PREFIX)/lib/kola/$(GOARCH) mantle/bin/$(GOARCH)/kolet


### PR DESCRIPTION
The PR is to add multiarch support to kolet build and kola/kolet installation.
The PR from mantle side to have kolet build also for s390x - https://github.com/coreos/mantle/pull/1048