### PR TITLE
compress: Skip rojig too

### DIFF
--- a/src/cmd-compress
+++ b/src/cmd-compress
@@ -44,7 +44,7 @@ else:
 print(f"Targeting build: {build}")
 
 # Don't compress certain images
-imgs_to_skip = ["ostree", "iso", "live-iso", "vmware", "initramfs", "live-initramfs", "kernel", "live-kernel"]
+imgs_to_skip = ["ostree", "iso", "rojig", "live-iso", "vmware", "initramfs", "live-initramfs", "kernel", "live-kernel"]
 
 
 def get_cpu_param(param):


### PR DESCRIPTION
RPMs are already compressed.