### PR TITLE
[rhcos-4.3] grub.cfg: set ip=dhcp,dhcp6

### DIFF
--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -331,7 +331,7 @@ s390x)
 	# this is only a temporary solution until we are able to do firstboot check at bootloader
 	# stage on s390x, either through zipl->grub2-emu or zipl standalone.
 	# See https://github.com/coreos/ignition-dracut/issues/84
-	echo "$(grep options $blsfile) ignition.firstboot rd.neednet=1 ip=dhcp" > $tmpfile
+	echo "$(grep options $blsfile) ignition.firstboot rd.neednet=1 ip=dhcp,dhcp6" > $tmpfile
 
 	# ideally we want to invoke zipl with bls and zipl.conf but we might need
 	# to chroot to rootfs/ to do so. We would also do that when FCOS boot on its own.

--- a/src/grub.cfg
+++ b/src/grub.cfg
@@ -45,7 +45,7 @@ fi
 set ignition_firstboot=""
 if [ -f "/ignition.firstboot" ]; then
     # default to dhcp networking parameters to be used with ignition
-    set ignition_network_kcmdline='rd.neednet=1 ip=dhcp'
+    set ignition_network_kcmdline='rd.neednet=1 ip=dhcp,dhcp6'
 
     # source in the `ignition.firstboot` file which could override the
     # above $ignition_network_kcmdline with static networking config.


### PR DESCRIPTION
Backport of https://github.com/coreos/coreos-assembler/pull/1067.

---

That way, it'll work on both IPv4 and IPv6 networks.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=1793591