### PR TITLE
WIP: Build image on mantle image

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "mantle"]
-	path = mantle
-	url = https://github.com/coreos/mantle
 [submodule "ostree-releng-scripts"]
 	path = ostree-releng-scripts
 	url = https://github.com/ostreedev/ostree-releng-scripts

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:31
+FROM localhost/mantle:latest
 WORKDIR /root/containerbuild
 
 # We split into multiple steps here so that local dev workflows which involve

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,10 @@ DESTDIR ?=
 # W504 line break after binary operator
 PYIGNORE ?= E128,E241,E402,E501,E722,W503,W504
 
-.PHONY: all check flake8 pycheck unittest clean mantle install
+.PHONY: all check flake8 pycheck unittest clean install
 
-all: mantle
+all:
+	@echo "No build step."
 
 src:=$(shell find src -maxdepth 1 -type f -executable -print)
 pysources=$(shell find src -type f -name '*.py') $(shell for x in $(src); do if head -1 $$x | grep -q python; then echo $$x; fi; done)
@@ -51,9 +52,6 @@ clean:
 	find . -name "*.py[co]" -type f | xargs rm -f
 	find . -name "__pycache__" -type d | xargs rm -rf
 
-mantle:
-	cd mantle && $(MAKE)
-
 install:
 	install -d $(DESTDIR)$(PREFIX)/lib/coreos-assembler
 	install -D -t $(DESTDIR)$(PREFIX)/lib/coreos-assembler $$(find src/ -maxdepth 1 -type f)
@@ -64,4 +62,3 @@ install:
 	ln -sf ../lib/coreos-assembler/coreos-assembler $(DESTDIR)$(PREFIX)/bin/
 	ln -sf ../lib/coreos-assembler/cp-reflink $(DESTDIR)$(PREFIX)/bin/
 	ln -sf coreos-assembler $(DESTDIR)$(PREFIX)/bin/cosa
-	cd mantle && $(MAKE) install DESTDIR=$(DESTDIR)

--- a/build.sh
+++ b/build.sh
@@ -86,11 +86,6 @@ _prep_make_and_make_install() {
     # /usr/bin/ostree-releng-script-rsync-repos
     mkdir -p /usr/app/
     rsync -rlv "${srcdir}"/ostree-releng-scripts/ /usr/app/ostree-releng-scripts/
-
-    if [ "$(git submodule status mantle | head -c1)" == "-" ]; then
-        echo -e "\033[1merror: submodules not initialized. Run: git submodule update --init\033[0m" 1>&2
-        exit 1
-    fi
 }
 
 make_and_makeinstall() {


### PR DESCRIPTION
Instead of using a submodule we split out the mantle specific code (kola, ore, etc..) into it's own container image which cosa then layers on.

Requires:
- https://github.com/coreos/mantle/pull/1133
- The above built and published 

TODO
- [ ] Update FROM in `Dockerfile`