### PR TITLE
rojig: Use correct name for sha256 checksum

### DIFF
--- a/src/cmd-buildextend-rojig
+++ b/src/cmd-buildextend-rojig
@@ -61,7 +61,7 @@ size = os.path.getsize(destpath)
 buildmeta['images']['rojig'] = {
     'path': os.path.basename(rojig_path),
     'size': size,
-    'checksum': checksum
+    'sha256': checksum
 }
 write_json(buildmeta_path, buildmeta)
 print(f"Updated: {buildmeta_path}")


### PR DESCRIPTION
It's `sha256` and not `checksum`; this caused `cosa compress` to fail.