### PR TITLE
Add a `build-validate` command

### DIFF
--- a/src/cmd-build-validate
+++ b/src/cmd-build-validate
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import subprocess
+import json
+import argparse
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from cosalib.builds import Builds
+from cosalib.cmdlib import sha256sum_file
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--build", help="Build ID")
+parser.add_argument("--image", help="Just verify given image type")
+parser.add_argument("--no-checksum", help="Skip validating checksum", action='store_true')
+args = parser.parse_args()
+
+
+def validate_checksum(builddir, imgtype, data):
+    path = os.path.join(builddir, data['path'])
+    if not args.no_checksum:
+        actual = sha256sum_file(path)
+        expected = data['sha256']
+        if actual != expected:
+            raise SystemExit(f"Corrupted image '{imgtype}'; found sha256={actual} expected={expected}")
+
+
+def validate_build(builddir):
+    buildmeta_path = os.path.join(builddir, 'meta.json')
+    with open(buildmeta_path) as f:
+        buildmeta = json.load(f)
+
+    found = args.image is None
+    for img_format, data in buildmeta['images'].items():
+        if args.image is not None and img_format != args.image:
+            continue
+        found = True
+        print(f"Validating artifact: {img_format}")
+        validate_checksum(builddir, img_format, data)
+        if img_format == 'ostree':
+            # In the future maybe we'll unpack and ostree fsck or so
+            continue
+        if img_format.endswith(('iso', 'kernel', 'initramfs')):
+            # And we could validate these too
+            continue
+        # Otherwise, assume it's a mountable disk image we can fsck
+        validate_image(builddir, img_format, data)
+    if not found:
+        raise SystemExit("Failed to find image type: {args.image}")
+
+
+def validate_image(builddir, imgtype, data):
+    path = os.path.join(builddir, data['path'])
+    rc = subprocess.call(['/usr/lib/coreos-assembler/gf-fsck', path])
+    if rc != 0:
+        raise SystemExit(f"Detected corrupted image: {imgtype}")
+    print(f"Validated image: {imgtype}")
+
+
+builds = Builds()
+
+# default to latest build if not specified
+if args.build:
+    build = args.build
+else:
+    build = builds.get_latest()
+
+for arch in builds.get_build_arches(build):
+    print(f"Validating build: {build}/{arch}")
+    builddir = builds.get_build_dir(build, arch)
+    validate_build(builddir)

--- a/src/gf-fsck
+++ b/src/gf-fsck
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Consistency check filesystems in a disk image
+set -euo pipefail
+
+dn=$(dirname "$0")
+# shellcheck source=src/cmdlib.sh
+. "${dn}"/cmdlib.sh
+# shellcheck source=src/libguestfish.sh
+. "${dn}"/libguestfish.sh
+
+img="$1"
+
+set -x
+
+coreos_gf_run "${img}" --ro
+# fsck the boot partition
+boot=$(coreos_gf findfs-label boot)
+# Amazingly, the libguestfs e2fsck API doesn't appear to let us do this
+coreos_gf debug sh "fsck.ext4 -f -n ${boot}"
+
+# ESP, if it exists
+if [ "$(coreos_gf part-get-gpt-type /dev/sda 1)" = "${EFI_SYSTEM_PARTITION_GUID}" ]; then
+    coreos_gf debug sh "fsck.vfat -f -n /dev/sda1"
+fi
+
+# And fsck the main rootfs
+rootfstype=$(coreos_gf vfs-type /dev/sda4)
+if [ "${rootfstype}" = "crypto_LUKS" ]; then
+    coreos_gf luks-open /dev/sda4 luks-00000000-0000-4000-a000-000000000002
+fi
+root=$(coreos_gf findfs-label root)
+coreos_gf debug sh "fsck.xfs -f -n ${root}"
+
+coreos_gf_shutdown

--- a/src/libguestfish.sh
+++ b/src/libguestfish.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 # A major assumption here is that the disk image uses OSTree
 # and also has `boot` and `root` filesystem labels.
 
+EFI_SYSTEM_PARTITION_GUID="C12A7328-F81F-11D2-BA4B-00A0C93EC93B"
+
 # We don't want to use libvirt for this, it inhibits debugging
 export LIBGUESTFS_BACKEND=direct
 if [ -z "${LIBGUESTFS_MEMSIZE:-}" ]; then
@@ -63,7 +65,6 @@ coreos_gf_run_mount() {
     coreos_gf mount "${boot}" /boot
     # As far as I can tell libguestfs doesn't have a "find partition by GPT type" API,
     # let's hack this and assume it's the first if present.
-    EFI_SYSTEM_PARTITION_GUID="C12A7328-F81F-11D2-BA4B-00A0C93EC93B"
     if [ "$(coreos_gf part-get-gpt-type /dev/sda 1)" = "${EFI_SYSTEM_PARTITION_GUID}" ]; then
         coreos_gf mount /dev/sda1 /boot/efi
     fi


### PR DESCRIPTION
We're seeing corrupted images when using reflinks; this
is a standard way to help find that.

We also validate the checksum.

- https://github.com/coreos/coreos-assembler/pull/935/commits/d47d3e6c7311808a0a7938c02b083948bc4ef0f6
- https://github.com/coreos/coreos-assembler/pull/936/commits/97fc409e56f3c6cf764c5e5c0171fdcada2d20bf

Note that this only works on uncompressed images right now.