### PR TITLE
Revert "create_disk: Drop the root= and rootflags= kargs by default"

### DIFF
--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -209,7 +209,7 @@ if [ "${remote_name}" != NONE ]; then
 fi
 ostree pull-local "$ostree" "$ref" --repo rootfs/ostree/repo $remote_arg
 ostree admin os-init "$os_name" --sysroot rootfs
-allkargs='$ignition_firstboot'
+allkargs='root=/dev/disk/by-label/root rootflags=defaults,prjquota rw $ignition_firstboot'
 allkargs="$allkargs $extrakargs"
 kargsargs=""
 for karg in $allkargs


### PR DESCRIPTION
This reverts commit 99f2ed566851d84af7f40d6b368b727e318a733f.

This breaks rebooting, we need to ensure the sysroot mount unit
runs on subsequent boots too.