### PR TITLE
[rhcos-4.2-multiarch] openstack: build on s390x

### DIFF
--- a/src/gf-platformid
+++ b/src/gf-platformid
@@ -70,6 +70,14 @@ sed -i -e 's, ignition.platform.id=[a-zA-Z0-9]*,,g' "${tmpd}"/bls.conf
 sed -i -e 's,^\(options .*\),\1 coreos.oem.id='"${platformid}"' ignition.platform.id='"${platformid}"',' "${tmpd}"/bls.conf
 coreos_gf upload "${tmpd}"/bls.conf "${blscfg_path}"
 
+if [ "$arch" = "s390x" ] ; then
+    coreos_gf debug sh "mount -o bind /sysroot/boot /sysroot/${deploydir}/boot"
+    # zipl wants /proc
+    coreos_gf debug sh "mount -t proc none /sysroot/${deploydir}/proc"
+    coreos_gf debug sh "chroot /sysroot/${deploydir} /usr/sbin/zipl"
+    coreos_gf debug sh "umount /sysroot/${deploydir}/proc /sysroot/${deploydir}/boot"
+fi
+
 coreos_gf_shutdown
 
 mv "${tmp_dest}" "${dest}"


### PR DESCRIPTION
If we run `guestfish --remote sh <command>`, guestfish would run /bin/sh
in the real rootfs - which is an ostree rootfs - and /bin/sh would be
not found. Running with `debug sh` would tell guestfish to run in
supermin's initrd space instead.

Running zipl inside ostree rootfs assumes /etc/zipl.conf exists, which
is created by anaconda in 4.2 branch.
coreos/fedora-coreos-tracker#278

This is for helping the case where a config drive (ISO) is used to pass
Ignition config file to guests, in the case of terraform's libvirt
provider.

Related:
dmacvicar/terraform-provider-libvirt#666
openshift/installer#2672

Co-Authored-By: Prashanth Sundararaman <psundara@redhat.com>