### PR TITLE
Try Except individually on module imports

### DIFF
--- a/src/cmd-koji-upload
+++ b/src/cmd-koji-upload
@@ -49,9 +49,11 @@ except ImportError:
 try:
     # Available in Koji v1.17, https://pagure.io/koji/issue/975
     from koji_cli.lib import unique_path
-    from koji_cli.lib import progress_callback as cb
 except ImportError:
     from koji_cli.lib import _unique_path as unique_path
+try:
+    from koji_cli.lib import progress_callback as cb
+except ImportError:
     from koji_cli.lib import _progress_callback as cb
 
 try:


### PR DESCRIPTION
Since 1.19.1 of koji the _unique_path def was officially removed,
however the progress_callback def does not exist. This causes the Except
clause to be called which then fails because _unique_path does not
exist.

We should Try/Except each import individually, to ensure we use the
appropriate import.