### PR TITLE
Live PXE/ISO, round III

### DIFF
--- a/src/cmd-buildextend-installer
+++ b/src/cmd-buildextend-installer
@@ -133,7 +133,6 @@ def generate_iso():
         os.rename(tmp_initramfs, initramfs)
         os.unlink(tmp_squashfs)
 
-    # TODO ignore EFI dir
     # Grab all the contents from the installer dir from the configs
     run_verbose(["rsync", "-av", f"src/config/{image_type}/", f"{tmpisoroot}/"])
     # Skip the development readme to avoid confusing users
@@ -228,13 +227,11 @@ def generate_iso():
                             '--user-mode', '--subpath', folderfullpath,
                             f"{buildmeta_commit}", destdir])
 
-            # Install binaries from boot partition and configs from installer/EFI
+            # Install binaries from boot partition
             # Manually construct the tarball to ensure proper permissions and ownership
             efitarfile = tempfile.NamedTemporaryFile(suffix=".tar")
             with tarfile.open(efitarfile.name, "w:", dereference=True) as tar:
                 tar.add(tmpimageefidir, arcname="/EFI", filter=strip)
-                tar.add(f'src/config/{image_type}/EFI/', arcname='/EFI',
-                        filter=strip)
 
             # Create the efiboot.img file (a fat filesystem) in the images/ dir
             # Note: virt-make-fs lets us do this as non-root

--- a/src/cmd-buildextend-installer
+++ b/src/cmd-buildextend-installer
@@ -20,6 +20,16 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from cmdlib import run_verbose, write_json, sha256sum_file
 from cmdlib import import_ostree_commit, Builds
 
+live_exclude_kargs = set([
+    '$ignition_firstboot',	# unsubstituted variable in grub config
+    'console',			# no serial console by default on ISO
+    'ignition.platform.id',	# we hardcode "metal"
+    'ostree',			# dracut finds the tree automatically
+    'root',			# we use root.squashfs
+    'rootflags',		# not needed
+    'rw',			# we have a read-only root
+])
+
 # Parse args and dispatch
 parser = argparse.ArgumentParser()
 parser.add_argument("--build", help="Build ID")
@@ -133,6 +143,13 @@ def generate_iso():
         os.rename(tmp_initramfs, initramfs)
         os.unlink(tmp_squashfs)
 
+    # Read and filter kernel arguments for substituting into ISO bootloader
+    result = run_verbose(['/usr/lib/coreos-assembler/gf-get-kargs',
+            img_qemu], stdout=subprocess.PIPE, text=True)
+    kargs = ' '.join(karg for karg in result.stdout.split()
+            if karg.split('=')[0] not in live_exclude_kargs)
+    print(f'Substituting ISO kernel arguments: {kargs}')
+
     # Grab all the contents from the installer dir from the configs
     srcdir_prefix=f"src/config/{image_type}/"
     for srcdir, dirnames, filenames in os.walk(srcdir_prefix):
@@ -149,6 +166,7 @@ def generate_iso():
             # Assumes all files are text
             with open(srcfile) as fh:
                 buf = fh.read()
+            buf = buf.replace('@@KERNEL-ARGS@@', kargs)
             with open(dstfile, 'w') as fh:
                 fh.write(buf)
             shutil.copystat(srcfile, dstfile)

--- a/src/cmd-buildextend-installer
+++ b/src/cmd-buildextend-installer
@@ -181,7 +181,7 @@ def generate_iso():
                   '-volset', f"{name_version}",
                   # For  greater portability, consider using both
                   # Joliet and Rock Ridge extensions. Umm, OK :)
-                  '-rock', '-J', '-joliet-long']
+                  '-rational-rock', '-J', '-joliet-long']
 
     ### For x86_64 legacy boot (BIOS) booting
     if arch == "x86_64":
@@ -215,7 +215,7 @@ def generate_iso():
                      '-o', os.path.join(tmpisoimages, 'fcos.img')])
         genisoargs = ['/usr/bin/xorrisofs', '-verbose',
                       '-volset', f"{name_version}",
-                      '-rock', '-J', '-joliet-long',
+                      '-rational-rock', '-J', '-joliet-long',
                       '-no-emul-boot', '-eltorito-boot',
                       os.path.join(os.path.relpath(tmpisoimages, tmpisoroot), 'fcos.img')]
 

--- a/src/cmd-buildextend-installer
+++ b/src/cmd-buildextend-installer
@@ -134,11 +134,25 @@ def generate_iso():
         os.unlink(tmp_squashfs)
 
     # Grab all the contents from the installer dir from the configs
-    run_verbose(["rsync", "-av", f"src/config/{image_type}/", f"{tmpisoroot}/"])
-    # Skip the development readme to avoid confusing users
-    devel_readme = f"{tmpisoroot}/README-devel.md"
-    if os.path.exists(devel_readme):
-        os.unlink(devel_readme)
+    srcdir_prefix=f"src/config/{image_type}/"
+    for srcdir, dirnames, filenames in os.walk(srcdir_prefix):
+        dir_suffix = srcdir.replace(srcdir_prefix, '', 1)
+        dstdir = os.path.join(tmpisoroot, dir_suffix)
+        if not os.path.exists(dstdir):
+            os.mkdir(dstdir)
+        for filename in filenames:
+            # Skip development readmes to avoid confusing users
+            if filename == 'README-devel.md':
+                continue
+            srcfile = os.path.join(srcdir, filename)
+            dstfile = os.path.join(dstdir, filename)
+            # Assumes all files are text
+            with open(srcfile) as fh:
+                buf = fh.read()
+            with open(dstfile, 'w') as fh:
+                fh.write(buf)
+            shutil.copystat(srcfile, dstfile)
+            print(f'{srcfile} -> {dstfile}')
 
     # These sections are based on lorax templates
     # see https://github.com/weldr/lorax/tree/master/share/templates.d/99-generic

--- a/src/gf-get-kargs
+++ b/src/gf-get-kargs
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+dn=$(dirname "$0")
+# shellcheck source=src/cmdlib.sh
+. "${dn}"/cmdlib.sh
+# shellcheck source=src/libguestfish.sh
+. "${dn}"/libguestfish.sh
+
+# Usage: gf-get-kargs <input image>
+# Example: gf-get-kargs fedora-coreos.qcow2
+#
+# This will print the kernel arguments embedded in the specified image.
+
+src="$1"
+
+if [[ $src == *.gz || $src == *.xz ]]; then
+    img="$(basename "$src")"
+    fatal "Cannot read $img; not an uncompressed image"
+fi
+
+set -x
+
+coreos_gf_run_mount "${src}" --ro
+
+coreos_gf glob read-file /boot/loader/entries/ostree*conf | \
+    sed -e '/^options/!d' -e 's/^options\s*//'
+
+coreos_gf_shutdown


### PR DESCRIPTION
In this PR:

- Read kernel arguments from qemu image; filter and substitute into ISO bootloader configs
- Rationalize file metadata in the ISO images
- Minor cleanups

Part of https://github.com/coreos/fedora-coreos-config/pull/177.