### PR TITLE
remote-prune: cleanup other platforms

### DIFF
--- a/src/cmd-remote-prune
+++ b/src/cmd-remote-prune
@@ -6,6 +6,7 @@
 
 import argparse
 import sys
+import os
 
 from cosalib.builds import Builds
 from cosalib.prune import fetch_build_meta, get_unreferenced_s3_builds, delete_build
@@ -14,6 +15,10 @@ parser = argparse.ArgumentParser(prog="coreos-assembler remote-prune")
 parser.add_argument("--workdir", default='.', help="Path to workdir")
 parser.add_argument("--dry-run", help="Don't actually delete anything",
                     action='store_true')
+parser.add_argument("--gcp-json-key", help="GCP Service Account JSON Auth",
+                    default=os.environ.get("GCP_JSON_AUTH"))
+parser.add_argument("--gcp-project", help="GCP Project name",
+                    default=os.environ.get("GCP_PROJECT_NAME"))
 
 subparsers = parser.add_subparsers(dest='cmd', title='subcommands')
 subparsers.required = True
@@ -44,13 +49,20 @@ if args.dry_run:
     print("Not removing anything: in dry-run mode")
     sys.exit(0)
 
+cloud_config = {
+    'gcp': {
+        'json-key': args.gcp_json_key,
+        'project': args.gcp_project,
+    }
+}
+
 error_during_pruning = False
 for unmatched_build_id in unreferenced_s3_builds:
     # TODO: fetch arches from s3
     build = fetch_build_meta(builds, unmatched_build_id, 'x86_64', args.bucket, args.prefix)
     if build:
         try:
-            delete_build(build, args.bucket, args.prefix)
+            delete_build(build, args.bucket, args.prefix, cloud_config)
         except Exception as e:
             error_during_pruning = True
             print(f"{e}")

--- a/src/cmd-remote-prune
+++ b/src/cmd-remote-prune
@@ -26,6 +26,8 @@ subparsers.required = True
 s3 = subparsers.add_parser('s3', help='Prune s3 buckets')
 s3.add_argument("--bucket", help="Bucket name")
 s3.add_argument("--prefix", help="Key prefix")
+s3.add_argument("--force", help="Wipe s3 key ignoring the errors",
+                action='store_true')
 
 args = parser.parse_args()
 
@@ -62,7 +64,7 @@ for unmatched_build_id in unreferenced_s3_builds:
     build = fetch_build_meta(builds, unmatched_build_id, 'x86_64', args.bucket, args.prefix)
     if build:
         try:
-            delete_build(build, args.bucket, args.prefix, cloud_config)
+            delete_build(build, args.bucket, args.prefix, cloud_config, args.force)
         except Exception as e:
             error_during_pruning = True
             print(f"{e}")

--- a/src/cosalib/aliyun.py
+++ b/src/cosalib/aliyun.py
@@ -1,0 +1,11 @@
+from cosalib.cmdlib import run_verbose
+
+
+def remove_aliyun_image(aliyun_id, region):
+    print(f"aliyun: removing image {aliyun_id} in {region}")
+    try:
+        run_verbose(['ore', 'aliyun', '--log-level', 'debug', 'delete-image',
+                     '--id', aliyun_id,
+                     '--force'])
+    except SystemExit:
+        raise Exception("Failed to remove image")

--- a/src/cosalib/gcp.py
+++ b/src/cosalib/gcp.py
@@ -1,0 +1,11 @@
+from cosalib.cmdlib import run_verbose
+
+
+def remove_gcp_image(gcp_id, json_key, project):
+    print(f"GCP: removing image {gcp_id}")
+    try:
+        run_verbose(['ore', 'gcloud', 'delete-images', gcp_id,
+                    '--json-key', json_key,
+                    '--project', project])
+    except SystemExit:
+        raise Exception("Failed to remove image")

--- a/src/cosalib/prune.py
+++ b/src/cosalib/prune.py
@@ -81,7 +81,7 @@ def fetch_build_meta(builds, buildid, arch, bucket, prefix):
         )
 
 
-def delete_build(build, bucket, prefix, cloud_config):
+def delete_build(build, bucket, prefix, cloud_config, force=False):
     print(f"Deleting build {build.id}")
     errors = []
     # Unregister AMIs and snapshots
@@ -125,7 +125,8 @@ def delete_build(build, bucket, prefix, cloud_config):
         print(f"Found errors when removing build {build.id}:")
         for e in errors:
             print(e)
-        raise Exception()
+        if not force:
+            raise Exception()
 
     # Delete s3 bucket
     print(f"Deleting key {prefix}{build.id} from bucket {bucket}")


### PR DESCRIPTION
Remove images/snapshots on aliyun/gcp during `remote-prune` using `ore`

Azure is currently skipped, as its not yet implemented in `ore` (https://github.com/coreos/mantle/issues/1115).

Tested on dev builds of RHCOS pipeline