### PR TITLE
create_disk: Enable read-only /sysroot

### DIFF
--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -378,6 +378,9 @@ s390x)
 esac
 
 ostree config --repo $rootfs/ostree/repo set sysroot.bootloader "${bootloader_backend}"
+# Opt-in to https://github.com/ostreedev/ostree/pull/1767 AKA
+# https://github.com/ostreedev/ostree/issues/1265
+ostree config --repo $rootfs/ostree/repo set sysroot.readonly true
 
 touch $rootfs/boot/ignition.firstboot
 


### PR DESCRIPTION
Let's opt-in to this by default.
See https://github.com/ostreedev/ostree/issues/1265

This currently is a no-op if the required ostree support hasn't
landed yet, so I think we can safely merge this PR first.