### PR TITLE
Change access mode to remove write permission from some artifacts

### DIFF
--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -206,6 +206,7 @@ runvm "${target_drive[@]}" -- \
             --save-var-subdirs "${save_var_subdirs}" \
             --rootfs-size "${rootfs_size}" \
             "${luks_flag}"
+/usr/lib/coreos-assembler/finalize-artifact "${path}.tmp"
 mv "${path}.tmp" "$path"
 echo "{}" > tmp/vm-iso-checksum.json
 
@@ -222,5 +223,6 @@ json.dump(j, sys.stdout, indent=4)
 " < "${builddir}/meta.json" | cat - tmp/vm-iso-checksum.json | jq -s add > meta.json.new
 
 # and now the crucial bit
+/usr/lib/coreos-assembler/finalize-artifact meta.json.new
 mv -T meta.json.new "${builddir}/meta.json"
 mv -T "${img}" "${builddir}/${img}"

--- a/src/finalize-artifact
+++ b/src/finalize-artifact
@@ -1,0 +1,12 @@
+#!/bin/bash
+# We expect things we generate to be immutable; they
+# have checksums covering them.  This helps avoid
+# mutating them accidentally.  By default `cosa run`
+# uses `-snapshot` for example, but I recently learned
+# that qemu does have a magic flag to write back to disk.
+#
+# Ideally, there'd be kernel-level support for this;
+# see also https://marc.info/?l=linux-fsdevel&m=139963046823575&w=2
+# and the more recent fs-verity work.
+#
+exec chmod a-w "$@"


### PR DESCRIPTION
I was recently reading `man qemu` and noticed this snippet:

```
       -snapshot
           Write to temporary files instead of disk image files. In this case, the raw disk image you use is not written back. You can however force the write back by pressing C-a s.
```

`cosa run` uses `-snapshot` and I heavily rely on it not mutating
the disk image.  Qemu having this magic command to mutate the disk
image could lead to really evil debugging sessions.

And I verified that in fact it works today to press `C-a s`.

Further, we use `qemu-img create -b` with backing files, and
that will completely break if the underlying backing file is
mutated.

This patch closes that down by removing write access from our
generated disk images.  When running processes as an ordinary user
without `CAP_DAC_OVERRIDE`, this denies write access.

And I verified that qemu's `C-a s` does not mutate the underlying
disk image with this patch (it seems to silently ignore the failure).

This only covers a few artifacts, I didn't try to get them all yet.