### PR TITLE
readme: update override rpm section for lockfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,5 +339,6 @@ As an example, from your assembler directory:
 ```
 $ mkdir -p overrides/rpm
 $ cp /path/to/my/name-version-release.rpm ./overrides/rpm
+$ cosa fetch --update-lockfile
 $ cosa build
 ```


### PR DESCRIPTION
Update the section on using override rpms to include a step to update
the lockfiles, otherwise the new rpms will not be pulled in.