### PR TITLE
cmd-build: add `.images.ostree` to meta.json

### DIFF
--- a/README-design.md
+++ b/README-design.md
@@ -5,7 +5,7 @@ Builds
 ----
 
 coreos-assembler operates on a "build directory", which can contain multiple
-builds.  A build is a pairing of an OSTree commit (stored as `ostree-commit.tar`)
+builds.  A build is a pairing of an OSTree commit (stored as `*-ostree.tar`)
 as well as an optional set of disk images.
 
 This is in contrast to [rpm-ostree](https://github.com/projectatomic/rpm-ostree/)

--- a/src/cmd-build
+++ b/src/cmd-build
@@ -108,8 +108,13 @@ fi
 echo "Previous build: ${previous_build:-none}"
 
 previous_commit=
+previous_ostree_tarfile_path=
 if [ -n "${previous_build}" ]; then
     previous_commit=$(jq -r '.["ostree-commit"]' < "${previous_builddir}/meta.json")
+    previous_ostree_tarfile_path=$(jq -r '.images.ostree.path' < "${previous_builddir}/meta.json")
+    if [ "${previous_ostree_tarfile_path}" = "null" ]; then
+        previous_ostree_tarfile_path=ostree-commit.tar
+    fi
 fi
 echo "Previous commit: ${previous_commit:-none}"
 
@@ -120,9 +125,9 @@ if [ -n "${previous_commit}" ]; then
     commitpath=${tmprepo}/objects/${previous_commit::2}/${previous_commit:2}.commit
     commitpartial=${tmprepo}/state/${previous_commit}.commitpartial
     if [ ! -f "${commitpath}" ] || [ -f "${commitpartial}" ]; then
-        if [ -f "${previous_builddir}/ostree-commit.tar" ]; then
+        if [ -f "${previous_builddir}/${previous_ostree_tarfile_path}" ]; then
             mkdir tmp/prev_repo
-            tar -C tmp/prev_repo -xf "${previous_builddir}/ostree-commit.tar"
+            tar -C tmp/prev_repo -xf "${previous_builddir}/${previous_ostree_tarfile_path}"
             ostree pull-local --repo="${tmprepo}" tmp/prev_repo "${previous_commit}"
             rm -rf tmp/prev_repo
         else
@@ -293,10 +298,11 @@ if [ ! -f /lib/coreos-assembler/.clean ]; then
 fi
 
 # And create the ostree repo tarball containing the commit
+ostree_tarfile_path=${name}-${buildid}-ostree.tar
 ostree_tarfile_sha256=
 if [ "${commit}" == "${previous_commit}" ] && \
-    [ -f "${previous_builddir}/ostree-commit.tar" ]; then
-    cp -a --reflink=auto "${previous_builddir}/ostree-commit.tar" .
+    [ -f "${previous_builddir}/${previous_ostree_tarfile_path}" ]; then
+    cp -a --reflink=auto "${previous_builddir}/${previous_ostree_tarfile_path}" "${ostree_tarfile_path}"
     ostree_tarfile_sha256=$(jq -r '.images.ostree.sha256' < "${previous_builddir}/meta.json")
     # backcompat: allow older build without this field
     if [ "${ostree_tarfile_sha256}" = "null" ]; then
@@ -311,12 +317,12 @@ else
     # Don't compress; archive repos are already compressed individually and we'd
     # gain ~20M at best. We could probably have better gains if we compress the
     # whole repo in bare/bare-user mode, but that's a different story...
-    tar -cf ostree-commit.tar -C repo .
+    tar -cf "${ostree_tarfile_path}" -C repo .
     rm -rf repo
 fi
 
 if [ -z "${ostree_tarfile_sha256:-}" ]; then
-    ostree_tarfile_sha256=$(sha256sum ostree-commit.tar | awk '{print$1}')
+    ostree_tarfile_sha256=$(sha256sum "${ostree_tarfile_path}" | awk '{print$1}')
 fi
 
 # The base metadata, plus locations for code sources.
@@ -345,7 +351,7 @@ cat > tmp/images.json <<EOF
 {
   "images": {
     "ostree": {
-        "path": "ostree-commit.tar",
+        "path": "${ostree_tarfile_path}",
         "sha256": "${ostree_tarfile_sha256}",
         "size": $(stat --format=%s "${ostree_tarfile_path}")
     }

--- a/src/cmd-build
+++ b/src/cmd-build
@@ -292,6 +292,23 @@ if [ ! -f /lib/coreos-assembler/.clean ]; then
     src_location="bind mount"
 fi
 
+# And create the ostree repo tarball containing the commit
+if [ "${commit}" == "${previous_commit}" ] && \
+    [ -f "${previous_builddir}/ostree-commit.tar" ]; then
+    cp -a --reflink=auto "${previous_builddir}/ostree-commit.tar" .
+else
+    ostree init --repo=repo --mode=archive
+    ostree pull-local --repo=repo "${tmprepo}" "${ref}"
+    if [ -n "${ref_is_temp}" ]; then
+        ostree refs --repo=repo --delete "${ref}"
+    fi
+    # Don't compress; archive repos are already compressed individually and we'd
+    # gain ~20M at best. We could probably have better gains if we compress the
+    # whole repo in bare/bare-user mode, but that's a different story...
+    tar -cf ostree-commit.tar -C repo .
+    rm -rf repo
+fi
+
 # The base metadata, plus locations for code sources.
 # If the following condition is true, then /lib/coreos-assembler has been bind
 # mounted in and is using a different build tree.
@@ -349,23 +366,6 @@ mv "${lockfile_out}" .
 # And add the commit metadata itself, which includes notably the rpmdb pkglist
 # in a format that'd be easy to generate diffs out of for higher level tools
 "${dn}"/commitmeta_to_json "${tmprepo}" "${commit}" > commitmeta.json
-
-# And create the ostree repo tarball containing the commit
-if [ "${commit}" == "${previous_commit}" ] && \
-    [ -f "${previous_builddir}/ostree-commit.tar" ]; then
-    cp -a --reflink=auto "${previous_builddir}/ostree-commit.tar" .
-else
-    ostree init --repo=repo --mode=archive
-    ostree pull-local --repo=repo "${tmprepo}" "${ref}"
-    if [ -n "${ref_is_temp}" ]; then
-        ostree refs --repo=repo --delete "${ref}"
-    fi
-    # Don't compress; archive repos are already compressed individually and we'd
-    # gain ~20M at best. We could probably have better gains if we compress the
-    # whole repo in bare/bare-user mode, but that's a different story...
-    tar -cf ostree-commit.tar -C repo .
-    rm -rf repo
-fi
 
 # Clean up our temporary data
 saved_build_tmpdir="${workdir}/tmp/last-build-tmp"

--- a/src/cmd-build
+++ b/src/cmd-build
@@ -293,9 +293,15 @@ if [ ! -f /lib/coreos-assembler/.clean ]; then
 fi
 
 # And create the ostree repo tarball containing the commit
+ostree_tarfile_sha256=
 if [ "${commit}" == "${previous_commit}" ] && \
     [ -f "${previous_builddir}/ostree-commit.tar" ]; then
     cp -a --reflink=auto "${previous_builddir}/ostree-commit.tar" .
+    ostree_tarfile_sha256=$(jq -r '.images.ostree.sha256' < "${previous_builddir}/meta.json")
+    # backcompat: allow older build without this field
+    if [ "${ostree_tarfile_sha256}" = "null" ]; then
+        ostree_tarfile_sha256=
+    fi
 else
     ostree init --repo=repo --mode=archive
     ostree pull-local --repo=repo "${tmprepo}" "${ref}"
@@ -307,6 +313,10 @@ else
     # whole repo in bare/bare-user mode, but that's a different story...
     tar -cf ostree-commit.tar -C repo .
     rm -rf repo
+fi
+
+if [ -z "${ostree_tarfile_sha256:-}" ]; then
+    ostree_tarfile_sha256=$(sha256sum ostree-commit.tar | awk '{print$1}')
 fi
 
 # The base metadata, plus locations for code sources.
@@ -331,7 +341,17 @@ cat > tmp/meta.json <<EOF
 }
 EOF
 
-echo '{ "images": {} }' > tmp/images.json
+cat > tmp/images.json <<EOF
+{
+  "images": {
+    "ostree": {
+        "path": "ostree-commit.tar",
+        "sha256": "${ostree_tarfile_sha256}",
+        "size": $(stat --format=%s "${ostree_tarfile_path}")
+    }
+  }
+}
+EOF
 
 overridesjson=tmp/overrides.json
 if [ -f "${overrides_active_stamp}" ]; then

--- a/src/cmd-buildextend-installer
+++ b/src/cmd-buildextend-installer
@@ -365,7 +365,10 @@ def generate_iso():
     print(f"Updated: {buildmeta_path}")
 
 
-commit_tar = os.path.join(builddir, 'ostree-commit.tar')
+commit_tar_name = 'ostree-commit.tar'
+if 'ostree' in buildmeta['images']:
+    commit_tar_name = buildmeta['images']['ostree']['path']
+commit_tar = os.path.join(builddir, commit_tar_name)
 import_ostree_commit(repo, buildmeta_commit, commit_tar)
 
 # Do it!

--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -128,7 +128,11 @@ if [ "${rev_parsed}" != "${commit}" ]; then
     echo "Cache for build ${build} is gone"
     echo "Importing commit ${commit} into temporary OSTree repo"
     mkdir -p tmp/repo
-    tar -C tmp/repo -xf "${builddir}/ostree-commit.tar"
+    commit_tar_name=$(jq -r .images.ostree.path < "${builddir}/meta.json")
+    if [ "${commit_tar_name}" = null ]; then
+        commit_tar_name=ostree-commit.tar
+    fi
+    tar -C tmp/repo -xf "${builddir}/${commit_tar_name}"
     ostree_repo=$PWD/tmp/repo
     if [ -n "${ref_is_temp}" ]; then
         # this gets promptly "dereferenced" back in run_virtinstall, but it

--- a/src/cmd-buildprep
+++ b/src/cmd-buildprep
@@ -56,10 +56,15 @@ def main():
     builddir = builddir[len("builds/"):]
 
     objects = ['meta.json', 'ostree-commit-object']
-    if args.ostree:
-        objects += ['ostree-commit.tar']
-
     for f in objects:
+        fetcher.fetch(f'{builddir}/{f}')
+
+    buildmeta = load_json(f'builds/{builddir}/meta.json')
+
+    if args.ostree:
+        f = 'ostree-commit.tar'
+        if 'ostree' in buildmeta['images']:
+            f = buildmeta['images']['ostree']['path']
         fetcher.fetch(f'{builddir}/{f}')
 
     # and finally the symlink
@@ -68,7 +73,6 @@ def main():
 
     # also nuke the any local matching OStree ref, since we want to build on
     # top of this new one
-    buildmeta = load_json(f'builds/{builddir}/meta.json')
     if 'ref' in buildmeta and os.path.isdir('tmp/repo'):
         subprocess.check_call(['ostree', 'refs', '--repo', 'tmp/repo',
                                '--delete', buildmeta['ref']],

--- a/src/cmd-compress
+++ b/src/cmd-compress
@@ -41,7 +41,7 @@ else:
 print(f"Targeting build: {build}")
 
 # Don't compress certain images
-imgs_to_skip = ["iso", "live-iso", "vmware", "initramfs", "live-initramfs", "kernel", "live-kernel"]
+imgs_to_skip = ["ostree", "iso", "live-iso", "vmware", "initramfs", "live-initramfs", "kernel", "live-kernel"]
 
 
 def get_cpu_param(param):


### PR DESCRIPTION
 We really should have the checksum for the tarfile in there so that
 anyone downloading it can integrity check it. This will be used by
 `coreos-ostree-importer` at least.
