### PR TITLE
koji-upload: pass build as kwarg

### DIFF
--- a/src/cmd-koji-upload
+++ b/src/cmd-koji-upload
@@ -639,7 +639,7 @@ Environment variables are supported:
 
     set_logger(args.log_level)
 
-    build = Build(args.buildroot, args.build, arch=args.arch)
+    build = Build(args.buildroot, build=args.build, arch=args.arch)
     if args.auth:
         kinit(args.keytab, args.owner)
 


### PR DESCRIPTION
Saw the following failure in the RHCOS pipeline:

```
+ coreos-assembler koji-upload --keytab /srv/.keytab/keytab --buildroot builds --owner rhcos-build/jenkins-redhat-coreos.cloud.paas.upshift.redhat.com@REDHAT.COM --profile brew --tag rhaos-4.3-rhel-8-build
Traceback (most recent call last):
  File "/usr/lib/coreos-assembler/cmd-koji-upload", line 659, in <module>
    cli()
  File "/usr/lib/coreos-assembler/cmd-koji-upload", line 642, in cli
    build = Build(args.buildroot, args.build, arch=args.arch)
  File "/usr/lib/coreos-assembler/cmd-koji-upload", line 104, in __init__
    _Build.__init__(self, *args, **kwargs)
TypeError: __init__() got an unexpected keyword argument 'arch'
```

It looks like `args.build` needs to be passed as kwarg, instead of
positional.