### PR TITLE
build: Add /.coreos-aleph-version.json to target 

### DIFF
--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -175,6 +175,8 @@ if [ -z "${use_anaconda}" ]; then
     runvm -drive "if=virtio,id=target,format=${image_format},file=${path}.tmp" -- \
             /usr/lib/coreos-assembler/create_disk.sh \
                 --disk /dev/vda \
+                --buildid "${build}" \
+                --imgid "${img}" \
                 --grub-script /usr/lib/coreos-assembler/grub.cfg \
                 --kargs "\"${kargs}\"" \
                 --osname "${name}" \


### PR DESCRIPTION
It will be very useful in the future to be able to more rigorously
know the build that a given machine *started* from.  For example,
small tweaks like `chattr +i /sysroot` are things that won't
happen for in-place updates.

If we decide to introduce a mechanism (e.g. systemd
unit) that performs those changes even for old in-place installs,
it could be useful to know exactly what the starting state was.

I chose `/boot` since it's a relatively fixed location which
people generally won't wipe and replace without also erasing
everything else.