### PR TITLE
src/cmd-buildextend-vultr: prepare a Vultr raw image

### DIFF
--- a/src/cmd-buildextend-vultr
+++ b/src/cmd-buildextend-vultr
@@ -1,0 +1,1 @@
+cmd-ore-wrapper

--- a/src/coreos-assembler
+++ b/src/coreos-assembler
@@ -43,7 +43,7 @@ cmd=${1:-}
 build_commands="init fetch build run prune clean"
 # commands more likely to be used in a prod pipeline only
 advanced_build_commands="buildprep buildupload oscontainer"
-buildextend_commands="qemu aws azure gcp openstack installer live vmware metal"
+buildextend_commands="qemu aws azure gcp openstack installer live vmware metal vultr"
 utility_commands="tag sign compress koji-upload kola aws-replicate remote-prune"
 other_commands="shell meta"
 if [ -z "${cmd}" ]; then

--- a/src/cosalib/cli.py
+++ b/src/cosalib/cli.py
@@ -9,7 +9,8 @@ from cosalib import (
     aliyun,
     aws,
     azure,
-    gcp
+    gcp,
+    vultr
 )
 
 CLOUD_CLI_TARGET = {
@@ -24,7 +25,10 @@ CLOUD_CLI_TARGET = {
                azure.azure_run_ore_replicate),
     "gcp":    (gcp.gcp_cli,
                gcp.gcp_run_ore,
-               gcp.gcp_run_ore_replicate)
+               gcp.gcp_run_ore_replicate),
+    "vultr":  (vultr.vultr_cli,
+               vultr.vultr_run_ore,
+               vultr.vultr_run_ore_replicate),
 }
 
 

--- a/src/cosalib/qemuvariants.py
+++ b/src/cosalib/qemuvariants.py
@@ -66,6 +66,10 @@ VARIANTS = {
         "convert_options":  {
             '-o': 'adapter_type=lsilogic,subformat=streamOptimized,compat6'
         }
+    },
+    "vultr": {
+        "image_format": "raw",
+        "platform": "vultr",
     }
 }
 

--- a/src/cosalib/vultr.py
+++ b/src/cosalib/vultr.py
@@ -9,11 +9,11 @@ def vultr_run_ore(build, args):
     """
     Placeholder to upload a raw image to Vultr.
     """
-    pass
+    raise Exception("not implemented yet")
 
 
 def vultr_run_ore_replicate(*args, **kwargs):
-    print("Images are not published to Vultr. This is a placeholder")
+    raise Exception("not implemented yet")
 
 
 def vultr_cli(parser):

--- a/src/cosalib/vultr.py
+++ b/src/cosalib/vultr.py
@@ -1,0 +1,23 @@
+from tenacity import (
+    retry,
+    stop_after_attempt
+)
+
+
+@retry(reraise=True, stop=stop_after_attempt(3))
+def vultr_run_ore(build, args):
+    """
+    Placeholder to upload a raw image to Vultr.
+    """
+    pass
+
+
+def vultr_run_ore_replicate(*args, **kwargs):
+    print("Images are not published to Vultr. This is a placeholder")
+
+
+def vultr_cli(parser):
+    """
+    Extend a parser with the Vultr options
+    """
+    return parser


### PR DESCRIPTION
* Build a raw image with the Ignition provider set to vultr to correspond with https://github.com/coreos/ignition/pull/918

With this, I was able to build a new coreos-assembler and use it to build a `fedora-coreos-31.20200128.dev.0-vultr.x86_64.raw` that claims to have the `vultr` platform id set. No change to Ignition yet, so its not of practical use yet, but its something.

```
cosa build
cosa buildextend-vultr
```