### PR TITLE
src/cmd-aliyun-replicate: add command to replicate aliyun images

### DIFF
--- a/src/cmd-aliyun-replicate
+++ b/src/cmd-aliyun-replicate
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+# NOTE: PYTHONUNBUFFERED is set in cmdlib.sh for unbuffered output
+#
+# An operation that mutates a build by replicating an existing
+# aliyun image to additional regions, extending the meta.json with
+# information about each region replicated to.
+#
+# Intended to be used in conjunction with buildextend-aliyun
+# to allow the initial upload to a single region for testing
+# purposes before replication to a list of regions.
+
+import os
+import sys
+import json
+import argparse
+import subprocess
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from cosalib.builds import Builds
+from cosalib.cmdlib import write_json
+
+
+def run_ore():
+    if len(buildmeta['aliyun']) < 1:
+        raise SystemExit("buildmeta doesn't contain source images. Run buildextend-aliyun first")
+    if not args.regions:
+        args.regions = subprocess.check_output(['ore', 'aws', 'list-regions']).decode().strip().split()
+    # only replicate to regions that don't already exist
+    existing_regions = [item['name'] for item in buildmeta['aliyun']]
+    duplicates = list(set(args.regions).intersection(existing_regions))
+    if len(duplicates) > 0:
+        print(f"Images already exist in {duplicates} region(s), skipping listed region(s)...")
+    region_list = list(set(args.regions) - set(duplicates))
+    if len(region_list) == 0:
+        print("no new regions detected")
+        sys.exit(0)
+
+    source_image = buildmeta['aliyun'][0]['id']
+    source_region = buildmeta['aliyun'][0]['name']
+    ore_args = ['ore']
+    if args.log_level:
+        ore_args.extend(['--log-level', args.log_level])
+    ore_args.extend(['aliyun', 'copy-image', '--image', source_image, '--region', source_region])
+
+    upload_failed_in_region = None
+    for upload_region in region_list:
+        region_ore_args = ore_args.copy() + [upload_region]
+        print("+ {}".format(subprocess.list2cmdline(region_ore_args)))
+        try:
+            ore_data = json.loads(subprocess.check_output(region_ore_args))
+        except subprocess.CalledProcessError:
+            upload_failed_in_region = upload_region
+            break
+        image_data = [{'name': region,
+                     'id': val}
+                    for region, val in ore_data.items()]
+        buildmeta['aliyun'].extend(image_data)
+
+    write_json(buildmeta_path, buildmeta)
+    print(f"Updated: {buildmeta_path}")
+
+    if upload_failed_in_region is not None:
+        raise Exception(f"Upload failed in {upload_failed_in_region} region")
+
+
+# Parse args and dispatch
+parser = argparse.ArgumentParser()
+parser.add_argument("--build", help="Build ID")
+parser.add_argument("--name-suffix", help="Suffix for name")
+parser.add_argument("--regions", help="aliyun regions, default: all regions",
+                    default=[], nargs='+')
+parser.add_argument("--log-level", help="ore log level")
+args = parser.parse_args()
+
+builds = Builds()
+if not args.build:
+    args.build = builds.get_latest()
+print(f"Targeting build: {args.build}")
+builddir = builds.get_build_dir(args.build)
+buildmeta_path = os.path.join(builddir, 'meta.json')
+with open(buildmeta_path) as f:
+    buildmeta = json.load(f)
+
+# Do it!
+run_ore()


### PR DESCRIPTION
Adds a new command that replicates aliyun images to different regions.

Also contains a mantle bump to pick up the `ore aliyun list-regions` command, shortlog in commit.

Closes #857 