### PR TITLE
use COSA for all meta-data operations, introduce cmd-meta

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,9 @@ PREFIX ?= /usr
 DESTDIR ?=
 # E402 module level import not at top of file
 # E722 do not use bare 'except'
-PYIGNORE ?= E402,E722
+# W503 line break before binary operator
+# W504 line break after binary operator
+PYIGNORE ?= E402,E722,W503,W504
 
 flake8sources = src/cosalib src/oscontainer.py src/cmd-kola
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts = --cov=cosalib.cli --cov=cmdlib --cov-report term --cov-fail-under=80
+addopts = --cov=cosalib.cli --cov=cosalib.meta --cov=cosalib.cmdlib --cov-report term --cov-fail-under=80

--- a/src/cmd-buildextend-aws
+++ b/src/cmd-buildextend-aws
@@ -9,7 +9,8 @@ import os,sys,json,yaml,shutil,argparse,subprocess,re,collections
 import tempfile,hashlib,gzip
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from cmdlib import run_verbose, write_json, sha256sum_file, Builds
+from cosalib.builds import Builds
+from cosalib.cmdlib import run_verbose, write_json, sha256sum_file
 
 # Parse args and dispatch
 parser = argparse.ArgumentParser()

--- a/src/cmd-buildextend-azure
+++ b/src/cmd-buildextend-azure
@@ -13,18 +13,12 @@ import shutil
 import sys
 import urllib.parse
 
-cosa_dir = os.path.dirname(os.path.abspath(__file__))
-sys.path.insert(0, cosa_dir)
-
-try:
-    from cosalib.build import _Build
-except ImportError:
-    # We're in the container and can't sense the cosa path
-    sys.path.insert(0, '/usr/lib/coreos-assembler/cosalib')
-    from cosalib.build import _Build
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from cosalib.build import _Build
+from cosalib.builds import Builds
 
 # pylint: disable=C0413
-from cmdlib import (
+from cosalib.cmdlib import (
         run_verbose,
         sha256sum_file,
         write_json)

--- a/src/cmd-buildextend-gcp
+++ b/src/cmd-buildextend-gcp
@@ -16,11 +16,11 @@ import urllib.parse
 cosa_dir = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, cosa_dir)
 # pylint: disable=C0413
-from cmdlib import (
+from cosalib.builds import Builds
+from cosalib.cmdlib import (
         run_verbose,
         sha256sum_file,
-        write_json,
-        Builds)
+        write_json)
 
 # Parse args and dispatch
 parser = argparse.ArgumentParser()

--- a/src/cmd-buildextend-installer
+++ b/src/cmd-buildextend-installer
@@ -17,8 +17,9 @@ import tempfile
 import yaml
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from cmdlib import run_verbose, write_json, sha256sum_file
-from cmdlib import import_ostree_commit, Builds
+from cosalib.builds import Builds
+from cosalib.cmdlib import run_verbose, write_json, sha256sum_file
+from cosalib.cmdlib import import_ostree_commit
 
 live_exclude_kargs = set([
     '$ignition_firstboot',	# unsubstituted variable in grub config

--- a/src/cmd-buildextend-openstack
+++ b/src/cmd-buildextend-openstack
@@ -11,7 +11,8 @@ import shutil
 import argparse
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from cmdlib import run_verbose, write_json, sha256sum_file, Builds
+from cosalib.builds import Builds
+from cosalib.cmdlib import run_verbose, write_json, sha256sum_file
 
 # Parse args and dispatch
 parser = argparse.ArgumentParser()

--- a/src/cmd-buildextend-vmware
+++ b/src/cmd-buildextend-vmware
@@ -11,7 +11,8 @@ import argparse
 import tarfile
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from cmdlib import run_verbose, load_json, write_json, sha256sum_file, Builds
+from cosalib.builds import Builds
+from cosalib.cmdlib import run_verbose, load_json, write_json, sha256sum_file
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--build", help="Build ID",

--- a/src/cmd-buildprep
+++ b/src/cmd-buildprep
@@ -15,7 +15,9 @@ from botocore.exceptions import ClientError
 from tenacity import retry, stop_after_delay, stop_after_attempt, retry_if_exception_type
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from cmdlib import load_json, rm_allow_noent, Builds, retry_stop, retry_s3_exception, retry_callback  # noqa: E402
+
+from cosalib.builds import Builds
+from cosalib.cmdlib import load_json, rm_allow_noent, retry_stop, retry_s3_exception, retry_callback  # noqa: E402
 
 retry_requests_exception = (retry_if_exception_type(requests.Timeout) | \
                             retry_if_exception_type(requests.ReadTimeout) | \

--- a/src/cmd-buildupload
+++ b/src/cmd-buildupload
@@ -13,7 +13,6 @@ from botocore.exceptions import ClientError
 from tenacity import retry
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from cmdlib import load_json, Builds, retry_stop, retry_s3_exception, retry_callback  # noqa: E402
 
 # set image artifact caching at 1y; it'll probably get evicted before that...
 # see also: https://stackoverflow.com/questions/2970938
@@ -21,6 +20,8 @@ CACHE_MAX_AGE_ARTIFACT = 60 * 60 * 24 * 365
 
 # set metadata caching to 5m
 CACHE_MAX_AGE_METADATA = 60 * 5
+from cosalib.builds import Builds
+from cosalib.cmdlib import load_json, retry_stop, retry_s3_exception, retry_callback  # noqa: E402
 
 
 def main():

--- a/src/cmd-compress
+++ b/src/cmd-compress
@@ -13,8 +13,12 @@ import argparse
 import subprocess
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from cmdlib import run_verbose, write_json, sha256sum_file
-from cmdlib import rm_allow_noent, Builds
+from cosalib.builds import Builds
+from cosalib.cmdlib import (
+    rm_allow_noent,
+    run_verbose,
+    sha256sum_file,
+    write_json)
 
 DEFAULT_COMPRESSOR = 'gzip'
 

--- a/src/cmd-kola
+++ b/src/cmd-kola
@@ -9,7 +9,9 @@ import sys
 cosa_dir = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, cosa_dir)
 
-import cmdlib
+from cosalib import cmdlib
+from cosalib.builds import Builds
+
 
 # Parse args and dispatch
 parser = argparse.ArgumentParser()
@@ -19,7 +21,7 @@ parser.add_argument("subargs", help="Remaining arguments for kola", nargs='*',
                     default=['run'])
 args = parser.parse_args()
 
-builds = cmdlib.Builds()
+builds = Builds()
 if args.build is None:
     args.build = builds.get_latest()
 builddir = builds.get_build_dir(args.build)

--- a/src/cmd-meta
+++ b/src/cmd-meta
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""
+cmd-meta is a helper for interacting with a builds meta.json
+"""
+
+import argparse
+import tempfile
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from cosalib.meta import GenericBuildMeta as Meta
+
+
+def new_cli():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--workdir', default=os.getcwd())
+    parser.add_argument('--build', default='latest')
+    sub_parser = parser.add_mutually_exclusive_group(required=True)
+    sub_parser.add_argument('--get', help='get a field', action='append')
+    sub_parser.add_argument('--set', help='set a field', action='append')
+    sub_parser.add_argument(
+        '--dump', help='dumps the entire structure', action='store_true')
+    args = parser.parse_args()
+
+    meta = Meta(args.workdir, args.build)
+
+    # Get keys
+    if args.get is not None:
+        dotpath = args.get[0]
+        keypath = dotpath.split('.')
+        loc = meta.get(*keypath)
+        print(f'{dotpath}: {loc}')
+    # Set keys
+    elif args.set is not None:
+        for item in args.set:
+            k, v = item.split('=')
+            keypath = k.split('.')
+            meta.set(keypath, v)
+        meta.write()
+    elif args.dump is True:
+        print(meta)
+
+
+if __name__ == '__main__':
+    new_cli()

--- a/src/cmd-tag
+++ b/src/cmd-tag
@@ -14,7 +14,7 @@ import os
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from cmdlib import fatal, rfc3339_time, Builds  # noqa: E402
+from cosalib.cmdlib import fatal, rfc3339_time, Builds  # noqa: E402
 
 
 def main():

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -157,7 +157,7 @@ disk_ignition_version() {
     python3 -c "
 import sys
 sys.path.insert(0, '${DIR}')
-from cmdlib import disk_ignition_version
+from cosalib.cmdlib import disk_ignition_version
 print(disk_ignition_version('${path}}'))"
 }
 
@@ -671,7 +671,7 @@ get_build_dir() {
     (python3 -c "
 import sys
 sys.path.insert(0, '${DIR}')
-from cmdlib import Builds
+from cosalib.builds import Builds
 print(Builds('${workdir:-$(pwd)}').get_build_dir('${buildid}'))")
 }
 

--- a/src/cosalib/build.py
+++ b/src/cosalib/build.py
@@ -2,16 +2,11 @@
 Provides a base abstration class for build reuse.
 """
 
-import json
 import logging as log
 import os.path
 import platform
-import tempfile
 import shutil
-import sys
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-from cmdlib import Builds
 
 # COSA_INPATH is the _in container_ path for the image build source
 COSA_INPATH = "/cosa"
@@ -19,45 +14,18 @@ COSA_INPATH = "/cosa"
 # ARCH is the current machine architecture
 ARCH = platform.machine()
 
+from cosalib.cmdlib import (
+    load_json,
+    write_json)
+
+from cosalib.builds import Builds
+
 
 class BuildError(Exception):
     """
     Base error for build issues.
     """
     pass
-
-
-def load_json(path):
-    """
-    Shortcut for loading json from a file path.
-    TODO: When porting to py3, use cmdlib's load_json
-
-    :param path: The full path to the file
-    :type: path: str
-    :returns: loaded json
-    :rtype: dict
-    :raises: IOError, ValueError
-    """
-    with open(path) as f:
-        return json.load(f)
-
-
-def write_json(path, data):
-    """
-    Shortcut for writing a structure as json to the file system.
-    TODO: When porting to py3, use cmdlib's write_json
-
-    :param path: The full path to the file to write
-    :type: path: str
-    :param data:  structure to write out as json
-    :type data: dict or list
-    :raises: ValueError, OSError
-    """
-    dn = os.path.dirname(path)
-    f = tempfile.NamedTemporaryFile(mode='w', dir=dn, delete=False)
-    json.dump(data, f, indent=4)
-    os.fchmod(f.file.fileno(), 0o644)
-    os.rename(f.name, path)
 
 
 class _Build:

--- a/src/cosalib/builds.py
+++ b/src/cosalib/builds.py
@@ -1,0 +1,108 @@
+"""
+Builds interacts with builds.json
+"""
+
+import os
+import semver
+
+from cosalib.cmdlib import (
+    get_basearch,
+    rfc3339_time,
+    load_json,
+    write_json)
+
+
+class Builds:  # pragma: nocover
+    def __init__(self, workdir=None):
+        self._workdir = workdir
+        self._fn = self._path("builds/builds.json")
+        if not os.path.isdir(self._path("builds")):
+            raise Exception("No builds/ dir found!")
+        elif os.path.isfile(self._fn):
+            self._data = load_json(self._fn)
+        else:
+            # must be a new workdir; use new schema
+            self._data = {
+                'schema-version': "1.0.0",
+                'builds': []
+            }
+            self.flush()
+        self._version = semver.parse_version_info(
+            self._data.get('schema-version', "0.0.1"))
+        # we understand < 2.0.0 only
+        if self._version._major >= 2:
+            raise Exception("Builds schema too new; please update cosa")
+        # for now, since we essentially just support "1.0.0" and "0.0.1",
+        # just dillute to a bool
+        self._legacy = (self._version._major < 1)
+
+    def _path(self, path):
+        if not self._workdir:
+            return path
+        return os.path.join(self._workdir, path)
+
+    def has(self, build_id):
+        if self._legacy:
+            return build_id in self._data['builds']
+        return any([b['id'] == build_id for b in self._data['builds']])
+
+    def is_empty(self):
+        return len(self._data['builds']) == 0
+
+    def get_latest(self):
+        # just let throw if there are none
+        if self._legacy:
+            return self._data['builds'][0]
+        return self._data['builds'][0]['id']
+
+    def get_build_arches(self, build_id):
+        assert not self._legacy
+        for build in self._data['builds']:
+            if build['id'] == build_id:
+                return build['arches']
+        assert False, "Build not found!"
+
+    def get_build_dir(self, build_id, basearch=None):
+        if build_id == 'latest':
+            build_id = self.get_latest()
+        if self._legacy:
+            return self._path(f"builds/{build_id}")
+        if not basearch:
+            # just assume caller wants build dir for current arch
+            basearch = get_basearch()
+        return self._path(f"builds/{build_id}/{basearch}")
+
+    def insert_build(self, build_id, basearch=None):
+        if self._legacy:
+            self._data['builds'].insert(0, build_id)
+        else:
+            if not basearch:
+                basearch = get_basearch()
+            # for future tooling: allow inserting in an existing build for a
+            # separate arch
+            for build in self._data['builds']:
+                if build['id'] == build_id:
+                    if basearch in build['arches']:
+                        raise "Build {build_id} for {basearch} already exists"
+                    build['arches'] += [basearch]
+                    break
+            else:
+                self._data['builds'].insert(0, {
+                    'id': build_id,
+                    'arches': [
+                        basearch
+                    ]
+                })
+
+    def bump_timestamp(self):
+        self._data['timestamp'] = rfc3339_time()
+        self.flush()
+
+    def is_legacy(self):
+        return self._legacy
+
+    def raw(self):
+        return self._data
+
+    def flush(self):
+        write_json(self._fn, self._data)

--- a/src/cosalib/cmdlib.py
+++ b/src/cosalib/cmdlib.py
@@ -10,9 +10,15 @@ import subprocess
 import sys
 import tempfile
 import gi
-import semver
-from botocore.exceptions import ConnectionClosedError, ConnectTimeoutError, IncompleteReadError, ReadTimeoutError, SSLError
-from tenacity import stop_after_delay, stop_after_attempt, retry_if_exception_type
+
+from botocore.exceptions import (
+    ConnectionClosedError,
+    ConnectTimeoutError,
+    IncompleteReadError,
+    ReadTimeoutError)
+
+from tenacity import (
+    stop_after_delay, stop_after_attempt, retry_if_exception_type)
 
 gi.require_version("RpmOstree", "1.0")
 from gi.repository import RpmOstree
@@ -196,100 +202,3 @@ def get_basearch():
     except AttributeError:
         get_basearch.saved = RpmOstree.get_basearch()
         return get_basearch.saved
-
-
-# FIXME: Add tests
-class Builds:  # pragma: nocover
-    def __init__(self, workdir=None):
-        self._workdir = workdir
-        self._fn = self._path("builds/builds.json")
-        if not os.path.isdir(self._path("builds")):
-            raise Exception("No builds/ dir found!")
-        elif os.path.isfile(self._fn):
-            self._data = load_json(self._fn)
-        else:
-            # must be a new workdir; use new schema
-            self._data = {
-                'schema-version': "1.0.0",
-                'builds': []
-            }
-            self.flush()
-        self._version = semver.parse_version_info(
-            self._data.get('schema-version', "0.0.1"))
-        # we understand < 2.0.0 only
-        if self._version._major >= 2:
-            raise Exception("Builds schema too new; please update cosa")
-        # for now, since we essentially just support "1.0.0" and "0.0.1",
-        # just dillute to a bool
-        self._legacy = (self._version._major < 1)
-
-    def _path(self, path):
-        if not self._workdir:
-            return path
-        return os.path.join(self._workdir, path)
-
-    def has(self, build_id):
-        if self._legacy:
-            return build_id in self._data['builds']
-        return any([b['id'] == build_id for b in self._data['builds']])
-
-    def is_empty(self):
-        return len(self._data['builds']) == 0
-
-    def get_latest(self):
-        # just let throw if there are none
-        if self._legacy:
-            return self._data['builds'][0]
-        return self._data['builds'][0]['id']
-
-    def get_build_arches(self, build_id):
-        assert not self._legacy
-        for build in self._data['builds']:
-            if build['id'] == build_id:
-                return build['arches']
-        assert False, "Build not found!"
-
-    def get_build_dir(self, build_id, basearch=None):
-        if build_id == 'latest':
-            build_id = self.get_latest()
-        if self._legacy:
-            return self._path(f"builds/{build_id}")
-        if not basearch:
-            # just assume caller wants build dir for current arch
-            basearch = get_basearch()
-        return self._path(f"builds/{build_id}/{basearch}")
-
-    def insert_build(self, build_id, basearch=None):
-        if self._legacy:
-            self._data['builds'].insert(0, build_id)
-        else:
-            if not basearch:
-                basearch = get_basearch()
-            # for future tooling: allow inserting in an existing build for a
-            # separate arch
-            for build in self._data['builds']:
-                if build['id'] == build_id:
-                    if basearch in build['arches']:
-                        raise "Build {build_id} for {basearch} already exists"
-                    build['arches'] += [basearch]
-                    break
-            else:
-                self._data['builds'].insert(0, {
-                    'id': build_id,
-                    'arches': [
-                        basearch
-                    ]
-                })
-
-    def bump_timestamp(self):
-        self._data['timestamp'] = rfc3339_time()
-        self.flush()
-
-    def is_legacy(self):
-        return self._legacy
-
-    def raw(self):
-        return self._data
-
-    def flush(self):
-        write_json(self._fn, self._data)

--- a/src/cosalib/meta.py
+++ b/src/cosalib/meta.py
@@ -1,0 +1,91 @@
+import json
+import os.path
+
+from cosalib.builds import Builds
+from cosalib.cmdlib import (
+    load_json,
+    write_json)
+
+
+class GenericBuildMeta(dict):
+    """
+    GenericBuildMeta interacts with a builds meta.json
+    """
+
+    def __init__(self, workdir, build='latest'):
+        builds = Builds(os.path.dirname(workdir))
+        if build != "latest":
+            if not builds.has(build):
+                raise Exception('Build was not found in builds.json')
+        else:
+            build = builds.get_latest()
+
+        self._meta_path = os.path.join(
+            builds.get_build_dir(build), 'meta.json')
+        self.read()
+
+    def read(self):
+        """
+        Read the meta.json file into this object instance.
+        """
+        # Remove any current data
+        self.clear()
+        # Load the file
+        self.update(load_json(self._meta_path))
+
+    def write(self):
+        """
+        Write out the dict to the meta path.
+        """
+        write_json(self._meta_path, dict(self))
+
+    def get(self, *args):
+        """
+        Returns the content of a key path.
+
+        :param args: Ordered key path
+        :type args: list
+        :returns: The value of the key
+        :rtype: any
+        :raises: TypeError, KeyError
+        """
+        haystack = dict(self)
+        for arg in args:
+            haystack = haystack[arg]
+        return haystack
+
+    def set(self, pathing, value):
+        """
+        Sets key path to a value.
+
+        :param pathing: Ordered key path
+        :type pathing: list
+        :param value: The value to use
+        :type value: any
+        :raises: IndexError, Exception
+        """
+        if not isinstance(pathing, list):
+            pathing = [pathing]
+        updated = False
+        if len(pathing) == 1:
+            self[pathing[0]] = value
+            return
+        loc = dict(self)
+        for p in pathing:
+            if isinstance(loc[p], dict):
+                loc = loc[p]
+            else:
+                loc[p] = value
+                updated = True
+                break
+        if updated is False:
+            raise Exception('Unable to set {key} to {value}')
+
+    def __str__(self):
+        """
+        Returns the entire structure in a pretty json string format.
+
+        :returns: The meta structure
+        :rtype: dict
+        """
+        return json.dumps(dict(self), indent=4)

--- a/src/prune_builds
+++ b/src/prune_builds
@@ -16,8 +16,8 @@ import collections
 from datetime import timedelta, datetime, timezone
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from cmdlib import get_basearch, Builds
-
+from cosalib.builds import Builds
+from cosalib.cmdlib import get_basearch
 
 def parse_date_string(date_string):
     """

--- a/tests/test_cosalib_cmdlib.py
+++ b/tests/test_cosalib_cmdlib.py
@@ -8,7 +8,7 @@ import uuid
 
 sys.path.insert(0, 'src')
 
-import cmdlib
+from cosalib import cmdlib
 
 PY_MAJOR, PY_MINOR, PY_PATCH = platform.python_version_tuple()
 

--- a/tests/test_cosalib_meta.py
+++ b/tests/test_cosalib_meta.py
@@ -1,0 +1,85 @@
+import os
+import json
+import sys
+import pytest
+
+sys.path.insert(0, 'src')
+
+from cosalib import meta
+
+
+def _create_test_files(tmpdir):
+    """
+    Creates test data for each run.
+    """
+    builds = {
+        "schema-version": "1.0.0",
+        "builds": [
+            {
+                "id": "1.2.3",
+                "arches": [
+                    "x86_64"
+                ]
+            }
+        ],
+        "timestamp": "2019-01-1T15:19:45Z"
+    }
+
+    data = {
+        'test': 'data',
+        'a': {
+            'b': 'c',
+        }
+    }
+    buildsdir = os.path.join(tmpdir, 'builds')
+    os.makedirs(buildsdir, exist_ok=True)
+    with open(os.path.join(buildsdir, 'builds.json'), 'w') as f:
+        f.write(json.dumps(builds))
+    metadir = os.path.join(
+        tmpdir, 'builds', '1.2.3', 'x86_64')
+    os.makedirs(metadir, exist_ok=True)
+    with open(os.path.join(metadir, 'meta.json'), 'w') as f:
+        f.write(json.dumps(data))
+    return buildsdir
+
+
+def test_init(tmpdir):
+    buildsdir = _create_test_files(tmpdir)
+    m = meta.GenericBuildMeta(buildsdir, '1.2.3')
+    assert m['test'] is not None
+
+
+def test_get(tmpdir):
+    buildsdir = _create_test_files(tmpdir)
+    m = meta.GenericBuildMeta(buildsdir, '1.2.3')
+    assert m.get('test') == 'data'
+    assert m.get('a', 'b') == 'c'
+    with pytest.raises(KeyError):
+        m.get('i', 'donot', 'exist')
+
+
+def test_set(tmpdir):
+    """
+    Verify setting works as expected.
+    """
+    buildsdir = _create_test_files(tmpdir)
+    m = meta.GenericBuildMeta(buildsdir, '1.2.3')
+    m.set('test', 'changed')
+    m.write()
+    assert m.get('test') == 'changed'
+    m.set(['a', 'b'], 'z')
+    m.write()
+    assert m.get('a', 'b') == 'z'
+    assert m['a']['b'] == 'z'
+    with pytest.raises(Exception):
+        m.set(['i', 'donot', 'exist'], 'boom')
+
+
+def test_str(tmpdir):
+    """
+    Verifies the string representation is exactly the same as the
+    instance dict.
+    """
+    buildsdir = _create_test_files(tmpdir)
+    m = meta.GenericBuildMeta(buildsdir, '1.2.3')
+    assert dict(m) == json.loads(str(m))


### PR DESCRIPTION
## Description
- Master rebase and test fix for https://github.com/coreos/coreos-assembler/pull/676
- cmd-meta:
```
$ cosa meta --get images.qemu.path --workdir=/srv/ --build 42.80.20190926.0
$ cosa meta --get images.qemu.path \
            --get ostree-n-metadata-total \
            --workdir=/srv/ --build 42.80.20190926.0
$ cosa meta --set images.qemu.path=test \
            --workdir=/srv/ --build 42.80.20190926.0
$ cosa meta --set images.qemu.path=test \
            --set ostree-n-metadata-total=123 \
            --workdir=/srv/ --build 42.80.20190926.0
$ cosa meta --dump \
            --workdir=/srv/ --build 42.80.20190926.0
```

## Original Description
This is an ugly WIP. Here be dragons. I want to float the idea before getting to-far into what could be a massive refactoring.

This moves:

* cmdlib.py into cosalib
* introduces a cosalib.meta as a stub for generically handling the meta.json for a build. Eventually, I want to have this replace all the jq madness.
* introduces a generic cmd-meta with the idea of using it over jq interacting with cosalib.meta.