### PR TITLE
cmdlib: set ignition 2.2.0 for rhcos-43 qcows

### DIFF
--- a/src/cmd-kola
+++ b/src/cmd-kola
@@ -41,7 +41,9 @@ if not any([x in args.subargs for x in ["-b", "--distro"]]):
     else:
         kolaargs.extend(['-b', 'fcos'])
 
+print(f"qemu path: {qemupath}")
 ignition_version = cmdlib.disk_ignition_version(qemupath)
+print(f"Using ignition version {ignition_version}")
 
 if ignition_version == "2.2.0":
     kolaargs.extend(["--ignition-version", "v2"])
@@ -54,6 +56,7 @@ kolaargs.extend(['--qemu-image', qemupath])
 outputdir = args.output_dir or "tmp/kola"
 kolaargs.extend(['--output-dir', outputdir])
 kolaargs.extend(args.subargs)
+
 # flush before exec; see https://docs.python.org/3.7/library/os.html#os.execvpe
 print(subprocess.list2cmdline(kolaargs), flush=True)
 os.execvp('kola', kolaargs)

--- a/src/cmdlib.py
+++ b/src/cmdlib.py
@@ -153,7 +153,7 @@ def rm_allow_noent(path):
 # be like a virtual time capsule!  If they still use email then...
 def disk_ignition_version(path):
     bn = os.path.basename(path)
-    if bn.startswith(("rhcos-41", "rhcos-42")):
+    if bn.startswith(("rhcos-41", "rhcos-42", "rhcos-43")):
         return "2.2.0"
     else:
         return "3.0.0"


### PR DESCRIPTION
This fixes kola test run in rhcos master pipeline - ign 3 is being used there after version bump