### PR TITLE
Drop support for i386 host systems

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -100,7 +100,6 @@ declare -A repository_dirs
 repository_dirs[aarch64]=fedora/linux
 repository_dirs[armhfp]=fedora/linux
 repository_dirs[x86_64]=fedora/linux
-repository_dirs[i386]=fedora-secondary
 repository_dirs[ppc64le]=fedora-secondary
 repository_dirs[s390x]=fedora-secondary
 

--- a/src/virt-install
+++ b/src/virt-install
@@ -287,7 +287,7 @@ try:
 
         # set correct location of the kernel image and initrd
         basearch = get_basearch()
-        if basearch == "x86_64" or arch == "i386":
+        if basearch == "x86_64":
             location_arg += ",kernel=isolinux/vmlinuz,initrd=isolinux/initrd.img"
         elif basearch == "ppc64le":
             location_arg += ",kernel=ppc/ppc64/vmlinuz,initrd=ppc/ppc64/initrd.img"


### PR DESCRIPTION
Fedora stopped building 32-bit x86 kernels and F31 will be the first
release without i386 repos altogether:

https://fedoraproject.org/wiki/Changes/Noi686Repositories

So there won't even be bootable media to install from.