### PR TITLE
ci: run full kola testsuite in parallel 

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -1,6 +1,6 @@
 @Library('github.com/coreos/coreos-ci-lib@master') _
 
-coreos.pod([image: 'registry.fedoraproject.org/fedora:30', privileged: true, kvm: true]) {
+coreos.pod([image: 'registry.fedoraproject.org/fedora:30', runAsUser: 0, kvm: true]) {
       checkout scm
 
       stage("Build") {

--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -1,4 +1,4 @@
-@Library('github.com/jlebon/coreos-ci-lib@master') _
+@Library('github.com/coreos/coreos-ci-lib@master') _
 
 coreos.pod([image: 'registry.fedoraproject.org/fedora:30', privileged: true, kvm: true]) {
       checkout scm

--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -1,6 +1,6 @@
 @Library('github.com/coreos/coreos-ci-lib@master') _
 
-coreos.pod([image: 'registry.fedoraproject.org/fedora:30', runAsUser: 0, kvm: true]) {
+coreos.pod([image: 'registry.fedoraproject.org/fedora:30', runAsUser: 0, kvm: true, memory: "9Gi"]) {
       checkout scm
 
       stage("Build") {
@@ -24,7 +24,7 @@ coreos.pod([image: 'registry.fedoraproject.org/fedora:30', runAsUser: 0, kvm: tr
               cosa_cmd("init https://github.com/coreos/fedora-coreos-config")
               cosa_cmd("fetch")
               cosa_cmd("build")
-              cosa_cmd("kola run fcos.basic")
+              cosa_cmd("kola run -- --parallel 8")
               // sanity check kola actually ran and dumped its output in tmp/
               coreos.shwrap("test -d /srv/tmp/kola")
               cosa_cmd("buildextend-metal")


### PR DESCRIPTION
This is a follow-up to #879. Instead of only running `fcos.basic`, run
everything, but in parallel. This should drastically lower the amount of
time it takes to run it.