### PR TITLE
build: Verify Python syntax in `make check`

### DIFF
--- a/src/cmd-buildextend-azure
+++ b/src/cmd-buildextend-azure
@@ -179,7 +179,7 @@ def run_ore(args, build):
         '--container', args.container,
         '--file', azure_vhd_path,
         '--resource-group', args.resource_group,
-        '--storage-account', args.storage_account]
+        '--storage-account', args.storage_account])
     if args.force:
         ore_upload_args.append('--overwrite')
     run_verbose(ore_upload_args)


### PR DESCRIPTION
We're not ready for the full flake8 (which honestly I find really
annoying anyways...) - but at least verify we're not shipping any
syntax errors.

Doing this since I saw a syntax error in an RHCOS build in
`cmd-buildextend-azure`, although I am not seeming to replicate
it locally from master at the moment.