### PR TITLE
Add swtpm to dependencies, ensure we cleanup tmpstate dir after `run`

### DIFF
--- a/src/cmd-run
+++ b/src/cmd-run
@@ -405,13 +405,9 @@ set -- -name coreos -m "${VM_MEMORY}" -nographic \
 # the swtpm and qemu processes.
 if [ "${SWTPM}" = 1 ] && [ -x /usr/bin/swtpm ]; then
     tpm_dir=$(mktemp -d -t cosa-tpmstate.XXXXXX)
-    setpriv --pdeathsig SIGTERM -- swtpm socket \
-        --terminate \
-        --tpmstate dir="${tpm_dir}" --tpm2 \
-        --ctrl type=unixio,path="${tpm_dir}/swtpm-sock" &
+    setpriv --pdeathsig SIGTERM -- "${dn}"/swtpm-wrapper "${tpm_dir}" &
     set -- -chardev socket,id=chrtpm,path="${tpm_dir}/swtpm-sock" \
            -tpmdev emulator,id=tpm0,chardev=chrtpm -device tpm-tis,tpmdev=tpm0 "$@"
-    trap 'rm -rf ${tpm_dir}' EXIT
 fi
 
 if [ -z "${SSH_ATTACH}" ]; then

--- a/src/deps.txt
+++ b/src/deps.txt
@@ -24,7 +24,7 @@ selinux-policy-targeted rpm-build
 make git rpm-build
 
 # virt dependencies
-libguestfs-tools /usr/bin/qemu-img qemu-kvm
+libguestfs-tools /usr/bin/qemu-img qemu-kvm swtpm
 
 # ostree-releng-scripts dependencies
 rsync

--- a/src/swtpm-wrapper
+++ b/src/swtpm-wrapper
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euo pipefail
+# Clean up tmpdir when terminated
+tpm_dir="$1"
+shift
+setpriv --pdeathsig SIGTERM swtpm socket \
+        --terminate \
+        --tpmstate dir="${tpm_dir}" --tpm2 \
+        --ctrl type=unixio,path="${tpm_dir}/swtpm-sock" &
+trap 'rm -rf ${tpm_dir}' EXIT
+wait


### PR DESCRIPTION
Fixes for post-merge review of commit to add swtpm.  We want it
in dependencies to help make "has a TPM" the default.  And ensure
we clean up after ourselves.