### PR TITLE
cmd-buildextend-dasd: disallow building on non s390x

### DIFF
--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -76,6 +76,10 @@ case "$arch" in
         ;;
 esac
 
+if [[ "$arch" != "s390x" && $image_type == dasd ]]; then
+    fatal "$arch is not supported for building dasd images"
+fi
+
 export LIBGUESTFS_BACKEND=direct
 
 prepare_build


### PR DESCRIPTION
Otherwise you get errors from qemu like:
    - 'virtio-blk-ccw' is not a valid device model name`