### PR TITLE
Add `cosa meta --image-path`

### DIFF
--- a/src/cmd-meta
+++ b/src/cmd-meta
@@ -20,6 +20,9 @@ def new_cli():
     sub_parser.add_argument('--set', help='set a field', action='append')
     sub_parser.add_argument(
         '--dump', help='dumps the entire structure', action='store_true')
+    sub_parser.add_argument(
+        '--image-path', help='Output path to artifact IMAGETYPE', action='store',
+        metavar='IMAGETYPE')
     args = parser.parse_args()
 
     meta = Meta(args.workdir, args.build)
@@ -39,6 +42,8 @@ def new_cli():
         meta.write()
     elif args.dump is True:
         print(meta)
+    elif args.image_path is not None:
+        print(os.path.join(os.path.dirname(meta.path), meta.get('images')[args.image_path]['path']))
 
 
 if __name__ == '__main__':

--- a/src/cmd-run
+++ b/src/cmd-run
@@ -173,12 +173,7 @@ if [ -z "${VM_DISK}" ]; then
     if ! [ -d "builds/${BUILDID}" ]; then
         die "No builds/${BUILDID}"
     fi
-    builddir=$(get_build_dir "${BUILDID}")
-    diskpath=$(jq -r '.["images"]["'"${IMAGE_TYPE}"'"]["path"]' < "${builddir}/meta.json")
-    if [ "${diskpath}" = "null" ]; then
-        die "No image ${IMAGE_TYPE} in build ${BUILDID}"
-    fi
-    VM_DISK=${builddir}/${diskpath}
+    VM_DISK=$(cosa meta --build="${BUILDID}" --image-path="${IMAGE_TYPE}")
     # For other image types (most usefully for metal) force
     # on injection into the /boot partition, since Ignition
     # won't pull from qemu userdata.

--- a/src/cosalib/meta.py
+++ b/src/cosalib/meta.py
@@ -24,6 +24,10 @@ class GenericBuildMeta(dict):
             builds.get_build_dir(build), 'meta.json')
         self.read()
 
+    @property
+    def path(self):
+        return self._meta_path
+
     def read(self):
         """
         Read the meta.json file into this object instance.


### PR DESCRIPTION
Will simplify the rpm-ostree test suite which also grew some shell/`jq`
for this similar to the removed code in `cmd-run`.