### PR TITLE
deps.txt: add strace for debugging running processes

### DIFF
--- a/src/deps.txt
+++ b/src/deps.txt
@@ -62,3 +62,6 @@ cryptsetup
 
 # For communicating with RoboSignatory for signing requests
 fedora-messaging
+
+# For debugging running processes in the pipelines
+strace


### PR DESCRIPTION
We ran into this recently where we thought a process was stuck.
After getting strace into the container we saw that it wasn't stuck,
just taking a really long time.