### PR TITLE
Remove write access from more artifacts

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -218,9 +218,10 @@ prepare_compose_overlays
 # shellcheck disable=SC2086
 runcompose --cache-only ${FORCE} --add-metadata-from-json "${commitmeta_input_json}" \
            --write-composejson-to "${composejson}" \
-           --ex-write-lockfile-to "${lockfile_out}" \
+           --ex-write-lockfile-to "${lockfile_out}".tmp \
            ${lock_arg} ${version_arg} ${parent_arg}
-strip_out_lockfile_digests "$lockfile_out"
+strip_out_lockfile_digests "$lockfile_out".tmp
+/usr/lib/coreos-assembler/finalize-artifact "${lockfile_out}"{.tmp,}
 # Very special handling for --write-composejson-to as rpm-ostree doesn't
 # write it if the commit didn't change.
 if [ -f "${changed_stamp}" ]; then
@@ -316,7 +317,8 @@ else
     # Don't compress; archive repos are already compressed individually and we'd
     # gain ~20M at best. We could probably have better gains if we compress the
     # whole repo in bare/bare-user mode, but that's a different story...
-    tar -cf "${ostree_tarfile_path}" -C repo .
+    tar -cf "${ostree_tarfile_path}".tmp -C repo .
+    /usr/lib/coreos-assembler/finalize-artifact "${ostree_tarfile_path}"{.tmp,}
     rm -rf repo
 fi
 
@@ -380,7 +382,7 @@ cat "${composejson}" "${overridesjson}" tmp/meta.json tmp/buildmeta.json tmp/dif
 # Filter out `ref` if it's temporary
 if [ -n "${ref_is_temp}" ]; then
     jq 'del(.ref)' < meta.json > meta.json.new
-    mv meta.json{.new,}
+    /usr/lib/coreos-assembler/finalize-artifact meta.json{.new,}
 fi
 
 # Move lockfile into build dir
@@ -388,7 +390,8 @@ mv "${lockfile_out}" .
 
 # And add the commit metadata itself, which includes notably the rpmdb pkglist
 # in a format that'd be easy to generate diffs out of for higher level tools
-"${dn}"/commitmeta_to_json "${tmprepo}" "${commit}" > commitmeta.json
+"${dn}"/commitmeta_to_json "${tmprepo}" "${commit}" > commitmeta.json.tmp
+/usr/lib/coreos-assembler/finalize-artifact commitmeta.json{.tmp,}
 
 # Clean up our temporary data
 saved_build_tmpdir="${workdir}/tmp/last-build-tmp"

--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -206,8 +206,7 @@ runvm "${target_drive[@]}" -- \
             --save-var-subdirs "${save_var_subdirs}" \
             --rootfs-size "${rootfs_size}" \
             "${luks_flag}"
-/usr/lib/coreos-assembler/finalize-artifact "${path}.tmp"
-mv "${path}.tmp" "$path"
+/usr/lib/coreos-assembler/finalize-artifact "${path}.tmp" "${path}"
 echo "{}" > tmp/vm-iso-checksum.json
 
 # there's probably a jq one-liner for this...
@@ -222,7 +221,6 @@ j['images']['${image_type}'] = {
 json.dump(j, sys.stdout, indent=4)
 " < "${builddir}/meta.json" | cat - tmp/vm-iso-checksum.json | jq -s add > meta.json.new
 
-# and now the crucial bit
-/usr/lib/coreos-assembler/finalize-artifact meta.json.new
-mv -T meta.json.new "${builddir}/meta.json"
-mv -T "${img}" "${builddir}/${img}"
+# and now the crucial bits
+/usr/lib/coreos-assembler/finalize-artifact meta.json.new "${builddir}/meta.json"
+/usr/lib/coreos-assembler/finalize-artifact "${img}" "${builddir}/${img}"

--- a/src/finalize-artifact
+++ b/src/finalize-artifact
@@ -9,4 +9,6 @@
 # see also https://marc.info/?l=linux-fsdevel&m=139963046823575&w=2
 # and the more recent fs-verity work.
 #
-exec chmod a-w "$@"
+set -euo pipefail
+chmod a-w "$1"
+mv -fT "$1" "$2"

--- a/src/write-commit-object
+++ b/src/write-commit-object
@@ -3,6 +3,7 @@
 # it can be useful to provide the previous commit during
 # builds, and this avoids a need for the full OSTree repo.
 
+import os
 import argparse
 import gi
 
@@ -22,4 +23,5 @@ r.open(None)
 [_, rev] = r.resolve_rev(args.rev, True)
 [_, commit, _] = r.load_commit(rev)
 with open(args.builddir + '/ostree-commit-object', 'wb') as f:
+    os.fchmod(f.fileno(), 0o444)
     f.write(commit.get_data_as_bytes().get_data())


### PR DESCRIPTION
Following up to our previous change to `chmod a-w` the qemu image
to avoid corruption:

- Rework the `finalize-artifact` API to also move into place
  so that its usage is more direct/required.
- Use it in more places

This makes a default `cosa build` + `ls -al builds/latest/x86_64`
show no write access.