### PR TITLE
cmd-{fetch,build}: strip out digests from lockfiles

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -215,6 +215,7 @@ runcompose --cache-only ${FORCE} --add-metadata-from-json "${commitmeta_input_js
            --write-composejson-to "${composejson}" \
            --ex-write-lockfile-to "${lockfile_out}" \
            ${lock_arg} ${version_arg} ${parent_arg}
+strip_out_lockfile_digests "$lockfile_out"
 # Very special handling for --write-composejson-to as rpm-ostree doesn't
 # write it if the commit didn't change.
 if [ -f "${changed_stamp}" ]; then

--- a/src/cmd-fetch
+++ b/src/cmd-fetch
@@ -92,10 +92,11 @@ if [ -n "${UPDATE_LOCKFILE}" ]; then
     # existing manifest lockfile if none was specified by the user
     if [ -n "${OUTPUT_LOCKFILE}" ]; then
         # assume given path is relative to toplevel workdir
-        outfile="${workdir}/${OUTPUT_LOCKFILE}" 
+        outfile="${workdir}/${OUTPUT_LOCKFILE}"
     else
         outfile=$manifest_lock
     fi
+    strip_out_lockfile_digests "${tmprepo}/tmp/manifest-lock.json"
     mv -f "${tmprepo}/tmp/manifest-lock.json" "${outfile}"
     echo "Wrote out lockfile ${outfile}"
 fi

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -402,6 +402,13 @@ runcompose() {
     fi
 }
 
+# Strips out the digest field from lockfiles since they subtly conflict with
+# various workflows.
+strip_out_lockfile_digests() {
+    jq 'del(.packages[].digest)' "$1" > "$1.tmp"
+    mv "$1.tmp" "$1"
+}
+
 runvm() {
     local qemu_args=()
     while true; do


### PR DESCRIPTION
The digest fields in lockfiles have been more trouble than they're worth
so far. The major problem is signing: adding a signature to an RPM of
course changes its digest.

There are two main issues. The first is that when adding an override,
there's no way to know the digest ahead of time since the package isn't
signed yet. It becomes signed when the override is accepted and tagged
into the pool.

The second is that the same package NEVRA may be present in different
repos and signed with different keys, resulting in different hashes,
even if the payload is the same (for more details on this case, see
https://github.com/coreos/rpm-ostree/pull/1927).

One could add repo origin information as part of the lockfile, but that
does not correspond to what we actually do in FCOS, since packages
initially come from Bodhi, and are then imported into the pool (and even
then, there's no guarantee that the package isn't already there with a
different signature).

A possible solution is to instead use the CPIO payload digest, but that
information is not part of the repo metadata, so it'd require some work
for rpm-ostree to download the packages and select the right one. Not
especially hard, but definitely non-trivial.

In practice, we don't really need digests in the lockfile. For repos
which don't use GPG checking, it could provide some security benefits.
Though in our case, GPG verification is turned on for all the repos
anyway. But more importantly, all our data comes from Koji, which
forbids buildings two packages with the same NEVRA.

We could fold this into rpm-ostree under a new flag, though I think its
current behaviour makes sense overall. It just doesn't work well for us.