### PR TITLE
[rhcos-4.2-multiarch] gf-platformid: remove duplicated coreos.oem.id

### DIFF
--- a/src/gf-platformid
+++ b/src/gf-platformid
@@ -67,6 +67,7 @@ blscfg_path=$(coreos_gf glob-expand /boot/loader/entries/ostree-*.conf)
 coreos_gf download "${blscfg_path}" "${tmpd}"/bls.conf
 # Remove any platformid currently there
 sed -i -e 's, ignition.platform.id=[a-zA-Z0-9]*,,g' "${tmpd}"/bls.conf
+sed -i -e 's, coreos.oem.id=[a-zA-Z0-9]*,,g' "${tmpd}"/bls.conf
 sed -i -e 's,^\(options .*\),\1 coreos.oem.id='"${platformid}"' ignition.platform.id='"${platformid}"',' "${tmpd}"/bls.conf
 coreos_gf upload "${tmpd}"/bls.conf "${blscfg_path}"
 


### PR DESCRIPTION
Without this, there would be 2 instances of coreos.oem.id= in the
kcmdline.