### PR TITLE
 Move shim dependencies into vmdeps-$(arch).txt

### DIFF
--- a/src/deps-aarch64.txt
+++ b/src/deps-aarch64.txt
@@ -1,5 +1,0 @@
-# For grub install when creating images
-grub2
-
-# For creating bootable UEFI media on aarch64
-shim-aa64 grub2-efi-aa64

--- a/src/deps-x86_64.txt
+++ b/src/deps-x86_64.txt
@@ -1,8 +1,2 @@
-# For grub install when creating images without anaconda
-grub2
-
 # For generating ISO images
 syslinux-nonlinux
-
-# For creating bootable UEFI media on x86_64
-shim-x64 grub2-efi-x64

--- a/src/vmdeps-aarch64.txt
+++ b/src/vmdeps-aarch64.txt
@@ -1,1 +1,5 @@
-grub2 grub2-efi-aa64
+# For grub install when creating images
+grub2
+
+# For creating bootable UEFI media on aarch64
+shim-aa64 grub2-efi-aa64

--- a/src/vmdeps-x86_64.txt
+++ b/src/vmdeps-x86_64.txt
@@ -1,1 +1,5 @@
-grub2 grub2-efi-x64
+# For grub install when creating images without anaconda
+grub2
+
+# For creating bootable UEFI media on x86_64
+shim-x64 grub2-efi-x64

--- a/src/vmdeps.txt
+++ b/src/vmdeps.txt
@@ -25,4 +25,4 @@ python3 python3-gobject-base buildah podman skopeo iptables iptables-libs
 # luks
 cryptsetup
 
-gdisk xfsprogs e2fsprogs dosfstools shim
+gdisk xfsprogs e2fsprogs dosfstools


### PR DESCRIPTION


Recent move to unify deps+vmdeps broke ppc64le as
`shim` was in pure `vmdeps` but it's arch dependent.
#1018 (comment)

This reveals more duplication between the two; move bootloader
bits consistently into `vmdeps-$(arch).txt`.