### PR TITLE
cmd-kola: transparently pass unknown flags to kola

### DIFF
--- a/src/cmd-kola
+++ b/src/cmd-kola
@@ -28,7 +28,7 @@ parser.add_argument("--basic-qemu-scenarios", help="Run the basic test across ue
 parser.add_argument("--output-dir", help="Output directory")
 parser.add_argument("subargs", help="Remaining arguments for kola", nargs='*',
                     default=['run'])
-args = parser.parse_args()
+args, unknown_args = parser.parse_known_args()
 
 builds = Builds()
 if args.build is None:
@@ -59,7 +59,7 @@ qemupath = os.path.join(builddir, qemuimg['path'])
 # https://github.com/coreos/coreos-assembler/pull/85
 kolaargs = ['kola']
 bn = os.path.basename(qemupath)
-if not any([x in args.subargs for x in ["-b", "--distro"]]):
+if not any([x in unknown_args for x in ["-b", "--distro"]]):
     if bn.startswith("rhcos-"):
         kolaargs.extend(['-b', 'rhcos'])
     else:
@@ -72,7 +72,7 @@ print(f"Using ignition version {ignition_version}")
 if ignition_version == "2.2.0":
     kolaargs.extend(["--ignition-version", "v2"])
 
-if os.getuid() != 0 and not ('-p' in args.subargs):
+if os.getuid() != 0 and not ('-p' in unknown_args):
     kolaargs.extend(['-p', 'qemu-unpriv'])
 
 # shellcheck disable=SC2086
@@ -80,6 +80,7 @@ kolaargs.extend(['--qemu-image', qemupath])
 outputdir = args.output_dir or "tmp/kola"
 kolaargs.extend(['--output-dir', outputdir])
 kolaargs.extend(args.subargs)
+kolaargs.extend(unknown_args)
 
 kolaargs.extend(blacklist_args)
 


### PR DESCRIPTION
Right now we're kind of in a messy situtation where we have some args
for `cosa kola`, and other args that we want to pass through to `kola`.
Unfortunately, argparse isn't very good for this use case. Using `--`
helps sometimes, but the issue arises when we want to pass flags to
*both* cosa and kola. The obvious `--cosa-arg -- --kola-arg` doesn't
work (https://bugs.python.org/issue15112).

Instead, just use `parse_known_args()` to tell argparse to leave the
unknown args untouched. We then pass those through as is to `kola`. This
also avoids us having to use `--` entirely. The caveat is that it can be
confusing if we support a `cosa kola` arg that `kola` natively supports,
but let's say we're not going to do this, or if we do, it's to just pass
it through to kola as well as do some auxiliary related thing.