### PR TITLE
Support blacklisting kola test by arch

### DIFF
--- a/src/cmd-kola
+++ b/src/cmd-kola
@@ -38,9 +38,11 @@ if os.path.isfile(blacklist_path):
     with open(blacklist_path) as f:
         blacklist = yaml.safe_load(f)
         for obj in (blacklist or []):
-            print(f"⚠️  Skipping kola test pattern \"{obj['pattern']}\":")
-            print(f"⚠️  {obj['tracker']}")
-            blacklist_args += ['--blacklist-test', obj['pattern']]
+            # if there are any arches specified, skip tests only for those arches. if not skip unconditionally.
+            if basearch in obj.get('arches', [basearch]):
+                print(f"⚠️  Skipping kola test pattern \"{obj['pattern']}\":")
+                print(f"⚠️  {obj['tracker']}")
+                blacklist_args += ['--blacklist-test', obj['pattern']]
 
 qemuimg = buildmeta['images'].get('qemu')
 if qemuimg is None:


### PR DESCRIPTION
Following up on #973, for the kola test runs to be successful on
s390x and pcc64le, the TPM test has to be excluded. An arches option would
be useful to list the arches to exclude. Here is an example:

- pattern: rhcos.luks.tpm
  tracker: none
  arches:
   - s390x
   - ppc64le

If no arch is specified, it means blacklist on all arches