### PR TITLE
buildextend*: unify behavior/code of `--build` option

### DIFF
--- a/src/cmd-buildextend-aws
+++ b/src/cmd-buildextend-aws
@@ -13,8 +13,7 @@ from cmdlib import run_verbose, write_json, sha256sum_file, Builds
 
 # Parse args and dispatch
 parser = argparse.ArgumentParser()
-parser.add_argument("--build", help="Build ID",
-                    required=True)
+parser.add_argument("--build", help="Build ID")
 parser.add_argument("--region", help="EC2 region",
                     required=True)
 parser.add_argument("--bucket", help="S3 Bucket",
@@ -25,7 +24,12 @@ parser.add_argument("--grant-user", help="Grant user launch permission",
 parser.add_argument("--log-level", help="ore log level")
 args = parser.parse_args()
 
+# Identify the builds and target the latest build if none provided
 builds = Builds()
+if not args.build:
+    args.build = builds.get_latest()
+print(f"Targeting build: {args.build}")
+
 builddir = builds.get_build_dir(args.build)
 buildmeta_path = os.path.join(builddir, 'meta.json')
 with open(buildmeta_path) as f:

--- a/src/cmd-buildextend-azure
+++ b/src/cmd-buildextend-azure
@@ -25,7 +25,6 @@ except ImportError:
 
 # pylint: disable=C0413
 from cmdlib import (
-        Builds,
         run_verbose,
         sha256sum_file,
         write_json)
@@ -128,12 +127,6 @@ def cli():
     parser.add_argument("--log-level", help="ore log level")
     args = parser.parse_args()
 
-    # Identify the builds and target the latest build if none provided
-    builds = Builds()
-    if not args.build:
-        args.build = builds.get_latest()
-    print(f"Targeting build: {args.build}")
-
     # Argument checks for environment strings that are required
     arg_exp_str = "parameter '--{}' or envVar '{}' must be defined"
     if args.auth is None:
@@ -150,7 +143,7 @@ def cli():
     # Identify the builds
     build = Build(
         os.path.join('builds'),
-        args.build,
+        args.build or 'latest',
         tmpbuilddir=os.path.abspath('tmp/buildpost-azure'))
 
     if 'azure' in build.meta['images'] and not args.force:
@@ -209,7 +202,7 @@ def run_ore(args, build):
             'size': size
         }
     })
-    buildmeta_path = os.path.join('builds', args.build, 'meta.json')
+    buildmeta_path = os.path.join('builds', build.build_id, 'meta.json')
     write_json(buildmeta_path, build.meta)
     print(f"Updated: {buildmeta_path}")
     shutil.rmtree(build.tmpbuilddir)

--- a/src/cmd-buildextend-azure
+++ b/src/cmd-buildextend-azure
@@ -25,6 +25,7 @@ except ImportError:
 
 # pylint: disable=C0413
 from cmdlib import (
+        Builds,
         run_verbose,
         sha256sum_file,
         write_json)
@@ -105,7 +106,7 @@ def cli():
     parser.add_argument(
         '--auth', help='Path to Azure auth file',
         required=True, default=os.environ.get("AZURE_AUTH"))
-    parser.add_argument('--build', help='Build ID', required=True)
+    parser.add_argument('--build', help='Build ID')
     parser.add_argument(
         '--container', help='Storage location to write to',
         required=True, default=os.environ.get("AZURE_CONTAINER"))
@@ -126,6 +127,12 @@ def cli():
         default=os.environ.get('AZURE_STORAGE_ACCOUNT'))
     parser.add_argument("--log-level", help="ore log level")
     args = parser.parse_args()
+
+    # Identify the builds and target the latest build if none provided
+    builds = Builds()
+    if not args.build:
+        args.build = builds.get_latest()
+    print(f"Targeting build: {args.build}")
 
     # Argument checks for environment strings that are required
     arg_exp_str = "parameter '--{}' or envVar '{}' must be defined"

--- a/src/cmd-buildextend-gcp
+++ b/src/cmd-buildextend-gcp
@@ -24,7 +24,7 @@ from cmdlib import (
 
 # Parse args and dispatch
 parser = argparse.ArgumentParser()
-parser.add_argument("--build", help="Build ID", required=True)
+parser.add_argument("--build", help="Build ID")
 parser.add_argument("--bucket", help="Storage account to write image to",
                     default=os.environ.get("GCP_BUCKET"))
 parser.add_argument("--gce", help="Use GCE as the platform ID instead of GCP",
@@ -48,8 +48,12 @@ if args.json_key is None:
 if args.project is None:
     raise Exception(arg_exp_str.format("project", "GCP_PROJECT"))
 
-# Identify the builds
+# Identify the builds and target the latest build if none provided
 builds = Builds()
+if not args.build:
+    args.build = builds.get_latest()
+print(f"Targeting build: {args.build}")
+
 builddir = builds.get_build_dir(args.build)
 buildmeta_path = os.path.join(builddir, 'meta.json')
 with open(buildmeta_path) as f:

--- a/src/cmd-buildextend-installer
+++ b/src/cmd-buildextend-installer
@@ -37,12 +37,10 @@ parser.add_argument("--force", action='store_true', default=False,
                     help="Overwrite previously generated installer")
 args = parser.parse_args()
 
+# Identify the builds and target the latest build if none provided
 builds = Builds()
-
-# default to latest build if not specified
 if not args.build:
     args.build = builds.get_latest()
-
 print(f"Targeting build: {args.build}")
 
 with open('src/config/image.yaml') as fh:

--- a/src/cmd-buildextend-openstack
+++ b/src/cmd-buildextend-openstack
@@ -18,12 +18,10 @@ parser = argparse.ArgumentParser()
 parser.add_argument("--build", help="Build ID")
 args = parser.parse_args()
 
+# Identify the builds and target the latest build if none provided
 builds = Builds()
-
-# default to latest build if not specified
 if not args.build:
     args.build = builds.get_latest()
-
 print(f"Targeting build: {args.build}")
 
 builddir = builds.get_build_dir(args.build)

--- a/src/cmd-buildextend-vmware
+++ b/src/cmd-buildextend-vmware
@@ -14,15 +14,14 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from cmdlib import run_verbose, load_json, write_json, sha256sum_file, Builds
 
 parser = argparse.ArgumentParser()
-parser.add_argument("--build", help="Build ID",
-                    required=False)
+parser.add_argument("--build", help="Build ID")
 args = parser.parse_args()
 
+# Identify the builds and target the latest build if none provided
 builds = Builds()
-
-# default to latest build if not specified
 if not args.build:
     args.build = builds.get_latest()
+print(f"Targeting build: {args.build}")
 
 builddir = builds.get_build_dir(args.build)
 buildmeta_path = os.path.join(builddir, 'meta.json')


### PR DESCRIPTION
- Default to the latest build
- Use the same code in each implementation