### PR TITLE
Work around supermin + kernel + ext2 filesystem bug

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -38,6 +38,10 @@ install_rpms() {
     # requires https://bugzilla.redhat.com/show_bug.cgi?id=1625641
     yum -y distro-sync
 
+    # XXX: Temporarily work around a bug in the way supermin creates ext2
+    # filesystems: https://bugzilla.redhat.com/show_bug.cgi?id=1770304
+    yum -y install https://kojipkgs.fedoraproject.org//packages/kernel/5.3.7/300.fc31/x86_64/kernel-core-5.3.7-300.fc31.x86_64.rpm
+
     # xargs is part of findutils, which may not be installed
     yum -y install /usr/bin/xargs
 


### PR DESCRIPTION
See all the details in:
https://bugzilla.redhat.com/show_bug.cgi?id=1770304

But the TL;DR is: there seems to be an issue in the way supermin creates
the root ext2 filesystem which became a hard error in 5.3.8. So for now,
let's just keep pulling 5.3.7.