### PR TITLE
buildextend-rojig: New command

### DIFF
--- a/src/cmd-buildextend-rojig
+++ b/src/cmd-buildextend-rojig
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+#
+# Create a "rojig" RPM - see https://github.com/projectatomic/rpm-ostree/issues/1081
+
+import argparse
+import json
+import os
+import sys
+import subprocess
+import tempfile
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from cosalib.builds import Builds
+from cosalib.cmdlib import run_verbose, write_json, sha256sum_file, get_basearch
+
+
+# Parse args and dispatch
+parser = argparse.ArgumentParser()
+parser.add_argument("--build", help="Build ID")
+args = parser.parse_args()
+workdir = os.path.abspath(os.getcwd())
+
+# Identify the builds and target the latest build if none provided
+builds = Builds()
+if not args.build:
+    args.build = builds.get_latest()
+builddir = builds.get_build_dir(args.build)
+print(f"Targeting build: {args.build}")
+
+buildmeta_path = os.path.join(builddir, 'meta.json')
+with open(buildmeta_path) as f:
+    buildmeta = json.load(f)
+# Grab the commit hash for this build
+buildmeta_commit = buildmeta['ostree-commit']
+repo = os.path.join(workdir, 'tmp/repo')
+pkgcache_repo = os.path.join(workdir, 'cache/pkgcache-repo')
+
+with tempfile.TemporaryDirectory(prefix='rojig-', dir=f"{workdir}/tmp") as tmpd:
+    uid = os.getuid()
+    try:
+        run_verbose(['sudo', 'rpm-ostree', 'ex', 'commit2rojig', f"--repo={repo}", f"--pkgcache-repo={pkgcache_repo}", buildmeta_commit, 'src/config/manifest.yaml', os.path.abspath(tmpd)])
+    finally:
+        subprocess.check_call(['sudo', 'chown', '-Rh', f"{uid}:{uid}", tmpd])
+    rojig_path = None
+    arch_destdir = os.path.join(tmpd, get_basearch())
+    if not os.path.isdir(arch_destdir):
+        raise Exception("Missing target directory {arch_destdir}")
+    for f in os.listdir(arch_destdir):
+        if not f.endswith('.rpm'):
+            continue
+        if rojig_path is not None:
+            raise Exception("Multiple rojig RPMs found")
+        rojig_path = os.path.join(arch_destdir, f)
+    if rojig_path is None:
+        raise Exception("No rojig RPM found")
+    srcpath = rojig_path
+    destpath = os.path.join(builddir, os.path.basename(rojig_path))
+    subprocess.check_call(['/usr/lib/coreos-assembler/finalize-artifact', srcpath, destpath])
+checksum = sha256sum_file(destpath)
+size = os.path.getsize(destpath)
+buildmeta['images']['rojig'] = {
+    'path': os.path.basename(rojig_path),
+    'size': size,
+    'checksum': checksum
+}
+write_json(buildmeta_path, buildmeta)
+print(f"Updated: {buildmeta_path}")


### PR DESCRIPTION
For Fedora Silverblue I want to possibly switch to rojig by default.
There are a few reasons for this; among them that on more "pet"
systems package layering is natural and rojig becomes advantageous
then.

This small buildextend just wraps up the rpm-ostree glue for
this into the cosa model.