### PR TITLE
init: Pass --branch to git clone command

### DIFF
--- a/src/cmd-init
+++ b/src/cmd-init
@@ -95,10 +95,7 @@ mkdir -p src
  if ! test -e config; then
      case "${source}" in
          /*) ln -s "${source}/${subdir}" config;;
-         *) git clone --recurse-submodules "${source}" config
-            if [ -n "${BRANCH}" ]; then
-                git -C config checkout "${BRANCH}"
-            fi
+         *) git clone ${BRANCH:+--branch=${BRANCH}} --recurse-submodules "${source}" config
             if [ -n "${subdir}" ]; then
                 mv config config-git
                 ln -sr config-git/"${subdir}" config


### PR DESCRIPTION
In the case where submodules are only on a branch, then
the initial clone won't get them.  We were only not using `--branch`
because of RHEL7 support, which we no longer care about.  Pass
`--branch` to the initial `git clone` so it's cleaner, and we handle
submodules correctly.