### PR TITLE
cmd-run: A bunch of SSH-related enhancements

### DIFF
--- a/src/cmd-run
+++ b/src/cmd-run
@@ -307,6 +307,13 @@ if [ -z "${VM_PERSIST_IMG}" ]; then
 fi
 
 if [ -n "${SSH_PORT}" ]; then
+    # If SSH_PORT is 0, then let's pick one ourselves. There's an inherent race
+    # here; ideally qemu would do this, but with --ssh-config, there'd be no way
+    # to write it out before exec'ing.
+    if [ "${SSH_PORT}" == 0 ]; then
+        SSH_PORT=$(python3 -c "import socket; sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM); sock.bind(('', 0)); print(sock.getsockname()[1])")
+        echo "SSH port: ${SSH_PORT}"
+    fi
    hostfwd=",hostfwd=tcp::${SSH_PORT}-:22"
 fi
 

--- a/src/cmd-run
+++ b/src/cmd-run
@@ -324,7 +324,7 @@ if [ -n "${SSH_PORT}" ]; then
         SSH_PORT=$(python3 -c "import socket; sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM); sock.bind(('', 0)); print(sock.getsockname()[1])")
         echo "SSH port: ${SSH_PORT}"
     fi
-   hostfwd=",hostfwd=tcp::${SSH_PORT}-:22"
+   hostfwd=",hostfwd=tcp:127.0.0.1:${SSH_PORT}-:22"
 fi
 
 if [ -n "${SSH_CONFIG}" ]; then

--- a/src/cmd-run
+++ b/src/cmd-run
@@ -193,6 +193,22 @@ EOF
 rowcol=$(stty -a | tr ';' '\n' | grep -e 'rows\|columns' | tr '\n' ' ' )
 rowcol=$(echo "stty ${rowcol}" | base64 --wrap 0)
 
+# if SSH port mapping is requested, automagically inject all the pubkeys
+ssh_pubkeys=""
+if [ -n "${SSH_PORT}" ]; then
+    for pubkey in ~/.ssh/*.pub; do
+        # in case there are no keys
+        if [ ! -f "${pubkey}" ]; then
+            break
+        fi
+        if [ -z "${ssh_pubkeys}" ]; then
+            ssh_pubkeys="\"$(cat "${pubkey}")\""
+        else
+            ssh_pubkeys="${ssh_pubkeys}, \"$(cat "${pubkey}")\""
+        fi
+    done
+fi
+
 f=$(mktemp)
 cat > "${f}" <<EOF
 {
@@ -217,6 +233,16 @@ cat > "${f}" <<EOF
                 "path": "/home/core/.bashrc",
                 "append": [
                     { "source": "data:text/plain;base64,${rowcol}" }
+                ]
+            }
+        ]
+    },
+    "passwd": {
+        "users": [
+            {
+                "name": "core",
+                "sshAuthorizedKeys": [
+                    ${ssh_pubkeys}
                 ]
             }
         ]

--- a/src/cmd-run
+++ b/src/cmd-run
@@ -35,7 +35,7 @@ Options:
     --srv src             Mount (via 9p) src on the host as /var/srv in guest
     -m MB                 RAM size in MB (2048)
     --size GB             Disk size in GB (matches base by default)
-    -p PORT               The port on localhost to map to the VM's sshd. [2222]
+    -p --ssh-port PORT    Map PORT on localhost to the VM's sshd.
     -h                    this ;-)
     -B --boot-inject      Force Ignition injection into /boot (useful for running metal images)
     --uefi                Boot using uefi (x86_64 only, implied on arm)

--- a/src/cmd-run
+++ b/src/cmd-run
@@ -22,6 +22,7 @@ VM_PERSIST_IMG=
 VM_NCPUS="${VM_NCPUS:-$(nproc)}"
 VM_SRV_MNT=
 SSH_PORT=${SSH_PORT:-}
+SSH_CONFIG=
 UEFI=0
 BOOT_INJECT=0
 SECURE=0
@@ -36,6 +37,7 @@ Options:
     -m MB                 RAM size in MB (2048)
     --size GB             Disk size in GB (matches base by default)
     -p --ssh-port PORT    Map PORT on localhost to the VM's sshd.
+    --ssh-config FILE     Write SSH config to FILE. Useful with '-p 0'.
     -h                    this ;-)
     -B --boot-inject      Force Ignition injection into /boot (useful for running metal images)
     --uefi                Boot using uefi (x86_64 only, implied on arm)
@@ -83,6 +85,9 @@ while [ $# -ge 1 ]; do
             shift 2 ;;
         -p|--ssh-port)
             SSH_PORT="$2"
+            shift 2 ;;
+        --ssh-config)
+            SSH_CONFIG="$2"
             shift 2 ;;
         -v|--verbose)
             set -x
@@ -192,6 +197,11 @@ EOF
 # generate a string like rows XX columns XX for stty
 rowcol=$(stty -a | tr ';' '\n' | grep -e 'rows\|columns' | tr '\n' ' ' )
 rowcol=$(echo "stty ${rowcol}" | base64 --wrap 0)
+
+# automatically turn on SSH if --ssh-config is given and default to port 0.
+if [ -n "${SSH_CONFIG}" ] && [ -z "${SSH_PORT}" ]; then
+    SSH_PORT=0
+fi
 
 # if SSH port mapping is requested, automagically inject all the pubkeys
 ssh_pubkeys=""
@@ -315,6 +325,17 @@ if [ -n "${SSH_PORT}" ]; then
         echo "SSH port: ${SSH_PORT}"
     fi
    hostfwd=",hostfwd=tcp::${SSH_PORT}-:22"
+fi
+
+if [ -n "${SSH_CONFIG}" ]; then
+    cat > "${SSH_CONFIG}" << EOF
+Host coreos
+    HostName localhost
+    Port ${SSH_PORT}
+    User core
+    StrictHostKeyChecking no
+    UserKnownHostsFile /dev/null
+EOF
 fi
 
 set -- -drive if=virtio,file="${VM_IMG}" "$@"

--- a/src/cmd-run
+++ b/src/cmd-run
@@ -21,6 +21,7 @@ VM_DISKSIZE=
 VM_PERSIST_IMG=
 VM_NCPUS="${VM_NCPUS:-$(nproc)}"
 VM_SRV_MNT=
+SSH_ATTACH=
 SSH_PORT=${SSH_PORT:-}
 SSH_CONFIG=
 UEFI=0
@@ -36,6 +37,7 @@ Options:
     --srv src             Mount (via 9p) src on the host as /var/srv in guest
     -m MB                 RAM size in MB (2048)
     --size GB             Disk size in GB (matches base by default)
+    --ssh                 Attach via SSH instead of console
     -p --ssh-port PORT    Map PORT on localhost to the VM's sshd.
     --ssh-config FILE     Write SSH config to FILE. Useful with '-p 0'.
     -h                    this ;-)
@@ -56,6 +58,9 @@ die(){
     echo "${1}" 1>&2
     exit 1
 }
+
+# remember in case we re-exec under ssh-agent
+args=("$0" "$@")
 
 while [ $# -ge 1 ]; do
     case "$1" in
@@ -89,6 +94,9 @@ while [ $# -ge 1 ]; do
         --ssh-config)
             SSH_CONFIG="$2"
             shift 2 ;;
+        --ssh)
+            SSH_ATTACH=1
+            shift ;;
         -v|--verbose)
             set -x
             shift ;;
@@ -111,6 +119,34 @@ while [ $# -ge 1 ]; do
             die "Unknown argument $1";;
     esac
 done
+
+# automatically turn on SSH if --ssh-config or --ssh is given and default
+# to port 0.
+if { [ -n "${SSH_CONFIG}" ] || [ -n "${SSH_ATTACH}" ]; } && [ -z "${SSH_PORT}" ]; then
+    SSH_PORT=0
+fi
+
+# check if we or the user will want to SSH and re-exec under ssh-agent if so
+ssh_pubkeys=""
+if [ -n "${SSH_PORT}" ]; then
+    if [ -z "${SSH_AUTH_SOCK:-}" ]; then
+        exec ssh-agent "${args[@]}"
+    fi
+
+    # if there are no keys, seed with defaults
+    if ( ssh-add -l || : ) | grep -q 'no identities'; then
+        ssh-add -q
+    fi
+
+    # and collect pubkeys to inject into the host
+    while read -r pubkey; do
+        if [ -z "${ssh_pubkeys}" ]; then
+            ssh_pubkeys="\"${pubkey}\""
+        else
+            ssh_pubkeys="${ssh_pubkeys}, \"${pubkey}\""
+        fi
+    done <<< "$(ssh-add -L)"
+fi
 
 preflight
 
@@ -150,17 +186,24 @@ ign_validate="ignition-validate"
 # We don't care about migration for this.
 set -- -machine accel=kvm -cpu host -smp "${VM_NCPUS}" "$@"
 
+systemd_units=
+append_systemd_unit() {
+    if [ -z "${systemd_units}" ]; then
+        systemd_units="${1}"
+    else
+        systemd_units="${systemd_units},$1"
+    fi
+}
+
 if [ -n "${VM_SRV_MNT}" ]; then
     set -- --fsdev local,id=var-srv,path="${VM_SRV_MNT}",security_model=mapped,readonly \
         -device virtio-9p-"${devtype}",fsdev=var-srv,mount_tag=/var/srv "$@"
     # The dependency changes are hacks around https://github.com/coreos/fedora-coreos-tracker/issues/223
-    ign_var_srv_mount=',{
+    append_systemd_unit '{
 "name": "var-srv.mount",
 "enabled": true,
 "contents": "[Unit]\nDefaultDependencies=no\nAfter=systemd-tmpfiles-setup.service\nBefore=basic.target\n[Mount]\nWhat=/var/srv\nWhere=/var/srv\nType=9p\nOptions=ro,trans=virtio,version=9p2000.L\n[Install]\nWantedBy=multi-user.target\n"
 }'
-else
-    ign_var_srv_mount=""
 fi
 
 if [ -n "${IGNITION_CONFIG_FILE:-}" ]; then
@@ -198,25 +241,16 @@ EOF
 rowcol=$(stty -a | tr ';' '\n' | grep -e 'rows\|columns' | tr '\n' ' ' )
 rowcol=$(echo "stty ${rowcol}" | base64 --wrap 0)
 
-# automatically turn on SSH if --ssh-config is given and default to port 0.
-if [ -n "${SSH_CONFIG}" ] && [ -z "${SSH_PORT}" ]; then
-    SSH_PORT=0
-fi
-
-# if SSH port mapping is requested, automagically inject all the pubkeys
-ssh_pubkeys=""
-if [ -n "${SSH_PORT}" ]; then
-    for pubkey in ~/.ssh/*.pub; do
-        # in case there are no keys
-        if [ ! -f "${pubkey}" ]; then
-            break
-        fi
-        if [ -z "${ssh_pubkeys}" ]; then
-            ssh_pubkeys="\"$(cat "${pubkey}")\""
-        else
-            ssh_pubkeys="${ssh_pubkeys}, \"$(cat "${pubkey}")\""
-        fi
-    done
+if [ -z "${SSH_ATTACH}" ]; then
+    append_systemd_unit "{
+    \"name\": \"serial-getty@${DEFAULT_TERMINAL}.service\",
+    \"dropins\": [
+        {
+            \"name\": \"autologin-core.conf\",
+            \"contents\": \"[Service]\\nTTYVTDisallocate=no\\nExecStart=\\nExecStart=-/usr/sbin/agetty --autologin core --noclear %I \$TERM\\n\"
+        }
+    ]
+}"
 fi
 
 f=$(mktemp)
@@ -259,16 +293,7 @@ cat > "${f}" <<EOF
     },
     "systemd": {
         "units": [
-            {
-                "name": "serial-getty@${DEFAULT_TERMINAL}.service",
-                "dropins": [
-                    {
-                        "name": "autologin-core.conf",
-                        "contents": "[Service]\\nTTYVTDisallocate=no\\nExecStart=\\nExecStart=-/usr/sbin/agetty --autologin core --noclear %I \$TERM\\n"
-                    }
-                ]
-            }
-            ${ign_var_srv_mount}
+            ${systemd_units}
         ]
     }
 }
@@ -363,9 +388,25 @@ if [ "$SECURE" == "1" ]; then
     set -- -machine q35 "$@"
 fi
 
-# shellcheck disable=SC2086
-exec ${QEMU_KVM} -name coreos -m "${VM_MEMORY}" -nographic \
+set -- -name coreos -m "${VM_MEMORY}" -nographic \
               -netdev user,id=eth0,hostname=coreos"${hostfwd:-}" \
               -device virtio-net-"${devtype}",netdev=eth0 \
               -object rng-random,filename=/dev/urandom,id=rng0 -device virtio-rng-"${devtype}",rng=rng0 \
               "$@"
+
+if [ -z "${SSH_ATTACH}" ]; then
+    # shellcheck disable=SC2086
+    exec ${QEMU_KVM} "$@"
+fi
+
+# shellcheck disable=SC2086
+setpriv --pdeathsig SIGTERM -- ${QEMU_KVM} "$@" < /dev/null &
+# A dumber but simpler version of https://github.com/jlebon/files/blob/master/bin/sshwait
+while true; do
+    out=$(echo | nc -w 1 localhost "${SSH_PORT}" 2>&1 || :)
+    if grep -q SSH <<< "$out"; then
+        break
+    fi
+    sleep 1
+done
+exec ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no core@localhost -p "${SSH_PORT}"


### PR DESCRIPTION
See individual commit messages for details. TL;DR: this allows one to do `cosa run --ssh`.

I initially developed this patchset with the intent of making use of it in rpm-ostree's CI. But I'm leaning now more towards leveraging `kola spawn` there. (I mention `kola spawn` in the last commit's message too). Though short of merging `cosa run` into `kola spawn`, having `--ssh` here too is useful.