### PR TITLE
[rhcos-4.3] mantle: bump to current master (39bcb1b)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ clean:
 	find . -name "__pycache__" -type d | xargs rm -rf
 
 mantle:
-	cd mantle && ./build ore kola kolet plume
+	cd mantle && make
 
 install:
 	install -d $(DESTDIR)$(PREFIX)/lib/coreos-assembler
@@ -63,6 +63,4 @@ install:
 	install -d $(DESTDIR)$(PREFIX)/bin
 	ln -sf ../lib/coreos-assembler/coreos-assembler $(DESTDIR)$(PREFIX)/bin/
 	ln -sf coreos-assembler $(DESTDIR)$(PREFIX)/bin/cosa
-	install -D -t $(DESTDIR)$(PREFIX)/bin mantle/bin/{ore,kola,plume}
-	install -d $(DESTDIR)$(PREFIX)/lib/kola/$(GOARCH)
-	install -D -m 0755 -t $(DESTDIR)$(PREFIX)/lib/kola/$(GOARCH) mantle/bin/$(GOARCH)/kolet
+	cd mantle && make install DESTDIR=$(DESTDIR)


### PR DESCRIPTION
To pick up https://github.com/coreos/mantle/commit/ca54c767faf93b462ca355cb06e192d697efcfee