### PR TITLE
cmd-koji-upload: adapt property access for basearch

### DIFF
--- a/src/cmd-koji-upload
+++ b/src/cmd-koji-upload
@@ -465,7 +465,7 @@ class Upload():
                 "id": 1,
                 "host": {
                     "os": HOST_OS,
-                    "arch": self.build.arch
+                    "arch": self.build.basearch
                 },
                 "content_generator": {
                     "name": "coreos-assembler",
@@ -475,7 +475,7 @@ class Upload():
                 },
                 "container": {
                     "type": "docker",
-                    "arch": self.build.arch,
+                    "arch": self.build.basearch,
                     "name": "coreos-assembler"
                 },
                 "components": "",


### PR DESCRIPTION
Follow-up to #799 and #810.

Closes: #817