### PR TITLE
Move shim to aarch64 and x86_64 only vmdeps

### DIFF
--- a/src/vmdeps-aarch64.txt
+++ b/src/vmdeps-aarch64.txt
@@ -1,1 +1,1 @@
-grub2 grub2-efi-aa64
+grub2 grub2-efi-aa64 shim

--- a/src/vmdeps-x86_64.txt
+++ b/src/vmdeps-x86_64.txt
@@ -1,1 +1,1 @@
-grub2 grub2-efi-x64
+grub2 grub2-efi-x64 shim

--- a/src/vmdeps.txt
+++ b/src/vmdeps.txt
@@ -25,4 +25,4 @@ python3 python3-gobject-base buildah podman skopeo iptables iptables-libs
 # luks
 cryptsetup
 
-gdisk xfsprogs e2fsprogs dosfstools shim
+gdisk xfsprogs e2fsprogs dosfstools


### PR DESCRIPTION
The shim package is not built for ppc64le or s390x.