### PR TITLE
[WIP] Allow builds for arches that arent currently built

### DIFF
--- a/src/cmd-buildprep
+++ b/src/cmd-buildprep
@@ -64,6 +64,13 @@ def main():
     # this a switch in the future.
 
     buildid = builds.get_latest()
+
+    # Check if current arch exists in builds.json
+    if not builds.has_build_arch(buildid):
+        print("Remote has no builds for current architecture")
+        builds = None
+        return
+
     builddir = builds.get_build_dir(buildid)
     os.makedirs(builddir, exist_ok=True)
 

--- a/src/cosalib/builds.py
+++ b/src/cosalib/builds.py
@@ -75,6 +75,11 @@ class Builds:  # pragma: nocover
                 return build['arches']
         assert False, "Build not found!"
 
+    def has_build_arch(self, build_id, basearch=None):
+        if not basearch:
+            basearch = get_basearch()
+        return (basearch in self.get_build_arches(build_id))
+
     def get_build_dir(self, build_id, basearch=None):
         if build_id == 'latest':
             build_id = self.get_latest()


### PR DESCRIPTION
buildprep will fail if the current arch does not exist in the
builds.json, since the directory structure is not in place. This checks
whether the arch is included in the builds.json already, and if not it
will continue through.