### PR TITLE
cmd-build*: add architecture into artifact names

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -298,7 +298,7 @@ if [ ! -f /lib/coreos-assembler/.clean ]; then
 fi
 
 # And create the ostree repo tarball containing the commit
-ostree_tarfile_path=${name}-${buildid}-ostree.tar
+ostree_tarfile_path=${name}-${buildid}-ostree.${basearch}.tar
 ostree_tarfile_sha256=
 if [ "${commit}" == "${previous_commit}" ] && \
     [ -f "${previous_builddir}/${previous_ostree_tarfile_path}" ]; then

--- a/src/cmd-buildextend-aws
+++ b/src/cmd-buildextend-aws
@@ -10,7 +10,7 @@ import tempfile,hashlib,gzip
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from cosalib.builds import Builds
-from cosalib.cmdlib import run_verbose, write_json, sha256sum_file
+from cosalib.cmdlib import run_verbose, write_json, sha256sum_file, get_basearch
 
 # Parse args and dispatch
 parser = argparse.ArgumentParser()
@@ -41,12 +41,13 @@ buildmeta_path = os.path.join(builddir, 'meta.json')
 with open(buildmeta_path) as f:
     buildmeta = json.load(f)
 
+arch = get_basearch()
 base_name = buildmeta['name']
 if args.name_suffix:
     ami_name_version = f'{base_name}-{args.name_suffix}-{args.build}'
 else:
     ami_name_version = f'{base_name}-{args.build}'
-aws_vmdk_name = f'{ami_name_version}-aws.vmdk'
+aws_vmdk_name = f'{ami_name_version}-aws.{arch}.vmdk'
 aws_vmdk_path = f"{builddir}/{aws_vmdk_name}"
 
 tmpdir='tmp/buildpost-aws'

--- a/src/cmd-buildextend-azure
+++ b/src/cmd-buildextend-azure
@@ -19,6 +19,7 @@ from cosalib.builds import Builds
 
 # pylint: disable=C0413
 from cosalib.cmdlib import (
+        get_basearch,
         run_verbose,
         sha256sum_file,
         write_json)
@@ -55,7 +56,8 @@ class Build(_Build):
         azure_nv = f'{base_name}-{self.build_id}'
 
         # Used in referencing
-        self.azure_vhd_name = f'{azure_nv}-azure.vhd'
+        arch = get_basearch()
+        self.azure_vhd_name = f'{azure_nv}-azure.{arch}.vhd'
 
         # Generate path locations
         img_qemu = os.path.join(

--- a/src/cmd-buildextend-gcp
+++ b/src/cmd-buildextend-gcp
@@ -18,6 +18,7 @@ sys.path.insert(0, cosa_dir)
 # pylint: disable=C0413
 from cosalib.builds import Builds
 from cosalib.cmdlib import (
+        get_basearch,
         run_verbose,
         sha256sum_file,
         write_json)
@@ -63,12 +64,13 @@ with open(buildmeta_path) as f:
     buildmeta = json.load(f)
 
 # Name the base build and tarball name
+arch = get_basearch()
 base_name = buildmeta['name']
 if args.name_suffix:
     gcp_name_version = f'{base_name}-{args.name_suffix}-{args.build}'
 else:
     gcp_name_version = f'{base_name}-{args.build}'
-gcp_tarball_name = f'{gcp_name_version}-gcp.tar.gz'
+gcp_tarball_name = f'{gcp_name_version}-gcp.{arch}.tar.gz'
 gcp_tarball_path = f"{builddir}/{gcp_tarball_name}"
 
 # Setup the tempdir

--- a/src/cmd-buildextend-installer
+++ b/src/cmd-buildextend-installer
@@ -70,8 +70,9 @@ if meta_keys['iso'] in buildmeta['images'] and not args.force:
     print("You can force a rebuild with '--force'.")
     sys.exit(0)
 
+arch = get_basearch()
 base_name = buildmeta['name']
-iso_name = f'{base_name}-{args.build}-{image_type}.iso'
+iso_name = f'{base_name}-{args.build}-{image_type}.{arch}.iso'
 name_version = f'{base_name}-{args.build}'
 
 tmpdir = os.environ.get("FORCE_TMPDIR", f"{workdir}/tmp/buildpost-{image_type}")
@@ -92,7 +93,6 @@ os.mkdir(tmpisoisolinux)
 initrd_ignition_padding = 256 * 1024
 
 def generate_iso():
-    arch = get_basearch()
     tmpisofile = os.path.join(tmpdir, iso_name)
     img_qemu = os.path.join(builddir, buildmeta['images']['qemu']['path'])
 
@@ -327,8 +327,8 @@ def generate_iso():
             isofh.write(struct.pack(fmt, b'coreiso+', offset, initrd_ignition_padding))
             print(f'Embedded {initrd_ignition_padding} bytes Ignition config space at {offset}')
 
-    kernel_name = f'{base_name}-{args.build}-{image_type}-kernel'
-    initramfs_name = f'{base_name}-{args.build}-{image_type}-initramfs.img'
+    kernel_name = f'{base_name}-{args.build}-{image_type}-kernel-{arch}'
+    initramfs_name = f'{base_name}-{args.build}-{image_type}-initramfs.{arch}.img'
     kernel_file = os.path.join(builddir, kernel_name)
     initramfs_file = os.path.join(builddir, initramfs_name)
     shutil.copyfile(os.path.join(tmpisoimages, "vmlinuz"), kernel_file)

--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -146,7 +146,7 @@ if [[ $image_type == qemu ]]; then
     image_format=qcow2
 fi
 
-img=${name}-${build}-${image_type}.${image_format}
+img=${name}-${build}-${image_type}.${arch}.${image_format}
 path=${PWD}/${img}
 
 # For bare metal images, we estimate the disk size. For qemu, we get it from

--- a/src/cmd-buildextend-openstack
+++ b/src/cmd-buildextend-openstack
@@ -12,7 +12,7 @@ import argparse
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from cosalib.builds import Builds
-from cosalib.cmdlib import run_verbose, write_json, sha256sum_file
+from cosalib.cmdlib import run_verbose, write_json, sha256sum_file, get_basearch
 
 # Parse args and dispatch
 parser = argparse.ArgumentParser()
@@ -30,9 +30,10 @@ buildmeta_path = os.path.join(builddir, 'meta.json')
 with open(buildmeta_path) as f:
     buildmeta = json.load(f)
 
+arch = get_basearch()
 base_name = buildmeta['name']
 img_prefix = f'{base_name}-{args.build}'
-openstack_name = f'{img_prefix}-openstack.qcow2'
+openstack_name = f'{img_prefix}-openstack.{arch}.qcow2'
 
 tmpdir = 'tmp/buildpost-openstack'
 if os.path.isdir(tmpdir):

--- a/src/cmd-buildextend-vmware
+++ b/src/cmd-buildextend-vmware
@@ -12,7 +12,12 @@ import tarfile
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from cosalib.builds import Builds
-from cosalib.cmdlib import run_verbose, load_json, write_json, sha256sum_file
+from cosalib.cmdlib import (
+        get_basearch,
+        load_json,
+        run_verbose,
+        sha256sum_file,
+        write_json)
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--build", help="Build ID")
@@ -24,11 +29,12 @@ if not args.build:
     args.build = builds.get_latest()
 print(f"Targeting build: {args.build}")
 
+arch = get_basearch()
 builddir = builds.get_build_dir(args.build)
 buildmeta_path = os.path.join(builddir, 'meta.json')
 buildmeta = load_json(buildmeta_path)
 base_name = buildmeta['name']
-vmware_prefix = f'{base_name}-{args.build}-vmware'
+vmware_prefix = f'{base_name}-{args.build}-vmware.{arch}'
 ova_name = f'{vmware_prefix}.ova'
 
 try:


### PR DESCRIPTION
We'd like to include the arch in each artifact name so that we can
disambiguate more easily. This will allow for one to download files
from different architectures into the same directory and not have
conflicts.

Fixes: https://github.com/coreos/fedora-coreos-tracker/issues/264
