### PR TITLE
init: Use `git clone --recurse-submodules`

### DIFF
--- a/src/cmd-init
+++ b/src/cmd-init
@@ -95,7 +95,7 @@ mkdir -p src
  if ! test -e config; then
      case "${source}" in
          /*) ln -s "${source}/${subdir}" config;;
-         *) git clone "${source}" config
+         *) git clone --recurse-submodules "${source}" config
             if [ -n "${BRANCH}" ]; then
                 git -C config checkout "${BRANCH}"
             fi


### PR DESCRIPTION
We are supporting a pattern where projects like RHCOS use
fedora-coreos-config as a git submodule.  Clone submodules by
default to make that work more nicely.