### PR TITLE
create_disk: Support rootfs-size

### DIFF
--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -142,6 +142,7 @@ path=${PWD}/${img}
 
 # For bare metal images, we estimate the disk size. For qemu, we get it from
 # image.yaml.
+rootfs_size="0"
 if [[ $image_type == metal || $image_type == dasd ]]; then
     echo "Estimating disk size..."
     /usr/lib/coreos-assembler/estimate-commit-disk-size --repo "$ostree_repo" "$ref" --add-percent 20 > "$PWD/tmp/ostree-size.json"
@@ -152,6 +153,7 @@ if [[ $image_type == metal || $image_type == dasd ]]; then
     ignition_platform_id="metal"
 else
     size="$(python3 -c 'import sys, yaml; print(yaml.safe_load(sys.stdin)["size"])' < "$configdir/image.yaml")G"
+    rootfs_size="$(python3 -c 'import sys, yaml; print(yaml.safe_load(sys.stdin).get("rootfs-size", "0"))' < "$configdir/image.yaml")"
     ignition_platform_id="$image_type"
 fi
 
@@ -191,6 +193,7 @@ runvm "${target_drive[@]}" -- \
             --ostree-remote "${ostree_remote}" \
             --ostree-repo "${ostree_repo}" \
             --save-var-subdirs "${save_var_subdirs}" \
+            --rootfs-size "${rootfs_size}" \
             "${luks_flag}"
 mv "${path}.tmp" "$path"
 echo "{}" > tmp/vm-iso-checksum.json

--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -27,6 +27,7 @@ Options:
     --ostree-remote: the ostree remote
     --ostree-repo: location of the ostree repo
     --save-var-subdirs: "yes" to workaround selabel issue for RHCOS
+    --rootfs-size: Create the root filesystem with specified size
     --luks-rootfs: place rootfs in a LUKS container
 
 You probably don't want to run this script by hand. This script is
@@ -34,6 +35,7 @@ run as part of 'coreos-assembler build'.
 EOC
 }
 
+rootfs_size="0"
 luks_rootfs=""
 extrakargs=""
 
@@ -52,6 +54,7 @@ do
         --ostree-remote)    remote_name="${1}"; shift;;
         --ostree-repo)      ostree="${1}"; shift;;
         --save-var-subdirs) save_var_subdirs="${1}"; shift;;
+        --rootfs-size)      rootfs_size="${1}"; shift;;
         --luks-rootfs)      luks_rootfs=1;;
          *) echo "${flag} is not understood."; usage; exit 10;;
          --) break;
@@ -83,6 +86,14 @@ set -x
 # Pin /boot and / to the partition number 1 and 4 respectivelly
 BOOTPN=1
 ROOTPN=4
+echo "rootfs_size=${rootfs_size}"
+if [ "${rootfs_size}" != 0 ]; then
+    case "${rootfs_size}" in
+        *[GMT]) ;;
+        *) rootfs_size="${rootfs_size}G" ;;
+    esac
+    rootfs_size="+${rootfs_size}"
+fi
 case "$arch" in
     x86_64)
         sgdisk -Z $disk \
@@ -90,7 +101,7 @@ case "$arch" in
         -n ${BOOTPN}:0:+384M -c ${BOOTPN}:boot \
         -n 2:0:+127M -c 2:EFI-SYSTEM -t 2:C12A7328-F81F-11D2-BA4B-00A0C93EC93B \
         -n 3:0:+1M   -c 3:BIOS-BOOT  -t 3:21686148-6449-6E6F-744E-656564454649 \
-        -n ${ROOTPN}:0:0     -c ${ROOTPN}:root       -t ${ROOTPN}:0FC63DAF-8483-4772-8E79-3D69D8477DE4
+        -n ${ROOTPN}:0:${rootfs_size}     -c ${ROOTPN}:root       -t ${ROOTPN}:0FC63DAF-8483-4772-8E79-3D69D8477DE4
         sgdisk -p "$disk"
         EFIPN=2
         BIOSPN=3
@@ -100,7 +111,7 @@ case "$arch" in
         -U 00000000-0000-4000-a000-000000000001 \
         -n ${BOOTPN}:0:+384M -c ${BOOTPN}:boot \
         -n 2:0:+127M -c 2:EFI-SYSTEM -t 2:C12A7328-F81F-11D2-BA4B-00A0C93EC93B \
-        -n ${ROOTPN}:0:0     -c ${ROOTPN}:root       -t ${ROOTPN}:0FC63DAF-8483-4772-8E79-3D69D8477DE4
+        -n ${ROOTPN}:0:${rootfs_size}     -c ${ROOTPN}:root       -t ${ROOTPN}:0FC63DAF-8483-4772-8E79-3D69D8477DE4
         sgdisk -p "$disk"
         EFIPN=2
         ;;
@@ -108,7 +119,7 @@ case "$arch" in
         sgdisk -Z $disk \
         -U 00000000-0000-4000-a000-000000000001 \
         -n ${BOOTPN}:0:+384M -c ${BOOTPN}:boot \
-        -n ${ROOTPN}:0:0     -c ${ROOTPN}:root       -t ${ROOTPN}:0FC63DAF-8483-4772-8E79-3D69D8477DE4
+        -n ${ROOTPN}:0:${rootfs_size}     -c ${ROOTPN}:root       -t ${ROOTPN}:0FC63DAF-8483-4772-8E79-3D69D8477DE4
         sgdisk -p "$disk"
         ;;
     ppc64le)
@@ -117,7 +128,7 @@ case "$arch" in
         -U 00000000-0000-4000-a000-000000000001 \
         -n 2:0:+4M   -c 2:PowerPC-PReP-boot -t 2:9E1A2D38-C612-4316-AA26-8B49521E5A8B \
         -n ${BOOTPN}:0:+384M -c ${BOOTPN}:boot \
-        -n ${ROOTPN}:0:0     -c ${ROOTPN}:root              -t ${ROOTPN}:0FC63DAF-8483-4772-8E79-3D69D8477DE4
+        -n ${ROOTPN}:0:${rootfs_size}     -c ${ROOTPN}:root              -t ${ROOTPN}:0FC63DAF-8483-4772-8E79-3D69D8477DE4
         sgdisk -p "$disk"
         PREPPN=2
         ;;


### PR DESCRIPTION
For RHCOS with encryption, we encrypt in early boot, and it's beneficial
if the root filesystem size is small initially - distinct from the
"default disk" size that applies in clouds (and libvirt).

This helps RHCOS maintain its default 16G size for libvirt without
requiring the installer and other tools to start resizing it.