### PR TITLE
buildextend-{aws,azure,gcp}: make uploading optional

### DIFF
--- a/src/cmd-buildextend-aws
+++ b/src/cmd-buildextend-aws
@@ -102,9 +102,17 @@ def run_ore():
                 'snapshot': ore_data['SnapshotID']}
     buildmeta['amis'] = [ami_data]
 
-# Do it!
-generate_aws_vmdk()
+
+# Generate the disk image to be uploaded
+if 'aws' not in buildmeta['images']:
+    generate_aws_vmdk()
+else:
+    print('AWS image already built. Skipping image creation')
+# Do the upload if asked
 if args.upload:
     run_ore()
+else:
+    print('--upload not passed. Skipping image upload to cloud')
+# Update the build metadata
 write_json(buildmeta_path, buildmeta)
 print(f"Updated: {buildmeta_path}")

--- a/src/cmd-buildextend-aws
+++ b/src/cmd-buildextend-aws
@@ -76,6 +76,7 @@ def generate_aws_vmdk():
             'size': size
         }
     })
+    write_json(buildmeta_path, buildmeta) # update build metadata
 
 def run_ore():
     ore_args = ['ore']
@@ -101,6 +102,7 @@ def run_ore():
                 'hvm': ore_data['HVM'],
                 'snapshot': ore_data['SnapshotID']}
     buildmeta['amis'] = [ami_data]
+    write_json(buildmeta_path, buildmeta) # update build metadata
 
 
 # Generate the disk image to be uploaded
@@ -113,6 +115,4 @@ if args.upload:
     run_ore()
 else:
     print('--upload not passed. Skipping image upload to cloud')
-# Update the build metadata
-write_json(buildmeta_path, buildmeta)
-print(f"Updated: {buildmeta_path}")
+print('buildextend-aws complete!')

--- a/src/cmd-buildextend-aws
+++ b/src/cmd-buildextend-aws
@@ -15,15 +15,20 @@ from cosalib.cmdlib import run_verbose, write_json, sha256sum_file
 # Parse args and dispatch
 parser = argparse.ArgumentParser()
 parser.add_argument("--build", help="Build ID")
-parser.add_argument("--region", help="EC2 region",
-                    required=True)
-parser.add_argument("--bucket", help="S3 Bucket",
-                    required=True)
+parser.add_argument("--region", help="EC2 region")
+parser.add_argument("--bucket", help="S3 Bucket")
 parser.add_argument("--name-suffix", help="Suffix for name")
 parser.add_argument("--grant-user", help="Grant user launch permission",
                     nargs="*", default=[])
 parser.add_argument("--log-level", help="ore log level")
+parser.add_argument("--upload", action='store_true', default=False,
+                    help="Upload to AWS")
 args = parser.parse_args()
+
+if args.upload:
+    for attr in ['region', 'bucket']:
+        if getattr(args, attr) is None:
+            raise Exception(f"Must provide --{attr} option in order to to upload")
 
 # Identify the builds and target the latest build if none provided
 builds = Builds()
@@ -42,6 +47,7 @@ if args.name_suffix:
 else:
     ami_name_version = f'{base_name}-{args.build}'
 aws_vmdk_name = f'{ami_name_version}-aws.vmdk'
+aws_vmdk_path = f"{builddir}/{aws_vmdk_name}"
 
 tmpdir='tmp/buildpost-aws'
 if os.path.isdir(tmpdir):
@@ -59,10 +65,19 @@ def generate_aws_vmdk():
                  '-o', 'adapter_type=lsilogic,subformat=streamOptimized,compat6',
                  tmp_img_aws_vmdk])
     os.unlink(tmp_img_aws)
-    return tmp_img_aws_vmdk
+    checksum = sha256sum_file(tmp_img_aws_vmdk)
+    size = os.path.getsize(tmp_img_aws_vmdk)
+    os.rename(tmp_img_aws_vmdk, aws_vmdk_path)
+    shutil.rmtree(tmpdir)
+    buildmeta['images'].update({
+        'aws': {
+            'path': aws_vmdk_name,
+            'sha256': checksum,
+            'size': size
+        }
+    })
 
 def run_ore():
-    tmp_img_aws_vmdk = generate_aws_vmdk()
     ore_args = ['ore']
     if args.log_level:
         ore_args.extend(['--log-level', args.log_level])
@@ -72,7 +87,7 @@ def run_ore():
                      '--ami-name', ami_name_version,
                      '--name', ami_name_version,
                      '--ami-description', f"{buildmeta['summary']} {args.build}",
-                     '--file', tmp_img_aws_vmdk,
+                     '--file', aws_vmdk_path,
                      '--disk-size-inspect',
                      '--delete-object',
                      '--force'])
@@ -80,25 +95,16 @@ def run_ore():
         ore_args.extend(['--grant-user', user])
     print("+ {}".format(subprocess.list2cmdline(ore_args)))
     ore_data = json.loads(subprocess.check_output(ore_args))
-    checksum = sha256sum_file(tmp_img_aws_vmdk)
-    size = os.path.getsize(tmp_img_aws_vmdk)
-    os.rename(tmp_img_aws_vmdk, f"{builddir}/{aws_vmdk_name}")
-    shutil.rmtree(tmpdir)
     # This matches the Container Linux schema:
     # https://stable.release.core-os.net/amd64-usr/current/coreos_production_ami_all.json
     ami_data = {'name': args.region,
                 'hvm': ore_data['HVM'],
                 'snapshot': ore_data['SnapshotID']}
     buildmeta['amis'] = [ami_data]
-    buildmeta['images'].update({
-        'aws': {
-            'path': aws_vmdk_name,
-            'sha256': checksum,
-            'size': size
-        }
-    })
-    write_json(buildmeta_path, buildmeta)
-    print(f"Updated: {buildmeta_path}")
 
 # Do it!
-run_ore()
+generate_aws_vmdk()
+if args.upload:
+    run_ore()
+write_json(buildmeta_path, buildmeta)
+print(f"Updated: {buildmeta_path}")

--- a/src/cmd-buildextend-azure
+++ b/src/cmd-buildextend-azure
@@ -101,6 +101,7 @@ class Build(_Build):
                 'size': size
             }
         })
+        self.meta_write() # update build metadata
 
 
 def cli():
@@ -192,6 +193,7 @@ def run_ore(args, build):
         'image': build.azure_vhd_name,
         'url': f"https://{url_path}",
     }
+    build.meta_write() # update build metadata
 
 if __name__ == '__main__':
     # parse provided args
@@ -215,7 +217,4 @@ if __name__ == '__main__':
         run_ore(args, build)
     else:
         print('--upload not passed. Skipping image upload to cloud')
-
-    # Update the metadata
-    build.meta_write()
-    print(f"Updated: Build Metadata")
+    print('buildextend-azure complete!')

--- a/src/cmd-buildextend-azure
+++ b/src/cmd-buildextend-azure
@@ -139,17 +139,10 @@ def cli():
     if args.upload:
         # Argument checks for environment strings that are required
         arg_exp_str = "parameter '--{}' or envVar '{}' must be defined when uploading"
-        if args.auth is None:
-            raise Exception(arg_exp_str.format('auth', 'AZURE_AUTH'))
-        if args.container is None:
-            raise Exception(arg_exp_str.format('container', 'AZURE_CONTAINER'))
-        if args.profile is None:
-            raise Exception(arg_exp_str.format('profile', 'AZURE_PROFILE'))
-        if args.resource_group is None:
-            raise Exception(arg_exp_str.format('resource_group', 'AZURE_RESOURCE_GROUP'))
-        if args.storage_account is None:
-            raise Exception(arg_exp_str.format('storage_account', 'AZURE_STORAGE_ACCOUNT'))
-
+        for attr in ['auth', 'container', 'profile',
+                     'resource_group', 'storage_account']:
+            if getattr(args, attr) is None:
+                raise Exception(arg_exp_str.format(attr, 'AZURE_' + attr.upper()))
 
     return args
 

--- a/src/cmd-buildextend-azure
+++ b/src/cmd-buildextend-azure
@@ -203,16 +203,18 @@ if __name__ == '__main__':
         args.build or 'latest',
         tmpbuilddir=os.path.abspath('tmp/buildpost-azure'))
 
-    if 'azure' in build.meta['images'] and not args.force:
-        print('Azure image already built; use --force to rebuild')
-        raise SystemExit()
-
     # Build the image artifacts
-    build.build_artifacts(cli_args=args)
+    if 'azure' in build.meta['images'] and not args.force:
+        print('Azure image is already built. Re-using that image. '
+              'Use --force to override!')
+    else:
+        build.build_artifacts(cli_args=args)
 
     # Do the upload if asked
     if args.upload:
         run_ore(args, build)
+    else:
+        print('--upload not passed. Skipping image upload to cloud')
 
     # Update the metadata
     build.meta_write()

--- a/src/cmd-buildextend-azure
+++ b/src/cmd-buildextend-azure
@@ -76,6 +76,7 @@ class Build(_Build):
         final_vhd = os.path.basename(tmp_img_azure_vhd)
         final_vhd_path = f"{self.build_dir}/{final_vhd}"
         os.rename(tmp_img_azure_vhd, final_vhd_path)
+        shutil.rmtree(self.tmpbuilddir)
 
         # TODO: This can be pulled out into a _Build method.
         fsize = os.stat(final_vhd_path).st_size
@@ -88,7 +89,18 @@ class Build(_Build):
         log.debug(
             " * size is %s",
             self._found_files[final_vhd_path]["size"])
-        # ---
+
+        # Update the metadata with info about the built image
+        checksum = sha256sum_file(final_vhd_path)
+        size = os.path.getsize(final_vhd_path)
+
+        self.meta['images'].update({
+            'azure': {
+                'path': build.azure_vhd_name,
+                'sha256': checksum,
+                'size': size
+            }
+        })
 
 
 def cli():
@@ -98,11 +110,11 @@ def cli():
     parser = argparse.ArgumentParser()
     parser.add_argument(
         '--auth', help='Path to Azure auth file',
-        required=True, default=os.environ.get("AZURE_AUTH"))
+        default=os.environ.get("AZURE_AUTH"))
     parser.add_argument('--build', help='Build ID')
     parser.add_argument(
         '--container', help='Storage location to write to',
-        required=True, default=os.environ.get("AZURE_CONTAINER"))
+        default=os.environ.get("AZURE_CONTAINER"))
     parser.add_argument(
         '--force', help='Replace existing images and upload',
         action='store_true',
@@ -111,41 +123,35 @@ def cli():
         default=os.environ.get("AZURE_LOCATION", "westus"))
     parser.add_argument(
         '--profile', help='Path to Azure profile',
-        required=True, default=os.environ.get('AZURE_PROFILE'))
+        default=os.environ.get('AZURE_PROFILE'))
     parser.add_argument(
-        '--resource-group', help='Resource group', required=True,
+        '--resource-group', help='Resource group',
         default=os.environ.get('AZURE_RESOURCE_GROUP'))
     parser.add_argument(
-        '--storage-account', help='Storage account', required=True,
+        '--storage-account', help='Storage account',
         default=os.environ.get('AZURE_STORAGE_ACCOUNT'))
     parser.add_argument("--log-level", help="ore log level")
+    parser.add_argument("--upload", action='store_true', default=False,
+                        help="Upload to Azure")
     args = parser.parse_args()
 
-    # Argument checks for environment strings that are required
-    arg_exp_str = "parameter '--{}' or envVar '{}' must be defined"
-    if args.auth is None:
-        raise Exception(arg_exp_str.format('auth', 'AZURE_AUTH'))
-    if args.container is None:
-        raise Exception(arg_exp_str.format('container', 'AZURE_CONTAINER'))
-    if args.profile is None:
-        raise Exception(arg_exp_str.format('profile', 'AZURE_PROFILE'))
-    if args.resource_group is None:
-        raise Exception(arg_exp_str.format('resource_group', 'AZURE_RESOURCE_GROUP'))
-    if args.storage_account is None:
-        raise Exception(arg_exp_str.format('storage_account', 'AZURE_STORAGE_ACCOUNT'))
+    if args.upload:
+        # Argument checks for environment strings that are required
+        arg_exp_str = "parameter '--{}' or envVar '{}' must be defined when uploading"
+        if args.auth is None:
+            raise Exception(arg_exp_str.format('auth', 'AZURE_AUTH'))
+        if args.container is None:
+            raise Exception(arg_exp_str.format('container', 'AZURE_CONTAINER'))
+        if args.profile is None:
+            raise Exception(arg_exp_str.format('profile', 'AZURE_PROFILE'))
+        if args.resource_group is None:
+            raise Exception(arg_exp_str.format('resource_group', 'AZURE_RESOURCE_GROUP'))
+        if args.storage_account is None:
+            raise Exception(arg_exp_str.format('storage_account', 'AZURE_STORAGE_ACCOUNT'))
 
-    # Identify the builds
-    build = Build(
-        os.path.join('builds'),
-        args.build or 'latest',
-        tmpbuilddir=os.path.abspath('tmp/buildpost-azure'))
 
-    if 'azure' in build.meta['images'] and not args.force:
-        print('Azure image already built; use --force to rebuild')
-        raise SystemExit()
+    return args
 
-    build.build_artifacts(cli_args=args)
-    run_ore(args, build)
 
 
 def run_ore(args, build):
@@ -178,9 +184,6 @@ def run_ore(args, build):
         ore_upload_args.append('--overwrite')
     run_verbose(ore_upload_args)
 
-    checksum = sha256sum_file(azure_vhd_path)
-    size = os.path.getsize(azure_vhd_path)
-
     url_path = urllib.parse.quote((
         f"{args.storage_account}.blob.core.windows.net/"
         f"{args.container}/{build.azure_vhd_name}"
@@ -189,16 +192,28 @@ def run_ore(args, build):
         'image': build.azure_vhd_name,
         'url': f"https://{url_path}",
     }
-    build.meta['images'].update({
-        'azure': {
-            'path': build.azure_vhd_name,
-            'sha256': checksum,
-            'size': size
-        }
-    })
-    build.meta_write()
-    print(f"Updated: Build Metadata")
-    shutil.rmtree(build.tmpbuilddir)
 
 if __name__ == '__main__':
-    cli()
+    # parse provided args
+    args = cli()
+
+    # Identify the builds
+    build = Build(
+        os.path.join('builds'),
+        args.build or 'latest',
+        tmpbuilddir=os.path.abspath('tmp/buildpost-azure'))
+
+    if 'azure' in build.meta['images'] and not args.force:
+        print('Azure image already built; use --force to rebuild')
+        raise SystemExit()
+
+    # Build the image artifacts
+    build.build_artifacts(cli_args=args)
+
+    # Do the upload if asked
+    if args.upload:
+        run_ore(args, build)
+
+    # Update the metadata
+    build.meta_write()
+    print(f"Updated: Build Metadata")

--- a/src/cmd-buildextend-azure
+++ b/src/cmd-buildextend-azure
@@ -65,7 +65,7 @@ class Build(_Build):
         tmp_img_azure_vhd = os.path.join(self.tmpbuilddir, self.azure_vhd_name)
 
         # Execute system commands
-        run_verbose([f"{cosa_dir}/gf-platformid",
+        run_verbose(['/usr/lib/coreos-assembler/gf-platformid',
                      img_qemu, tmp_img_azure, PLATFORM_AZURE])
         # Convert the qcow2 to a raw image
         # See: https://docs.openstack.org/image-guide/convert-images.html

--- a/src/cmd-buildextend-gcp
+++ b/src/cmd-buildextend-gcp
@@ -62,10 +62,6 @@ buildmeta_path = os.path.join(builddir, 'meta.json')
 with open(buildmeta_path) as f:
     buildmeta = json.load(f)
 
-if 'gcp' in buildmeta['images']:
-  print("GCP image already built")
-  sys.exit(0)
-
 # Name the base build and tarball name
 base_name = buildmeta['name']
 if args.name_suffix:
@@ -141,9 +137,16 @@ def run_ore():
     }
 
 
-# Do it!
-generate_gcp_tar()
+# Generate the disk image to be uploaded
+if 'gcp' not in buildmeta['images']:
+    generate_gcp_tar()
+else:
+    print('GCP image already built. Skipping image creation')
+# Do the upload if asked
 if args.upload:
     run_ore()
+else:
+    print('--upload not passed. Skipping image upload to cloud')
+# Update the build metadata
 write_json(buildmeta_path, buildmeta)
 print(f"Updated: {buildmeta_path}")

--- a/src/cmd-buildextend-gcp
+++ b/src/cmd-buildextend-gcp
@@ -37,16 +37,19 @@ parser.add_argument("--name-suffix", help="Append suffix to name",
 parser.add_argument("--project", help="GCP Project name",
                     default=os.environ.get("GCP_PROJECT_NAME"))
 parser.add_argument("--log-level", help="ore log level")
+parser.add_argument("--upload", action='store_true', default=False,
+                    help="Upload to GCP")
 args = parser.parse_args()
 
-# Argument checks for environment strings that are required
-arg_exp_str = "parameter '--{}' or envVar '{}' must be defined"
-if args.bucket is None:
-    raise Exception(arg_exp_str.format("bucket", "GCP_BUCKET"))
-if args.json_key is None:
-    raise Exception(arg_exp_str.format("json-key", "GCP_JSON_AUTH"))
-if args.project is None:
-    raise Exception(arg_exp_str.format("project", "GCP_PROJECT"))
+if args.upload:
+    # Argument checks for environment strings that are required
+    arg_exp_str = "parameter '--{}' or envVar '{}' must be defined"
+    if args.bucket is None:
+        raise Exception(arg_exp_str.format("bucket", "GCP_BUCKET"))
+    if args.json_key is None:
+        raise Exception(arg_exp_str.format("json-key", "GCP_JSON_AUTH"))
+    if args.project is None:
+        raise Exception(arg_exp_str.format("project", "GCP_PROJECT"))
 
 # Identify the builds and target the latest build if none provided
 builds = Builds()
@@ -70,6 +73,7 @@ if args.name_suffix:
 else:
     gcp_name_version = f'{base_name}-{args.build}'
 gcp_tarball_name = f'{gcp_name_version}-gcp.tar.gz'
+gcp_tarball_path = f"{builddir}/{gcp_tarball_name}"
 
 # Setup the tempdir
 tmpdir = 'tmp/buildpost-gcp'
@@ -94,12 +98,20 @@ def generate_gcp_tar():
                  f"disk.raw"])
     os.unlink(tmp_img_gcp)
     os.unlink(tmp_img_gcp_raw)
-    return tmp_img_gcp_tar
+    checksum = sha256sum_file(tmp_img_gcp_tar)
+    size = os.path.getsize(tmp_img_gcp_tar)
+    os.rename(tmp_img_gcp_tar, gcp_tarball_path)
+    shutil.rmtree(tmpdir)
+    buildmeta['images'].update({
+        'gcp': {
+            'path': gcp_tarball_name,
+            'sha256': checksum,
+            'size': size
+        }
+    })
 
 def run_ore():
     """ Execute ore to upload the tarball and register the image """
-    build_tarball = f"{builddir}/{gcp_tarball_name}"
-    tmp_img_gcp_tarball = generate_gcp_tar()
     ore_args = ['ore']
     if args.log_level:
         ore_args.extend(['--log-level', args.log_level])
@@ -113,13 +125,10 @@ def run_ore():
         '--bucket', f'gs://{args.bucket}/{base_name}',
         '--json-key', args.json_key,
         '--name', f'{args.build}',
-        '--file', tmp_img_gcp_tarball
+        '--file', gcp_tarball_path
     ])
 
     run_verbose(ore_args)
-    os.rename(tmp_img_gcp_tarball, build_tarball)
-    checksum = sha256sum_file(build_tarball)
-    size = os.path.getsize(build_tarball)
 
     gcp_name = f"{base_name}-{args.build.replace('.', '-')}"
     url_path = urllib.parse.quote((
@@ -130,17 +139,11 @@ def run_ore():
             'image': gcp_name,
             'url': f"https://{url_path}",
     }
-    buildmeta['images'].update({
-        'gcp': {
-            'path': gcp_tarball_name,
-            'sha256': checksum,
-            'size': size
-        }
-    })
-    write_json(buildmeta_path, buildmeta)
-    print(f"Updated: {buildmeta_path}")
-    shutil.rmtree(tmpdir)
 
 
 # Do it!
-run_ore()
+generate_gcp_tar()
+if args.upload:
+    run_ore()
+write_json(buildmeta_path, buildmeta)
+print(f"Updated: {buildmeta_path}")

--- a/src/cmd-buildextend-gcp
+++ b/src/cmd-buildextend-gcp
@@ -105,6 +105,7 @@ def generate_gcp_tar():
             'size': size
         }
     })
+    write_json(buildmeta_path, buildmeta) # update build metadata
 
 def run_ore():
     """ Execute ore to upload the tarball and register the image """
@@ -135,6 +136,7 @@ def run_ore():
             'image': gcp_name,
             'url': f"https://{url_path}",
     }
+    write_json(buildmeta_path, buildmeta) # update build metadata
 
 
 # Generate the disk image to be uploaded
@@ -147,6 +149,4 @@ if args.upload:
     run_ore()
 else:
     print('--upload not passed. Skipping image upload to cloud')
-# Update the build metadata
-write_json(buildmeta_path, buildmeta)
-print(f"Updated: {buildmeta_path}")
+print('buildextend-gcp complete!')


### PR DESCRIPTION
This makes it easier to test invidvidual pieces of the cloud provider
generation. It also would allow for people who want to build their own
image and then share the file with others to do so.