### PR TITLE
Add a Dockerfile.buildroot

### DIFF
--- a/Dockerfile.buildroot
+++ b/Dockerfile.buildroot
@@ -1,0 +1,15 @@
+# This layers on top of the primary cosa container, and includes
+# the build dependencies for some key packages such as
+# ignition, rpm-ostree, libpod, systemd, and kernel.  If you want
+# another package in this list, submit a PR and we can probably add it.
+#
+# Further, the entrypoint is reset to bash, and the user to root, making
+# this container easier to use generically.  For example, the rpm-ostree
+# CI system will likely use this as a base image.
+FROM quay.io/coreos-assembler/coreos-assembler:latest
+USER root
+ENTRYPOINT ["/usr/bin/bash"]
+WORKDIR /root/containerbuild
+COPY src src
+RUN ./src/install-buildroot.sh && yum clean all && rm src -rf
+WORKDIR /root

--- a/src/buildroot-buildreqs.txt
+++ b/src/buildroot-buildreqs.txt
@@ -1,0 +1,9 @@
+# This is what the CoreOS developers tend to actively develop/own.
+# If you want to extend this, feel free to file a PR.
+ignition
+ostree
+rpm-ostree
+kernel
+systemd
+dracut
+podman

--- a/src/buildroot-reqs.txt
+++ b/src/buildroot-reqs.txt
@@ -1,0 +1,29 @@
+# This is a list of basic buildrequires; it'd be a bit better to
+# yum -y install @buildsys-build but unfortunately that hits a bug:
+# https://fedoraproject.org/wiki/Common_F30_bugs#Conflicts_between_fedora-release_packages_when_installing_package_groups
+# So here we inline it, minus the -release package.
+bash
+bzip2
+coreutils
+cpio
+diffutils
+findutils
+gawk
+glibc-minimal-langpack
+grep
+gzip
+info
+make
+patch
+redhat-rpm-config
+rpm-build
+sed
+shadow-utils
+tar
+unzip
+util-linux
+which
+xz
+
+# Also, add clang since it's useful at least in CI for C/C++ projects
+clang

--- a/src/install-buildroot.sh
+++ b/src/install-buildroot.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# This is invoked by Dockerfile.buildroot
+set -euo pipefail
+dn=$(dirname "$0")
+deps=$(grep -v '^#' "${dn}"/buildroot-reqs.txt)
+echo "Installing requirements"
+echo "${deps}" | xargs yum -y install
+brs=$(grep -v '^#' "${dn}"/buildroot-buildreqs.txt)
+echo "Installing build dependencies of primary packages"
+echo "${brs}" | xargs yum -y builddep
+echo 'Done!'


### PR DESCRIPTION
We've talked before about how cosa isn't useful for people
developing on e.g. rpm-ostree; this is a primary reason I personally
use cosa via installing it inside my personal toolbox container.

This PR implements something talked about before; we add a
"buildroot" container (e.g. `quay.io/coreos-assembler/coreos-buildroot:latest`)
that is basically `yum builddep` for the parts we care about.

The main reason I want to do this right now is I am working
on using cosa in rpm-ostree's CI, and having an up-to-date "buildroot"
container with the dependencies pre-installed will help a lot with that.

I ran into issues trying to use cosa as a base and do the `yum builddep`
dynamically because of the `USER builder` directive; Prow isn't expecting that.

Another reason to do this is that in the future I'd like to
add first-class support to cosa for e.g.
`ln -s /path/to/ostree overrides/src`
and cosa would take care of building a layer (or RPM?) from that
source.