### PR TITLE
cmd-ore-wrapper: fix using basename to auto-detect command

### DIFF
--- a/src/cmd-ore-wrapper
+++ b/src/cmd-ore-wrapper
@@ -5,6 +5,7 @@
 # as a replacement for 'cmd-*-replicate' and 'cmd-buildextend-*'.
 
 import logging as log
+import os
 import sys
 
 from cosalib.cli import (
@@ -33,18 +34,20 @@ Each target has its own sub options. To access them us:
     replicate = False
     build_build = False
 
+    self_basename = os.path.basename(sys.argv[0])
+
     # Check if this is a legacy interface
-    if str(sys.argv[0]).endswith("-replicate"):
+    if str(self_basename).endswith("-replicate"):
         log.info("symlink is for a replication command")
         replicate = True
 
-    if str(sys.argv[0]).startswith("cmd-buildextend-"):
+    if str(self_basename).startswith("cmd-buildextend-"):
         log.info("symlink is for a build and publish command")
         build_build = True
 
     # previous cmd-buildextend-<target> used symlinks
     for k in cloud_clis():
-        if k in sys.argv[0]:
+        if k in self_basename:
             sys_target = k
             log.info(f"ore target {sys_target} found via symlink")
             break

--- a/src/cmd-ore-wrapper
+++ b/src/cmd-ore-wrapper
@@ -77,6 +77,7 @@ Each target has its own sub options. To access them us:
     parser.add_argument("--upload", action='store_true',
                         help="Upload the disk to the ore target")
     parser.add_argument("--replicate", action='store_true',
+                        default=replicate,
                         help="For specific clouds, replicate various regions")
     parser.add_argument("--region", "--regions", dest="region",
                         help="Upload/replicate to specific regions",

--- a/src/cmd-ore-wrapper
+++ b/src/cmd-ore-wrapper
@@ -31,19 +31,19 @@ Each target has its own sub options. To access them us:
 
     # Determine if this a symlink, default to that.
     sys_target = None
-    replicate = False
-    build_build = False
+    default_replicate = False
+    default_build_artifact = False
 
     self_basename = os.path.basename(sys.argv[0])
 
     # Check if this is a legacy interface
     if str(self_basename).endswith("-replicate"):
         log.info("symlink is for a replication command")
-        replicate = True
+        default_replicate = True
 
     if str(self_basename).startswith("cmd-buildextend-"):
         log.info("symlink is for a build and publish command")
-        build_build = True
+        default_build_artifact = True
 
     # previous cmd-buildextend-<target> used symlinks
     for k in cloud_clis():
@@ -68,7 +68,7 @@ Each target has its own sub options. To access them us:
     # Extend the CLI for the target
     parser = get_cloud_cli(target, parser)
     parser.add_argument("--build-artifact", "--build-if-missing",
-                        action='store_true', default=build_build,
+                        action='store_true', default=default_build_artifact,
                         help="Build the artifact if missing")
     parser.add_argument("--force", action='store_true',
                         help="Force the operation if it has already happened")
@@ -77,7 +77,7 @@ Each target has its own sub options. To access them us:
     parser.add_argument("--upload", action='store_true',
                         help="Upload the disk to the ore target")
     parser.add_argument("--replicate", action='store_true',
-                        default=replicate,
+                        default=default_replicate,
                         help="For specific clouds, replicate various regions")
     parser.add_argument("--region", "--regions", dest="region",
                         help="Upload/replicate to specific regions",


### PR DESCRIPTION
We were using `startswith()` directly on `argv[0]` to know which symlink
we were called as, but that might be the full path to the script. So
pass through `basename()` first.

Closes: #1039