### PR TITLE
openstack: build on s390x

### DIFF
--- a/src/gf-platformid
+++ b/src/gf-platformid
@@ -47,6 +47,14 @@ sed -i -e 's, ignition.platform.id=[a-zA-Z0-9]*,,g' "${tmpd}"/bls.conf
 sed -i -e 's,^\(options .*\),\1 ignition.platform.id='"${platformid}"',' "${tmpd}"/bls.conf
 coreos_gf upload "${tmpd}"/bls.conf "${blscfg_path}"
 
+if [ "$basearch" = "s390x" ] ; then
+    coreos_gf debug sh "mount -o bind /sysroot/boot /sysroot/${deploydir}/boot"
+    # zipl wants /proc
+    coreos_gf debug sh "mount -t proc none /sysroot/${deploydir}/proc"
+    coreos_gf debug sh "chroot /sysroot/${deploydir} /usr/sbin/zipl"
+    coreos_gf debug sh "umount /sysroot/${deploydir}/proc /sysroot/${deploydir}/boot"
+fi
+
 coreos_gf_shutdown
 
 mv "${tmp_dest}" "${dest}"


### PR DESCRIPTION
If we run `guestfish --remote sh <command>`, guestfish would run /bin/sh
in the real rootfs - which is an ostree rootfs - and /bin/sh would be
not found. Running with `debug sh` would tell guestfish to run in
supermin's initrd space instead.

This is for helping the case where a config drive (ISO) is used to pass
Ignition config file to guests, in the case of terraform's libvirt
provider.

Related:
https://github.com/dmacvicar/terraform-provider-libvirt/pull/666
https://github.com/openshift/installer/pull/2672

Co-Authored-By: Prashanth Sundararaman <psundara@redhat.com>