### PR TITLE
buildupload: Don't set Content-Encoding for gzip

### DIFF
--- a/src/cmd-buildupload
+++ b/src/cmd-buildupload
@@ -176,9 +176,6 @@ def s3_copy(src, bucket, key, max_age, acl, extra_args={}, dry_run=False):
             # use a standard MIME type for "binary blob" instead of the default
             # 'binary/octet-stream' AWS slaps on
             extra_args['ContentType'] = 'application/octet-stream'
-    if 'ContentEncoding' not in extra_args:
-        if key.endswith('.gz'):
-            extra_args['ContentEncoding'] = 'gzip'
     upload_args = {
         'CacheControl': f'max-age={max_age}',
         'ACL': acl


### PR DESCRIPTION
https://github.com/coreos/coreos-assembler/pull/862#issuecomment-567069130
This regressed OpenShift on OpenStack installs, which had adjusted
to deal with the lack of `Content-Encoding` and a switch to add `.gz`
to images.

Basically, if we're going to say things are explicitly compressed,
let's not also tell people to *transparently* decompress them because
it's easy to end up with a file named `.gz` that was decompressed.