### PR TITLE
create_disk: Set --pbkdf-memsize to 512MB

### DIFF
--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -98,9 +98,14 @@ if [ -n "${luks_rootfs}"  ]; then
     touch tmp.key
     # Create the LUKS partition using the null_cipher and a sentinal
     # UUID similiar to the one used by coreos-gpt-setup. This is used
-    # by ignition-dracut-reecrypt.
+    # by ignition-dracut-reecrypt.  We use argon2i as it's the cryptsetup
+    # default today, but explicitly specify just 512Mb in order to support
+    # booting on smaller systems.
     cryptsetup luksFormat \
         -q \
+        --type luks2 \
+        --pbkdf argon2i \
+        --pbkdf-memory 524288 \
         --label="crypt_rootfs" \
         --cipher=cipher_null \
         --key-file=tmp.key \


### PR DESCRIPTION
cryptsetup defaults to argon2i and a memsize of half of the
physical RAM.  This means the default RAM size of 2048 for
our build VMs "leaks" into the memory requirement of the
target system.

We discovered this because libguestfs uses a smaller memory size
by default.

Explicitly specify that we want luks2 and the default argon2i
(to be resilient to changes), then drop the PBKDF memory requirement
down to 512MB to be conservative so we can boot even on smaller
systems.

(That said, this type of stuff is why we really want
 to get to the end game of full Ignition support, because
 that way cryptsetup could work in the way it was designed to
 on the target system)