### PR TITLE
cmd-kola: change default output dir for upgrade testing

### DIFF
--- a/src/cmd-kola
+++ b/src/cmd-kola
@@ -33,8 +33,10 @@ args, unknown_args = parser.parse_known_args()
 
 if args.upgrades:
     default_cmd = 'run-upgrade'
+    default_output_dir = "tmp/kola-upgrade"
 else:
     default_cmd = 'run'
+    default_output_dir = "tmp/kola"
 
 builds = Builds()
 if args.build is None:
@@ -84,7 +86,7 @@ if os.getuid() != 0 and not ('-p' in unknown_args):
 
 # shellcheck disable=SC2086
 kolaargs.extend(['--cosa-build', buildmeta_path])
-outputdir = args.output_dir or "tmp/kola"
+outputdir = args.output_dir or default_output_dir
 kolaargs.extend(['--output-dir', outputdir])
 kolaargs.extend(args.subargs or [default_cmd])
 kolaargs.extend(unknown_args)

--- a/src/cmd-kola
+++ b/src/cmd-kola
@@ -110,8 +110,7 @@ elif args.upgrades:
     if '--qemu-image-dir' not in unknown_args:
         os.makedirs('tmp/kola-qemu-cache', exist_ok=True)
         kolaargs.extend(['--qemu-image-dir', 'tmp/kola-qemu-cache'])
-    kolaargs.extend(['-v', '--find-parent-image', '--qemu-image-dir',
-                     'tmp/kola-qemu-cache'])
+    kolaargs.extend(['-v', '--find-parent-image'])
     print(subprocess.list2cmdline(kolaargs), flush=True)
     os.execvpe('kola', kolaargs, env)
 else:


### PR DESCRIPTION
The rationale for this is that it's a different "kind" of test, and so
it shouldn't clobber the results of a previous `cosa kola run`
invocation. It also makes it easier to run in parallel with it.