### PR TITLE
cmd-init: set up rootfs overrides dir during init

### DIFF
--- a/src/cmd-init
+++ b/src/cmd-init
@@ -116,3 +116,4 @@ mkdir -p cache
 mkdir -p builds
 mkdir -p tmp
 mkdir -p overrides/rpm
+mkdir -p overrides/rootfs

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -326,7 +326,7 @@ gpgcheck=0
 EOF
     fi
     rootfs_overlay="${overridesdir}/rootfs"
-    if [ -d "${rootfs_overlay}" ]; then
+    if [[ -d "${rootfs_overlay}" && -n $(ls -A "${rootfs_overlay}") ]]; then
         echo -n "Committing ${rootfs_overlay}... "
         ostree commit --repo="${tmprepo}" --tree=dir="${rootfs_overlay}" -b cosa-bin-overlay \
           --owner-uid 0 --owner-gid 0 --no-xattrs --no-bindings --parent=none \


### PR DESCRIPTION
The support for rootfs overrides was added in c8cab23 but never
tacked on to cmd-init. It's useful to have it created so the user
doesn't have to remember the name of the dir each time he/she cleans
their local cache.