### PR TITLE
[rhcos-4.2-multiarch] Backport #732, DASD work

### DIFF
--- a/src/cmd-buildextend-installer
+++ b/src/cmd-buildextend-installer
@@ -7,6 +7,7 @@ import argparse
 import json
 import os
 import platform
+import struct
 import shutil
 import sys
 import tarfile
@@ -67,6 +68,10 @@ os.mkdir(tmpisoisolinux)
 
 def generate_iso():
     arch = platform.machine()
+    # convention for kernel and initramfs names
+    kernel_img = 'vmlinuz'
+    initramfs_img = 'initramfs.img'
+
     tmpisofile = os.path.join(tmpdir, iso_name)
 
     # Find the directory under `/usr/lib/modules/<kver>` where the
@@ -78,7 +83,7 @@ def generate_iso():
     moduledir = process.stdout.decode().split('\0')[1]
 
     # copy those files out of the ostree into the iso root dir
-    for file in ['initramfs.img', 'vmlinuz']:
+    for file in [kernel_img, initramfs_img]:
         run_verbose(['/usr/bin/ostree', 'checkout', '--repo', repo,
                      '--user-mode', '--subpath', os.path.join(moduledir, file),
                      f"{buildmeta_commit}", tmpisoimages])
@@ -124,17 +129,47 @@ def generate_iso():
         genisoargs += ['-r', '-l', '-sysid', 'PPC',
                        '-chrp-boot', '-graft-points']
     elif arch == "s390x":
+        INITRD_ADDRESS = '0x02000000'
+        lorax_templates = '/usr/share/lorax/templates.d/99-generic/config_files/s390'
+        shutil.copy(os.path.join(lorax_templates, 'redhat.exec'), tmpisoimages)
+        with open(os.path.join(lorax_templates, 'generic.ins'), 'r') as fp1:
+            with open(os.path.join(tmpisoroot, 'generic.ins'), 'w') as fp2:
+                [fp2.write(line.replace('@INITRD_LOAD_ADDRESS@', INITRD_ADDRESS)) for line in fp1]
+        for prmfile in ['cdboot.prm', 'genericdvd.prm', 'generic.prm']:
+            with open(os.path.join(tmpisoimages, prmfile), 'w') as fp1:
+                line1 = 'cio_ignore=all,!condev rd.cmdline=ask'
+                with open(os.path.join(tmpisoroot, 'zipl.prm'), 'r') as fp2:
+                    line1 += ' ' + ' '.join([line2.strip('\n') for line2 in fp2])
+                fp1.write(line1)
+
+        # s390x's z/VM CMS files are limited to 8 char for filenames and extensions
+        # Also it is nice to keep naming convetion with Fedora/RHEL for existing users and code
+        shutil.move(os.path.join(tmpisoimages, kernel_img), os.path.join(tmpisoimages, 'kernel.img'))
+        shutil.move(os.path.join(tmpisoimages, initramfs_img), os.path.join(tmpisoimages, 'initrd.img'))
+        kernel_img = 'kernel.img'
+        initramfs_img = 'initrd.img'
+
         # combine kernel, initramfs and cmdline using lorax/mk-s390-cdboot tool
         run_verbose(['/usr/bin/mk-s390-cdboot',
-                     '-i', os.path.join(tmpisoimages, 'vmlinuz'),
-                     '-r', os.path.join(tmpisoimages, 'initramfs.img'),
-                     '-p', os.path.join(tmpisoroot, 'zipl.prm'),
-                     '-o', os.path.join(tmpisoimages, 'fcos.img')])
+                     '-i', os.path.join(tmpisoimages, kernel_img),
+                     '-r', os.path.join(tmpisoimages, initramfs_img),
+                     '-p', os.path.join(tmpisoimages, 'cdboot.prm'),
+                     '-o', os.path.join(tmpisoimages, 'cdboot.img')])
+        # generate .addrsize file for LPAR
+        with open(os.path.join(tmpisoimages, 'initrd.addrsize'), 'wb') as addrsize:
+            addrsize_data = struct.pack(">iiii", 0, int(INITRD_ADDRESS, 16), 0,
+                                        os.stat(os.path.join(tmpisoimages, initramfs_img)).st_size)
+            addrsize.write(addrsize_data)
+
+        # safely remove things we don't need in the final ISO tree
+        for d in ['EFI', 'isolinux', 'zipl.prm']:
+            run_verbose(['rm', '-rf', os.path.join(tmpisoroot, d)])
+
         genisoargs = ['/usr/bin/xorrisofs', '-verbose',
                       '-volset', f"{name_version}",
-                      '-rock', '-J', '-joliet-long',
+                      '-rational-rock', '-J', '-joliet-long',
                       '-no-emul-boot', '-eltorito-boot',
-                      os.path.join(os.path.relpath(tmpisoimages, tmpisoroot), 'fcos.img')]
+                      os.path.join(os.path.relpath(tmpisoimages, tmpisoroot), 'cdboot.img')]
 
     ### For x86_64 and aarch64 UEFI booting
     if arch in ("x86_64", "aarch64"):
@@ -203,8 +238,8 @@ def generate_iso():
     initramfs_name = f'{base_name}-{args.build}-installer-initramfs.img'
     kernel_file = os.path.join(builddir, kernel_name)
     initramfs_file = os.path.join(builddir, initramfs_name)
-    shutil.copyfile(os.path.join(tmpisoimages, "vmlinuz"), kernel_file)
-    shutil.copyfile(os.path.join(tmpisoimages, "initramfs.img"), initramfs_file)
+    shutil.copyfile(os.path.join(tmpisoimages, kernel_img), kernel_file)
+    shutil.copyfile(os.path.join(tmpisoimages, initramfs_img), initramfs_file)
 
     kernel_checksum = sha256sum_file(kernel_file)
     initramfs_checksum = sha256sum_file(initramfs_file)

--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -8,19 +8,20 @@ dn=$(dirname "$0")
 print_help() {
     cat 1>&2 <<'EOF'
 Usage: coreos-assembler buildextend-metal --help
-       coreos-assembler buildextend-metal [--build ID] [--bios] [--uefi]
+       coreos-assembler buildextend-metal [--build ID] [--bios] [--uefi] [--dasd]
 
-  Build raw metal images for bios or metal. If neither switches are provided,
-  both targets are built.
+  Build raw metal images for bios or uefi or dasd. If none of the switches are
+  provided, both bios and uefi are built.
 EOF
 }
 
 # Parse options
 BIOS=
 UEFI=
+DASD=
 rc=0
 build=
-options=$(getopt --options h --longoptions help,build:,bios,uefi -- "$@") || rc=$?
+options=$(getopt --options h --longoptions help,build:,bios,uefi,dasd -- "$@") || rc=$?
 [ $rc -eq 0 ] || {
     print_help
     exit 1
@@ -37,6 +38,9 @@ while true; do
             ;;
         --uefi)
             UEFI=1
+            ;;
+        --dasd)
+            DASD=1
             ;;
         --build)
             build=$2
@@ -62,8 +66,8 @@ if [ $# -ne 0 ]; then
     fatal "Too many arguments passed"
 fi
 
-# default to both of them
-if [ -z "${BIOS}" ] && [ -z "${UEFI}" ]; then
+# default to both BIOS and UEFI
+if [ -z "${BIOS}" ] && [ -z "${UEFI}" ] && [ -z "${DASD}" ]; then
     BIOS=1
     UEFI=1
 fi
@@ -121,7 +125,7 @@ fi
 # for anaconda logs
 mkdir -p tmp/anaconda
 
-for itype in ${BIOS:+metal-bios} ${UEFI:+metal-uefi}; do
+for itype in ${BIOS:+metal-bios} ${UEFI:+metal-uefi} ${DASD:+metal-dasd}; do
     img=${name}-${build}-${itype}.raw
     if [ -f "${builddir}/${img}" ]; then
         echo "Image $itype already exists"

--- a/src/gf-anaconda-cleanup
+++ b/src/gf-anaconda-cleanup
@@ -9,11 +9,13 @@ dn=$(dirname "$0")
 . "${dn}"/libguestfish.sh
 
 SAVE_VAR=
-options=$(getopt --options '' --longoptions save-var-subdirs-for-selabel-workaround -- "$@")
+BLOCK_SIZE=
+options=$(getopt --options '' --longoptions save-var-subdirs-for-selabel-workaround --longoptions blocksize: -- "$@")
 eval set -- "$options"
 while true; do
     case "$1" in
         --save-var-subdirs-for-selabel-workaround) SAVE_VAR=1;;
+        --blocksize) BLOCK_SIZE="$2";;
         --) shift; break;;
     esac
     shift
@@ -23,7 +25,11 @@ src="$1"
 shift
 
 set -x
-coreos_gf_run "${src}"
+if [ -z "$BLOCK_SIZE" ]; then
+    coreos_gf_run "${src}"
+else
+    coreos_gf_run "${src}" "blocksize:$BLOCK_SIZE"
+fi
 # We don't have a way to do this with Anaconda/kickstart right now.
 # This bootstraps us to be able to do all of the mounts.
 if [ "$arch" != "s390x" ]; then

--- a/src/gf-platformid
+++ b/src/gf-platformid
@@ -35,7 +35,12 @@ cp --reflink=auto "${src}" "${tmp_dest}"
 # <walters> I commonly chmod a-w VM images
 chmod u+w "${tmp_dest}"
 
-coreos_gf_run_mount "${tmp_dest}"
+# if our image is a DASD, we need to add blocksize:4096 to coreos_gf_run
+if ! grep -q -i dasd <<< "$dest"; then
+    coreos_gf_run_mount "${tmp_dest}"
+else
+    coreos_gf_run_mount "${tmp_dest}" "blocksize:4096"
+fi
 
 # Inject PLATFORM label in all relevant places:
 # * grub config

--- a/src/libguestfish.sh
+++ b/src/libguestfish.sh
@@ -41,7 +41,12 @@ coreos_gf_run() {
         return
     fi
     coreos_gf_launch "$@"
-    coreos_gf run
+    # passing an empty string to guestfish's run command does not work
+    if ! grep -q -o 'blocksize:[^ :]*' <<< "$@"; then
+        coreos_gf run
+    else
+        coreos_gf run "$(grep -o 'blocksize:[^ :]*' <<< "$@")"
+    fi
     GUESTFISH_RUNNING=1
 }
 

--- a/src/virt-install
+++ b/src/virt-install
@@ -40,7 +40,7 @@ parser.add_argument("--create-disk", help="Automatically create disk as qcow2, p
 parser.add_argument("--configdir", help="coreos-assembler configdir",
                     action='store', required=True)
 parser.add_argument("--variant", help="Configure image variant",
-                    choices=('metal-bios', 'metal-uefi', 'cloud'), default=None)
+                    choices=('metal-bios', 'metal-uefi', 'metal-dasd', 'cloud'), default=None)
 parser.add_argument("--kickstart-out", help="Save flattened kickstart",
                     action='store')
 parser.add_argument("--location", help="Installer location",
@@ -123,7 +123,12 @@ with open('/usr/lib/coreos-assembler/image-base.ks') as basef:
     if platform.machine() == "s390x":
         # no grub for s390x, so gf-platform-id won't work. need to add it here
         if args.create_disk and args.variant.startswith('metal-'):
-            extra_kargs.append("ignition.firstboot rd.neednet=1 ip=dhcp ignition.platform.id=metal")
+            # Firstboot parameters put here would be inherited to BLS files later, not some thing we want
+            # rd.neednet=1 would be provided in rhcos-config/installer/zipl.prm
+            # ignition.firstboot would be provided in coreos-installer
+            # ip=dhcp or ip=<static-ip> must be entered by user when installing with coreos-installer.
+            # This is to allow s390x users who want to use static IP assignment.
+            extra_kargs.append("ignition.platform.id=metal")
         else:
             extra_kargs.append("ignition.firstboot rd.neednet=1 ip=dhcp ignition.platform.id=qemu")
         buf = buf.replace('%%DISKLABEL%%','')
@@ -305,6 +310,9 @@ try:
         else:
             raise SystemExit("Unknown machine architecture "+arch+" can't determine the kernel and initrd location")
 
+    dest_disk = "--disk=path={},cache=unsafe".format(args.dest)
+    if args.variant == 'metal-dasd':
+        dest_disk += ",physical_block_size=4096,logical_block_size=4096"
     vinstall_args.extend(["--wait={}".format(args.wait), "--noreboot", "--nographics",
                           "--memory={}".format(args.memory), get_libvirt_smp_arg(),
                           "--os-variant=rhel7.6", "--rng=/dev/urandom",
@@ -312,7 +320,7 @@ try:
                           "--check", "path_in_use=off",
                           "--network=user",  # user mode networking
                           location_arg,
-                          "--disk=path={},cache=unsafe".format(args.dest),
+                          "{}".format(dest_disk),
                           "--initrd-inject={}".format(ks_tmp.name),
                           "--extra-args", "ks=file://{} console=tty0 console={},115200n8 inst.cmdline inst.notmux".format(os.path.basename(ks_tmp.name),os.environ.get('DEFAULT_TERMINAL', 'ttyS0'))])
     if args.variant == 'metal-uefi':
@@ -324,6 +332,8 @@ try:
     cleanup_argv = ['/usr/lib/coreos-assembler/gf-anaconda-cleanup', args.dest]
     if image_conf.get('save-var-subdirs-for-selabel-workaround'):
         cleanup_argv += ['--save-var-subdirs-for-selabel-workaround']
+    if args.variant == 'metal-dasd':
+        cleanup_argv += ['--blocksize', '4096']
     run_sync_verbose(cleanup_argv)
 
     # This one is part of the "API" we provide to config repositories.  At least


### PR DESCRIPTION
Two commits:
1.
installer: use lorax s390x templates, allow adding parameters at boot
Backport from PR #732 with some small changes.

2.
dasd: allow building and running

This requires libguestfs support for adding custom blocksize for image
file. The patch at upstream is :
https://www.redhat.com/archives/libguestfs/2019-November/msg00025.html

This patch or its later version should go to F30/F31 and eventually be
used by the cosa container.

We never had the issue with libguestfs/guestfish and custom blocksize on
master because we have moved away from anaconda before DASD support
landed.

