### PR TITLE
Add `offline-update` command

### DIFF
--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -87,10 +87,6 @@ if [ ! -d "${builddir}" ]; then
     fatal "Build dir ${builddir} does not exist."
 fi
 
-json_key() {
-    jq -r ".[\"$1\"]" < "${builddir}/meta.json"
-}
-
 # check if the image already exists in the meta.json
 meta_img=$(jq -r ".[\"images\"][\"${image_type}\"]" < "${builddir}/meta.json")
 if [ "${meta_img}" != "null" ]; then

--- a/src/cmd-offline-update
+++ b/src/cmd-offline-update
@@ -1,0 +1,93 @@
+#!/usr/bin/bash
+# Given a disk image and a coreos-assembler build, use supermin
+# to update the disk image to the target OSTree commit "offline".
+# Concretely for example if used on a pristine disk image, Ignition
+# will not have run.
+#
+# Example usage to upgrade *from* RHCOS 4.2 to a just-built 4.4 OSTree tree,
+# then do a kola basic run on it.
+#
+# cd /path/to/rhcos-4.4
+# cp --reflink=auto /path/to/rhcos-4.2.0-x86_64-qemu.qcow2 tmp/
+# cosa offline-update tmp/rhcos-4.2.0-x86_64-qemu.qcow2
+# kola run --ignition-version v2 -p qemu-unpriv -b rhcos --qemu-image tmp/rhcos-4.2.0-x86_64-qemu.qcow2 basic
+
+set -euo pipefail
+
+dn=$(dirname "$0")
+# shellcheck source=src/cmdlib.sh
+. "${dn}"/cmdlib.sh
+
+
+print_help() {
+    cat 1>&2 <<EOF
+Usage: coreos-assembler offline-update --help
+       coreos-assembler offline-update [--build ID] DISK
+
+  In-place update DISK to the OSTree commit from the provided build.
+EOF
+}
+
+rc=0
+build=
+options=$(getopt --options h --longoptions help,build: -- "$@") || rc=$?
+[ $rc -eq 0 ] || {
+    print_help
+    exit 1
+}
+eval set -- "$options"
+while true; do
+    case "$1" in
+        -h | --help)
+            print_help
+            exit 0
+            ;;
+        --build)
+            build=$2
+            shift
+            ;;
+        --)
+            shift
+            break
+            ;;
+        -*)
+            fatal "$0: unrecognized option: $1"
+            exit 1
+            ;;
+        *)
+            break
+            ;;
+    esac
+    shift
+done
+
+if [ $# -gt 1 ]; then
+    print_help
+    fatal "Too many arguments passed"
+fi
+if [ $# -eq 0 ]; then
+    print_help
+    fatal "Missing required argument"
+fi
+
+disk=$(realpath "$1")
+shift
+workdir=$(pwd)
+TMPDIR=${workdir}/tmp
+
+if [ -z "${build}" ]; then
+    build=$(get_latest_build)
+    if [ -z "${build}" ]; then
+        fatal "No build found."
+    fi
+fi
+
+builddir=$(get_build_dir "$build")
+if [ ! -d "${builddir}" ]; then
+    fatal "Build dir ${builddir} does not exist."
+fi
+
+commit=$(json_key ostree-commit)
+
+runvm -drive if=virtio,id=target,format=qcow2,file="${disk}" -- \
+    /usr/lib/coreos-assembler/offline-update-impl "${workdir}/tmp/repo" "${commit}"

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -422,6 +422,10 @@ strip_out_lockfile_digests() {
     mv "$1.tmp" "$1"
 }
 
+json_key() {
+    jq -r ".[\"$1\"]" < "${builddir}/meta.json"
+}
+
 runvm() {
     local qemu_args=()
     while true; do

--- a/src/offline-update-impl
+++ b/src/offline-update-impl
@@ -1,0 +1,61 @@
+#!/bin/bash
+set -xeuo pipefail
+# See docs in cmd-offline-update.  This bit of code is run inside
+# a supermin VM; the cmd-offline-update is run outside.
+
+disk=/dev/vda
+
+udevadm trigger
+udevadm settle
+
+# We don't have systemd/udev running
+findlabel() {
+    local label=$1
+    local path=
+    for p in $(lsblk -nrp -o NAME ${disk}); do
+        if blkid -o export $p | grep -qe "LABEL=$label"; then
+            echo $p
+            return
+        fi
+    done
+    echo "Failed to find LABEL=$label" 1>&2
+    return 1
+}
+
+echo "mounting"
+sysroot=/mnt
+mkdir -p "${sysroot}"
+rootdev=$(findlabel root)
+bootdev=$(findlabel boot)
+mount "$rootdev" "${sysroot}"
+mount "$bootdev" "${sysroot}/boot"
+
+repo=$1
+shift
+ref=$1
+shift
+
+set -x
+ostree pull-local --repo="${sysroot}"/ostree/repo ${repo} ${ref}
+stateroot=$(basename $(ls -d ${sysroot}/ostree/deploy/* | head -1))
+# HACK for old systems that use grub2-mkconfig
+if ! grep -q bootloader=none "${sysroot}"/ostree/repo/config; then
+    cat >/usr/bin/dummy-mkconfig << 'EOF'
+    exec touch $2
+EOF
+    chmod a+x /usr/bin/dummy-mkconfig
+fi
+env OSTREE_DEBUG_GRUB2=1 OSTREE_GRUB2_EXEC=/usr/bin/dummy-mkconfig ostree admin --sysroot="${sysroot}" --os=${stateroot} deploy ${ref}
+# EVEN MORE tremendous hackery for old systems that use grub2-mkconfig
+if ! grep -q bootloader=none "${sysroot}"/ostree/repo/config; then
+    deploydir=$(ls -d ${sysroot}/ostree/deploy/*/deploy/* | grep -v '\.origin' | head -1)
+    mount -t proc /proc "${deploydir}/proc"
+    mount -t sysfs /sys "${deploydir}/sys"
+    mount -t devtmpfs devtmpfs "${deploydir}/dev"
+    mount -t tmpfs tmpfs "${deploydir}/var"
+    mount --bind "${sysroot}" "${deploydir}"/sysroot
+    mount -M "${sysroot}/boot" "${deploydir}"/boot
+    chroot "${deploydir}" env GRUB_DISABLE_OS_PROBER=true grub2-mkconfig -o /boot/loader/grub.cfg
+fi
+umount -R "${sysroot}"
+


### PR DESCRIPTION
We need to do some upgrade testing.  My specific goal here
is to be able to use `kola`, which is oriented around providing
Ignition - so we need to do the update fully "offline".  I wrote
the quick/obvious script to do this and ran up against the need
for absolutely horrid hacks if grub2-mkconfig is still needed.

But anyways, it works.