### PR TITLE
cosalib/meta.py: support sub schemas

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ flake8:
 	# find src -maxdepth 1 -name "*.py" | xargs flake8 --ignore=$(PYIGNORE)
 
 unittest:
-	COSA_TEST_META_JSON=`pwd`/fixtures/rhcos.json \
+	COSA_TEST_META_PATH=`pwd`/fixtures \
 		COSA_META_SCHEMA=`pwd`/src/schema/v1.json \
 		PYTHONPATH=`pwd`/src python3 -m pytest tests/
 

--- a/fixtures/fcos.json
+++ b/fixtures/fcos.json
@@ -1,0 +1,118 @@
+{
+    "ref": "fedora/x86_64/coreos/testing-devel",
+    "ostree-n-metadata-total": 9075,
+    "ostree-n-metadata-written": 18,
+    "ostree-n-content-total": 4659,
+    "ostree-n-content-written": 26,
+    "ostree-n-cache-hits": 15280,
+    "ostree-content-bytes-written": 74744943,
+    "ostree-commit": "f4804b55772a66be779db86e27bbda71aed1d61daebea4f766fd9894d958b140",
+    "ostree-content-checksum": "23efb91032f078a0621556e57aa83fef5083b9a9ec4d78e7ab3853aa8d7899ff",
+    "ostree-version": "31.20200127.20.2",
+    "ostree-timestamp": "2020-01-28T14:36:27Z",
+    "rpm-ostree-inputhash": "7f6f3c29927170a09ad70bb681b2eff696f193a6de436d99ba1bff2f69f6f890",
+    "pkgdiff": [],
+    "buildid": "31.20200127.20.2",
+    "coreos-assembler.image-genver": 0,
+    "name": "fedora-coreos",
+    "summary": "Fedora CoreOS testing-devel",
+    "coreos-assembler.build-timestamp": "2020-01-28T14:38:49Z",
+    "coreos-assembler.image-config-checksum": "8fc8f4a0777d4e6a9d393677e7c5dc17af7c9f3bf6f26b766b7d2c0681b803ab",
+    "coreos-assembler.image-input-checksum": "4d4016076f4ba9a9000f9c9eb36b614dc2043b84bc71f119f708860503b82a9c",
+    "coreos-assembler.code-source": "container",
+    "coreos-assembler.container-config-git": {
+        "commit": "4438fbd1821b3cc2f23a2f4cc3d2d068413c00eb",
+        "origin": "https://github.com/coreos/fedora-coreos-config",
+        "branch": "testing-devel",
+        "dirty": "false"
+    },
+    "images": {
+        "ostree": {
+            "path": "fedora-coreos-31.20200127.20.2-ostree.x86_64.tar",
+            "sha256": "746cdefd426e263f38d283e82780dc06305ff4e9647d95d78ba77c3f2bb2e314",
+            "size": 636467200
+        },
+        "qemu": {
+            "path": "fedora-coreos-31.20200127.20.2-qemu.x86_64.qcow2.xz",
+            "sha256": "9c48c5ab67e9b84aeb53247843bee420b13b16913905f861993fd57c1f84653c",
+            "size": 454417284,
+            "uncompressed-sha256": "0505b34810948308717b90844c1a423e6c403a3fb522714021289150e2d27821",
+            "uncompressed-size": 1707540480
+        },
+        "metal": {
+            "path": "fedora-coreos-31.20200127.20.2-metal.x86_64.raw.xz",
+            "sha256": "2f6e75f85b116817c99ea9fe886a545637339a82be542418514f12b74f1bdffa",
+            "size": 455882892,
+            "uncompressed-sha256": "6e7966e2a0eada061940de2b484dc968edfb52b1dbf2b2d208704f7c2021da8b",
+            "uncompressed-size": 2793406464
+        },
+        "live-iso": {
+            "path": "fedora-coreos-31.20200127.20.2-live.x86_64.iso",
+            "sha256": "4879a23a5239e7c28c76bfa4b94e721c8628f805aba72a796ec691645a30f95e"
+        },
+        "live-kernel": {
+            "path": "fedora-coreos-31.20200127.20.2-live-kernel-x86_64",
+            "sha256": "2e895c2cc9717e32ba78ff728003410509ff57dcbe25a487b22ba66997b344b8"
+        },
+        "live-initramfs": {
+            "path": "fedora-coreos-31.20200127.20.2-live-initramfs.x86_64.img",
+            "sha256": "6faa217b1db2fe697365e2880d5009b6cab35ed978bf02ffd2540cef0750db71"
+        },
+        "azure": {
+            "path": "fedora-coreos-31.20200127.20.2-azure.x86_64.vhd.xz",
+            "sha256": "370d45adc7e3fbbafa67cb0605c9c384af794370316494b4517eea39cdc0dbe3",
+            "size": 454410068,
+            "uncompressed-sha256": "75c3cbf0b73d917a86e0029b577de33ae3866eaeebed19d2967ee9e0baa6f1b7",
+            "uncompressed-size": 1751568384
+        },
+        "openstack": {
+            "path": "fedora-coreos-31.20200127.20.2-openstack.x86_64.qcow2.xz",
+            "sha256": "212cbfc9d6d4ba3637b70214efb62b9e3e3449f3a13a3d9e80fb8ea97f04924e",
+            "size": 453823640,
+            "uncompressed-sha256": "deda906a95444bfc90669293482f983910ebb3cdbb6ea5becce3227f285add11",
+            "uncompressed-size": 1680539648
+        },
+        "aliyun": {
+            "path": "fedora-coreos-31.20200127.20.2-aliyun.x86_64.qcow2.xz",
+            "sha256": "e19be1c6cc0099d889d7ad17941c8c327e5508a1c753e8574521ba3c322e8016",
+            "size": 453834524,
+            "uncompressed-sha256": "1deaba6612ca8a00ebaad7ad48edd0af251df28d49b37d2b282c6287098f12a5",
+            "uncompressed-size": 1680539648
+        },
+        "vmware": {
+            "path": "fedora-coreos-31.20200127.20.2-vmware.x86_64.ova",
+            "sha256": "76d8eb9475c4c4ca0623a62f71da21d7fe517adfacf1805a8e21059f6eafd339",
+            "size": 711311360
+        },
+        "gcp": {
+            "path": "fedora-coreos-31.20200127.20.2-gcp.x86_64.tar.gz",
+            "sha256": "c5bf7eb10f1de9a6757e5738183c038f63ba5623473a23a8901d0e465afcead7",
+            "size": 697838891
+        },
+        "aws": {
+            "path": "fedora-coreos-31.20200127.20.2-aws.x86_64.vmdk.xz",
+            "sha256": "9d21826078cc3f62ad382b42312826f4e23d2444daffe2c95bcd294ee0bf0013",
+            "size": 673121632,
+            "uncompressed-sha256": "2e2fa5b0ca8a87eb53ee5bfe324654c9e86f873f6fa7023fbe2b019d4c727aeb",
+            "uncompressed-size": 711297024
+        }
+    },
+    "coreos-assembler.container-image-git": {
+        "commit": "4f7f2f651d8265d2ad5b8fdfe07c84fec68df064",
+        "origin": "git@github.com:coreos/coreos-assembler.git",
+        "branch": "HEAD",
+        "dirty": "false"
+    },
+    "coreos-assembler.config-gitrev": "4438fbd1821b3cc2f23a2f4cc3d2d068413c00eb",
+    "coreos-assembler.config-dirty": "false",
+    "coreos-assembler.basearch": "x86_64",
+    "fedora-coreos.parent-version": "31.20200127.20.1",
+    "fedora-coreos.parent-commit": "896bbf4681b23b607235285662a7c57b92240f8ff934439cd79b97850363a19f",
+    "amis": [
+        {
+            "name": "us-east-1",
+            "hvm": "ami-0260775b1132d4eb3",
+            "snapshot": "snap-0f0dcc48a69cff9be"
+        }
+    ]
+}

--- a/src/cosalib/meta.py
+++ b/src/cosalib/meta.py
@@ -36,7 +36,6 @@ class GenericBuildMeta(dict):
 
         # Load the schema
         self._validator = None
-        self._schema_path = schema
         if schema:
             with open(schema, 'r') as data:
                 self._validator = jsonschema.Draft7Validator(
@@ -57,6 +56,7 @@ class GenericBuildMeta(dict):
         expected.
         """
         if not self._validator:
+            print("no validator")
             return
         self._validator.validate(dict(self))
 

--- a/src/schema/v1.json
+++ b/src/schema/v1.json
@@ -3,63 +3,119 @@
  "$schema":"http://json-schema.org/draft-07/schema#",
  "$id":"http://github.com/coreos/coreos-assembler/blob/master/schema/v1.json",
  "type":"object",
- "title":"CoreOS v1 meta schema",
- "required": [
-   "buildid",
-   "coreos-assembler.basearch",
-   "coreos-assembler.build-timestamp",
-   "coreos-assembler.code-source",
-   "coreos-assembler.config-dirty",
-   "coreos-assembler.config-gitrev",
-   "coreos-assembler.image-config-checksum",
-   "coreos-assembler.image-genver",
-   "coreos-assembler.image-input-checksum",
-   "images",
-   "name",
-   "ostree-commit",
-   "ostree-content-bytes-written",
-   "ostree-content-checksum",
-   "ostree-n-cache-hits",
-   "ostree-n-content-total",
-   "ostree-n-content-written",
-   "ostree-n-metadata-total",
-   "ostree-n-metadata-written",
-   "ostree-timestamp",
-   "ostree-version",
-   "rpm-ostree-inputhash",
-   "summary"
-  ],
- "optional": [
-   "aliyun",
-   "amis",
-   "azure",
-   "build-url",
-   "gcp",
-   "oscontainer",
-   "pkgdiff",
-   "coreos-assembler.container-config-git",
-   "coreos-assembler.container-image-git"
-  ],
+ "title":"CoreOS Assember v1 meta.json schema",
+ "allOf": [
+     {
+         "required": [
+             "buildid",
+             "name",
+             "ostree-commit",
+             "ostree-content-bytes-written",
+             "ostree-content-checksum",
+             "ostree-n-cache-hits",
+             "ostree-n-content-total",
+             "ostree-n-content-written",
+             "ostree-n-metadata-total",
+             "ostree-n-metadata-written",
+             "ostree-timestamp",
+             "ostree-version",
+             "rpm-ostree-inputhash",
+             "summary"
+         ],
+         "optional": [
+           "images",
+           "aliyun",
+           "amis",
+           "azure",
+           "build-url",
+           "gcp",
+           "oscontainer",
+           "pkgdiff",
+
+           "coreos-assembler.basearch",
+           "coreos-assembler.build-timestamp",
+           "coreos-assembler.code-source",
+           "coreos-assembler.config-dirty",
+           "coreos-assembler.config-gitrev",
+           "coreos-assembler.container-config-git",
+           "coreos-assembler.container-image-git",
+           "coreos-assembler.image-config-checksum",
+           "coreos-assembler.image-genver",
+           "coreos-assembler.image-input-checksum",
+           "fedora-coreos.parent-commit",
+           "fedora-coreos.parent-version",
+           "ref"
+          ]
+     },
+     {
+         "if": {
+             "properties": {
+                 "name": { "const": "fedora-coreos"  }
+             }
+         },
+         "then": {
+                "required": [
+                   "fedora-coreos.parent-commit",
+                   "fedora-coreos.parent-version",
+                   "ref"
+                  ]
+         },
+         "else": {}
+    },
+    {
+         "if": {
+             "properties": {
+                 "name": { "pattern": "^(rhcos|fedora-coreos)"  }
+             }
+         },
+         "then": {
+                "required": [
+                   "coreos-assembler.basearch",
+                   "coreos-assembler.build-timestamp",
+                   "coreos-assembler.code-source",
+                   "coreos-assembler.config-dirty",
+                   "coreos-assembler.config-gitrev",
+                   "coreos-assembler.container-config-git",
+                   "coreos-assembler.container-image-git",
+                   "coreos-assembler.image-config-checksum",
+                   "coreos-assembler.image-genver",
+                   "coreos-assembler.image-input-checksum"
+                  ]
+         },
+         "else": {}
+    }
+ ],
+ "additionalProperties":false,
  "properties": {
+   "ref": {
+     "$id":"#/properties/ref",
+     "type":"string",
+     "title":"BuildRef",
+     "default":"",
+     "examples": [
+       "fedora/x86_64/coreos/testing-devel"
+      ],
+     "pattern":"^(?!\\s*$).+"
+    },
    "build-url": {
      "$id":"#/properties/build-url",
      "type":"string",
-     "title":"The Build-url",
+     "title":"Build URL",
      "default":"",
      "examples": [
        "https://jenkins-host.example.com/job/rhcos/5/"
       ],
-     "pattern":"^(.*)$"
+     "pattern":"^(?!\\s*$).+"
     },
    "buildid": {
      "$id":"#/properties/buildid",
      "type":"string",
-     "title":"The Buildid",
+     "title":"BuildID",
      "default":"",
      "examples": [
        "31-202001010000-0"
       ],
-     "pattern":"^(.*)$"
+     "pattern":"^(?!\\s*$).+"
     },
    "coreos-assembler.basearch": {
      "$id":"#/properties/coreos-assembler.basearch",
@@ -69,7 +125,7 @@
      "examples": [
        "x86_64"
       ],
-     "pattern":"^(.*)$"
+     "pattern":"^(?!\\s*$).+"
     },
    "coreos-assembler.build-timestamp": {
      "$id":"#/properties/coreos-assembler.build-timestamp",
@@ -89,7 +145,7 @@
      "examples": [
        "container"
       ],
-     "pattern":"^(.*)$"
+     "pattern":"^(?!\\s*$).+"
     },
    "coreos-assembler.config-dirty": {
      "$id":"#/properties/coreos-assembler.config-dirty",
@@ -99,7 +155,7 @@
      "examples": [
        "true"
       ],
-     "pattern":"^(.*)$"
+     "pattern":"^(?!\\s*$).+"
     },
    "coreos-assembler.config-gitrev": {
      "$id":"#/properties/coreos-assembler.config-gitrev",
@@ -109,7 +165,7 @@
      "examples": [
        "v3.1-728-g742edc307e58f35824d906958b6493510e12b593"
       ],
-     "pattern":"^(.*)$"
+     "pattern":"^(?!\\s*$).+"
     },
    "coreos-assembler.container-config-git": {
      "$id":"#/properties/coreos-assembler.container-config-git",
@@ -130,7 +186,7 @@
          "examples": [
            "HEAD"
           ],
-         "pattern":"^(.*)$"
+         "pattern":"^(?!\\s*$).+"
         },
        "commit": {
          "$id":"#/properties/coreos-assembler.container-config-git/properties/commit",
@@ -150,7 +206,7 @@
          "examples": [
            "true"
           ],
-         "pattern":"^(.*)$"
+         "pattern":"^(?!\\s*$).+"
         },
        "origin": {
          "$id":"#/properties/coreos-assembler.container-config-git/properties/origin",
@@ -160,9 +216,29 @@
          "examples": [
            "https://github.com/coreos/fedora-coreos-config"
           ],
-         "pattern":"^(.*)$"
+         "pattern":"^(?!\\s*$).+"
         }
       }
+    },
+    "fedora-coreos.parent-version": {
+     "$id":"#/properties/fedora-coreos.parent-version",
+     "type":"string",
+     "title":"Fedora CoreOS Parent Version",
+     "default":"",
+     "examples": [
+       "31.20200127.20.1"
+      ],
+      "pattern":"[0-9]{2}\\.[0-9]{8,}\\.[0-9]{2}\\.[0-1]"
+    },
+    "fedora-coreos.parent-commit": {
+     "$id":"#/properties/fedora-coreos.parent-commit",
+     "type":"string",
+     "title":"Fedora CoreOS parent commit",
+     "default":"",
+     "examples": [
+       "f15f5b25cf138a7683e3d200c53ece2091bf71d31332135da87892ab72ff4ee3"
+      ],
+      "pattern":"[A-Fa-f0-9]{64}$"
     },
    "coreos-assembler.container-image-git": {
      "$id":"#/properties/coreos-assembler.container-image-git",
@@ -183,7 +259,7 @@
          "examples": [
            "HEAD"
           ],
-         "pattern":"^(.*)$"
+         "pattern":"^(?!\\s*$).+"
         },
        "commit": {
          "$id":"#/properties/coreos-assembler.container-image-git/properties/commit",
@@ -203,7 +279,7 @@
          "examples": [
            "false"
           ],
-         "pattern":"^(.*)$"
+         "pattern":"^(?!\\s*$).+"
         },
        "origin": {
          "$id":"#/properties/coreos-assembler.container-image-git/properties/origin",
@@ -213,7 +289,7 @@
          "examples": [
            "git@github.com:coreos/coreos-assembler.git"
           ],
-         "pattern":"^(.*)$"
+         "pattern":"^(?!\\s*$).+"
         }
       }
     },
@@ -244,7 +320,7 @@
      "examples": [
        "59b0904f91aafcf55a66075b731476f802c9d60f17b0c670fb5c43d26333b876"
       ],
-     "pattern":"^(.*)$"
+     "pattern":"^(?!\\s*$).+"
     },
    "images": {
      "$id":"#/properties/images",
@@ -311,7 +387,7 @@
        "qemu": {
          "$id":"#/properties/images/properties/qemu",
          "type":"object",
-         "title":"The Qemu",
+         "title":"Qemu",
          "required": [
            "path",
            "sha256",
@@ -354,7 +430,7 @@
            "uncompressed-sha256": {
              "$id":"#/properties/images/properties/qemu/properties/uncompressed-sha256",
              "type":"string",
-             "title":"The Uncompressed-sha256",
+             "title":"Uncompressed-sha256",
              "default":"",
              "examples": [
                "72775ed71e40fce806a5a76bee73b22155f9a2d2ef1a9a9ea9a1a12f5bbbf3ac"
@@ -364,7 +440,7 @@
            "uncompressed-size": {
              "$id":"#/properties/images/properties/qemu/properties/uncompressed-size",
              "type":"integer",
-             "title":"The Uncompressed-size",
+             "title":"Uncompressed-size",
              "default": 0,
              "examples": [
                 2476539904
@@ -375,7 +451,7 @@
        "metal": {
          "$id":"#/properties/images/properties/metal",
          "type":"object",
-         "title":"The Metal",
+         "title":"Metal",
          "required": [
            "path",
            "sha256",
@@ -404,7 +480,7 @@
              "examples": [
                "2899aa904e7646a10f25dae6ecc2c1099673b3fd39c122265d2d5faa5b9a7595"
               ],
-             "pattern":"^(.*)$"
+             "pattern":"^(?!\\s*$).+"
             },
            "size": {
              "$id":"#/properties/images/properties/metal/properties/size",
@@ -418,7 +494,7 @@
            "uncompressed-sha256": {
              "$id":"#/properties/images/properties/metal/properties/uncompressed-sha256",
              "type":"string",
-             "title":"The Uncompressed-sha256",
+             "title":"Uncompressed-sha256",
              "default":"",
              "examples": [
                "0f135871fe452b66f28383f5882aa5544fdb700755a68fbbb4b3dc42e3c5896e"
@@ -428,7 +504,7 @@
            "uncompressed-size": {
              "$id":"#/properties/images/properties/metal/properties/uncompressed-size",
              "type":"integer",
-             "title":"The Uncompressed-size",
+             "title":"Uncompressed-size",
              "default": 0,
              "examples": [
                 3824156672
@@ -439,7 +515,7 @@
        "iso": {
          "$id":"#/properties/images/properties/iso",
          "type":"object",
-         "title":"The Iso",
+         "title":"Iso",
          "required": [
            "path",
            "sha256"
@@ -470,7 +546,7 @@
        "kernel": {
          "$id":"#/properties/images/properties/kernel",
          "type":"object",
-         "title":"The Kernel",
+         "title":"Kernel",
          "required": [
            "path",
            "sha256"
@@ -501,7 +577,7 @@
        "initramfs": {
          "$id":"#/properties/images/properties/initramfs",
          "type":"object",
-         "title":"The Initramfs",
+         "title":"Initramfs",
          "required": [
            "path",
            "sha256"
@@ -525,14 +601,14 @@
              "examples": [
                "6cf23a16b8da57d35a0b066dfca7c2a2815654a0e84e65ba463a8ae45031a05b"
               ],
-             "pattern":"^(.*)$"
+             "pattern":"^(?!\\s*$).+"
             }
           }
         },
        "openstack": {
          "$id":"#/properties/images/properties/openstack",
          "type":"object",
-         "title":"The Openstack",
+         "title":"Openstack",
          "required": [
            "path",
            "sha256",
@@ -575,7 +651,7 @@
            "uncompressed-sha256": {
              "$id":"#/properties/images/properties/openstack/properties/uncompressed-sha256",
              "type":"string",
-             "title":"The Uncompressed-sha256",
+             "title":"Uncompressed-sha256",
              "default":"",
              "examples": [
                "f43e20128d46e33c3a3a05985848647be11d51087cf2c24f6aee9310b4c53868"
@@ -585,7 +661,7 @@
            "uncompressed-size": {
              "$id":"#/properties/images/properties/openstack/properties/uncompressed-size",
              "type":"integer",
-             "title":"The Uncompressed-size",
+             "title":"Uncompressed-size",
              "default": 0,
              "examples": [
                 2476605440
@@ -596,7 +672,7 @@
        "vmware": {
          "$id":"#/properties/images/properties/vmware",
          "type":"object",
-         "title":"The Vmware",
+         "title":"Vmware",
          "required": [
            "path",
            "sha256",
@@ -637,7 +713,7 @@
        "aliyun": {
          "$id":"#/properties/images/properties/aliyun",
          "type":"object",
-         "title":"The Aliyun",
+         "title":"Aliyun",
          "required": [
            "path",
            "sha256",
@@ -680,7 +756,7 @@
            "uncompressed-sha256": {
              "$id":"#/properties/images/properties/aliyun/properties/uncompressed-sha256",
              "type":"string",
-             "title":"The Uncompressed-sha256",
+             "title":"Uncompressed-sha256",
              "default":"",
              "examples": [
                "5abd1223cfd0283c0be7a2a29bf0326b37ed14b6771916c17806dc9dae22bdf1"
@@ -690,7 +766,7 @@
            "uncompressed-size": {
              "$id":"#/properties/images/properties/aliyun/properties/uncompressed-size",
              "type":"integer",
-             "title":"The Uncompressed-size",
+             "title":"Uncompressed-size",
              "default": 0,
              "examples": [
                 2476605440
@@ -701,7 +777,7 @@
        "aws": {
          "$id":"#/properties/images/properties/aws",
          "type":"object",
-         "title":"The Aws",
+         "title":"Aws",
          "required": [
            "path",
            "sha256",
@@ -744,7 +820,7 @@
            "uncompressed-sha256": {
              "$id":"#/properties/images/properties/aws/properties/uncompressed-sha256",
              "type":"string",
-             "title":"The Uncompressed-sha256",
+             "title":"Uncompressed-sha256",
              "default":"",
              "examples": [
                "7d9216eeb942df24a46c320667222c2f7677290d631c2dace2874a5b8be4e833"
@@ -754,7 +830,7 @@
            "uncompressed-size": {
              "$id":"#/properties/images/properties/aws/properties/uncompressed-size",
              "type":"integer",
-             "title":"The Uncompressed-size",
+             "title":"Uncompressed-size",
              "default": 0,
              "examples": [
                 927316480
@@ -765,7 +841,7 @@
        "azure": {
          "$id":"#/properties/images/properties/azure",
          "type":"object",
-         "title":"The Azure",
+         "title":"Azure",
          "required": [
            "path",
            "sha256",
@@ -808,7 +884,7 @@
            "uncompressed-sha256": {
              "$id":"#/properties/images/properties/azure/properties/uncompressed-sha256",
              "type":"string",
-             "title":"The Uncompressed-sha256",
+             "title":"Uncompressed-sha256",
              "default":"",
              "examples": [
                "910e3a0a9c59eea1dd9303414fa987377f301cd519c52573cdf993793711f1d8"
@@ -818,7 +894,7 @@
            "uncompressed-size": {
              "$id":"#/properties/images/properties/azure/properties/uncompressed-size",
              "type":"integer",
-             "title":"The Uncompressed-size",
+             "title":"Uncompressed-size",
              "default": 0,
              "examples": [
                 2521427456
@@ -829,7 +905,7 @@
        "gcp": {
          "$id":"#/properties/images/properties/gcp",
          "type":"object",
-         "title":"The Gcp",
+         "title":"Gcp",
          "required": [
            "path",
            "sha256",
@@ -872,17 +948,17 @@
    "name": {
      "$id":"#/properties/name",
      "type":"string",
-     "title":"The Name",
-     "default":"",
+     "title":"Name",
+     "default":"fedora-coreos",
      "examples": [
-       "rhcos"
-      ],
-     "pattern":"^(.*)$"
+       "rhcos",
+       "fedora-coreos"
+      ]
     },
    "oscontainer": {
      "$id":"#/properties/oscontainer",
      "type":"object",
-     "title":"The Oscontainer",
+     "title":"Oscontainer",
      "required": [
        "digest",
        "image"
@@ -891,7 +967,7 @@
        "digest": {
          "$id":"#/properties/oscontainer/properties/digest",
          "type":"string",
-         "title":"The Digest",
+         "title":"Digest",
          "default":"",
          "examples": [
            "sha256:f8d18011913e87ae59d3781f3d07819267d43401ab444fb3b5794a5eb392b915"
@@ -901,12 +977,12 @@
        "image": {
          "$id":"#/properties/oscontainer/properties/image",
          "type":"string",
-         "title":"The Image",
+         "title":"Image",
          "default":"",
          "examples": [
            "registry.example.org/devel/machine-os-content"
           ],
-         "pattern":"^(.*)$"
+         "pattern":"^(?!\\s*$).+"
         }
       }
     },
@@ -992,7 +1068,7 @@
      "examples": [
        "2020-01-15T19:31:31Z"
       ],
-     "pattern":"^(.*)$"
+     "pattern":"^(?!\\s*$).+"
     },
    "ostree-version": {
      "$id":"#/properties/ostree-version",
@@ -1002,7 +1078,7 @@
      "examples": [
        "31-202001010000-0"
       ],
-     "pattern":"^(.*)$"
+     "pattern":"^(?!\\s*$).+"
     },
    "pkgdiff": {
      "$id":"#/properties/pkgdiff",
@@ -1014,13 +1090,13 @@
        "title":"Package Set differences",
        "items": {
          "$id":"#/properties/pkgdiff/items/items",
-         "title":"The Items",
+         "title":"Items",
          "default":"",
          "examples": [
            "foo-bar",
             2
           ],
-         "pattern":"^(.*)$"
+         "pattern":"^(?!\\s*$).+"
         }
       }
     },
@@ -1042,7 +1118,7 @@
      "examples": [
        "FCOS 31"
       ],
-     "pattern":"^(.*)$"
+     "pattern":"^(?!\\s*$).+"
     },
    "aliyun": {
      "$id":"#/properties/aliyun",
@@ -1065,17 +1141,17 @@
            "examples": [
              "us-west-1"
             ],
-           "pattern":"^(.*)$"
+           "pattern":"^(?!\\s*$).+"
           },
          "id": {
            "$id":"#/properties/aliyun/items/properties/id",
            "type":"string",
-           "title":"The Id",
+           "title":"Id",
            "default":"",
            "examples": [
              "m-rj9d477fe8uxzai8d8zf"
             ],
-           "pattern":"^(.*)$"
+           "pattern":"^(?!\\s*$).+"
           }
         }
       }
@@ -1087,7 +1163,7 @@
      "items": {
        "$id":"#/properties/amis/items",
        "type":"object",
-       "title":"The Items",
+       "title":"Items",
        "required": [
          "name",
          "hvm",
@@ -1102,7 +1178,7 @@
            "examples": [
              "us-east-1"
             ],
-           "pattern":"^(.*)$"
+           "pattern":"^(?!\\s*$).+"
           },
          "hvm": {
            "$id":"#/properties/amis/items/properties/hvm",
@@ -1112,17 +1188,17 @@
            "examples": [
              "ami-0de107f30d290b9a1"
             ],
-           "pattern":"^ami-(\\w{17})$"
+           "pattern":"^ami-(\\w{15,})$"
           },
          "snapshot": {
            "$id":"#/properties/amis/items/properties/snapshot",
            "type":"string",
-           "title":"The Snapshot",
+           "title":"Snapshot",
            "default":"",
            "examples": [
              "snap-006453e8b55eddb0e"
             ],
-           "pattern":"^snap-(\\w{17})$"
+           "pattern":"^snap-(\\w{15,})$"
           }
         }
       }
@@ -1139,22 +1215,22 @@
        "image": {
          "$id":"#/properties/azure/properties/image",
          "type":"string",
-         "title":"The Image",
+         "title":"Image",
          "default":"",
          "examples": [
            "fcos-31-202001010000-0-azure.x86_64.vhd"
           ],
-         "pattern":"^(.*)$"
+         "pattern":"^(?!\\s*$).+"
         },
        "url": {
          "$id":"#/properties/azure/properties/url",
          "type":"string",
-         "title":"URL for Artifact",
+         "title":"Artifact URL",
          "default":"",
          "examples": [
            "https://example.com/imagebucket/fcos-31-202001010000-0-azure.x86_64.vhd"
           ],
-         "pattern":"^(.*)$"
+         "pattern":"^(?!\\s*$).+"
         }
       }
     },
@@ -1170,12 +1246,12 @@
        "image": {
          "$id":"#/properties/gcp/properties/image",
          "type":"string",
-         "title":"The Image",
+         "title":"Image",
          "default":"",
          "examples": [
            "fcos-31-202001010000-0"
           ],
-         "pattern":"^(.*)$"
+         "pattern":"^(?!\\s*$).+"
         },
        "url": {
          "$id":"#/properties/gcp/properties/url",

--- a/src/schema/v1.json
+++ b/src/schema/v1.json
@@ -55,17 +55,19 @@
          },
          "then": {
                 "required": [
-                   "fedora-coreos.parent-commit",
-                   "fedora-coreos.parent-version",
                    "ref"
-                  ]
+                  ],
+                "optional": [
+                  "fedora-coreos.parent-commit",
+                  "fedora-coreos.parent-version"
+                ]
          },
          "else": {}
     },
     {
          "if": {
              "properties": {
-                 "name": { "pattern": "^(rhcos|fedora-coreos)"  }
+                 "name": { "pattern": "^(rhcos|fedora-coreos)$"  }
              }
          },
          "then": {
@@ -75,8 +77,6 @@
                    "coreos-assembler.code-source",
                    "coreos-assembler.config-dirty",
                    "coreos-assembler.config-gitrev",
-                   "coreos-assembler.container-config-git",
-                   "coreos-assembler.container-image-git",
                    "coreos-assembler.image-config-checksum",
                    "coreos-assembler.image-genver",
                    "coreos-assembler.image-input-checksum"


### PR DESCRIPTION
This adds support for discerning whether or not a sub-schema should
exist based on the name in 'meta.json' to support variants.

The new behavior to treat the main schema file as a basename. Any schema
that is found in the same directory with the basename is loaded. The
"name" field is then used to find any sub schemas. For example, given
"v1.json" with a build name of "fedora-coreos", a schema named
"fedora-coreos-v1.json" in the same directory will be applied.

fixtures/fcos.json: defined test JSON for Fedora CoreOS

src/schema/{fedora-coreos,rhcos}-v1.json: stub out for the different
  schemas. This is to support the FCOS use of:
        "fedora-coreos.parent-version" and
        "fedora-coreos.parent-commit" keys.

tests/test_cosalib_meta.py: support testing both FCOS and RHCOS schemas
- looks for all schemas in fixtures directory
- validated the required items against both.

Makefile: set the directory for the test JSON.