### PR TITLE
cosalib/build.py: drop 'meta.json' handling infavor GenericBuildMeta

### DIFF
--- a/src/cmd-meta
+++ b/src/cmd-meta
@@ -21,23 +21,33 @@ def new_cli():
     sub_parser.add_argument(
         '--dump', help='dumps the entire structure', action='store_true')
     sub_parser.add_argument(
-        '--image-path', help='Output path to artifact IMAGETYPE', action='store',
+        '--image-path', help='Output path to artifact IMAGETYPE',
+        action='store',
         metavar='IMAGETYPE')
     args = parser.parse_args()
 
     meta = Meta(args.workdir, args.build)
 
+    # support the coreos-assembler.* keys
+    def pather(val):
+        path = val.split('.')
+        if val.startswith("coreos-assembler."):
+            new_path = [f"{path[0]}.{path[1]}"]
+            new_path.extend(path[2:])
+            return new_path
+        return path
+
     # Get keys
     if args.get is not None:
         dotpath = args.get[0]
-        keypath = dotpath.split('.')
-        loc = meta.get(*keypath)
+        keypath = pather(dotpath)
+        loc = meta.get(keypath)
         print(f'{dotpath}: {loc}')
     # Set keys
     elif args.set is not None:
         for item in args.set:
             k, v = item.split('=')
-            keypath = k.split('.')
+            keypath = pather(k)
             meta.set(keypath, v)
         meta.write()
     elif args.dump is True:

--- a/src/cosalib/build.py
+++ b/src/cosalib/build.py
@@ -11,8 +11,7 @@ import tempfile
 from cosalib.cmdlib import (
     get_basearch,
     load_json,
-    sha256sum_file,
-    write_json)
+    sha256sum_file)
 from cosalib.builds import Builds
 from cosalib.meta import GenericBuildMeta as Meta
 

--- a/tests/test_cosalib_meta.py
+++ b/tests/test_cosalib_meta.py
@@ -3,7 +3,9 @@ import json
 import sys
 import pytest
 
-sys.path.insert(0, 'src')
+parent_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, f'{parent_path}/src')
+sys.path.insert(0, parent_path)
 
 from cosalib import meta
 from cosalib.cmdlib import get_basearch
@@ -52,9 +54,9 @@ def test_init(tmpdir):
 def test_get(tmpdir):
     m = meta.GenericBuildMeta(_create_test_files(tmpdir), '1.2.3')
     assert m.get('test') == 'data'
-    assert m.get('a', 'b') == 'c'
-    with pytest.raises(KeyError):
-        m.get('i', 'donot', 'exist')
+    assert m.get('nope', 'default') == 'default'
+    assert m.get(['a', 'b']) == 'c'
+    assert m.get(['a', 'd'], 'nope') == 'nope'
 
 
 def test_set(tmpdir):
@@ -67,7 +69,7 @@ def test_set(tmpdir):
     assert m.get('test') == 'changed'
     m.set(['a', 'b'], 'z')
     m.write()
-    assert m.get('a', 'b') == 'z'
+    assert m.get(['a', 'b']) == 'z'
     assert m['a']['b'] == 'z'
     with pytest.raises(Exception):
         m.set(['i', 'donot', 'exist'], 'boom')


### PR DESCRIPTION
Drop the meta.json reading, writing and parsing function in favor of the GenericBuildMeta class. This moves all `cosalib` functions around the GeneraicBuildMeta instead of having two handlers.

This also changes the interface for `GenericBuildMeta.{get,set}` to support the `dict` such that it can used like a standard `dict` or as a nested one. The `get` and `set` functions now use `arg[0]` to determine the path. 