### PR TITLE
cmdlib: Only check sudo if we're not root

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -88,7 +88,7 @@ has_privileges() {
         elif ! capsh --print | grep -q 'Bounding.*cap_sys_admin'; then
             info "Missing CAP_SYS_ADMIN; using virt"
             _privileged=0
-        elif ! sudo true; then
+        elif [ "$(id -u)" != "0" ] && ! sudo true; then
             info "Missing sudo privs; using virt"
             _privileged=0
         else


### PR DESCRIPTION
We may need to run some commands in e.g. `podman unshare`,
and `sudo` won't work in that scenario, but we have the privileges
we need.  So just avoid requiring `sudo` if our uid is zero.