### PR TITLE
Run `git describe` for config git on init and each build operation

### DIFF
--- a/src/cmd-init
+++ b/src/cmd-init
@@ -103,6 +103,7 @@ mkdir -p src
                 mv config config-git
                 ln -sr config-git/"${subdir}" config
             fi
+            (set +x; cd config && echo -n "Config commit: " && git describe --tags --always --abbrev=42)
             ;;
      esac
      manifest=config/manifest.yaml

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -192,6 +192,9 @@ prepare_build() {
         fatal "Failed to find ${manifest}"
     fi
 
+    if [ -d "${configdir}/.git" ]; then
+        (cd "${configdir}" && echo -n "Config commit: " && git describe --tags --always --abbrev=42)
+    fi
     echo "Using manifest: ${manifest}"
 
     # Be nice to people who have older versions that


### PR DESCRIPTION
In the situation where cosa itself does the clone, it's really
useful for debugging to see directly in the logs the output of `git describe`
for the config.