### PR TITLE
cosalib: fix azure and required meta-data

### DIFF
--- a/src/cmd-koji-upload
+++ b/src/cmd-koji-upload
@@ -101,6 +101,10 @@ class Build(_Build):
     """
     def __init__(self, *args, **kwargs):
         self._tmpdir = tempfile.mkdtemp(prefix="koji-build")
+        kwargs.update({
+            "require_commit": True,
+            "require_cosa": True,
+        })
         _Build.__init__(self, *args, **kwargs)
 
     def __del__(self):

--- a/src/cmd-koji-upload
+++ b/src/cmd-koji-upload
@@ -470,7 +470,10 @@ class Upload():
                 "owner": self._owner,
                 "source": source['origin'],
                 "start_time": stamp,
-                "version": f"{self.build.build_id}"
+                # RHCOS wants to be semver-compatible, but Koji doesn't
+                # accept `-`.  See
+                # https://github.com/openshift/oc/pull/209#issuecomment-564876535
+                "version": f"{self.build.build_id.replace('-', '.')}"
             },
             "buildroots": [{
                 "id": 1,

--- a/src/cosalib/aliyun.py
+++ b/src/cosalib/aliyun.py
@@ -118,7 +118,7 @@ def aliyun_run_ore(build, args):
     # convert the binary output to string and remove trailing white space
     ore_data = subprocess.check_output(ore_args).decode('utf-8').strip()
     build.meta['aliyun'] = [{
-        'name': args.region,
+        'name': region,
         'id': ore_data
     }]
     build.meta_write()

--- a/src/cosalib/build.py
+++ b/src/cosalib/build.py
@@ -45,7 +45,7 @@ class CommitMetaRequired(BuildError):
     """
     Raised when the Commit Metadata is missing
     """
-
+    pass
 
 
 class _Build:
@@ -283,7 +283,6 @@ class _Build:
             if e:
                 raise e(f"{file_path} is required")
             else:
-                log.warn(f"{file_path} was not found, but is not required")
                 return {}
 
     def get_obj(self, key):

--- a/src/cosalib/gcp.py
+++ b/src/cosalib/gcp.py
@@ -70,6 +70,7 @@ def gcp_run_ore(build, args):
         'image': gcp_name,
         'url': f"https://{url_path}",
     }
+    build.meta_write()
 
 
 def gcp_run_ore_replicate(*args, **kwargs):


### PR DESCRIPTION
This fixes two problems:
- Azure was missing the `ore` command. 
- GH-1049: for RHCOS builds the commitmeta.json is present, however, only Koji uploads generally require it. This changes the `cosalib.build._Build` to have conditional checks on the required artifacts needed to parse the meta-data. 