### PR TITLE
[4.1] Dockerfile: bump to F30

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:29
+FROM registry.fedoraproject.org/fedora:30
 WORKDIR /root/containerbuild
 
 # Only need a few of our scripts for the first few steps


### PR DESCRIPTION
RHCOS needs a newer version of `rpm-ostree` in the `coreos-assembler`
container to correctly build RHCOS with RHEL 8.1 content.  The updated
`rpm-ostree` is only available in F30 or newer.