### PR TITLE
(take2) create_disk: Drop the root= and rootflags= kargs by default

### DIFF
--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -209,8 +209,9 @@ if [ "${remote_name}" != NONE ]; then
 fi
 ostree pull-local "$ostree" "$ref" --repo rootfs/ostree/repo $remote_arg
 ostree admin os-init "$os_name" --sysroot rootfs
-allkargs='root=/dev/disk/by-label/root rootflags=defaults,prjquota rw $ignition_firstboot'
-allkargs="$allkargs $extrakargs"
+# Note that $ignition_firstboot is interpreted by grub at boot time,
+# *not* the shell here.  Hence the backslash escape.
+allkargs="\$ignition_firstboot $extrakargs"
 kargsargs=""
 for karg in $allkargs
 do


### PR DESCRIPTION
This reverts commit e92be856d2546cdd9a7f509804246de94fae2011.

It will work now with https://github.com/coreos/fedora-coreos-config/pull/210