### PR TITLE
Change kernel-core to be arch specific

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -40,7 +40,7 @@ install_rpms() {
 
     # XXX: Temporarily work around a bug in the way supermin creates ext2
     # filesystems: https://bugzilla.redhat.com/show_bug.cgi?id=1770304
-    yum -y install https://kojipkgs.fedoraproject.org//packages/kernel/5.3.7/300.fc31/x86_64/kernel-core-5.3.7-300.fc31.x86_64.rpm
+    yum -y install https://kojipkgs.fedoraproject.org//packages/kernel/5.3.7/300.fc31/"${arch}"/kernel-core-5.3.7-300.fc31."${arch}".rpm
 
     # xargs is part of findutils, which may not be installed
     yum -y install /usr/bin/xargs


### PR DESCRIPTION
The work around added to install kernel-core from koji will now install
the specific archs package.