### PR TITLE
[rhcos-4.2-multiarch] metal: guard check for DASD and UEFI

### DIFF
--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -72,6 +72,12 @@ if [ -z "${BIOS}" ] && [ -z "${UEFI}" ] && [ -z "${DASD}" ]; then
     UEFI=1
 fi
 
+if [ -n "${UEFI}" ] && [ "${arch}" = "s390x" ]; then
+    fatal "${arch} is not supported for building UEFI image"
+elif [ -n "${DASD}" ] && [ "${arch}" != "s390x" ]; then
+    fatal "${arch} is not supported for building DASD image"
+fi
+
 export LIBGUESTFS_BACKEND=direct
 
 prepare_build


### PR DESCRIPTION
Similar to fada24b7dd225f3419e170f4570c15e0c496b6d6