### PR TITLE
incomplete-hack-ign-3to2: Fix translation of s/merge/append/

### DIFF
--- a/src/incomplete-hack-ign-3to2
+++ b/src/incomplete-hack-ign-3to2
@@ -39,8 +39,9 @@ for f in ign['storage'].get('files', []):
         f['contents'] = append[0]
 
 # replace the merge keyword with append
-merge = ign['ignition'].pop('merge', None)
+ignconfig = ign['ignition'].get('config', {})
+merge = ignconfig.pop('merge', None)
 if merge is not None:
-    ign['ignition']['append'] = merge
+    ignconfig['append'] = merge
 
 json.dump(ign, sys.stdout)


### PR DESCRIPTION
I was trying to test out some Ignition via `cosa run -i` with
RHCOS and it wasn't working.  Turns out the code to do this
introduced with
https://github.com/coreos/coreos-assembler/commit/7e2a920f70a68b0d9637feddac36db19065e1891
wasn't quite right.