### PR TITLE
Set PYTHONUNBUFFERED=1 in the entrypoint

### DIFF
--- a/src/cmd-aliyun-replicate
+++ b/src/cmd-aliyun-replicate
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# NOTE: PYTHONUNBUFFERED is set in cmdlib.sh for unbuffered output
+# NOTE: PYTHONUNBUFFERED is set in the entrypoint for unbuffered output
 #
 # An operation that mutates a build by replicating an existing
 # aliyun image to additional regions, extending the meta.json with

--- a/src/cmd-aws-replicate
+++ b/src/cmd-aws-replicate
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# NOTE: PYTHONUNBUFFERED is set in cmdlib.sh for unbuffered output
+# NOTE: PYTHONUNBUFFERED is set in the entrypoint for unbuffered output
 #
 # An operation that mutates a build by replicating an existing
 # EC2 AMI to additional regions, extending the meta.json with

--- a/src/cmd-buildextend-aliyun
+++ b/src/cmd-buildextend-aliyun
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# NOTE: PYTHONUNBUFFERED is set in cmdlib.sh for unbuffered output
+# NOTE: PYTHONUNBUFFERED is set in the entrypoint for unbuffered output
 #
 # An operation that mutates a build by generating an aliyun image.
 

--- a/src/cmd-buildextend-aws
+++ b/src/cmd-buildextend-aws
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# NOTE: PYTHONUNBUFFERED is set in cmdlib.sh for unbuffered output
+# NOTE: PYTHONUNBUFFERED is set in the entrypoint for unbuffered output
 #
 # An operation that mutates a build by uploading to EC2,
 # extending the meta.json with AMI information.

--- a/src/cmd-buildextend-azure
+++ b/src/cmd-buildextend-azure
@@ -4,7 +4,7 @@
 An operation that mutates a build by uploading to Azure,
 extending the meta.json with the Azure image name.
 """
-# NOTE: PYTHONUNBUFFERED is set in cmdlib.sh for unbuffered output
+# NOTE: PYTHONUNBUFFERED is set in the entrypoint for unbuffered output
 
 import argparse
 import logging as log

--- a/src/cmd-buildextend-gcp
+++ b/src/cmd-buildextend-gcp
@@ -4,7 +4,7 @@
 An operation that mutates a build by uploading to GCP,
 extending the meta.json with GCP image name.
 """
-# NOTE: PYTHONUNBUFFERED is set in cmdlib.sh for unbuffered output
+# NOTE: PYTHONUNBUFFERED is set in the entrypoint for unbuffered output
 
 import argparse
 import json

--- a/src/cmd-buildextend-installer
+++ b/src/cmd-buildextend-installer
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# NOTE: PYTHONUNBUFFERED is set in cmdlib.sh for unbuffered output
+# NOTE: PYTHONUNBUFFERED is set in the entrypoint for unbuffered output
 #
 # An operation that creates an ISO image for installing CoreOS
 

--- a/src/cmd-buildextend-openstack
+++ b/src/cmd-buildextend-openstack
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# NOTE: PYTHONUNBUFFERED is set in cmdlib.sh for unbuffered output
+# NOTE: PYTHONUNBUFFERED is set in the entrypoint for unbuffered output
 #
 # An operation that mutates a build by generating an OpenStack image.
 

--- a/src/cmd-buildextend-vmware
+++ b/src/cmd-buildextend-vmware
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# NOTE: PYTHONUNBUFFERED is set in cmdlib.sh for unbuffered output
+# NOTE: PYTHONUNBUFFERED is set in the entrypoint for unbuffered output
 #
 # An operation that mutates a build by generating an ova
 

--- a/src/cmd-buildprep
+++ b/src/cmd-buildprep
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# NOTE: PYTHONUNBUFFERED is set in cmdlib.sh for unbuffered output
+# NOTE: PYTHONUNBUFFERED is set in the entrypoint for unbuffered output
 #
 # Fetches the bare minimum from external servers to create the next build. May
 # require configured AWS credentials if bucket and objects are not public.

--- a/src/cmd-compress
+++ b/src/cmd-compress
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# NOTE: PYTHONUNBUFFERED is set in cmdlib.sh for unbuffered output
+# NOTE: PYTHONUNBUFFERED is set in the entrypoint for unbuffered output
 #
 # Compresses all images in a build.
 

--- a/src/cmd-tag
+++ b/src/cmd-tag
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# NOTE: PYTHONUNBUFFERED is set in cmdlib.sh for unbuffered output
+# NOTE: PYTHONUNBUFFERED is set in the entrypoint for unbuffered output
 #
 # Allows users to operate on the tags in `builds.json`
 #

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -5,11 +5,6 @@ set -euo pipefail
 DIR=$(dirname "$0")
 RFC3339="%Y-%m-%dT%H:%M:%SZ"
 
-# Set PYTHONUNBUFFERED=1 so that we get unbuffered output. We should
-# be able to do this on the shebang lines but env doesn't support args
-# right now. In Fedora we should be able to use the `env -S` option.
-export PYTHONUNBUFFERED=1
-
 # Detect what platform we are on
 if grep -q '^Fedora' /etc/redhat-release; then
     export ISFEDORA=1

--- a/src/coreos-assembler
+++ b/src/coreos-assembler
@@ -4,6 +4,11 @@ set -euo pipefail
 # Currently this just wraps the two binaries we have today
 # under a global entrypoint with subcommands.
 
+# Set PYTHONUNBUFFERED=1 so that we get unbuffered output. We should
+# be able to do this on the shebang lines but env doesn't support args
+# right now. In Fedora we should be able to use the `env -S` option.
+export PYTHONUNBUFFERED=1
+
 # docker/podman don't run through PAM, but we want this set for the privileged
 # (non-virtualized) path
 export USER="${USER:-$(id -nu)}"

--- a/src/cosalib/cli.py
+++ b/src/cosalib/cli.py
@@ -1,4 +1,4 @@
-# NOTE: PYTHONUNBUFFERED is set in cmdlib.sh for unbuffered output
+# NOTE: PYTHONUNBUFFERED is set in the entrypoint for unbuffered output
 # pylint: disable=C0103
 
 import argparse

--- a/src/oscontainer.py
+++ b/src/oscontainer.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# NOTE: PYTHONUNBUFFERED is set in cmdlib.sh for unbuffered output
+# NOTE: PYTHONUNBUFFERED is set in the entrypoint for unbuffered output
 #
 # An "oscontainer" is an ostree (archive) repository stuck inside
 # a Docker/OCI container at /srv/repo.  For more information,


### PR DESCRIPTION
Before, we were setting it in `cmdlib.sh`, but the entrypoint (which is
the code that actually `exec`s any Python commands) doesn't source that.
Move the export directly there instead.