### PR TITLE
platformid: Copy (reflink) rather than use qemu-img snapshots

### DIFF
--- a/src/gf-platformid
+++ b/src/gf-platformid
@@ -33,8 +33,7 @@ set -x
 tmpd=$(mktemp -tdp "$(dirname "${dest}")" gf-platformid.XXXXXX)
 tmp_dest=${tmpd}/box.img
 
-qemu-img create -q -f qcow2 -b "$(realpath "${src}")" "${tmp_dest}"
-# <walters> I commonly chmod a-w VM images
+/usr/lib/coreos-assembler/cp-reflink "${src}" "${tmp_dest}"
 chmod u+w "${tmp_dest}"
 
 # Mount everything read-only by default


### PR DESCRIPTION
We can't use backing files since we can't rely on users to have
them.

Another approach would be flattening after, but I think the
copy approach is clearer.

Closes: https://github.com/coreos/fedora-coreos-tracker/issues/327