### PR TITLE
WIP: setup raspberry pi firmware

### DIFF
--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -123,6 +123,22 @@ set prefix=($prefix)/grub2
 normal
 EOF
 
+# copy the boot binaries needed for Raspberry pi support
+if  [ -d "/usr/share/uboot/" ]; then
+	if [ "$arch" == "aarch64" ]; then
+		cp -P /boot/efi/*.bin rootfs/boot/efi/
+		cp -P /boot/efi/*.dat rootfs/boot/efi/
+		cp -P /boot/efi/*.dtb rootfs/boot/efi/
+		cp -P /boot/efi/*.elf rootfs/boot/efi/
+		cp -rP /boot/efi/overlays/ rootfs/boot/efi/
+		cp -P /usr/share/uboot/rpi_3/u-boot.bin rootfs/boot/efi/rpi3-u-boot.bin
+		# rpi4 is only supported in Fedora 31 and on
+		if [ -f "/usr/share/uboot/rpi_4/u-boot.bin" ]; then
+			cp -P /usr/share/uboot/rpi_4/u-boot.bin rootfs/boot/efi/rpi4-u-boot.bin
+		fi
+	fi
+fi
+
 	# copy the grub config and any other files we might need
 	cp $grub_script rootfs/boot/grub2/grub.cfg
 else

--- a/src/deps-aarch64.txt
+++ b/src/deps-aarch64.txt
@@ -3,3 +3,6 @@ grub2
 
 # For creating bootable UEFI media on aarch64
 shim-aa64 grub2-efi-aa64
+
+# firmware for booting raspberry pi
+bcm283x-firmware uboot-images-armv8

--- a/src/vmdeps-aarch64.txt
+++ b/src/vmdeps-aarch64.txt
@@ -1,1 +1,4 @@
 grub2 grub2-efi-aa64
+
+# firmware for booting raspberry pi
+bcm283x-firmware uboot-images-armv8


### PR DESCRIPTION
install u-boot and the firmware needed to boot on the raspberry pi
This is only needed on Fedora CoreOS and needs a way to happen only
when building for a suitable OS

Signed-off-by: Dennis Gilmore <dennis@ausil.us>