### PR TITLE
Retry skopeo inspect calls

### DIFF
--- a/src/oscontainer.py
+++ b/src/oscontainer.py
@@ -19,9 +19,35 @@ import json
 import os
 import shutil
 import subprocess
-
+from functools import wraps
+from time import sleep
 
 OSCONTAINER_COMMIT_LABEL = 'com.coreos.ostree-commit'
+
+
+# oscontainer.py can't use external python libs since its running in RHCOS
+def retry(attempts=5):
+    def retry_decorator(f):
+
+        @wraps(f)
+        def retry_function(*args, **kwargs):
+            delay = 5
+            i = attempts
+            while i > 1:
+                try:
+                    return f(*args, **kwargs)
+                except subprocess.CalledProcessError as e:
+                    print(f"{str(e)}, retrying in {delay} seconds...")
+                    sleep(delay)
+                    i -= 1
+            return f(*args, **kwargs)
+        return retry_function
+    return retry_decorator
+
+
+@retry(attempts=5)
+def run_get_json_retry(args):
+    return run_get_json(args)
 
 
 def run_get_json(args):
@@ -168,7 +194,7 @@ def oscontainer_build(containers_storage, src, ref, image_name_and_tag,
             skopeoCmd.append("--authfile={}".format(authfile))
 
         skopeoCmd.append("docker://" + image_name_and_tag)
-        inspect = run_get_json(skopeoCmd)
+        inspect = run_get_json_retry(skopeoCmd)
     else:
         inspect = run_get_json([
             'podman', rootarg, 'inspect', image_name_and_tag])[0]


### PR DESCRIPTION
This would ensure `podman inspect` / `skopeo inspect` operations are retried up to 5 times with 5 sec delay.

External python deps cannot be used in `oscontainer.py` as its running inside RHCOS system