### PR TITLE
installer: use lorax s390x templates, allow adding parameters at boot

### DIFF
--- a/src/cmd-buildextend-installer
+++ b/src/cmd-buildextend-installer
@@ -93,6 +93,10 @@ initrd_ignition_padding = 256 * 1024
 
 
 def generate_iso():
+    # convention for kernel and initramfs names
+    kernel_img = 'vmlinuz'
+    initramfs_img = 'initramfs.img'
+
     tmpisofile = os.path.join(tmpdir, iso_name)
     img_qemu = os.path.join(builddir, buildmeta['images']['qemu']['path'])
 
@@ -105,7 +109,7 @@ def generate_iso():
     moduledir = process.stdout.decode().split('\0')[1]
 
     # copy those files out of the ostree into the iso root dir
-    for file in ['initramfs.img', 'vmlinuz']:
+    for file in [kernel_img, initramfs_img]:
         run_verbose(['/usr/bin/ostree', 'checkout', '--repo', repo,
                      '--user-mode', '--subpath', os.path.join(moduledir, file),
                      f"{buildmeta_commit}", tmpisoimages])
@@ -113,7 +117,7 @@ def generate_iso():
         os.chmod(os.path.join(tmpisoimages, file), 0o755)
 
     if is_live:
-        initramfs = os.path.join(tmpisoimages, 'initramfs.img')
+        initramfs = os.path.join(tmpisoimages, initramfs_img)
         tmp_squashfs = os.path.join(tmpdir, 'root.squashfs')
         tmp_cpio = os.path.join(tmpdir, 'root.cpio')
         tmp_initramfs = os.path.join(tmpdir, 'initramfs')
@@ -206,17 +210,49 @@ def generate_iso():
         genisoargs += ['-r', '-l', '-sysid', 'PPC',
                        '-chrp-boot', '-graft-points']
     elif basearch == "s390x":
+        # Reserve 32MB for the kernel, starting memory address of the initramfs
+        # See https://github.com/weldr/lorax/blob/master/share/templates.d/99-generic/s390.tmpl
+        INITRD_ADDRESS = '0x02000000'
+        lorax_templates = '/usr/share/lorax/templates.d/99-generic/config_files/s390'
+        shutil.copy(os.path.join(lorax_templates, 'redhat.exec'), tmpisoimages)
+        with open(os.path.join(lorax_templates, 'generic.ins'), 'r') as fp1:
+            with open(os.path.join(tmpisoroot, 'generic.ins'), 'w') as fp2:
+                [fp2.write(line.replace('@INITRD_LOAD_ADDRESS@', INITRD_ADDRESS)) for line in fp1]
+        for prmfile in ['cdboot.prm', 'genericdvd.prm', 'generic.prm']:
+            with open(os.path.join(tmpisoimages, prmfile), 'w') as fp1:
+                line1 = 'cio_ignore=all,!condev rd.cmdline=ask'
+                with open(os.path.join(tmpisoroot, 'zipl.prm'), 'r') as fp2:
+                    line1 += ' ' + ' '.join([line2.strip('\n') for line2 in fp2])
+                fp1.write(line1)
+
+        # s390x's z/VM CMS files are limited to 8 char for filenames and extensions
+        # Also it is nice to keep naming convetion with Fedora/RHEL for existing users and code
+        shutil.move(os.path.join(tmpisoimages, kernel_img), os.path.join(tmpisoimages, 'kernel.img'))
+        shutil.move(os.path.join(tmpisoimages, initramfs_img), os.path.join(tmpisoimages, 'initrd.img'))
+        kernel_img = 'kernel.img'
+        initramfs_img = 'initrd.img'
+
         # combine kernel, initramfs and cmdline using lorax/mk-s390-cdboot tool
         run_verbose(['/usr/bin/mk-s390-cdboot',
-                     '-i', os.path.join(tmpisoimages, 'vmlinuz'),
-                     '-r', os.path.join(tmpisoimages, 'initramfs.img'),
-                     '-p', os.path.join(tmpisoroot, 'zipl.prm'),
-                     '-o', os.path.join(tmpisoimages, 'fcos.img')])
+                     '-i', os.path.join(tmpisoimages, kernel_img),
+                     '-r', os.path.join(tmpisoimages, initramfs_img),
+                     '-p', os.path.join(tmpisoimages, 'cdboot.prm'),
+                     '-o', os.path.join(tmpisoimages, 'cdboot.img')])
+        # generate .addrsize file for LPAR
+        with open(os.path.join(tmpisoimages, 'initrd.addrsize'), 'wb') as addrsize:
+            addrsize_data = struct.pack(">iiii", 0, int(INITRD_ADDRESS, 16), 0,
+                                        os.stat(os.path.join(tmpisoimages, initramfs_img)).st_size)
+            addrsize.write(addrsize_data)
+
+        # safely remove things we don't need in the final ISO tree
+        for d in ['EFI', 'isolinux', 'zipl.prm']:
+            run_verbose(['rm', '-rf', os.path.join(tmpisoroot, d)])
+
         genisoargs = ['/usr/bin/xorrisofs', '-verbose',
                       '-volset', f"{name_version}",
                       '-rational-rock', '-J', '-joliet-long',
                       '-no-emul-boot', '-eltorito-boot',
-                      os.path.join(os.path.relpath(tmpisoimages, tmpisoroot), 'fcos.img')]
+                      os.path.join(os.path.relpath(tmpisoimages, tmpisoroot), 'cdboot.img')]
 
     # For x86_64 and aarch64 UEFI booting
     if basearch in ("x86_64", "aarch64"):
@@ -306,14 +342,14 @@ def generate_iso():
         # -rw-rw-r--   1 1750 1750       553961457 Sep 18 2019 [   4733 00]  initramfs.img
         #                           match the logical block number ^^^^ ||
         #                                          file type, always 00 ^^
-        matches = list(re.finditer(r'\[\s*([0-9]+) 00\]\s+initramfs\.img\s*$',
+        matches = list(re.finditer(r'\[\s*([0-9]+) 00\]\s+{}\s*$'.format(initramfs_img),
                 isoinfo.stdout, re.MULTILINE))
         if len(matches) != 1:
-            raise Exception('Found {} copies of initramfs.img'.format(len(matches)))
+            raise Exception('Found {} copies of {}'.format(len(matches), initramfs_img))
         # Start of the initramfs within the ISO
         offset = int(matches[0].group(1)) * 2048  # assume 2 KB per logical block
         # End of the initramfs within the ISO
-        offset += os.stat(os.path.join(tmpisoimages, "initramfs.img")).st_size
+        offset += os.stat(os.path.join(tmpisoimages, initramfs_img)).st_size
         # Start of the initramfs padding
         offset -= initrd_ignition_padding
         with open(tmpisofile, 'r+b') as isofh:
@@ -332,8 +368,8 @@ def generate_iso():
     initramfs_name = f'{base_name}-{args.build}-{image_type}-initramfs.{basearch}.img'
     kernel_file = os.path.join(builddir, kernel_name)
     initramfs_file = os.path.join(builddir, initramfs_name)
-    shutil.copyfile(os.path.join(tmpisoimages, "vmlinuz"), kernel_file)
-    with open(os.path.join(tmpisoimages, "initramfs.img"), 'rb') as fsrc:
+    shutil.copyfile(os.path.join(tmpisoimages, kernel_img), kernel_file)
+    with open(os.path.join(tmpisoimages, initramfs_img), 'rb') as fsrc:
         with open(initramfs_file, 'wb') as fdst:
             shutil.copyfileobj(fsrc, fdst)
             if is_live:


### PR DESCRIPTION
 installer: use lorax s390x templates, allow adding parameters at boot

Significant changes include:

- Use a naming convention for kernel and initramfs file, which would
help for s390x case. The reasoning is that z/VM's CMS files do not allow
names and extentions more than 8 characters. While we are renaming, lets
stick with traditional RHEL/Fedora naming so redhat.exec and generic.ins
don't require changes from lorax templates.

- Allow us to add parameters (ignition, raw image, etc.) at boot time
for s390x using 'rd.cmdline=ask' dracut parameters. It is
better to reuse lorax templates rather than adding it on our own.

- generic.ins and redhat.exec from lorax allow us to loop mount the ISO
image and expose its mount point via FTP, then LPAR and z/VM can fetch
kernel and initramfs from there to boot, basically the same netboot
method on RHEL/Fedora, and the same PXE experience on x86.

- We also need to add 'rd.neednet=1 coreos.inst=yes' from zipl.prm so that
coreos-installer-generator will replace default.target with
coreos-installer.target, before user adds any parameter at
dracut-cmdline-ask.

Signed-off-by: Tuan Hoang <tmhoang@linux.ibm.com>