### PR TITLE
move scsibus definition

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -423,13 +423,12 @@ EOF
         srcvirtfs=("-virtfs" "local,id=source,path=${workdir}/src/config,security_model=none,mount_tag=source")
     fi
 
-    pcibus="${devtype}.0"
-    scsibus="bus=${pcibus},addr=0x3"
+    scsibus="bus=pci.0,addr=0x3"
     arch_args=
     case $arch in
         "aarch64")
             # 'pci' bus doesn't work on aarch64
-            pcibus=pcie.0
+            scsibus="bus=pcie.0,addr=0x3"
             arch_args='-bios /usr/share/AAVMF/AAVMF_CODE.fd'
 	    ;;
         "s390x") scsibus="devno=fe.0.0003" ;;


### PR DESCRIPTION
while defaulting to pci bus for ppc64le and x86_64 pcie is needed
on aarch64 and s390x defines its own structure. The code as is is
evaluated before the arch conditionals giving aarch64 a pci bus
that does not work.

Signed-off-by: Dennis Gilmore <dennis@ausil.us>