### PR TITLE
cmd-buildprep: make necessary dirs when fetching files

### DIFF
--- a/src/cmd-buildprep
+++ b/src/cmd-buildprep
@@ -98,6 +98,9 @@ class Fetcher(object):
         # on Windows anytime soon.
         url = os.path.join(self.url_base, path)
         print(f"Fetching: {url}")
+        # ensure the dir for dest file exists
+        # otherwise s3 download_file won't be able to write temp file
+        os.makedirs(os.path.dirname(dest), exist_ok=True)
         self.fetch_impl(url, dest)
         return dest
 


### PR DESCRIPTION
AWS CLI has been conveniently creating missing dirs if `key` contained those. Now `download_file` would require those to write at temporary file.

Now intermediate dirs are created - this should resolve failure in FCOS pipeline. RHCOS pipeline wasn't affected, as it already had builds dir created.