### PR TITLE
installer: Rely on tmp/repo

### DIFF
--- a/src/cmd-buildextend-installer
+++ b/src/cmd-buildextend-installer
@@ -457,12 +457,5 @@ def generate_iso():
     write_json(buildmeta_path, buildmeta)
     print(f"Updated: {buildmeta_path}")
 
-
-commit_tar_name = 'ostree-commit.tar'
-if 'ostree' in buildmeta['images']:
-    commit_tar_name = buildmeta['images']['ostree']['path']
-commit_tar = os.path.join(builddir, commit_tar_name)
-import_ostree_commit(repo, buildmeta_commit, commit_tar)
-
 # Do it!
 generate_iso()


### PR DESCRIPTION
This came up in discussion about delaying creation of the "ostree repo tarball":
https://github.com/coreos/coreos-assembler/pull/985

Today the other artifact types *rely* on `tmp/repo` having the just-built
commit, so let's make the installer be consistent.  This aims to reduce
dependence on the tarball.