### PR TITLE
build: Only prepare overlays when doing build, not fetch 

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -204,6 +204,7 @@ fi
 composejson=${PWD}/tmp/compose.json
 # Put this under tmprepo so it gets automatically chown'ed if needed
 lockfile_out=${tmprepo}/tmp/manifest-lock.generated.${basearch}.json
+prepare_compose_overlays
 # --cache-only is here since `fetch` is a separate verb.
 # shellcheck disable=SC2086
 runcompose --cache-only ${FORCE} --add-metadata-from-json "${commitmeta_input_json}" \


### PR DESCRIPTION
I have `cosa fetch; and cosa build` in my shell history and use
it somewhat often.  We only need to commit the overlay directories
on actual builds, not fetch which is just about RPMs.  Mostly
doing this because:

 - The overlay commit is more visual noise
 - For `overrides/rootfs` it can be a nontrivial cost