### PR TITLE
build: Clean up internal runvm API

### DIFF
--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -172,7 +172,8 @@ if [ -z "${use_anaconda}" ]; then
     if [ -n "${ref_is_temp}" ]; then
         ref_arg=${commit}
     fi
-    runvm_with_disk "${path}.tmp" ${image_format} /usr/lib/coreos-assembler/create_disk.sh /dev/vda "$ostree_repo" "${ref_arg}" "${ostree_remote}" /usr/lib/coreos-assembler/grub.cfg "$name" "${save_var_subdirs}" "\"$kargs\""
+
+    runvm -drive "if=virtio,id=target,format=${image_format},file=${path}.tmp" -- /usr/lib/coreos-assembler/create_disk.sh /dev/vda "$ostree_repo" "${ref_arg}" "${ostree_remote}" /usr/lib/coreos-assembler/grub.cfg "$name" "${save_var_subdirs}" "\"$kargs\""
     mv "${path}.tmp" "$path"
     echo "{}" > tmp/vm-iso-checksum.json
 else

--- a/src/cmd-oscontainer
+++ b/src/cmd-oscontainer
@@ -22,5 +22,5 @@ if has_privileges; then
     exec "${osc}" "$@"
 else
     info "Required privileges not detected; running via supermin appliance"
-    runvm "${osc}" --workdir /host/container-work "$@"
+    runvm -- "${osc}" --workdir /host/container-work "$@"
 fi


### PR DESCRIPTION
Have `runvm` accept arbitrary arguments for qemu along with
arguments for the target code.  This makes it far more
flexible.  Prep for passing `create_disk.sh` arguments via
a read-only virtio mount.