### PR TITLE
remote-prune: fix typo in azure params

### DIFF
--- a/src/cmd-remote-prune
+++ b/src/cmd-remote-prune
@@ -61,7 +61,7 @@ cloud_config = {
     'azure': {
         'auth': args.azure_auth,
         'profile': args.azure_profile,
-        'resource-group': args.azure_resouce_group,
+        'resource-group': args.azure_resource_group,
     },
     'gcp': {
         'json-key': args.gcp_json_key,


### PR DESCRIPTION
A typo in args prevents from cleaning up Azure images