### PR TITLE
create_disk: Add the immutable bit to the physical root

### DIFF
--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -156,4 +156,13 @@ fi
 
 touch rootfs/boot/ignition.firstboot
 
+# Finally, add the immutable bit to the physical root; we don't
+# expect people to be creating anything there.  A use case for
+# OSTree in general is to support installing *inside* the existing
+# root of a deployed OS, so OSTree doesn't do this by default, but
+# we have no reason not to enable it here.  Administrators should
+# generally expect that state data is in /etc and /var; if anything
+# else is in /sysroot it's probably by accident.
+chattr +i rootfs
+
 umount -R rootfs


### PR DESCRIPTION
Add the immutable bit to the physical root; we don't
expect people to be creating anything there.  A use case for
OSTree in general is to support installing *inside* the existing
root of a deployed OS, so OSTree doesn't do this by default, but
we have no reason not to enable it here.  Administrators should
generally expect that state data is in /etc and /var; if anything
else is in /sysroot it's probably by accident.

I just happened to think of this while working on
https://github.com/coreos/coreos-assembler/pull/736