### PR TITLE
[rhcos-4.2-multiarch] virt-install: set ostree bootloader backend to zipl

### DIFF
--- a/src/virt-install
+++ b/src/virt-install
@@ -132,6 +132,10 @@ with open('/usr/lib/coreos-assembler/image-base.ks') as basef:
         else:
             extra_kargs.append("ignition.firstboot rd.neednet=1 ip=dhcp ignition.platform.id=qemu")
         buf = buf.replace('%%DISKLABEL%%','')
+        # set the bootloader backend to zipl
+        buf += ("\n%post --nochroot --erroronfail\n" +
+                "ostree config --repo /mnt/sysimage/ostree/repo set sysroot.bootloader zipl\n" +
+                "%end\n")
     else:
         buf = buf.replace('%%DISKLABEL%%',' --disklabel=gpt')
     buf = buf.replace('%%KARGS%%', ' '.join(extra_kargs))


### PR DESCRIPTION
As suggested in
https://github.com/coreos/ignition-dracut/pull/117#discussion_r336516583