### PR TITLE
buildextend-aliyun: add aliyun image building

### DIFF
--- a/src/cmd-buildextend-aliyun
+++ b/src/cmd-buildextend-aliyun
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+# NOTE: PYTHONUNBUFFERED is set in cmdlib.sh for unbuffered output
+#
+# An operation that mutates a build by generating an aliyun image.
+
+import os
+import sys
+import json
+import shutil
+import argparse
+import subprocess
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from cosalib.builds import Builds
+from cosalib.cmdlib import run_verbose, write_json, sha256sum_file, get_basearch
+
+# Parse args and dispatch
+parser = argparse.ArgumentParser()
+parser.add_argument("--build", help="Build ID")
+parser.add_argument("--region", help="Cloud Region")
+parser.add_argument("--bucket", help="OSS Bucket")
+parser.add_argument("--log-level", help="ore log level")
+parser.add_argument("--upload", action='store_true', default=False,
+                    help="Upload to Aliyun")
+args = parser.parse_args()
+
+# Identify the builds and target the latest build if none provided
+builds = Builds()
+if not args.build:
+    args.build = builds.get_latest()
+print(f"Targeting build: {args.build}")
+
+if args.upload:
+    for attr in ['region', 'bucket']:
+        if getattr(args, attr) is None:
+            raise Exception(f"Must provide --{attr} option in order to upload")
+
+builddir = builds.get_build_dir(args.build)
+buildmeta_path = os.path.join(builddir, 'meta.json')
+with open(buildmeta_path) as f:
+    buildmeta = json.load(f)
+
+basearch = get_basearch()
+base_name = buildmeta['name']
+img_prefix = f'{base_name}-{args.build}'
+aliyun_name = f'{img_prefix}-aliyun.{basearch}.qcow2'
+
+tmpdir = 'tmp/buildpost-aliyun'
+if os.path.isdir(tmpdir):
+    shutil.rmtree(tmpdir)
+os.mkdir(tmpdir)
+
+
+def generate_aliyun():
+    buildmeta_images = buildmeta['images']
+    img_qemu = os.path.join(builddir, buildmeta_images['qemu']['path'])
+    tmp_img_aliyun = os.path.join(tmpdir, aliyun_name)
+    run_verbose(['/usr/lib/coreos-assembler/gf-platformid',
+                 img_qemu, tmp_img_aliyun, 'aliyun'])
+    checksum = sha256sum_file(tmp_img_aliyun)
+    size = os.path.getsize(tmp_img_aliyun)
+    buildmeta_images['aliyun'] = {
+        'path': aliyun_name,
+        'sha256': checksum,
+        'size': size
+    }
+    os.rename(tmp_img_aliyun, f"{builddir}/{aliyun_name}")
+    write_json(buildmeta_path, buildmeta)
+    print(f"Updated: {buildmeta_path}")
+
+
+def run_ore():
+    ore_args = ['ore']
+    if args.log_level:
+        ore_args.extend(['--log-level', args.log_level])
+    ore_args.extend(['aliyun', 'create-image',
+                     '--region', args.region,
+                     '--bucket', args.bucket,
+                     '--name', img_prefix,
+                     '--description', f"{buildmeta['summary']} {args.build}",
+                     '--file', f"{builddir}/{aliyun_name}",
+                     '--architecture', basearch,
+                     '--disk-size-inspect',
+                     '--force'])
+    print("+ {}".format(subprocess.list2cmdline(ore_args)))
+    # convert the binary output to string and remove trailing white space
+    ore_data = subprocess.check_output(ore_args).decode('utf-8').strip()
+    data = {'name': args.region,
+            'id': ore_data}
+    buildmeta['aliyun'] = [data]
+    write_json(buildmeta_path, buildmeta)  # update build metadata
+
+
+# Do it!
+if 'aliyun' not in buildmeta['images']:
+    generate_aliyun()
+else:
+    print('Aliyun image already built. Skipping image creation')
+# Do the upload if asked
+if args.upload:
+    run_ore()
+else:
+    print('--upload not passed. Skipping image upload to cloud')
+print('buildextend-aliyun complete!')


### PR DESCRIPTION
Adds a new command `buildextend-aliyun` that can both create the image
as well as upload it.