### PR TITLE
buildroot: Add libdnf and librepo

### DIFF
--- a/src/buildroot-buildreqs.txt
+++ b/src/buildroot-buildreqs.txt
@@ -3,6 +3,8 @@
 ignition
 ostree
 rpm-ostree
+libdnf
+librepo
 kernel
 systemd
 dracut


### PR DESCRIPTION
This ensures we get e.g. `zchunk-devel` today, but is also
what we want on general principle since rpm-ostree developers
will likely need to hack on both.