### PR TITLE
build: Use cache=unsafe when making disk images

### DIFF
--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -173,9 +173,9 @@ ref_arg=${ref}
 if [ -n "${ref_is_temp}" ]; then
     ref_arg=${commit}
 fi
-target_drive=("-drive" "if=virtio,id=target,format=${image_format},file=${path}.tmp")
+target_drive=("-drive" "if=virtio,id=target,format=${image_format},file=${path}.tmp,cache=unsafe")
 if [[ $image_format == raw && $image_type == dasd ]]; then
-    target_drive=("-drive" "if=none,id=target,format=${image_format},file=${path}.tmp" \
+    target_drive=("-drive" "if=none,id=target,format=${image_format},file=${path}.tmp,cache=unsafe" \
                     # we need 4096 block size for ECKD DASD
                     "-device" "virtio-blk-ccw,drive=target,physical_block_size=4096,logical_block_size=4096,scsi=off")
 fi

--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -208,7 +208,7 @@ if [ "${remote_name}" != NONE ]; then
     remote_arg="--remote=${remote_name}"
     deploy_ref="${remote_name}:${ref}"
 fi
-ostree pull-local "$ostree" "$ref" --repo rootfs/ostree/repo $remote_arg
+time ostree pull-local "$ostree" "$ref" --repo rootfs/ostree/repo $remote_arg
 ostree admin os-init "$os_name" --sysroot rootfs
 # Note that $ignition_firstboot is interpreted by grub at boot time,
 # *not* the shell here.  Hence the backslash escape.


### PR DESCRIPTION
We did this before with `virt-install`; if an image build
fails, we always dispose of the disk image.  Using `cache=unsafe`
means that e.g. the `fsync` invocations that ostree makes
inside the build, as well as filesystem-internal synchronous
writes to the journal and metadata aren't passed through to the host filesystem
by default.  This allows the host filesystem to defer writeback,
speeding up image builds.