### PR TITLE
hack-ign-3to2: Don't crash if no storage section is defined

### DIFF
--- a/src/incomplete-hack-ign-3to2
+++ b/src/incomplete-hack-ign-3to2
@@ -29,7 +29,7 @@ if vmajor == 2:
 elif vmajor != 3:
     raise SystemExit(f"Unsupported version {v}")
 ign['ignition']['version'] = '2.2.0'
-for f in ign['storage'].get('files', []):
+for f in ign.get('storage', {}).get('files', []):
     f['filesystem'] = "root"
     append = f.get('append')
     if append is not None:


### PR DESCRIPTION
I hit this in a config that only writes `systemd` units.