### PR TITLE
cmd-buildextend-metal: support for rootfs in LUKS containers.

### DIFF
--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -163,6 +163,8 @@ kargs="$kargs $tty ignition.platform.id=$image_type"
 
 ostree_remote="$(python3 -c 'import sys, yaml; print(yaml.safe_load(sys.stdin).get("ostree-remote", "NONE"))' < "$configdir/image.yaml")"
 save_var_subdirs="$(python3 -c 'import sys, yaml; print(yaml.safe_load(sys.stdin).get("save-var-subdirs-for-selabel-workaround", "NONE"))' < "$configdir/image.yaml")"
+luks_flag="$(python3 -c 'import sys, yaml; lf=yaml.safe_load(sys.stdin).get("luks_rootfs", ""); print("--luks-rootfs" if lf.lower() in ("yes", "true") else "")' < "$configdir/image.yaml")"
+
 
 if [ -z "${use_anaconda}" ]; then
     qemu-img create -f ${image_format} "${path}.tmp" "$size"
@@ -183,7 +185,8 @@ if [ -z "${use_anaconda}" ]; then
                 --ostree-ref "${ref_arg}" \
                 --ostree-remote "${ostree_remote}" \
                 --ostree-repo "${ostree_repo}" \
-                --save-var-subdirs "${save_var_subdirs}"
+                --save-var-subdirs "${save_var_subdirs}" \
+                "${luks_flag}"
     mv "${path}.tmp" "$path"
     echo "{}" > tmp/vm-iso-checksum.json
 else

--- a/src/deps.txt
+++ b/src/deps.txt
@@ -60,3 +60,6 @@ python3-flake8 python3-pytest python3-pytest-cov
 
 # Support for Koji uploads.
 krb5-libs krb5-workstation koji-utils python3-koji python3-koji-cli-plugins
+
+# LUKS support
+cryptsetup

--- a/src/vmdeps.txt
+++ b/src/vmdeps.txt
@@ -18,4 +18,7 @@ selinux-policy selinux-policy-targeted policycoreutils
 # coreos-assembler
 python3 python3-gobject-base buildah podman skopeo iptables iptables-libs
 
+# luks
+cryptsetup
+
 gdisk xfsprogs e2fsprogs dosfstools shim


### PR DESCRIPTION
This will install the rootfs in a LUKS container using a null cipher. The
actual encryption of the LUKS container will be handled by a new dracut
module, tentatively named "ignition-dracut-reecrypt."

By default, the rootfs is not installed into a LUKS container. To enable
rootfs in LUKS, add the following to the recipe image.yaml:
`    luks_rootfs: "yes"`

This implements the agreed-to-design in:
https://github.com/openshift/enhancements/blob/master/enhancements/automated-policy-based-disencryption.cmd