### PR TITLE
Add log-level param for buildextend subcommands

### DIFF
--- a/src/cmd-aws-replicate
+++ b/src/cmd-aws-replicate
@@ -28,6 +28,7 @@ parser.add_argument("--build", help="Build ID",
 parser.add_argument("--name-suffix", help="Suffix for name")
 parser.add_argument("--regions", help="EC2 regions",
                     default=default_all_regions, nargs='+')
+parser.add_argument("--log-level", help="ore log level")
 args = parser.parse_args()
 
 builds = Builds()
@@ -57,8 +58,10 @@ def run_ore():
 
     source_image = buildmeta['amis'][0]['hvm']
     source_region = buildmeta['amis'][0]['name']
-    ore_args = ['ore', 'aws', 'copy-image',
-                '--image', source_image, '--region', source_region]
+    ore_args = ['ore']
+    if args.log_level:
+        ore_args.extend(['--log-level', args.log_level])
+    ore_args.extend(['aws', 'copy-image', '--image', source_image, '--region', source_region])
     ore_args.extend(region_list)
     print("+ {}".format(subprocess.list2cmdline(ore_args)))
     ore_data = json.loads(subprocess.check_output(ore_args))

--- a/src/cmd-buildextend-aws
+++ b/src/cmd-buildextend-aws
@@ -22,6 +22,7 @@ parser.add_argument("--bucket", help="S3 Bucket",
 parser.add_argument("--name-suffix", help="Suffix for name")
 parser.add_argument("--grant-user", help="Grant user launch permission",
                     nargs="*", default=[])
+parser.add_argument("--log-level", help="ore log level")
 args = parser.parse_args()
 
 builds = Builds()
@@ -57,16 +58,19 @@ def generate_aws_vmdk():
 
 def run_ore():
     tmp_img_aws_vmdk = generate_aws_vmdk()
-    ore_args = ['ore', 'aws', 'upload',
-                '--region', args.region,
-                '--bucket', args.bucket,
-                '--ami-name', ami_name_version,
-                '--name', ami_name_version,
-                '--ami-description', f"{buildmeta['summary']} {args.build}",
-                '--file', tmp_img_aws_vmdk,
-                '--disk-size-inspect',
-                '--delete-object',
-                '--force']
+    ore_args = ['ore']
+    if args.log_level:
+        ore_args.extend(['--log-level', args.log_level])
+    ore_args.extend(['aws', 'upload',
+                     '--region', args.region,
+                     '--bucket', args.bucket,
+                     '--ami-name', ami_name_version,
+                     '--name', ami_name_version,
+                     '--ami-description', f"{buildmeta['summary']} {args.build}",
+                     '--file', tmp_img_aws_vmdk,
+                     '--disk-size-inspect',
+                     '--delete-object',
+                     '--force'])
     for user in args.grant_user:
         ore_args.extend(['--grant-user', user])
     print("+ {}".format(subprocess.list2cmdline(ore_args)))

--- a/src/cmd-buildextend-azure
+++ b/src/cmd-buildextend-azure
@@ -124,6 +124,7 @@ def cli():
     parser.add_argument(
         '--storage-account', help='Storage account', required=True,
         default=os.environ.get('AZURE_STORAGE_ACCOUNT'))
+    parser.add_argument("--log-level", help="ore log level")
     args = parser.parse_args()
 
     # Argument checks for environment strings that are required
@@ -166,8 +167,11 @@ def run_ore(args, build):
     :type build: Build
     """
     azure_vhd_path = os.path.join(build.build_dir, build.azure_vhd_name)
-    ore_upload_args = [
-        'ore', 'azure', 'upload-blob-arm',
+    ore_upload_args = ['ore']
+    if args.log_level:
+        ore_upload_args.extend(['--log-level', args.log_level])
+    ore_upload_args.extend([
+        'azure', 'upload-blob-arm',
         '--azure-auth', args.auth,
         '--azure-location', args.location,
         '--azure-profile', args.profile,

--- a/src/cmd-buildextend-gcp
+++ b/src/cmd-buildextend-gcp
@@ -36,6 +36,7 @@ parser.add_argument("--name-suffix", help="Append suffix to name",
                     required=False)
 parser.add_argument("--project", help="GCP Project name",
                     default=os.environ.get("GCP_PROJECT_NAME"))
+parser.add_argument("--log-level", help="ore log level")
 args = parser.parse_args()
 
 # Argument checks for environment strings that are required
@@ -95,17 +96,21 @@ def run_ore():
     """ Execute ore to upload the tarball and register the image """
     build_tarball = f"{builddir}/{gcp_tarball_name}"
     tmp_img_gcp_tarball = generate_gcp_tar()
-    ore_args = ['ore', 'gcloud',
-                '--project', args.project,
-                '--basename', base_name,
-                'upload',
-                '--force',  # We want to support restarting the pipeline
-                '--board=""',
-                '--bucket', f'gs://{args.bucket}/{base_name}',
-                '--json-key', args.json_key,
-                '--name', f'{args.build}',
-                '--file', tmp_img_gcp_tarball
-               ]
+    ore_args = ['ore']
+    if args.log_level:
+        ore_args.extend(['--log-level', args.log_level])
+    ore_args.extend([
+        'gcloud',
+        '--project', args.project,
+        '--basename', base_name,
+        'upload',
+        '--force',  # We want to support restarting the pipeline
+        '--board=""',
+        '--bucket', f'gs://{args.bucket}/{base_name}',
+        '--json-key', args.json_key,
+        '--name', f'{args.build}',
+        '--file', tmp_img_gcp_tarball
+    ])
 
     run_verbose(ore_args)
     os.rename(tmp_img_gcp_tarball, build_tarball)


### PR DESCRIPTION
When log-level is set for buildextend command it would be passed to `ore`.
This would help with getting more info when upload fails.

Tested this in RHCOS pipeline