### PR TITLE
[rhcos-4.3] Dockerfile: blowout quay.io cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /root/containerbuild
 # Only need a few of our scripts for the first few steps
 COPY ./src/cmdlib.sh /root/containerbuild/src/
 COPY ./build.sh ./deps*.txt ./vmdeps*.txt ./build-deps.txt /root/containerbuild/
-RUN ./build.sh configure_yum_repos
+RUN ./build.sh configure_yum_repos # nocache 20200110
 RUN ./build.sh install_rpms
 
 # Ok copy in the rest of them for the next few steps


### PR DESCRIPTION
This is essentially the same as 88c17bc

We want the `rhcos-4.3` tag to have the latest version of `rpm-ostree`
so folks can pull and build locally if they want to.  But the last two
attempts to rebuild the container are using the cached RPM layer and
therefore pulling in and older version of `rpm-ostree`
(rpm-ostree-2019.6.24.gfec61ce5-1.fc31.x86_64)