### PR TITLE
buildextend-azure: fix extend() syntax

### DIFF
--- a/src/cmd-buildextend-azure
+++ b/src/cmd-buildextend-azure
@@ -179,7 +179,7 @@ def run_ore(args, build):
         '--container', args.container,
         '--file', azure_vhd_path,
         '--resource-group', args.resource_group,
-        '--storage-account', args.storage_account]
+        '--storage-account', args.storage_account])
     if args.force:
         ore_upload_args.append('--overwrite')
     run_verbose(ore_upload_args)


### PR DESCRIPTION
#777 introduced a syntax error in buildextend-azure:

```
+ coreos-assembler buildextend-azure --auth /srv/.azure/azure.json --build 43.80.20190925.0 --container imagebucket --profile /srv/.azure/azureProfile.json --resource-group os4-common --storage-account rhcos --force
  File "/usr/lib/coreos-assembler/cmd-buildextend-azure", line 183
    if args.force:
                 ^
SyntaxError: invalid syntax
```