### PR TITLE
Fix local src config handling in unprivileged path

### DIFF
--- a/src/cmd-init
+++ b/src/cmd-init
@@ -94,7 +94,7 @@ mkdir -p src
 (cd src
  if ! test -e config; then
      case "${source}" in
-         /*) ln -sr "${source}/${subdir}" config;;
+         /*) ln -s "${source}/${subdir}" config;;
          *) git clone "${source}" config
             if [ -n "${BRANCH}" ]; then
                 git -C config checkout "${BRANCH}"

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -173,7 +173,7 @@ prepare_build() {
     fi
 
     workdir="$(pwd)"
-    configdir=${COSA_CONFIG_GIT:-${workdir}/src/config}
+    configdir=${workdir}/src/config
     manifest=${configdir}/manifest.yaml
     manifest_lock=${configdir}/manifest-lock.${basearch}.json
     manifest_lock_overrides=${configdir}/manifest-lock.overrides.${basearch}.json
@@ -184,6 +184,13 @@ prepare_build() {
     fi
 
     echo "Using manifest: ${manifest}"
+
+    # backcompat for local setups that initialized with `ln -sr`
+    if [ -L "${configdir}" ]; then
+        if [[ $(readlink "${configdir}") != /* ]]; then
+            ln -sfn "$(realpath "${configdir}")" "${configdir}"
+        fi
+    fi
 
     tmprepo=${workdir}/tmp/repo
     if [ ! -d "${tmprepo}" ]; then

--- a/src/supermin-init-prelude.sh
+++ b/src/supermin-init-prelude.sh
@@ -26,9 +26,8 @@ umask 002
 mkdir -p "${workdir:?}"
 mount -t 9p -o rw,trans=virtio,version=9p2000.L workdir "${workdir}"
 if [ -L "${workdir}"/src/config ]; then
-    tmpd=$(mktemp -d)
-    mount -t 9p -o rw,trans=virtio,version=9p2000.L source "${tmpd}"
-    export COSA_CONFIG_GIT="${tmpd}"
+    mkdir -p "$(readlink "${workdir}"/src/config)"
+    mount -t 9p -o rw,trans=virtio,version=9p2000.L source "${workdir}"/src/config
 fi
 mkdir -p "${workdir}"/cache /host/container-work
 if [ -b /dev/sdb1 ]; then


### PR DESCRIPTION
This is a different approach from
https://github.com/coreos/coreos-assembler/pull/605 towards fixing
local src configs.

There are two core issues:
1. `COSA_CONFIG_GIT` is understood by cosa only, so it doesn't help if
   the target command we want to execute is not a cosa subcommand.
2. The arguments we pass to the target command might already embed
   expanded/absolute `${workdir}/src/config/...` paths.

So instead, let's just make sure we don't use relative symlinks so that
`src/config` in such cases is always a symlink to an absolute path.

Then the `mkdir -p $(readlink ...)` approach should just work.