### PR TITLE
Revert "update Makefile to support build and install binaries for s390x arch"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,12 +16,6 @@ tests:=$(shell find tests -maxdepth 1 -type f -executable -print)
 tests_checked:=$(patsubst tests/%,tests/.%.shellchecked,${tests})
 cwd:=$(shell find . -maxdepth 1 -type f -executable -print)
 cwd_checked:=$(patsubst ./%,.%.shellchecked,${cwd})
-GOARCH:=$(shell uname -m)
-ifeq ($(GOARCH),x86_64)
-        GOARCH="amd64"
-else ifeq ($(GOARCH),aarch64)
-        GOARCH="arm64"
-endif
 
 .%.shellchecked: %
 	./tests/check_one.sh $< $@
@@ -56,5 +50,5 @@ install:
 	ln -sf ../lib/coreos-assembler/coreos-assembler $(DESTDIR)$(PREFIX)/bin/
 	ln -sf coreos-assembler $(DESTDIR)$(PREFIX)/bin/cosa
 	install -D -t $(DESTDIR)$(PREFIX)/bin mantle/bin/{ore,kola,plume}
-	install -d $(DESTDIR)$(PREFIX)/lib/kola/$(GOARCH)
-	install -D -m 0755 -t $(DESTDIR)$(PREFIX)/lib/kola/$(GOARCH) mantle/bin/$(GOARCH)/kolet
+	install -d $(DESTDIR)$(PREFIX)/lib/kola/amd64
+	install -D -m 0755 -t $(DESTDIR)$(PREFIX)/lib/kola/amd64 mantle/bin/amd64/kolet


### PR DESCRIPTION

This reverts commit 13d69fe843d1404508e895323f65270a7d4eb0c7.

We need to do the mantle PRs first.