### PR TITLE
src: use consistent implementation for getting architecture

### DIFF
--- a/src/cmd-buildextend-installer
+++ b/src/cmd-buildextend-installer
@@ -19,7 +19,7 @@ import yaml
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from cosalib.builds import Builds
 from cosalib.cmdlib import run_verbose, write_json, sha256sum_file
-from cosalib.cmdlib import import_ostree_commit
+from cosalib.cmdlib import import_ostree_commit, get_basearch
 
 live_exclude_kargs = set([
     '$ignition_firstboot',	# unsubstituted variable in grub config
@@ -92,7 +92,7 @@ os.mkdir(tmpisoisolinux)
 initrd_ignition_padding = 256 * 1024
 
 def generate_iso():
-    arch = platform.machine()
+    arch = get_basearch()
     tmpisofile = os.path.join(tmpdir, iso_name)
     img_qemu = os.path.join(builddir, buildmeta['images']['qemu']['path'])
 

--- a/src/cmd-koji-upload
+++ b/src/cmd-koji-upload
@@ -20,7 +20,6 @@ import koji
 import koji_cli.lib as klib
 import logging as log
 import os.path
-import platform
 import shutil
 import subprocess
 import sys
@@ -29,6 +28,8 @@ import tempfile
 cosa_dir = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, f"{cosa_dir}/cosalib")
 sys.path.insert(0, cosa_dir)
+
+from cosalib.cmdlib import get_basearch
 
 try:
     from cosalib.build import _Build
@@ -44,7 +45,7 @@ except IOError:
     HOST_OS = "unknown"
 
 # ARCH is the current machine architecture
-ARCH = platform.machine()
+ARCH = get_basearch()
 
 COSA_INPATH = "/cosa"
 

--- a/src/cosalib/build.py
+++ b/src/cosalib/build.py
@@ -4,21 +4,21 @@ Provides a base abstration class for build reuse.
 
 import logging as log
 import os.path
-import platform
 import shutil
 
 
 # COSA_INPATH is the _in container_ path for the image build source
 COSA_INPATH = "/cosa"
 
-# ARCH is the current machine architecture
-ARCH = platform.machine()
-
 from cosalib.cmdlib import (
+    get_basearch,
     load_json,
     write_json)
 
 from cosalib.builds import Builds
+
+# ARCH is the current machine architecture
+ARCH = get_basearch()
 
 
 class BuildError(Exception):

--- a/src/virt-install
+++ b/src/virt-install
@@ -13,6 +13,9 @@ import tempfile,yaml,platform,json,threading
 import http.server
 import socketserver
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from cosalib.cmdlib import get_basearch
+
 PID = os.getpid()
 
 # Currently we spin up a temporary webserver, but we could also
@@ -283,7 +286,7 @@ try:
         # https://bugzilla.redhat.com/show_bug.cgi?id=1659242
 
         # set correct location of the kernel image and initrd
-        arch = platform.machine()
+        arch = get_basearch()
         if arch == "x86_64" or arch == "i386":
             location_arg += ",kernel=isolinux/vmlinuz,initrd=isolinux/initrd.img"
         elif arch == "ppc64le":


### PR DESCRIPTION
Let's use a single implementation. Considering a41e434 let's use
get_basearch() from cmdlib.
