### PR TITLE
cmd-aws-replicate: append individual regions to ore command

### DIFF
--- a/src/cmd-aws-replicate
+++ b/src/cmd-aws-replicate
@@ -63,7 +63,8 @@ def run_ore():
     if args.log_level:
         ore_args.extend(['--log-level', args.log_level])
     ore_args.extend(['aws', 'copy-image', '--image', source_image, '--region', source_region])
-    ore_args.extend(region_list)
+    for r in region_list:
+        ore_args.append(r)
     print("+ {}".format(subprocess.list2cmdline(ore_args)))
     ore_data = json.loads(subprocess.check_output(ore_args))
     # This matches the Container Linux schema:


### PR DESCRIPTION
An error was observed when calling this command in the RHCOS pipeline,
where the list of comma separated regions was used as a prefix to the
AWS URL:

```
+ coreos-assembler aws-replicate --build 43devel.80.20191004.0 --regions ap-northeast-1,ap-northeast-2,ap-south-1,ap-southeast-1,ap-southeast-2,ca-central-1,eu-central-1,eu-north-1,eu-west-1,eu-west-2,eu-west-3,sa-east-1,us-east-2,us-west-1,us-west-2
Couldn't copy images: couldn't describe images: RequestError: send request failed
caused by: Post https://ec2.ap-northeast-1,ap-northeast-2,ap-south-1,ap-southeast-1,ap-southeast-2,ca-central-1,eu-central-1,eu-north-1,eu-west-1,eu-west-2,eu-west-3,sa-east-1,us-east-2,us-west-1,us-west-2.amazonaws.com/: dial tcp: lookup ec2.ap-northeast-1,ap-northeast-2,ap-south-1,ap-southeast-1,ap-southeast-2,ca-central-1,eu-central-1,eu-north-1,eu-west-1,eu-west-2,eu-west-3,sa-east-1,us-east-2,us-west-1,us-west-2.amazonaws.com: no such host
```

This expands the list of regions and appends them individually.