### PR TITLE
Revert "build.sh: backport latest coreutils with statx fix"

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,6 @@ $ cosa init https://github.com/coreos/fedora-coreos-config.git
 $ cosa fetch && cosa build
 ```
 
-
 #### Using a locally built Assembler container
 
 If you have [built a local assembler container](#container-build)
@@ -341,3 +340,10 @@ $ mkdir -p overrides/rpm
 $ cp /path/to/my/name-version-release.rpm ./overrides/rpm
 $ cosa build
 ```
+
+### Pulling in fixed packages into the COSA container
+
+To pull in fixed packages before they make it through Bodhi,
+you can simply tag them into the
+`f${releasever}-coreos-continuous` tag and trigger a
+rebuild.

--- a/build.sh
+++ b/build.sh
@@ -53,17 +53,6 @@ install_rpms() {
     archdeps=$(grep -v '^#' "${srcdir}/deps-$(arch)".txt)
     echo "${builddeps}" "${deps}" "${archdeps}" | xargs yum -y install
 
-    # XXX: import glibc in testing to work around statx issues:
-    # https://github.com/coreos/coreos-assembler/pull/853
-    # https://bugzilla.redhat.com/show_bug.cgi?id=1760300
-    basearch=$(python3 -c '
-import gi
-gi.require_version("RpmOstree", "1.0")
-from gi.repository import RpmOstree
-print(RpmOstree.get_basearch())')
-    # shellcheck disable=SC2086
-    yum -y install https://kojipkgs.fedoraproject.org//packages/coreutils/8.31/6.fc30/${basearch}/coreutils{,-common}-8.31-6.fc30.${basearch}.rpm
-
     # Commented out for now, see above
     #dnf remove -y ${builddeps}
     # can't remove grubby on el7 because libguestfs-tools depends on it


### PR DESCRIPTION
This reverts commit 648f26c42366b61d5bd39598072ffd0e6b0e3b7b.

The package is part of the continuous tag now, so it should get pulled
in automatically.