### PR TITLE
cosalib/meta: make workdir optional

### DIFF
--- a/src/cosalib/meta.py
+++ b/src/cosalib/meta.py
@@ -12,8 +12,8 @@ class GenericBuildMeta(dict):
     GenericBuildMeta interacts with a builds meta.json
     """
 
-    def __init__(self, workdir, build='latest'):
-        builds = Builds(os.path.dirname(workdir))
+    def __init__(self, workdir=None, build='latest'):
+        builds = Builds(workdir)
         if build != "latest":
             if not builds.has(build):
                 raise Exception('Build was not found in builds.json')

--- a/tests/test_cosalib_meta.py
+++ b/tests/test_cosalib_meta.py
@@ -40,18 +40,16 @@ def _create_test_files(tmpdir):
     os.makedirs(metadir, exist_ok=True)
     with open(os.path.join(metadir, 'meta.json'), 'w') as f:
         f.write(json.dumps(data))
-    return buildsdir
+    return tmpdir
 
 
 def test_init(tmpdir):
-    buildsdir = _create_test_files(tmpdir)
-    m = meta.GenericBuildMeta(buildsdir, '1.2.3')
+    m = meta.GenericBuildMeta(_create_test_files(tmpdir), '1.2.3')
     assert m['test'] is not None
 
 
 def test_get(tmpdir):
-    buildsdir = _create_test_files(tmpdir)
-    m = meta.GenericBuildMeta(buildsdir, '1.2.3')
+    m = meta.GenericBuildMeta(_create_test_files(tmpdir), '1.2.3')
     assert m.get('test') == 'data'
     assert m.get('a', 'b') == 'c'
     with pytest.raises(KeyError):
@@ -62,8 +60,7 @@ def test_set(tmpdir):
     """
     Verify setting works as expected.
     """
-    buildsdir = _create_test_files(tmpdir)
-    m = meta.GenericBuildMeta(buildsdir, '1.2.3')
+    m = meta.GenericBuildMeta(_create_test_files(tmpdir), '1.2.3')
     m.set('test', 'changed')
     m.write()
     assert m.get('test') == 'changed'
@@ -80,6 +77,5 @@ def test_str(tmpdir):
     Verifies the string representation is exactly the same as the
     instance dict.
     """
-    buildsdir = _create_test_files(tmpdir)
-    m = meta.GenericBuildMeta(buildsdir, '1.2.3')
+    m = meta.GenericBuildMeta(_create_test_files(tmpdir), '1.2.3')
     assert dict(m) == json.loads(str(m))


### PR DESCRIPTION
This matches the semantics for `Builds` too. I want to make use of this
class in `cosa sign`.

This also fixes a bug where we were passing the parent dir to `Builds()`
instead of the workdir directly.