### PR TITLE
schema: Unmark container-config* keys as required

### DIFF
--- a/src/schema/v1.json
+++ b/src/schema/v1.json
@@ -11,8 +11,6 @@
    "coreos-assembler.code-source",
    "coreos-assembler.config-dirty",
    "coreos-assembler.config-gitrev",
-   "coreos-assembler.container-config-git",
-   "coreos-assembler.container-image-git",
    "coreos-assembler.image-config-checksum",
    "coreos-assembler.image-genver",
    "coreos-assembler.image-input-checksum",
@@ -38,7 +36,9 @@
    "build-url",
    "gcp",
    "oscontainer",
-   "pkgdiff"
+   "pkgdiff",
+   "coreos-assembler.container-config-git",
+   "coreos-assembler.container-image-git"
   ],
  "properties": {
    "build-url": {


### PR DESCRIPTION
I install coreos-assembler inside my existing toolbox so that
I can have one place to develop on e.g. rpm-ostree and other
tools.  This needs to be supported, even if not a primary path.

In this scenario we won't have the bits from `Dockerfile` builds,
so remove those from the required metadata keys.