### PR TITLE
gf-platformid: Just mount the boot partition

### DIFF
--- a/src/gf-platformid
+++ b/src/gf-platformid
@@ -37,7 +37,10 @@ qemu-img create -q -f qcow2 -b "$(realpath "${src}")" "${tmp_dest}"
 # <walters> I commonly chmod a-w VM images
 chmod u+w "${tmp_dest}"
 
-coreos_gf_run_mount "${tmp_dest}"
+# Mount everything read-only by default
+coreos_gf_run_mount ro "${tmp_dest}"
+# We just mount the boot partition writable
+coreos_gf remount /boot rw:true
 
 # Inject PLATFORM label in BLS config (for subsequent config regeneration)
 blscfg_path=$(coreos_gf glob-expand /boot/loader/entries/ostree-*.conf)

--- a/src/libguestfish.sh
+++ b/src/libguestfish.sh
@@ -46,26 +46,37 @@ coreos_gf_run() {
 }
 
 # Run libguestfs and mount the root and boot partitions.
-# Export `stateroot` and `deploydir` variables.
+# Export `stateroot` and `deploydir` variables.  The
+# special option `ro` (if provided first) mounts read-only
+# by default.
 coreos_gf_run_mount() {
+    local mntarg=mount
+    if [ "$1" = ro ]; then
+        mntarg=mount-ro
+        shift
+    fi
     coreos_gf_run "$@"
     # Detect the RHCOS LUKS case; first check if there's
     # no visible "root" labeled filesystem
     local fstype
     fstype=$(coreos_gf vfs-type /dev/sda4)
     if [ "${fstype}" = "crypto_LUKS" ]; then
-        coreos_gf luks-open /dev/sda4 luks-00000000-0000-4000-a000-000000000002
+        local luksopenarg=luks-open
+        if [ "${mntarg}" = "mount-ro" ]; then
+            luksopenarg=luks-open-ro
+        fi
+        coreos_gf "${luksopenarg}" /dev/sda4 luks-00000000-0000-4000-a000-000000000002
     fi
     root=$(coreos_gf findfs-label root)
-    coreos_gf mount "${root}" /
+    coreos_gf ${mntarg} "${root}" /
     local boot
     boot=$(coreos_gf findfs-label boot)
-    coreos_gf mount "${boot}" /boot
+    coreos_gf ${mntarg} "${boot}" /boot
     # As far as I can tell libguestfs doesn't have a "find partition by GPT type" API,
     # let's hack this and assume it's the first if present.
     EFI_SYSTEM_PARTITION_GUID="C12A7328-F81F-11D2-BA4B-00A0C93EC93B"
     if [ "$(coreos_gf part-get-gpt-type /dev/sda 1)" = "${EFI_SYSTEM_PARTITION_GUID}" ]; then
-        coreos_gf mount /dev/sda1 /boot/efi
+        coreos_gf ${mntarg} /dev/sda1 /boot/efi
     fi
 
     # Export these variables for further use


### PR DESCRIPTION
This is all we need; no reason to touch the other partitions
and possibly dirty their superblocks, etc.

Motivated by chasing down corruption with reflinks.