### PR TITLE
src/*: rename arch -> basearch and ARCH -> BASEARCH

### DIFF
--- a/src/cmd-buildextend-aws
+++ b/src/cmd-buildextend-aws
@@ -41,13 +41,13 @@ buildmeta_path = os.path.join(builddir, 'meta.json')
 with open(buildmeta_path) as f:
     buildmeta = json.load(f)
 
-arch = get_basearch()
+basearch = get_basearch()
 base_name = buildmeta['name']
 if args.name_suffix:
     ami_name_version = f'{base_name}-{args.name_suffix}-{args.build}'
 else:
     ami_name_version = f'{base_name}-{args.build}'
-aws_vmdk_name = f'{ami_name_version}-aws.{arch}.vmdk'
+aws_vmdk_name = f'{ami_name_version}-aws.{basearch}.vmdk'
 aws_vmdk_path = f"{builddir}/{aws_vmdk_name}"
 
 tmpdir='tmp/buildpost-aws'

--- a/src/cmd-buildextend-azure
+++ b/src/cmd-buildextend-azure
@@ -56,8 +56,8 @@ class Build(_Build):
         azure_nv = f'{base_name}-{self.build_id}'
 
         # Used in referencing
-        arch = get_basearch()
-        self.azure_vhd_name = f'{azure_nv}-azure.{arch}.vhd'
+        basearch = get_basearch()
+        self.azure_vhd_name = f'{azure_nv}-azure.{basearch}.vhd'
 
         # Generate path locations
         img_qemu = os.path.join(

--- a/src/cmd-buildextend-gcp
+++ b/src/cmd-buildextend-gcp
@@ -64,13 +64,13 @@ with open(buildmeta_path) as f:
     buildmeta = json.load(f)
 
 # Name the base build and tarball name
-arch = get_basearch()
+basearch = get_basearch()
 base_name = buildmeta['name']
 if args.name_suffix:
     gcp_name_version = f'{base_name}-{args.name_suffix}-{args.build}'
 else:
     gcp_name_version = f'{base_name}-{args.build}'
-gcp_tarball_name = f'{gcp_name_version}-gcp.{arch}.tar.gz'
+gcp_tarball_name = f'{gcp_name_version}-gcp.{basearch}.tar.gz'
 gcp_tarball_path = f"{builddir}/{gcp_tarball_name}"
 
 # Setup the tempdir

--- a/src/cmd-buildextend-installer
+++ b/src/cmd-buildextend-installer
@@ -70,9 +70,9 @@ if meta_keys['iso'] in buildmeta['images'] and not args.force:
     print("You can force a rebuild with '--force'.")
     sys.exit(0)
 
-arch = get_basearch()
+basearch = get_basearch()
 base_name = buildmeta['name']
-iso_name = f'{base_name}-{args.build}-{image_type}.{arch}.iso'
+iso_name = f'{base_name}-{args.build}-{image_type}.{basearch}.iso'
 name_version = f'{base_name}-{args.build}'
 
 tmpdir = os.environ.get("FORCE_TMPDIR", f"{workdir}/tmp/buildpost-{image_type}")
@@ -183,7 +183,7 @@ def generate_iso():
                   '-rational-rock', '-J', '-joliet-long']
 
     ### For x86_64 legacy boot (BIOS) booting
-    if arch == "x86_64":
+    if basearch == "x86_64":
         # Install binaries from syslinux package
         isolinuxfiles = [('/usr/share/syslinux/isolinux.bin', 0o755),
                          ('/usr/share/syslinux/ldlinux.c32',  0o755),
@@ -202,10 +202,10 @@ def generate_iso():
                        '-boot-load-size', '4',
                        '-boot-info-table']
 
-    elif arch == "ppc64le":
+    elif basearch == "ppc64le":
         genisoargs += ['-r', '-l', '-sysid', 'PPC',
                        '-chrp-boot', '-graft-points']
-    elif arch == "s390x":
+    elif basearch == "s390x":
         # combine kernel, initramfs and cmdline using lorax/mk-s390-cdboot tool
         run_verbose(['/usr/bin/mk-s390-cdboot',
                      '-i', os.path.join(tmpisoimages, 'vmlinuz'),
@@ -219,7 +219,7 @@ def generate_iso():
                       os.path.join(os.path.relpath(tmpisoimages, tmpisoroot), 'fcos.img')]
 
     ### For x86_64 and aarch64 UEFI booting
-    if arch in ("x86_64", "aarch64"):
+    if basearch in ("x86_64", "aarch64"):
         # Create the efiboot.img file. This is a fat32 formatted
         # filesystem that contains all the files needed for EFI boot
         # from an ISO.
@@ -280,7 +280,7 @@ def generate_iso():
     run_verbose(genisoargs)
 
     # Add MBR for x86_64 legacy (BIOS) boot when ISO is copied to a USB stick
-    if arch == "x86_64":
+    if basearch == "x86_64":
         run_verbose(['/usr/bin/isohybrid', tmpisofile])
 
     # We've already padded the initrd with initrd_ignition_padding bytes of
@@ -299,7 +299,7 @@ def generate_iso():
     #
     # Skip on s390x because that platform uses an embedded El Torito image
     # with its own copy of the initramfs.
-    if is_live and arch != "s390x":
+    if is_live and basearch != "s390x":
         isoinfo = run_verbose(['isoinfo', '-lR', '-i', tmpisofile],
                 stdout=subprocess.PIPE, text=True)
         # -rw-rw-r--   1 1750 1750       553961457 Sep 18 2019 [   4733 00]  initramfs.img 
@@ -327,8 +327,8 @@ def generate_iso():
             isofh.write(struct.pack(fmt, b'coreiso+', offset, initrd_ignition_padding))
             print(f'Embedded {initrd_ignition_padding} bytes Ignition config space at {offset}')
 
-    kernel_name = f'{base_name}-{args.build}-{image_type}-kernel-{arch}'
-    initramfs_name = f'{base_name}-{args.build}-{image_type}-initramfs.{arch}.img'
+    kernel_name = f'{base_name}-{args.build}-{image_type}-kernel-{basearch}'
+    initramfs_name = f'{base_name}-{args.build}-{image_type}-initramfs.{basearch}.img'
     kernel_file = os.path.join(builddir, kernel_name)
     initramfs_file = os.path.join(builddir, initramfs_name)
     shutil.copyfile(os.path.join(tmpisoimages, "vmlinuz"), kernel_file)

--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -62,7 +62,7 @@ if [ $# -ne 0 ]; then
     fatal "Too many arguments passed"
 fi
 
-case "$arch" in
+case "$basearch" in
     "x86_64"|"aarch64"|"s390x") use_anaconda=;;
     *)
         # for qemu, we can fallback to Anaconda
@@ -71,13 +71,13 @@ case "$arch" in
         else
             # otherwise, we don't know how to create bare metal images for this
             # architecture
-            fatal "$arch is not supported for this command"
+            fatal "$basearch is not supported for this command"
         fi
         ;;
 esac
 
-if [[ "$arch" != "s390x" && $image_type == dasd ]]; then
-    fatal "$arch is not supported for building dasd images"
+if [[ "$basearch" != "s390x" && $image_type == dasd ]]; then
+    fatal "$basearch is not supported for building dasd images"
 fi
 
 export LIBGUESTFS_BACKEND=direct
@@ -146,7 +146,7 @@ if [[ $image_type == qemu ]]; then
     image_format=qcow2
 fi
 
-img=${name}-${build}-${image_type}.${arch}.${image_format}
+img=${name}-${build}-${image_type}.${basearch}.${image_format}
 path=${PWD}/${img}
 
 # For bare metal images, we estimate the disk size. For qemu, we get it from
@@ -167,7 +167,7 @@ fi
 kargs="$(python3 -c 'import sys, yaml; args = yaml.safe_load(sys.stdin).get("extra-kargs", []); print(" ".join(args))' < "$configdir/image.yaml")"
 tty="console=tty0 console=${DEFAULT_TERMINAL},115200n8"
 # tty0 does not exist on s390x
-if [ "$arch" == "s390x" ]; then
+if [ "$basearch" == "s390x" ]; then
     tty="console=${DEFAULT_TERMINAL}"
 fi
 kargs="$kargs $tty ignition.platform.id=$ignition_platform_id"

--- a/src/cmd-buildextend-openstack
+++ b/src/cmd-buildextend-openstack
@@ -30,10 +30,10 @@ buildmeta_path = os.path.join(builddir, 'meta.json')
 with open(buildmeta_path) as f:
     buildmeta = json.load(f)
 
-arch = get_basearch()
+basearch = get_basearch()
 base_name = buildmeta['name']
 img_prefix = f'{base_name}-{args.build}'
-openstack_name = f'{img_prefix}-openstack.{arch}.qcow2'
+openstack_name = f'{img_prefix}-openstack.{basearch}.qcow2'
 
 tmpdir = 'tmp/buildpost-openstack'
 if os.path.isdir(tmpdir):

--- a/src/cmd-buildextend-vmware
+++ b/src/cmd-buildextend-vmware
@@ -29,12 +29,12 @@ if not args.build:
     args.build = builds.get_latest()
 print(f"Targeting build: {args.build}")
 
-arch = get_basearch()
+basearch = get_basearch()
 builddir = builds.get_build_dir(args.build)
 buildmeta_path = os.path.join(builddir, 'meta.json')
 buildmeta = load_json(buildmeta_path)
 base_name = buildmeta['name']
-vmware_prefix = f'{base_name}-{args.build}-vmware.{arch}'
+vmware_prefix = f'{base_name}-{args.build}-vmware.{basearch}'
 ova_name = f'{vmware_prefix}.ova'
 
 try:

--- a/src/cmd-koji-upload
+++ b/src/cmd-koji-upload
@@ -45,7 +45,7 @@ except IOError:
     HOST_OS = "unknown"
 
 # ARCH is the current machine architecture
-ARCH = get_basearch()
+BASEARCH = get_basearch()
 
 COSA_INPATH = "/cosa"
 
@@ -55,24 +55,24 @@ COSA_INPATH = "/cosa"
 #   is unknown to Koji, then the upload will fail.
 KOJI_CG_TYPES = {
     # key: (description, extension, architecture, type)
-    "iso": ("CD/DVD Image", "iso", ARCH, "image"),
+    "iso": ("CD/DVD Image", "iso", BASEARCH, "image"),
     "json": ("JSON data", "json", "noarch", "source"),
     "log": ("log file", "log", "noarch", "log"),
     "ova": ("Open Virtualization Archive", "ova", ARCH, "image"),
-    "qcow": ("QCOW image", "qcow", ARCH, "image"),
-    "qcow2": ("QCOW2 image", "qcow2", ARCH, "image"),
-    "qcow2.gz": ("Compressed QCOW2", "qcow2.gz", ARCH, "image"),
-    "qcow2.xz": ("Compressed QCOW2", "qcow2.gz", ARCH, "image"),
-    "raw": ("Raw disk image", "raw", ARCH, "image"),
-    "raw.gz": ("Compressed Raw", "raw.gz", ARCH, "image"),
-    "raw.xz": ("Compressed Raw", "raw.xz", ARCH, "image"),
+    "qcow": ("QCOW image", "qcow", BASEARCH, "image"),
+    "qcow2": ("QCOW2 image", "qcow2", BASEARCH, "image"),
+    "qcow2.gz": ("Compressed QCOW2", "qcow2.gz", BASEARCH, "image"),
+    "qcow2.xz": ("Compressed QCOW2", "qcow2.gz", BASEARCH, "image"),
+    "raw": ("Raw disk image", "raw", BASEARCH, "image"),
+    "raw.gz": ("Compressed Raw", "raw.gz", BASEARCH, "image"),
+    "raw.xz": ("Compressed Raw", "raw.xz", BASEARCH, "image"),
     "tar": ("Tar file", "tar", "noarch", "source"),
     "tar.gz": ("Tar file", "tar.gz", "noarch", "source"),
     "tar.xz": ("Tar file", "tar.xz", "noarch", "source"),
-    "vdi": ("VirtualBox Virtual Disk Image", "vdi", ARCH, "image"),
-    "vhd": ("Hyper-V image", "vhd", ARCH, "image"),
-    "vhdx": ("Hyper-V Virtual Hard Disk v2 image", "vhdx", ARCH, "image"),
-    "vmdk": ("vSphere image", "vmdk", ARCH, "image"),
+    "vdi": ("VirtualBox Virtual Disk Image", "vdi", BASEARCH, "image"),
+    "vhd": ("Hyper-V image", "vhd", BASEARCH, "image"),
+    "vhdx": ("Hyper-V Virtual Hard Disk v2 image", "vhdx", BASEARCH, "image"),
+    "vmdk": ("vSphere image", "vmdk", BASEARCH, "image"),
     "yaml": ("YAML data", "yaml", "noarch", "source")
 }
 
@@ -450,7 +450,7 @@ class Upload():
                 "extra": {
                     "typeinfo": {
                         "image": {
-                            "arch": ARCH
+                            "arch": BASEARCH
                         }
                     }
                 },

--- a/src/cosalib/build.py
+++ b/src/cosalib/build.py
@@ -18,7 +18,7 @@ from cosalib.cmdlib import (
 from cosalib.builds import Builds
 
 # ARCH is the current machine architecture
-ARCH = get_basearch()
+BASEARCH = get_basearch()
 
 
 class BuildError(Exception):
@@ -87,7 +87,7 @@ class _Build:
             raise BuildError("%s %s" % self.__file("meta"), emsg)
 
         log.info("Proccessed build for: %s (%s-%s) %s",
-                 self.summary, self.build_name.upper(), self.arch,
+                 self.summary, self.build_name.upper(), self.basearch,
                  self.build_id)
 
     def _create_work_dir(self):
@@ -117,9 +117,9 @@ class _Build:
         return self._workdir
 
     @property
-    def arch(self):
+    def basearch(self):
         """ get the build arch """
-        return ARCH
+        return BASEARCH
 
     @property
     def build_id(self):

--- a/src/virt-install
+++ b/src/virt-install
@@ -286,17 +286,17 @@ try:
         # https://bugzilla.redhat.com/show_bug.cgi?id=1659242
 
         # set correct location of the kernel image and initrd
-        arch = get_basearch()
-        if arch == "x86_64" or arch == "i386":
+        basearch = get_basearch()
+        if basearch == "x86_64" or arch == "i386":
             location_arg += ",kernel=isolinux/vmlinuz,initrd=isolinux/initrd.img"
-        elif arch == "ppc64le":
+        elif basearch == "ppc64le":
             location_arg += ",kernel=ppc/ppc64/vmlinuz,initrd=ppc/ppc64/initrd.img"
-        elif arch == "aarch64":
+        elif basearch == "aarch64":
             location_arg += ",kernel=images/pxeboot/vmlinuz,initrd=images/pxeboot/initrd.img"
-        elif arch == "s390x":
+        elif basearch == "s390x":
             location_arg += ",kernel=images/kernel.img,initrd=images/initrd.img"
         else:
-            raise SystemExit("Unknown machine architecture "+arch+" can't determine the kernel and initrd location")
+            raise SystemExit("Unknown machine architecture "+basearch+" can't determine the kernel and initrd location")
 
     vinstall_args.extend(["--wait={}".format(args.wait), "--noreboot", "--nographics",
                           "--memory={}".format(args.memory), get_libvirt_smp_arg(),


### PR DESCRIPTION
Since we are using the get_basearch function we'll use basearch instead
of arch for the variable names. basearch is a yum/dnf concept to group
binary compatibile architectures and not exactly matching up with uname.

See also e02ef26
