### PR TITLE
[rhcos-4.2-multiarch] s390x: right the tty on target ostre sysroot

### DIFF
--- a/src/image-base.ks
+++ b/src/image-base.ks
@@ -18,7 +18,7 @@ firewall --disabled
 # rw and $ignition_firstboot are used by https://github.com/coreos/ignition-dracut/
 # Console settings are so we see output everywhere
 # %%KARGS%% is for distro-specific arguments
-bootloader --timeout=1 --append="console=%%TERM%%,115200n8 console=tty0 rootflags=defaults,prjquota rw %%KARGS%% $ignition_firstboot"
+bootloader --timeout=1 --append="%%TERM%% rootflags=defaults,prjquota rw %%KARGS%% $ignition_firstboot"
 # Anaconda currently writes out configs for this which we don't want to persist; see below
 network --bootproto=dhcp --onboot=on
 

--- a/src/virt-install
+++ b/src/virt-install
@@ -136,10 +136,11 @@ with open('/usr/lib/coreos-assembler/image-base.ks') as basef:
         buf += ("\n%post --nochroot --erroronfail\n" +
                 "ostree config --repo /mnt/sysimage/ostree/repo set sysroot.bootloader zipl\n" +
                 "%end\n")
+        buf = buf.replace('%%TERM%%', '')
     else:
         buf = buf.replace('%%DISKLABEL%%',' --disklabel=gpt')
+        buf = buf.replace('%%TERM%%', 'console={},115200n8 console=tty0'.format(os.environ.get('DEFAULT_TERMINAL', 'ttyS0')))
     buf = buf.replace('%%KARGS%%', ' '.join(extra_kargs))
-    buf = buf.replace('%%TERM%%', os.environ.get('DEFAULT_TERMINAL', 'ttyS0'))
     ks_tmp.write(buf)
 
 # To support different distro builds using Fedora anaconda,


### PR DESCRIPTION
Same as https://github.com/coreos/coreos-assembler/pull/932.

We only need to change what goes into Kickstart file and we can keep the
console= in virt-install since it only matters for build process, so
less conditional changes.