### PR TITLE
*build*: Make ppc64le build anacondaless

### DIFF
--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -63,7 +63,7 @@ if [ $# -ne 0 ]; then
 fi
 
 case "$basearch" in
-    "x86_64"|"aarch64"|"s390x") use_anaconda=;;
+    "x86_64"|"aarch64"|"s390x"|"ppc64le") use_anaconda=;;
     *)
         # for qemu, we can fallback to Anaconda
         if [[ ${image_type} == qemu ]]; then

--- a/src/deps-ppc64le.txt
+++ b/src/deps-ppc64le.txt
@@ -1,2 +1,3 @@
-# Place-holder for ppc64le arch specific dependencies
+# To support pseries in anacondaless installs
+grub2 powerpc-utils
 

--- a/src/vmdeps-ppc64le.txt
+++ b/src/vmdeps-ppc64le.txt
@@ -1,1 +1,2 @@
-grub2
+# To support pseries in anacondaless installs
+grub2 powerpc-utils


### PR DESCRIPTION
ppc64le(pseries,PowerNV) anacondaless build.

Allow partition layout to differ per arch, i.e. to include and omit certain partitions.
Use generic Linux FS uuid for root partition as discussed in the #795

Fix: #795