### PR TITLE
README: delete unused env var from documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,17 +295,6 @@ $ cosa init https://github.com/coreos/fedora-coreos-config.git
 $ cosa fetch && cosa build
 ```
 
-#### Running in privileged mode
-
-If you'd like to run the Assembler in [privileged mode](#privileged-mode)
-you can use the `COREOS_ASSEMBLER_PRIVILEGED` env var:
-
-```
-$ export COREOS_ASSEMBLER_PRIVILEGED=true
-$ cosa init https://github.com/coreos/fedora-coreos-config.git
-$ cosa fetch && cosa build
-```
-
 
 #### Using a locally built Assembler container
 


### PR DESCRIPTION
We stopped documenting the use of the COREOS_ASSEMBLER_PRIVILEGED
environment variable in 19ba574.