### PR TITLE
cmd-buildupload: Auto-set ContentType for JSON files

### DIFF
--- a/src/cmd-buildupload
+++ b/src/cmd-buildupload
@@ -161,6 +161,8 @@ def s3_check_exists(bucket, key):
 
 @retry(stop=retry_stop, retry=retry_s3_exception, retry_error_callback=retry_callback)
 def s3_copy(src, bucket, key, max_age, acl, extra_args={}, dry_run=False):
+    if key.endswith('.json') and 'ContentType' not in extra_args:
+        extra_args['ContentType'] = 'application/json'
     upload_args = {
         'CacheControl': f'max-age={max_age}',
         'ACL': acl


### PR DESCRIPTION
The JSON files were being uploaded without a set `Content-Type` header
(except for `meta.json`), so e.g. the FCOS build browser link for
`commitmeta.json` would ask to download the file instead of opening in
the browser directly.

I think this is a minor regression from switching to uploading via boto;
previously, `aws s3 cp` would do this auto-detection for us.