### PR TITLE
cmdlib: set size to "unknown" if stat in prepare_git_artifacts fails

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -624,7 +624,7 @@ prepare_git_artifacts() {
         "checksum_type": "sha256",
         "format": "tar.gz",
         "name": "$(basename ${tarball})",
-        "size": $(stat --format=%s ${tarball})
+        "size": $(stat --format=%s ${tarball} || echo unknown)
     }
 }
 EOC


### PR DESCRIPTION
During a test COSA build I got:
```
++ basename /cosa/coreos-assembler-git.tar.gz
++ stat --format=%s /cosa/coreos-assembler-git.tar.gz
stat: cannot statx '/cosa/coreos-assembler-git.tar.gz': Operation not permitted
```
(probably new openshift builder didn't allow `statx` syscall). The build progressed further although `cmdlib` has `set -euo pipefail` set. Produced JSON was corrupted and broke `coreos-assembler build`

This PR ensures size is set to "unknown" and produced JSON is valid


