### PR TITLE
Run kola without TPM on s390x and pcc64le

### DIFF
--- a/src/cmd-kola
+++ b/src/cmd-kola
@@ -14,6 +14,7 @@ sys.path.insert(0, cosa_dir)
 from cosalib import cmdlib
 from cosalib.builds import Builds
 
+basearch = cmdlib.get_basearch()
 
 # Parse args and dispatch
 parser = argparse.ArgumentParser()
@@ -65,6 +66,10 @@ if ignition_version == "2.2.0":
 
 if os.getuid() != 0 and not ('-p' in args.subargs):
     kolaargs.extend(['-p', 'qemu-unpriv'])
+
+# tpm devices for qemu not supported on s390x/ppc
+if basearch in ["s390x", "ppc64le"]:
+    kolaargs.extend(['--qemu-swtpm=false'])
 
 # shellcheck disable=SC2086
 kolaargs.extend(['--qemu-image', qemupath])


### PR DESCRIPTION
On s390x and pcc64le, there is no TPM device support in qemu. With support in
mantle to run without TPM(#970 and #971), enforcing this option for s390x and pcc64le
so kola tests can run