### PR TITLE
cmd-ore-wrapper: fix publication regressions

### DIFF
--- a/src/cmd-ore-wrapper
+++ b/src/cmd-ore-wrapper
@@ -70,6 +70,8 @@ Each target has its own sub options. To access them us:
     parser.add_argument("--build-artifact", "--build-if-missing",
                         action='store_true', default=default_build_artifact,
                         help="Build the artifact if missing")
+    parser.add_argument("--config", "--config-file",
+                        help="ore configuration")
     parser.add_argument("--force", action='store_true',
                         help="Force the operation if it has already happened")
     parser.add_argument("--help", action='store_true',

--- a/src/cosalib/azure.py
+++ b/src/cosalib/azure.py
@@ -6,7 +6,7 @@ from tenacity import (
 )
 
 
-@retry(stop=stop_after_attempt(3))
+@retry(reraise=True, stop=stop_after_attempt(3))
 def remove_azure_image(image, resource_group, auth, profile):
     print(f"Azure: removing image {image}")
     try:
@@ -22,7 +22,7 @@ def remove_azure_image(image, resource_group, auth, profile):
         raise Exception("Failed to remove image")
 
 
-@retry(stop=stop_after_attempt(3))
+@retry(reraise=True, stop=stop_after_attempt(3))
 def azure_run_ore(*args):
     print("""
 Azure currently does not produce virtual machine
@@ -30,7 +30,7 @@ registrations. This command is a place-holder only.
 """)
 
 
-@retry(stop=stop_after_attempt(3))
+@retry(reraise=True, stop=stop_after_attempt(3))
 def azure_run_ore_replicate(*args):
     print("""
 Azure currently does not produce virtual machine


### PR DESCRIPTION
This addresses un-intended consequences with the refactor:
- reraise exceptions with the @retry wrapper
- use arg.region since '--region' and '--regions' are synonyms
- use the old meta.json 'amis' instead of 'aws'
- introduce wrapper for `ore` call `run_ore' to de-duplicate the
  the logging code and support use of --config-file