### PR TITLE
buildupload: Drop --freshen argument

### DIFF
--- a/src/cmd-buildupload
+++ b/src/cmd-buildupload
@@ -35,8 +35,6 @@ def parse_args():
     parser.add_argument("--dry-run", help="Just print and exit",
                         action='store_true')
     group = parser.add_mutually_exclusive_group()
-    group.add_argument("--freshen", help="Only push builds.json",
-                       action='store_true')
     group.add_argument("--skip-builds-json", help="Don't push builds.json",
                        action='store_true')
 
@@ -57,26 +55,25 @@ def parse_args():
 
 def cmd_upload_s3(args):
     bucket, prefix = args.url.split('/', 1)
-    if not args.freshen:
-        builds = Builds()
-        if args.build == 'latest':
-            args.build = builds.get_latest()
-        print(f"Targeting build: {args.build}")
-        if builds.is_legacy():
-            s3_upload_build(args, builds.get_build_dir(args.build), bucket, f'{prefix}/{args.build}')
-        else:
-            for arch in builds.get_build_arches(args.build):
-                s3_upload_build(args, builds.get_build_dir(args.build, arch),
-                                bucket, f'{prefix}/{args.build}/{arch}')
-            # if there's anything else in the build dir, just upload it too,
-            # e.g. pipelines might inject additional metadata
-            for f in os.listdir(f'builds/{args.build}'):
-                # arches already uploaded higher up
-                if f in builds.get_build_arches(args.build):
-                    continue
-                # assume it's metadata
-                s3_copy(f'builds/{args.build}/{f}', bucket, f'{prefix}/{args.build}/{f}',
-                        CACHE_MAX_AGE_METADATA, args.acl)
+    builds = Builds()
+    if args.build == 'latest':
+        args.build = builds.get_latest()
+    print(f"Targeting build: {args.build}")
+    if builds.is_legacy():
+        s3_upload_build(args, builds.get_build_dir(args.build), bucket, f'{prefix}/{args.build}')
+    else:
+        for arch in builds.get_build_arches(args.build):
+            s3_upload_build(args, builds.get_build_dir(args.build, arch),
+                            bucket, f'{prefix}/{args.build}/{arch}')
+        # if there's anything else in the build dir, just upload it too,
+        # e.g. pipelines might inject additional metadata
+        for f in os.listdir(f'builds/{args.build}'):
+            # arches already uploaded higher up
+            if f in builds.get_build_arches(args.build):
+                continue
+            # assume it's metadata
+            s3_copy(f'builds/{args.build}/{f}', bucket, f'{prefix}/{args.build}/{f}',
+                    CACHE_MAX_AGE_METADATA, args.acl)
     if not args.skip_builds_json:
         s3_copy('builds/builds.json', bucket, f'{prefix}/builds.json',
                 CACHE_MAX_AGE_METADATA, args.acl, extra_args={}, dry_run=args.dry_run)


### PR DESCRIPTION
We added this when the OpenShift installer was *directly* pulling
from the RHCOS build stream.  They wanted to be resilient to
"update denial attacks".  Since then, the installer pins RHCOS
and actually no customer-facing tool talks to the RHCOS cosa build
stream.

So we don't need to worry about "freshening" it.  I also
dropped the call to `--freshen` in the RHCOS pipeline a while
ago.

Prep for further work in this file around build cancellation.