### PR TITLE
build.sh: backport latest coreutils with statx fix

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -53,6 +53,17 @@ install_rpms() {
     archdeps=$(grep -v '^#' "${srcdir}/deps-$(arch)".txt)
     echo "${builddeps}" "${deps}" "${archdeps}" | xargs yum -y install
 
+    # XXX: import glibc in testing to work around statx issues:
+    # https://github.com/coreos/coreos-assembler/pull/853
+    # https://bugzilla.redhat.com/show_bug.cgi?id=1760300
+    basearch=$(python3 -c '
+import gi
+gi.require_version("RpmOstree", "1.0")
+from gi.repository import RpmOstree
+print(RpmOstree.get_basearch())')
+    # shellcheck disable=SC2086
+    yum -y install https://kojipkgs.fedoraproject.org//packages/coreutils/8.31/6.fc30/${basearch}/coreutils{,-common}-8.31-6.fc30.${basearch}.rpm
+
     # Commented out for now, see above
     #dnf remove -y ${builddeps}
     # can't remove grubby on el7 because libguestfs-tools depends on it


### PR DESCRIPTION
There's a new update awaiting karma that fixes the `statx` failures:
https://bodhi.fedoraproject.org/updates/FEDORA-2019-566ad52d5e

I strongly suspect this is also the root cause behind the recent CI
failures:

https://github.com/coreos/fedora-coreos-config/pull/201#issuecomment-542849262
https://github.com/coreos/rpm-ostree/pull/1929#issuecomment-543195228

Let's just pull it in right now so we can get things unblocked.