### PR TITLE
buildextend-rojig: Support unprivileged mode

### DIFF
--- a/src/buildextend-rojig-impl
+++ b/src/buildextend-rojig-impl
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+dn=$(dirname "$0")
+# shellcheck source=src/cmdlib.sh
+. "${dn}"/cmdlib.sh
+
+commit=$1
+shift
+tmpdir=$1
+shift
+
+sudo() {
+    if [ "$(id -u)" != 0 ]; then
+        /usr/bin/sudo -E "$@"
+    else
+        "$@"
+    fi
+}
+
+if has_privileges; then
+    # Avoid using the builddir inside the VM, since rpmbuild will fail
+    # to preserve permissions in `mv`
+    orig_tmpdir=
+    if [ -f /etc/cosa-supermin ]; then
+        orig_tmpdir="${tmpdir}"
+        tmpdir=$(mktemp -d -p /var/tmp)
+    fi
+    sudo rpm-ostree ex commit2rojig --repo="$(pwd)/tmp/repo" --pkgcache-repo="$(pwd)/cache/pkgcache-repo" \
+        "${commit}" "$(pwd)/src/config/manifest.yaml" "${tmpdir}"
+    if ! [ -f /etc/cosa-supermin ]; then
+        sudo chown -R -h "${USER}:${USER}" "${tmpdir}"
+    else
+        cp -r --preserve=mode "${tmpdir}"/* "${orig_tmpdir}"/
+    fi
+else
+    info "Required privileges not detected; running via supermin appliance"
+    prepare_build
+    runvm -- "${0}" "${commit}" "${tmpdir}"
+fi

--- a/src/cmd-buildextend-rojig
+++ b/src/cmd-buildextend-rojig
@@ -36,11 +36,7 @@ repo = os.path.join(workdir, 'tmp/repo')
 pkgcache_repo = os.path.join(workdir, 'cache/pkgcache-repo')
 
 with tempfile.TemporaryDirectory(prefix='rojig-', dir=f"{workdir}/tmp") as tmpd:
-    uid = os.getuid()
-    try:
-        run_verbose(['sudo', 'rpm-ostree', 'ex', 'commit2rojig', f"--repo={repo}", f"--pkgcache-repo={pkgcache_repo}", buildmeta_commit, 'src/config/manifest.yaml', os.path.abspath(tmpd)])
-    finally:
-        subprocess.check_call(['sudo', 'chown', '-Rh', f"{uid}:{uid}", tmpd])
+    run_verbose(['/usr/lib/coreos-assembler/buildextend-rojig-impl', buildmeta_commit, os.path.abspath(tmpd)])
     rojig_path = None
     arch_destdir = os.path.join(tmpd, get_basearch())
     if not os.path.isdir(arch_destdir):


### PR DESCRIPTION
Trying to actually deploy this in the FSBCOS pipeline, it failed
because it wants privileges, just like the main compose path.

Tweak things so that we do the same "run in VM if not privileged"
that main composes do.

The code/logic for this stuff really needs cleaning up and deduping,
it's quite messy.  Particularly because the supermin API is only
in shell.

We had some duplicates between `deps.txt` and `vmdeps.txt`; let's
consistently have the rpm-ostree bits in `vmdeps.txt`.  We
specifically need `rpm-build` in `vmdeps.txt` for rojig.