### PR TITLE
doc/gcp-nested-virt: Bump memory to 3Gi

### DIFF
--- a/doc/openshift-gcp-nested-virt.md
+++ b/doc/openshift-gcp-nested-virt.md
@@ -64,10 +64,12 @@ spec:
     name: cosa
     resources:
       requests:
-        memory: "1Gi"
+        # Today COSA hardcodes 2048 for launching VMs.  We could
+        # probably shrink that in the future.
+        memory: "3Gi"
         devices.kubevirt.io/kvm: "1"
       limits:
-        memory: "1Gi"
+        memory: "3Gi"
         devices.kubevirt.io/kvm: "1"
     volumeMounts:
     - mountPath: /srv


### PR DESCRIPTION
I stood up a new cluster and was hitting OOMs until I did this.
(We need to clean up and consolidate our memory usage)