### PR TITLE
[rhcos-4.3]: Fix DASD image size for s390x

### DIFF
--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -156,9 +156,9 @@ rootfs_size="$(jq '."estimate-mb".final' "$PWD/tmp/ostree-size.json")"
 image_size="$(( rootfs_size + 513 ))M"
 echo "Disk size estimated to ${image_size}"
 
-# For bare metal images, we use the estimated image size. For IaaS/virt, we get it from
+# For bare metal and dasd images, we use the estimated image size. For IaaS/virt, we get it from
 # image.yaml because we want a "default" disk size that has some free space.
-if [ "${image_type}" = metal ]; then
+if [[ "${image_type}" = metal || "${image_type}" = dasd ]]; then
     # Unset the root size, which will inherit from the image size
     rootfs_size=0
 else


### PR DESCRIPTION
The metal dasd images were huge - 17G which was causing OOMs when trying to
install the images on a zVM. Fixed it to use estimated size rather than use
the one from image.yaml

(cherry picked from commit 9893a8305a3d9d79fc69a78038e4b4f44588f9bc)