### PR TITLE
remove the commented line in the cosa shell fucntion

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ here need to change for that.
 ```
 cosa() {
    env | grep COREOS_ASSEMBLER
-   set -x # so we can see what command gets run
+   set -x
    podman run --rm -ti --security-opt label=disable --privileged                                    \
               --uidmap=1000:0:1 --uidmap=0:1:1000 --uidmap 1001:1001:64536                          \
               -v ${PWD}:/srv/ --device /dev/kvm --device /dev/fuse                                  \


### PR DESCRIPTION
Writing the `cosa()` function as indicated in the README let us with an error when running the function.
```
$ cosa shell
cosa:2: bad pattern: # 
```

Removing the offending part **# so we can see what command gets run** remove this issue.
```
$ cosa shell
+cosa:3> podman run ....
bash: cannot set terminal process group (-1): Inappropriate ioctl for device
bash: no job control in this shell
[coreos-assembler]$
```

