### PR TITLE
cmdlib: fallback to virt when on overlayfs

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -82,6 +82,9 @@ has_privileges() {
         elif ! sudo true; then
             info "Missing sudo privs; using virt"
             _privileged=0
+        elif [ "$(stat -f --printf="%T" .)" = "overlayfs" ]; then
+            info "Detected overlayfs; using virt"
+            _privileged=0
         else
             _privileged=1
         fi
@@ -123,10 +126,6 @@ preflight() {
     archdeps=$(sed "s/${filter}//" /usr/lib/coreos-assembler/deps-"$(arch)".txt | grep -v '^#')
 
     depcheck "${deps} ${archdeps}"
-
-    if [ "$(stat -f --printf="%T" .)" = "overlayfs" ]; then
-        fatal "$(pwd) must be a volume"
-    fi
 
     if ! stat /dev/kvm >/dev/null; then
         fatal "Unable to find /dev/kvm"


### PR DESCRIPTION
Really, we can support overlayfs fine if we just do the compose in virt.
This is important in CI contexts where code runs in a pod and a PVC
mount might not be available.

(Of course, in *most* CI contexts, we're already not privileged so we
weren't hitting this.)

A more generic approach here would just be to test xattr capabilities
given the target filesystem and environment we're in.