### PR TITLE
add dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,7 @@
+version: 1
+
+update_configs:
+  - package_manager: "submodules"
+    directory: "/"
+    update_schedule: "daily"
+


### PR DESCRIPTION
This should enable us to keep the `mantle` submodule up to date more
easiy.