### PR TITLE
cmd-kola: Fix blacklist handling when there are none

### DIFF
--- a/src/cmd-kola
+++ b/src/cmd-kola
@@ -36,7 +36,7 @@ blacklist_path = "src/config/kola-blacklist.yaml"
 if os.path.isfile(blacklist_path):
     with open(blacklist_path) as f:
         blacklist = yaml.safe_load(f)
-        for obj in blacklist:
+        for obj in (blacklist or []):
             print(f"⚠️  Skipping kola test pattern \"{obj['pattern']}\":")
             print(f"⚠️  {obj['tracker']}")
             blacklist_args += ['--blacklist-test', obj['pattern']]


### PR DESCRIPTION
E.g. right now RHCOS doesn't need any test blacklisted at all.