### PR TITLE
src/*: more ARCH -> BASEARCH

### DIFF
--- a/src/cmd-koji-upload
+++ b/src/cmd-koji-upload
@@ -44,7 +44,7 @@ try:
 except IOError:
     HOST_OS = "unknown"
 
-# ARCH is the current machine architecture
+# BASEARCH is the current machine architecture
 BASEARCH = get_basearch()
 
 COSA_INPATH = "/cosa"
@@ -58,7 +58,7 @@ KOJI_CG_TYPES = {
     "iso": ("CD/DVD Image", "iso", BASEARCH, "image"),
     "json": ("JSON data", "json", "noarch", "source"),
     "log": ("log file", "log", "noarch", "log"),
-    "ova": ("Open Virtualization Archive", "ova", ARCH, "image"),
+    "ova": ("Open Virtualization Archive", "ova", BASEARCH, "image"),
     "qcow": ("QCOW image", "qcow", BASEARCH, "image"),
     "qcow2": ("QCOW2 image", "qcow2", BASEARCH, "image"),
     "qcow2.gz": ("Compressed QCOW2", "qcow2.gz", BASEARCH, "image"),

--- a/src/cosalib/build.py
+++ b/src/cosalib/build.py
@@ -17,7 +17,7 @@ from cosalib.cmdlib import (
 
 from cosalib.builds import Builds
 
-# ARCH is the current machine architecture
+# BASEARCH is the current machine architecture
 BASEARCH = get_basearch()
 
 


### PR DESCRIPTION
Follow up to #799

The real need is the fix to `cmd-koji-upload`; currently failing in
RHCOS pipeline.