### PR TITLE
[rhcos-4.2] virt-install: use correct console on each arch 

### DIFF
--- a/src/cmd-run
+++ b/src/cmd-run
@@ -156,7 +156,7 @@ EOF
     "systemd": {
         "units": [
             {
-                "name": "serial-getty@${VM_TERMINAL}.service",
+                "name": "serial-getty@${DEFAULT_TERMINAL}.service",
                 "dropins": [
                     {
                         "name": "autologin-core.conf",

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -43,13 +43,13 @@ arch=$(uname -m)
 export arch
 
 case $arch in
-    "x86_64")  VM_TERMINAL="ttyS0"    ;;
-    "ppc64le") VM_TERMINAL="hvc0"     ;;
-    "aarch64") VM_TERMINAL="ttyAMA0"  ;;
-    "s390x")   VM_TERMINAL="ttysclp0" ;;
+    "x86_64")  DEFAULT_TERMINAL="ttyS0"    ;;
+    "ppc64le") DEFAULT_TERMINAL="hvc0"     ;;
+    "aarch64") DEFAULT_TERMINAL="ttyAMA0"  ;;
+    "s390x")   DEFAULT_TERMINAL="ttysclp0"; devtype=ccw ;;
     *)         fatal "Architecture $(arch) not supported"
 esac
-export VM_TERMINAL
+export DEFAULT_TERMINAL
 
 if [ -x /usr/libexec/qemu-kvm ]; then
     QEMU_KVM="/usr/libexec/qemu-kvm"
@@ -402,7 +402,8 @@ EOF
         -device scsi-hd,bus=scsi0.0,channel=0,scsi-id=0,lun=0,drive=drive-scsi0-0-0-0,id=scsi0-0-0-0,bootindex=1 \
         "${cachedisk[@]}" \
         -virtfs local,id=workdir,path="${workdir}",security_model=none,mount_tag=workdir \
-        "${srcvirtfs[@]}" -serial stdio -append "root=/dev/sda console=${VM_TERMINAL} selinux=1 enforcing=0 autorelabel=1"
+        "${srcvirtfs[@]}" -serial stdio -append "root=/dev/sda console=${DEFAULT_TERMINAL} selinux=1 enforcing=0 autorelabel=1" \
+	"${extradisk[@]}"
 
     if [ ! -f "${workdir}"/tmp/rc ]; then
         fatal "Couldn't find rc file, something went terribly wrong!"

--- a/src/image-base.ks
+++ b/src/image-base.ks
@@ -18,7 +18,7 @@ firewall --disabled
 # rw and $ignition_firstboot are used by https://github.com/coreos/ignition-dracut/
 # Console settings are so we see output everywhere
 # %%KARGS%% is for distro-specific arguments
-bootloader --timeout=1 --append="console=ttyS0,115200n8 console=tty0 rootflags=defaults,prjquota rw %%KARGS%% $ignition_firstboot"
+bootloader --timeout=1 --append="console=%%TERM%%,115200n8 console=tty0 rootflags=defaults,prjquota rw %%KARGS%% $ignition_firstboot"
 # Anaconda currently writes out configs for this which we don't want to persist; see below
 network --bootproto=dhcp --onboot=on
 

--- a/src/virt-install
+++ b/src/virt-install
@@ -119,6 +119,7 @@ extra_kargs = image_conf.get('extra-kargs', [])
 with open('/usr/lib/coreos-assembler/image-base.ks') as basef:
     buf = basef.read()
     buf = buf.replace('%%KARGS%%', ' '.join(extra_kargs))
+    buf = buf.replace('%%TERM%%', os.environ.get('DEFAULT_TERMINAL', 'ttyS0'))
     ks_tmp.write(buf)
 
 # To support different distro builds using Fedora anaconda,
@@ -302,7 +303,7 @@ try:
                           location_arg,
                           "--disk=path={},cache=unsafe".format(args.dest),
                           "--initrd-inject={}".format(ks_tmp.name),
-                          "--extra-args", "ks=file://{} console=tty0 console=ttyS0,115200n8 inst.cmdline inst.notmux".format(os.path.basename(ks_tmp.name))])
+                          "--extra-args", "ks=file://{} console=tty0 console={},115200n8 inst.cmdline inst.notmux".format(os.path.basename(ks_tmp.name),os.environ.get('DEFAULT_TERMINAL', 'ttyS0'))])
     if args.variant == 'metal-uefi':
         vinstall_args.append('--boot=uefi')
     run_sync_verbose(vinstall_args)


### PR DESCRIPTION
cherry-pick of 622adaeaf452ce0fdc38ccc677a8ae7383ecc59e  in to the 4.2 branch

