### PR TITLE
Dockerfile: Blow out Quay.io cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /root/containerbuild
 # Only need a few of our scripts for the first few steps
 COPY ./src/cmdlib.sh /root/containerbuild/src/
 COPY ./build.sh ./deps*.txt ./vmdeps*.txt ./build-deps.txt /root/containerbuild/
-RUN ./build.sh configure_yum_repos
+RUN ./build.sh configure_yum_repos # nocache 20191205
 RUN ./build.sh install_rpms
 
 # Ok copy in the rest of them for the next few steps


### PR DESCRIPTION
We want to get the latest RPMs, this is the standard hack for
this absent an explicit API on the build system side to do so.
(Like how OpenShift buildconfigs have an option)