### PR TITLE
cmd-sign: bump timeout to 1 hour

### DIFF
--- a/src/cmd-sign
+++ b/src/cmd-sign
@@ -50,7 +50,8 @@ FEDORA_MESSAGING_TOPIC_PREFIX = {
     'prod': 'org.fedoraproject.prod.coreos.build.request',
     'stg': 'org.fedoraproject.stg.coreos.build.request',
 }
-ROBOSIGNATORY_REQUEST_TIMEOUT_SEC = 60 * 10
+# this is really the worst case scenario, it's usually pretty fast otherwise
+ROBOSIGNATORY_REQUEST_TIMEOUT_SEC = 60 * 60
 
 fedenv = 'prod'
 


### PR DESCRIPTION
RoboSignatory signing is normally pretty fast. We've hit the worst case
scenario however today, where our request was queue behind a request to
sign texlive, which has ~6000 subpackages...

Ideally, it'd be able to handle multiple requests at once. Though for
now, just adapt for this. Note that this is different from signing
failures; RoboSignatory does reply back if something went wrong with
signing. So we won't just sit there for 1hr if e.g. we didn't send a
proper request or something.