### PR TITLE
cmd-aws-replicate: upload to one region at a time

### DIFF
--- a/src/cmd-aws-replicate
+++ b/src/cmd-aws-replicate
@@ -69,7 +69,7 @@ def run_ore():
         ore_args.extend(['--log-level', args.log_level])
     ore_args.extend(['aws', 'copy-image', '--image', source_image, '--region', source_region])
 
-    upload_failed_in_regions = []
+    upload_failed_in_region = ""
     for upload_region in region_list:
         region_ore_args = ore_args.copy()
         region_ore_args.append(upload_region)
@@ -77,8 +77,8 @@ def run_ore():
         try:
             ore_data = json.loads(subprocess.check_output(region_ore_args))
         except subprocess.CalledProcessError:
-            upload_failed_in_regions.append(upload_region)
-            continue
+            upload_failed_in_region = upload_region
+            break
         # This matches the Container Linux schema:
         # https://stable.release.core-os.net/amd64-usr/current/coreos_production_ami_all.json
         ami_data = [{'name': region,
@@ -90,9 +90,8 @@ def run_ore():
     write_json(buildmeta_path, buildmeta)
     print(f"Updated: {buildmeta_path}")
 
-    if upload_failed_in_regions:
-        error_msg = ' '.join(upload_failed_in_regions)
-        raise Exception(f"Upload failed in regions {error_msg}")
+    if upload_failed_in_region != "":
+        raise Exception(f"Upload failed in {upload_failed_in_region} region")
 
 
 # Do it!

--- a/src/cmd-aws-replicate
+++ b/src/cmd-aws-replicate
@@ -68,18 +68,31 @@ def run_ore():
     if args.log_level:
         ore_args.extend(['--log-level', args.log_level])
     ore_args.extend(['aws', 'copy-image', '--image', source_image, '--region', source_region])
-    ore_args.extend(region_list)
-    print("+ {}".format(subprocess.list2cmdline(ore_args)))
-    ore_data = json.loads(subprocess.check_output(ore_args))
-    # This matches the Container Linux schema:
-    # https://stable.release.core-os.net/amd64-usr/current/coreos_production_ami_all.json
-    ami_data = [{'name': region,
-                 'hvm': vals['ami'],
-                 'snapshot': vals['snapshot']}
-                for region, vals in ore_data.items()]
-    buildmeta['amis'].extend(ami_data)
+
+    upload_failed_in_regions = []
+    for upload_region in region_list:
+        region_ore_args = ore_args.copy()
+        region_ore_args.append(upload_region)
+        print("+ {}".format(subprocess.list2cmdline(region_ore_args)))
+        try:
+            ore_data = json.loads(subprocess.check_output(region_ore_args))
+        except subprocess.CalledProcessError:
+            upload_failed_in_regions.append(upload_region)
+            continue
+        # This matches the Container Linux schema:
+        # https://stable.release.core-os.net/amd64-usr/current/coreos_production_ami_all.json
+        ami_data = [{'name': region,
+                     'hvm': vals['ami'],
+                     'snapshot': vals['snapshot']}
+                    for region, vals in ore_data.items()]
+        buildmeta['amis'].extend(ami_data)
+
     write_json(buildmeta_path, buildmeta)
     print(f"Updated: {buildmeta_path}")
+
+    if upload_failed_in_regions:
+        error_msg = ' '.join(upload_failed_in_regions)
+        raise Exception(f"Upload failed in regions {error_msg}")
 
 
 # Do it!

--- a/src/cmd-aws-replicate
+++ b/src/cmd-aws-replicate
@@ -71,8 +71,7 @@ def run_ore():
 
     upload_failed_in_region = ""
     for upload_region in region_list:
-        region_ore_args = ore_args.copy()
-        region_ore_args.append(upload_region)
+        region_ore_args = ore_args.copy() + [upload_region]
         print("+ {}".format(subprocess.list2cmdline(region_ore_args)))
         try:
             ore_data = json.loads(subprocess.check_output(region_ore_args))


### PR DESCRIPTION
Pass one region from the list and write meta.json if the result was a success.

This fixes the issue with meta.json containing only the original AMI if ore upload errors occurred in some regions

xref: GRPA-374