### PR TITLE
 Remove support for "legacy" build schema

### DIFF
--- a/src/cmd-buildupload
+++ b/src/cmd-buildupload
@@ -59,21 +59,18 @@ def cmd_upload_s3(args):
     if args.build == 'latest':
         args.build = builds.get_latest()
     print(f"Targeting build: {args.build}")
-    if builds.is_legacy():
-        s3_upload_build(args, builds.get_build_dir(args.build), bucket, f'{prefix}/{args.build}')
-    else:
-        for arch in builds.get_build_arches(args.build):
-            s3_upload_build(args, builds.get_build_dir(args.build, arch),
-                            bucket, f'{prefix}/{args.build}/{arch}')
-        # if there's anything else in the build dir, just upload it too,
-        # e.g. pipelines might inject additional metadata
-        for f in os.listdir(f'builds/{args.build}'):
-            # arches already uploaded higher up
-            if f in builds.get_build_arches(args.build):
-                continue
-            # assume it's metadata
-            s3_copy(f'builds/{args.build}/{f}', bucket, f'{prefix}/{args.build}/{f}',
-                    CACHE_MAX_AGE_METADATA, args.acl)
+    for arch in builds.get_build_arches(args.build):
+        s3_upload_build(args, builds.get_build_dir(args.build, arch),
+                        bucket, f'{prefix}/{args.build}/{arch}')
+    # if there's anything else in the build dir, just upload it too,
+    # e.g. pipelines might inject additional metadata
+    for f in os.listdir(f'builds/{args.build}'):
+        # arches already uploaded higher up
+        if f in builds.get_build_arches(args.build):
+            continue
+        # assume it's metadata
+        s3_copy(f'builds/{args.build}/{f}', bucket, f'{prefix}/{args.build}/{f}',
+                CACHE_MAX_AGE_METADATA, args.acl)
     if not args.skip_builds_json:
         s3_copy('builds/builds.json', bucket, f'{prefix}/builds.json',
                 CACHE_MAX_AGE_METADATA, args.acl, extra_args={}, dry_run=args.dry_run)

--- a/src/cmd-compress
+++ b/src/cmd-compress
@@ -131,12 +131,9 @@ def compress_one_builddir(builddir):
 
 
 changed = []
-if builds.is_legacy():
-    changed.append(compress_one_builddir(builds.get_build_dir(build)))
-else:
-    for arch in builds.get_build_arches(build):
-        builddir = builds.get_build_dir(build, arch)
-        changed.append(compress_one_builddir(builddir))
+for arch in builds.get_build_arches(build):
+    builddir = builds.get_build_dir(build, arch)
+    changed.append(compress_one_builddir(builddir))
 
 if not any(changed):
     print(f"All builds already compressed")

--- a/src/cosalib/builds.py
+++ b/src/cosalib/builds.py
@@ -32,9 +32,9 @@ class Builds:  # pragma: nocover
         # we understand < 2.0.0 only
         if self._version._major >= 2:
             raise Exception("Builds schema too new; please update cosa")
-        # for now, since we essentially just support "1.0.0" and "0.0.1",
-        # just dillute to a bool
-        self._legacy = (self._version._major < 1)
+        if self._version._major < 1:
+            err = f"Unsupported build metadata version {self._version}"
+            raise SystemExit(err)
 
     def _path(self, path):
         if not self._workdir:
@@ -42,8 +42,6 @@ class Builds:  # pragma: nocover
         return os.path.join(self._workdir, path)
 
     def has(self, build_id):
-        if self._legacy:
-            return build_id in self._data['builds']
         return any([b['id'] == build_id for b in self._data['builds']])
 
     def is_empty(self):
@@ -51,12 +49,9 @@ class Builds:  # pragma: nocover
 
     def get_latest(self):
         # just let throw if there are none
-        if self._legacy:
-            return self._data['builds'][0]
         return self._data['builds'][0]['id']
 
     def get_build_arches(self, build_id):
-        assert not self._legacy
         for build in self._data['builds']:
             if build['id'] == build_id:
                 return build['arches']
@@ -65,41 +60,33 @@ class Builds:  # pragma: nocover
     def get_build_dir(self, build_id, basearch=None):
         if build_id == 'latest':
             build_id = self.get_latest()
-        if self._legacy:
-            return self._path(f"builds/{build_id}")
         if not basearch:
             # just assume caller wants build dir for current arch
             basearch = get_basearch()
         return self._path(f"builds/{build_id}/{basearch}")
 
     def insert_build(self, build_id, basearch=None):
-        if self._legacy:
-            self._data['builds'].insert(0, build_id)
+        if not basearch:
+            basearch = get_basearch()
+        # for future tooling: allow inserting in an existing build for a
+        # separate arch
+        for build in self._data['builds']:
+            if build['id'] == build_id:
+                if basearch in build['arches']:
+                    raise "Build {build_id} for {basearch} already exists"
+                build['arches'] += [basearch]
+                break
         else:
-            if not basearch:
-                basearch = get_basearch()
-            # for future tooling: allow inserting in an existing build for a
-            # separate arch
-            for build in self._data['builds']:
-                if build['id'] == build_id:
-                    if basearch in build['arches']:
-                        raise "Build {build_id} for {basearch} already exists"
-                    build['arches'] += [basearch]
-                    break
-            else:
-                self._data['builds'].insert(0, {
-                    'id': build_id,
-                    'arches': [
-                        basearch
-                    ]
-                })
+            self._data['builds'].insert(0, {
+                'id': build_id,
+                'arches': [
+                    basearch
+                ]
+            })
 
     def bump_timestamp(self):
         self._data['timestamp'] = rfc3339_time()
         self.flush()
-
-    def is_legacy(self):
-        return self._legacy
 
     def raw(self):
         return self._data

--- a/src/prune_builds
+++ b/src/prune_builds
@@ -17,7 +17,6 @@ from datetime import timedelta, datetime, timezone
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from cosalib.builds import Builds
-from cosalib.cmdlib import get_basearch
 
 
 def parse_date_string(date_string):
@@ -108,13 +107,6 @@ with os.scandir(builds_dir) as it:
             # those are really the only two non-dir things we expect there
             if entry.name not in ['builds.json', 'latest']:
                 print(f"Ignoring non-directory {entry.path}")
-            continue
-
-        if builds.is_legacy():
-            ts = get_timestamp(entry)
-            if ts:
-                scanned_builds.append(Build(id=entry.name, timestamp=ts,
-                                            basearches=[get_basearch()]))
             continue
 
         # scan all per-arch builds, pick up the most recent build of those as


### PR DESCRIPTION
Depends: https://github.com/coreos/coreos-assembler/pull/811

The new build layout includes architecture-awareness.
It was really nice that we supported both for a while, but
RHCOS for 4.3 has switched to the new layout.  There's no
reason to keep around the legacy build layout code, so remove
it for at least three minutes of warm fuzzy "code deletion high".

Also prep for work around failed builds handling.