### PR TITLE
create_disk.sh: Query the host page size when fs-verity is enabled

### DIFF
--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -143,10 +143,23 @@ if [ "${image_type}" = dasd ]; then
     ignition_platform_id=metal
 fi
 
+# First parse the old luks_rootfs flag
+rootfs_type="$(python3 -c 'import sys, yaml; lf=yaml.safe_load(sys.stdin).get("luks_rootfs", ""); print("luks" if lf.lower() in ("yes", "true") else "")' < "$configdir/image.yaml")"
+if [ -z "${rootfs_type}" ]; then
+    rootfs_type="$(python3 -c 'import sys, yaml; print(yaml.safe_load(sys.stdin).get("rootfs", "xfs"))' < "$configdir/image.yaml")"
+fi
+
+# fs-verity requires block size = page size. We need to take that into account
+# in the disk size estimation due to higher fragmentation on larger blocks.
+BLKSIZE=""
+if [ "${rootfs_type}" = "ext4verity" ]; then
+    BLKSIZE="$(getconf PAGE_SIZE)"
+fi
+
 echo "Estimating disk size..."
 # The additional 35% here is obviously a hack, but we can't easily completely fill the filesystem,
 # and doing so has apparently negative performance implications.
-/usr/lib/coreos-assembler/estimate-commit-disk-size --repo "$ostree_repo" "$ref" --add-percent 35 > "$PWD/tmp/ostree-size.json"
+/usr/lib/coreos-assembler/estimate-commit-disk-size ${BLKSIZE:+--blksize ${BLKSIZE}} --repo "$ostree_repo" "$ref" --add-percent 35 > "$PWD/tmp/ostree-size.json"
 rootfs_size="$(jq '."estimate-mb".final' "$PWD/tmp/ostree-size.json")"
 # extra size is the non-ostree partitions, see create_disk.sh
 image_size="$(( rootfs_size + 513 ))M"
@@ -195,11 +208,6 @@ kargs="$kargs $tty ignition.platform.id=$ignition_platform_id"
 
 ostree_remote="$(python3 -c 'import sys, yaml; print(yaml.safe_load(sys.stdin).get("ostree-remote", "NONE"))' < "$configdir/image.yaml")"
 save_var_subdirs="$(python3 -c 'import sys, yaml; print(yaml.safe_load(sys.stdin).get("save-var-subdirs-for-selabel-workaround", "NONE"))' < "$configdir/image.yaml")"
-# First parse the old luks_rootfs flag
-rootfs_type="$(python3 -c 'import sys, yaml; lf=yaml.safe_load(sys.stdin).get("luks_rootfs", ""); print("luks" if lf.lower() in ("yes", "true") else "")' < "$configdir/image.yaml")"
-if [ -z "${rootfs_type}" ]; then
-    rootfs_type="$(python3 -c 'import sys, yaml; print(yaml.safe_load(sys.stdin).get("rootfs", "xfs"))' < "$configdir/image.yaml")"
-fi
 
 qemu-img create -f ${image_format} "${path}.tmp" "${image_size}"
 # We support deploying a commit directly instead of a ref

--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -186,9 +186,9 @@ fi
 
 bootargs=
 if [ "${boot_verity}" = 1 ]; then
-    # Need 4k blocks to match host page size; TODO
-    # really mkfs.ext4 should know this.  This is arch-dependent probably.
-    bootargs="-b 4096 -O verity"
+    # Need blocks to match host page size; TODO
+    # really mkfs.ext4 should know this.
+    bootargs="-b $(getconf PAGE_SIZE) -O verity"
 fi
 mkfs.ext4 ${bootargs} "${disk}${BOOTPN}" -L boot
 if [ ${EFIPN:+x} ]; then
@@ -206,7 +206,7 @@ if [ "${rootfs}" = "ext4verity" ]; then
     # So basically, we're choosing performance over half-implemented security.
     # Eventually, we'd like both - once XFS gains verity (probably not too hard),
     # we could unconditionally enable it there.
-    mkfs.ext4 -O verity -L root "${root_dev}"
+    mkfs.ext4 -b $(getconf PAGE_SIZE) -O verity -L root "${root_dev}"
 else
     mkfs.xfs "${root_dev}" -L root -m reflink=1
 fi


### PR DESCRIPTION
ext4 fs-verity requires the fs block size to be the same as the kernel page
size, and different architectures use different page sizes. So, we have to
query the host page size and use that as the block size when fs-verity is
enabled.

We also have to take the block size into account in the rootfs size estimation,
since larger blocks waste more disk space with internal fragmentation.

Fixes #1031