### PR TITLE
buildextend-live: More live PXE/ISO work

### DIFF
--- a/src/cmd-buildextend-installer
+++ b/src/cmd-buildextend-installer
@@ -14,6 +14,7 @@ import subprocess
 import sys
 import tarfile
 import tempfile
+import yaml
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from cmdlib import run_verbose, write_json, sha256sum_file
@@ -33,6 +34,10 @@ if not args.build:
     args.build = builds.get_latest()
 
 print(f"Targeting build: {args.build}")
+
+with open('src/config/image.yaml') as fh:
+    image_yaml = yaml.safe_load(fh)
+squashfs_compression = image_yaml.get('squashfs-compression', 'zstd')
 
 # Hacky mode switch, until we can drop support for the installer images
 is_live = os.path.basename(sys.argv[0]).endswith('-live')
@@ -104,8 +109,9 @@ def generate_iso():
         tmp_cpio = os.path.join(tmpdir, 'root.cpio')
         tmp_initramfs = os.path.join(tmpdir, 'initramfs')
 
+        print(f'Compressing squashfs with {squashfs_compression}')
         run_verbose(['/usr/lib/coreos-assembler/gf-mksquashfs',
-                     img_qemu, tmp_squashfs])
+                     img_qemu, tmp_squashfs, squashfs_compression])
         run_verbose(['cpio', '-o', '-H', 'newc', '-R', 'root:root',
                 '--quiet', '--reproducible', '--force-local',
                 '-D', os.path.dirname(tmp_squashfs), '-O', tmp_cpio],

--- a/src/cmd-buildextend-installer
+++ b/src/cmd-buildextend-installer
@@ -7,7 +7,10 @@ import argparse
 import json
 import os
 import platform
+import re
 import shutil
+import struct
+import subprocess
 import sys
 import tarfile
 import tempfile
@@ -71,6 +74,10 @@ os.mkdir(tmpisoroot)
 os.mkdir(tmpisoimages)
 os.mkdir(tmpisoisolinux)
 
+# Number of padding bytes at the end of the ISO initramfs for embedding
+# an Ignition config
+initrd_ignition_padding = 256 * 1024
+
 def generate_iso():
     arch = platform.machine()
     tmpisofile = os.path.join(tmpdir, iso_name)
@@ -114,6 +121,9 @@ def generate_iso():
                 shutil.copyfileobj(fsrc, fdst)
             with open(tmp_cpio + '.gz', 'rb') as fsrc:
                 shutil.copyfileobj(fsrc, fdst)
+            # Pad with NUL bytes for the ISO image.  We'll truncate the
+            # padding off again when copying the PXE initrd.
+            fdst.write(bytes(initrd_ignition_padding))
         os.rename(tmp_initramfs, initramfs)
         os.unlink(tmp_squashfs)
 
@@ -239,12 +249,65 @@ def generate_iso():
     if arch == "x86_64":
         run_verbose(['/usr/bin/isohybrid', tmpisofile])
 
+    # We've already padded the initrd with initrd_ignition_padding bytes of
+    # zeroes.  Find the byte offset of that padding within the ISO image and
+    # write it into a custom header at the end of the ISO 9660 System Area,
+    # which is 32 KB at the start of the image "reserved for system use".
+    # The System Area usually contains partition tables and the like, and
+    # we're assuming that none of our platforms use the last 24 bytes of it.
+    #
+    # This allows an external tool, coreos-iso-embed-ignition, to modify
+    # an existing ISO image to embed a user's custom Ignition config.
+    # The tool wraps the Ignition config in a cpio.gz and uses our header
+    # to write it directly into the ISO image.  The cpio.gz will be read
+    # into the initramfs filesystem at runtime and ignition-dracut will
+    # ensure that the config is moved where Ignition will see it.
+    #
+    # Skip on s390x because that platform uses an embedded El Torito image
+    # with its own copy of the initramfs.
+    if is_live and arch != "s390x":
+        isoinfo = run_verbose(['isoinfo', '-lR', '-i', tmpisofile],
+                stdout=subprocess.PIPE, text=True)
+        # -rw-rw-r--   1 1750 1750       553961457 Sep 18 2019 [   4733 00]  initramfs.img 
+        #                           match the logical block number ^^^^ ||
+        #                                          file type, always 00 ^^
+        matches = list(re.finditer(r'\[\s*([0-9]+) 00\]\s+initramfs\.img\s*$',
+                isoinfo.stdout, re.MULTILINE))
+        if len(matches) != 1:
+            raise Exception('Found {} copies of initramfs.img'.format(len(matches)))
+        # Start of the initramfs within the ISO
+        offset = int(matches[0].group(1)) * 2048  # assume 2 KB per logical block
+        # End of the initramfs within the ISO
+        offset += os.stat(os.path.join(tmpisoimages, "initramfs.img")).st_size
+        # Start of the initramfs padding
+        offset -= initrd_ignition_padding
+        with open(tmpisofile, 'r+b') as isofh:
+            # Verify that the calculated byte range is empty
+            isofh.seek(offset)
+            if isofh.read(initrd_ignition_padding) != bytes(initrd_ignition_padding):
+                raise Exception(f'ISO image {initrd_ignition_padding} bytes at {offset} are not zero')
+            # Write header at the end of the System Area
+            fmt = '<8s2Q'
+            isofh.seek(32768 - struct.calcsize(fmt))
+            # Magic number + offset + length
+            isofh.write(struct.pack(fmt, b'coreiso+', offset, initrd_ignition_padding))
+            print(f'Embedded {initrd_ignition_padding} bytes Ignition config space at {offset}')
+
     kernel_name = f'{base_name}-{args.build}-{image_type}-kernel'
     initramfs_name = f'{base_name}-{args.build}-{image_type}-initramfs.img'
     kernel_file = os.path.join(builddir, kernel_name)
     initramfs_file = os.path.join(builddir, initramfs_name)
     shutil.copyfile(os.path.join(tmpisoimages, "vmlinuz"), kernel_file)
-    shutil.copyfile(os.path.join(tmpisoimages, "initramfs.img"), initramfs_file)
+    with open(os.path.join(tmpisoimages, "initramfs.img"), 'rb') as fsrc:
+        with open(initramfs_file, 'wb') as fdst:
+            shutil.copyfileobj(fsrc, fdst)
+            if is_live:
+                # Verify ISO initrd padding and truncate it away
+                pad_offset = fsrc.tell() - initrd_ignition_padding
+                fsrc.seek(pad_offset)
+                if fsrc.read() != bytes(initrd_ignition_padding):
+                    raise Exception(f"Expected {initrd_ignition_padding} bytes of trailing zeroes in initrd, didn't find it")
+                fdst.truncate(pad_offset)
 
     kernel_checksum = sha256sum_file(kernel_file)
     initramfs_checksum = sha256sum_file(initramfs_file)

--- a/src/cmd-buildextend-installer
+++ b/src/cmd-buildextend-installer
@@ -120,6 +120,10 @@ def generate_iso():
     # TODO ignore EFI dir
     # Grab all the contents from the installer dir from the configs
     run_verbose(["rsync", "-av", f"src/config/{image_type}/", f"{tmpisoroot}/"])
+    # Skip the development readme to avoid confusing users
+    devel_readme = f"{tmpisoroot}/README-devel.md"
+    if os.path.exists(devel_readme):
+        os.unlink(devel_readme)
 
     # These sections are based on lorax templates
     # see https://github.com/weldr/lorax/tree/master/share/templates.d/99-generic

--- a/src/gf-mksquashfs
+++ b/src/gf-mksquashfs
@@ -7,13 +7,14 @@ dn=$(dirname "$0")
 # shellcheck source=src/libguestfish.sh
 . "${dn}"/libguestfish.sh
 
-# Usage: gf-mksquashfs <input image> <output image>
-# Example: gf-mksquashfs fedora-coreos.qcow2 fedora-coreos.squashfs
+# Usage: gf-mksquashfs <input image> <output image> [compression]
+# Example: gf-mksquashfs fedora-coreos.qcow2 fedora-coreos.squashfs xz
 #
 # This will generate a squashfs from the contents of the root partition.
 
 src="$1"
 dest="$2"
+compression="${3:-zstd}"
 
 if [[ $src == *.gz || $src == *.xz ]]; then
     img="$(basename "$src")"
@@ -35,7 +36,7 @@ coreos_gf_run "${src}" --ro
 root=$(coreos_gf findfs-label root)
 coreos_gf mount "${root}" /
 
-coreos_gf mksquashfs / "${tmp_dest}" compress:zstd
+coreos_gf mksquashfs / "${tmp_dest}" "compress:${compression}"
 
 coreos_gf_shutdown
 

--- a/src/virt-install
+++ b/src/virt-install
@@ -28,7 +28,8 @@ def fatal(msg):
 
 # Set of valid keys in image.yaml
 IMAGE_CONF_KEYS = ['size', 'postprocess-script', 'extra-kargs',
-                   'save-var-subdirs-for-selabel-workaround', 'ostree-remote']
+                   'save-var-subdirs-for-selabel-workaround', 'ostree-remote',
+                   'squashfs-compression']
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--dest", help="Destination disk",


### PR DESCRIPTION
In this PR:
- Allow patching live ISO to embed Ignition config
- Allow overriding squashfs compression in `image.yaml` to support EL 8
- Ignore `README-devel.md` when copying ISO contents from config

Part of https://github.com/coreos/fedora-coreos-config/pull/171.