### PR TITLE
Dockerfile: Bump to f31

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -1,6 +1,6 @@
 @Library('github.com/coreos/coreos-ci-lib@master') _
 
-coreos.pod([image: 'registry.fedoraproject.org/fedora:30', runAsUser: 0, kvm: true, memory: "9Gi"]) {
+coreos.pod([image: 'registry.fedoraproject.org/fedora:31', runAsUser: 0, kvm: true, memory: "9Gi"]) {
       checkout scm
 
       stage("Build") {

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:30
+FROM registry.fedoraproject.org/fedora:31
 WORKDIR /root/containerbuild
 
 # We split into multiple steps here so that local dev workflows which involve


### PR DESCRIPTION
We should match https://github.com/coreos/fedora-coreos-config/pull/200
on general principle, but also specifically because we now also have
a buildroot container that derives from this, and we want to support
people building content in that buildroot that targets the host.