### PR TITLE
create_disk: Drop the root= and rootflags= kargs by default

### DIFF
--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -209,7 +209,7 @@ if [ "${remote_name}" != NONE ]; then
 fi
 ostree pull-local "$ostree" "$ref" --repo rootfs/ostree/repo $remote_arg
 ostree admin os-init "$os_name" --sysroot rootfs
-allkargs='root=/dev/disk/by-label/root rootflags=defaults,prjquota rw $ignition_firstboot'
+allkargs='$ignition_firstboot'
 allkargs="$allkargs $extrakargs"
 kargsargs=""
 for karg in $allkargs


### PR DESCRIPTION
This is prep for reprovisioning the rootfs:
https://github.com/coreos/fedora-coreos-tracker/issues/94

Requires: https://github.com/coreos/fedora-coreos-config/pull/187
(Do not merge until RHCOS has also rebased to FCOS with that change)

Closes: https://github.com/coreos/coreos-assembler/issues/781