### PR TITLE
Build and add fcct

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN ./build.sh install_rpms
 COPY ./ /root/containerbuild/
 RUN ./build.sh write_archive_info
 RUN ./build.sh make_and_makeinstall
+RUN ./build.sh build_fcct
 RUN ./build.sh configure_user
 
 RUN make check

--- a/build.sh
+++ b/build.sh
@@ -93,6 +93,21 @@ _prep_make_and_make_install() {
     fi
 }
 
+# Yes, this is a hack that loses sane auditing around what git commit
+# we used to build fcct, etc.  In the future we'll probably give in and package
+# it or something, see also https://github.com/coreos/fedora-coreos-tracker/issues/235
+build_fcct() {
+    cd /tmp
+    git clone https://github.com/coreos/fcct
+    cd fcct
+    git describe --tags --always > /usr/share/fcct-build.revision
+    ./build
+    fcct=$(find bin -type f -name fcct | head -1)
+    install -m 0755 -D -t /usr/bin "${fcct}"
+    cd /tmp
+    rm fcct -rf
+}
+
 make_and_makeinstall() {
     _prep_make_and_make_install
     make && make install


### PR DESCRIPTION
As the new comment says:
Yes, this is a hack that loses sane auditing around what git commit
we used to build fcct, etc.  In the future we'll probably give in and package
it or something, see also https://github.com/coreos/fedora-coreos-tracker/issues/235

But for now I want to have it in cosa by default so we can use it;
see also https://github.com/coreos/coreos-assembler/pull/670