### PR TITLE
buildextend-installer: error out early if missing src config

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -33,7 +33,7 @@ coreos.pod([image: 'registry.fedoraproject.org/fedora:31', runAsUser: 0, kvm: tr
               // sanity check kola actually ran and dumped its output in tmp/
               coreos.shwrap("test -d /srv/tmp/kola")
               cosa_cmd("buildextend-metal")
-              cosa_cmd("buildextend-installer")
+              cosa_cmd("buildextend-live")
               cosa_cmd("buildextend-openstack")
               cosa_cmd("buildextend-vmware")
               cosa_cmd("compress")

--- a/src/cmd-buildextend-installer
+++ b/src/cmd-buildextend-installer
@@ -68,6 +68,14 @@ else:
     image_type = 'installer'
 meta_keys = {k: 'live-' + k if is_live else k for k in ('iso', 'kernel', 'initramfs')}
 
+config_src = image_type
+if image_type == 'fulliso':
+    config_src = 'live'
+srcdir_prefix = f"src/config/{config_src}/"
+
+if not os.path.isdir(srcdir_prefix):
+    raise Exception(f"missing directory {srcdir_prefix}")
+
 workdir = os.path.abspath(os.getcwd())
 builddir = builds.get_build_dir(args.build)
 buildmeta_path = os.path.join(builddir, 'meta.json')
@@ -222,10 +230,6 @@ def generate_iso():
     print(f'Substituting ISO kernel arguments: {kargs}')
 
     # Grab all the contents from the installer dir from the configs
-    config_src = image_type
-    if image_type == 'fulliso':
-        config_src = 'live'
-    srcdir_prefix = f"src/config/{config_src}/"
     for srcdir, dirnames, filenames in os.walk(srcdir_prefix):
         dir_suffix = srcdir.replace(srcdir_prefix, '', 1)
         dstdir = os.path.join(tmpisoroot, dir_suffix)


### PR DESCRIPTION
In FCOS, we're looking to drop the installer ISO in favour of the live
images:

https://github.com/coreos/fedora-coreos-tracker/issues/203
https://github.com/coreos/fedora-coreos-config/pull/261

AFAIK, RHCOS should be able to follow suit once the new
coreos-installer binary makes it there.

Until then though, rather than entirely drop support for building it, at
least check upfront that the `installer/` directory exists so we don't
do a bunch of work for nothing.