### PR TITLE
gf-platformid: use `qemu-img create` instead of reflinks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ install:
 	install -D -t $(DESTDIR)$(PREFIX)/lib/coreos-assembler/cosalib $$(find src/cosalib/ -maxdepth 1 -type f)
 	install -d $(DESTDIR)$(PREFIX)/bin
 	ln -sf ../lib/coreos-assembler/coreos-assembler $(DESTDIR)$(PREFIX)/bin/
+	ln -sf ../lib/coreos-assembler/cp-reflink $(DESTDIR)$(PREFIX)/bin/
 	ln -sf coreos-assembler $(DESTDIR)$(PREFIX)/bin/cosa
 	install -D -t $(DESTDIR)$(PREFIX)/bin mantle/bin/{ore,kola,plume}
 	install -d $(DESTDIR)$(PREFIX)/lib/kola/$(GOARCH)

--- a/src/cmd-build
+++ b/src/cmd-build
@@ -228,7 +228,7 @@ if [ -f "${changed_stamp}" ]; then
     # Clean up prior versions
     rm -f "${workdir}"/tmp/compose-*.json
     # Save this in case the image build fails
-    cp -a --reflink=auto "${composejson}" "${workdir}"/tmp/compose-"${commit}".json
+    cp-reflink "${composejson}" "${workdir}"/tmp/compose-"${commit}".json
 else
     # Pick up from tmprepo; that's what rpm-ostree is comparing against. It may
     # be the same as previous_commit, or newer if a previous build failed image
@@ -254,7 +254,7 @@ else
     cached_previous_composejson=${workdir}/tmp/compose-${commit}.json
     if [ -f "${cached_previous_composejson}" ]; then
         echo "Resuming partial build from: ${commit}"
-        cp -a --reflink=auto "${cached_previous_composejson}" "${composejson}"
+        cp-reflink "${cached_previous_composejson}" "${composejson}"
     else
         if [ -z "${previous_build}" ]; then
             # This can happen if building the OSTree worked on the first time,
@@ -265,7 +265,7 @@ else
         echo "Commit ${commit} unchanged; reusing previous build's rpm-ostree metadata"
         # This will have all of the data from the previous build, but we'll
         # overwrite things.
-        cp -a --reflink=auto "${previous_builddir}"/meta.json "${composejson}"
+        cp-reflink "${previous_builddir}"/meta.json "${composejson}"
     fi
 fi
 
@@ -301,7 +301,7 @@ ostree_tarfile_path=${name}-${buildid}-ostree.${basearch}.tar
 ostree_tarfile_sha256=
 if [ "${commit}" == "${previous_commit}" ] && \
     [ -f "${previous_builddir}/${previous_ostree_tarfile_path}" ]; then
-    cp -a --reflink=auto "${previous_builddir}/${previous_ostree_tarfile_path}" "${ostree_tarfile_path}"
+    cp-reflink "${previous_builddir}/${previous_ostree_tarfile_path}" "${ostree_tarfile_path}"
     ostree_tarfile_sha256=$(jq -r '.images.ostree.sha256' < "${previous_builddir}/meta.json")
     # backcompat: allow older build without this field
     if [ "${ostree_tarfile_sha256}" = "null" ]; then

--- a/src/cmd-buildprep
+++ b/src/cmd-buildprep
@@ -53,7 +53,7 @@ def main():
         # Record the origin and original state
         with open(BUILDFILES['sourceurl'], 'w') as f:
             f.write(args.url + '\n')
-        subprocess.check_call(['cp', '-pf', '--reflink=auto', BUILDFILES['list'], BUILDFILES['sourcedata']])
+        subprocess.check_call(['cp-reflink', BUILDFILES['list'], BUILDFILES['sourcedata']])
         builds = Builds()
 
     if not builds or builds.is_empty():

--- a/src/cmd-buildupload
+++ b/src/cmd-buildupload
@@ -81,7 +81,7 @@ def cmd_upload_s3(args):
         # And now update our cached copy to note we've successfully sync'd.
         with open(BUILDFILES['sourceurl'], 'w') as f:
             f.write(f"s3://{bucket}/{prefix}\n")
-        subprocess.check_call(['cp', '-pf', '--reflink=auto', BUILDFILES['list'], BUILDFILES['sourcedata']])
+        subprocess.check_call(['cp-reflink', BUILDFILES['list'], BUILDFILES['sourcedata']])
 
 
 def s3_upload_build(args, builddir, bucket, prefix):

--- a/src/cp-reflink
+++ b/src/cp-reflink
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec cp -a --reflink=auto "$@"

--- a/src/cp-reflink
+++ b/src/cp-reflink
@@ -1,2 +1,4 @@
 #!/bin/bash
-exec cp -a --reflink=auto "$@"
+# XXX: disable reflinks for now due to possible corruption:
+# https://github.com/coreos/coreos-assembler/pull/935
+exec cp -a --reflink=never "$@"

--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -276,9 +276,9 @@ install_uefi() {
     local target_efi="rootfs/boot/efi"
     local target_efiboot="${target_efi}/EFI/BOOT"
     mkdir -p "${target_efiboot}"
-    cp -a --reflink=auto "${source_efidir}/EFI/BOOT/BOOT"* "${target_efiboot}"
+    /usr/lib/coreos-assembler/cp-reflink "${source_efidir}/EFI/BOOT/BOOT"* "${target_efiboot}"
     local src_grubefi=$(find "${source_efidir}"/EFI/ -name 'grub*.efi')
-    cp -a --reflink=auto "${src_grubefi}" "${target_efiboot}"
+    /usr/lib/coreos-assembler/cp-reflink "${src_grubefi}" "${target_efiboot}"
 
     local vendor_id="$(basename $(dirname ${src_grubefi}))"
     local vendordir="${target_efi}/EFI/${vendor_id}"

--- a/src/gf-platformid
+++ b/src/gf-platformid
@@ -33,7 +33,7 @@ set -x
 tmpd=$(mktemp -tdp "$(dirname "${dest}")" gf-platformid.XXXXXX)
 tmp_dest=${tmpd}/box.img
 
-cp-reflink "${src}" "${tmp_dest}"
+qemu-img create -q -f qcow2 -b "$(realpath "${src}")" "${tmp_dest}"
 # <walters> I commonly chmod a-w VM images
 chmod u+w "${tmp_dest}"
 

--- a/src/gf-platformid
+++ b/src/gf-platformid
@@ -33,7 +33,7 @@ set -x
 tmpd=$(mktemp -tdp "$(dirname "${dest}")" gf-platformid.XXXXXX)
 tmp_dest=${tmpd}/box.img
 
-cp --reflink=auto "${src}" "${tmp_dest}"
+cp-reflink "${src}" "${tmp_dest}"
 # <walters> I commonly chmod a-w VM images
 chmod u+w "${tmp_dest}"
 


### PR DESCRIPTION
I spent a few hours yesterday trying to figure out why my Azure images
were failing to boot in the cloud with:

    error: ../../grub-core/fs/fshelp.c:257:file `/grub2/i386-pc/normal.mod' not found.

What it came down to was whether or not we were doing a reflink copy in
`gf-platformid`. (My root filesystem is configured with reflink support,
so `--reflink=auto` would use reflinks.)

I seem to be hitting a kernel regression of some kind where reflinks +
interactions with guestfish cause the `grub2/` directory of the boot
partition to become corrupted:

```
$ guestmount -a tmp/azure.vhd -m /dev/sda1 tmp/mount && ll /srv/rhcos/tmp/mount
ls: cannot access 'grub2': Bad message
total 20
drwxrwxr-x. 2 root root  1024 Nov 19 11:55 efi
d?????????? ? ?    ?        ?            ? grub2
-rw-rw-r--. 1 root root     0 Nov 19 11:56 ignition.firstboot
lrwxrwxrwx. 1 root root     8 Nov 19 11:56 loader -> loader.1
drwxr-xr-x. 3 root root  1024 Nov 19 11:56 loader.1
drwx------. 2 root root 12288 Nov 19 11:55 lost+found
drwxrwxr-x. 3 root root  1024 Nov 19 11:56 ostree
```

In fact, reproducing the cloud failure is easy to do locally too,
because qemu-kvm will happily boot VHDs, so one can just do
`cosa run -d /path/to/vhd`.

I haven't filed a bug report for this yet because I've been trying to
get a more minimal reproducer and bisecting kernel versions without much
success (for one, it doesn't seem to reproduce in VMs).

The previous patch disabled reflinks globally. Though this makes
`gf-platformid` much slower because it has to copy the full qcow2.
Another more lightweight method here is to just create a new qcow2 and
use the source as its backing file. (Not to mention it also makes it
much faster for all the other devs/CI pipelines which *don't* run with
reflinks on).