### PR TITLE
Expand RHCOS Ignition detection to handle rhcos-4.2.0- images

### DIFF
--- a/src/cosalib/cmdlib.py
+++ b/src/cosalib/cmdlib.py
@@ -171,7 +171,13 @@ def rm_allow_noent(path):
 # be like a virtual time capsule!  If they still use email then...
 def disk_ignition_version(path):
     bn = os.path.basename(path)
-    if bn.startswith(("rhcos-41", "rhcos-42", "rhcos-43")):
+    ignition_spec2_openshift_releases = [1, 2, 3]
+    # The output from the RHCOS pipeline names images like
+    # rhcos-42.81.$datestamp.  The images are renamed when
+    # placed at e.g. https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.2/4.2.0/
+    prefixes = [f"rhcos-4{x}" for x in ignition_spec2_openshift_releases] + \
+               [f"rhcos-4.{x}" for x in ignition_spec2_openshift_releases]
+    if bn.startswith(tuple(prefixes)):
         return "2.2.0"
     else:
         return "3.0.0"


### PR DESCRIPTION
I downloaded the openstack image from
https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.2/4.2.0/
and used `guestfish` to hack the platformid back to `qemu`, but `cosa run`
failed because it didn't recognize the image prefix.

Detect both versions.