### PR TITLE
vmdeps-s390x: remove haveged

### DIFF
--- a/src/vmdeps-s390x.txt
+++ b/src/vmdeps-s390x.txt
@@ -1,1 +1,1 @@
-s390utils-base haveged
+s390utils-base


### PR DESCRIPTION
s390x never actually needed haveged.

The only reason I put haveged in my patches in the early days, is
because I only had a z/VM guest to install F29, which would run another
supermin VM to run anaconda. And 3-4 nested virtualization layers made
it slow to generate SSH keys during early boot of supermin due to lack
of entropy.

Putting haveged here creates the impression that s390x actually has the
needs for haveged, compared to other architectures, which is not correct.