### PR TITLE
cmd-compress: skip compressing already compressed files

### DIFF
--- a/src/cmd-compress
+++ b/src/cmd-compress
@@ -95,7 +95,10 @@ def compress_one_builddir(builddir):
         img = buildmeta['images'][img_format]
         file = img['path']
         filepath = os.path.join(builddir, file)
-        if not file.endswith(ext):
+        # check if it's not already compressed, even if with a different
+        # compressor (like for GCP, which needs .tar.gz, see:
+        # https://github.com/coreos/coreos-assembler/pull/1009)
+        if not file.endswith(tuple(ext_dict.values())):
             tmpfile = os.path.join(tmpdir, (file + ext))
             # SHA256 + size for uncompressed image was already calculated
             # during 'build'


### PR DESCRIPTION
Even if they're compressed by a different compressor.

(How many more derivatives of the word `compress` can we fit in this
commit message?)

This came up with `buildextend-gcp`, which currently hardcodes `tar.gz`,
because that's what the cloud wants when uploading. But then we'd
recompress it again with `xz` at the `compress` stage, which probably
gains us some space, but having a `.tar.gz.xz` is pretty confusing.