### PR TITLE
cmdlib: Add logic for default meta.json schema or skipping validation 

### DIFF
--- a/src/cmd-artifact-disk
+++ b/src/cmd-artifact-disk
@@ -13,10 +13,11 @@ import cosalib.qemuvariants as QVariants
 import cosalib.vmware as VmwareOVA
 
 
-def get_builder(imgtype, build_root, build="latest", force=False):
+def get_builder(imgtype, build_root, build="latest", force=False, schema=None):
     args = [build_root, build]
     kargs = {
         "force": force,
+        "schema": schema,
         "variant": imgtype
     }
 
@@ -87,13 +88,14 @@ def artifact_cli():
 
     if build_target:
         builder = get_builder(build_target, args.buildroot, args.build,
-                              force=args.force)
+                              force=args.force, schema=args.schema)
     elif "manual" in args:
         kwargs = {
             'force': args.force,
             'image_format': args.image_format,
             'image_suffix': args.image_suffix,
             'platform': args.platform,
+            'schema': args.schema,
         }
         if args.convert_options:
             kwargs["convert_options"] = {'-o': f'{args.convert_options}'}

--- a/src/coreos-assembler
+++ b/src/coreos-assembler
@@ -73,7 +73,13 @@ if [ -z "${cmd}" ]; then
 fi
 shift
 
-export COSA_META_SCHEMA="/usr/lib/coreos-assembler/schema/v1.json"
+COSA_META_SCHEMA="${COSA_META_SCHEMA:-/usr/lib/coreos-assembler/schema/v1.json}"
+schema_override="${PWD}/src/config/schema.json"
+if [ -e "${schema_override}" ]; then
+    COSA_META_SCHEMA=$(realpath "${schema_override}")
+fi
+export COSA_META_SCHEMA
+
 
 target=/usr/lib/coreos-assembler/cmd-${cmd}
 if test -x "${target}"; then

--- a/src/cosalib/build.py
+++ b/src/cosalib/build.py
@@ -14,6 +14,7 @@ from cosalib.cmdlib import (
     sha256sum_file)
 from cosalib.builds import Builds
 from cosalib.meta import GenericBuildMeta as Meta
+from cosalib.meta import SCHEMA_PATH
 
 # BASEARCH is the current machine architecture
 BASEARCH = get_basearch()
@@ -104,12 +105,13 @@ class _Build:
         self._tmpdir = tempfile.mkdtemp(dir=tmpdir)
         self._image_name = None
 
+        schema = kwargs.pop("schema", SCHEMA_PATH)
         # Setup the instance properties.
         self._build_json = {
             "commit": None,
             "config": None,
             "image": None,
-            "meta": Meta(self.workdir, build)
+            "meta": Meta(self.workdir, build, schema=schema)
         }
 
         os.environ['workdir'] = self._workdir

--- a/src/cosalib/cli.py
+++ b/src/cosalib/cli.py
@@ -135,3 +135,7 @@ class BuildCli(Cli):
         self.add_argument(
             '--dump', default=False, action='store_true',
             help='Dump the manfiest and exit')
+        self.add_argument(
+            '--schema', env_var="META_SCHEMA",
+            default='/usr/lib/coreos-assembler/schema/v1.json',
+            help='Schema to use. Set to NONE to skip all validation')

--- a/src/cosalib/meta.py
+++ b/src/cosalib/meta.py
@@ -36,7 +36,7 @@ class GenericBuildMeta(dict):
 
         # Load the schema
         self._validator = None
-        if schema:
+        if schema and schema.lower() not in ("false", "none"):
             with open(schema, 'r') as data:
                 self._validator = jsonschema.Draft7Validator(
                     json.loads(data.read())

--- a/src/cosalib/qemuvariants.py
+++ b/src/cosalib/qemuvariants.py
@@ -89,6 +89,7 @@ def get_qemu_variant(variant, parser, kwargs={}):
     return QemuVariantImage(
         parser.buildroot,
         parser.build,
+        schema=parser.schema,
         variant=variant,
         force=parser.force,
         **kwargs)


### PR DESCRIPTION
This fixes the "COSA_META_SCHEMA" to support the value of `NONE`, while I work out the nuances of the schema. 

To skip the meta.json validation: set the `COSA_META_SCHEMA=NONE`
To change the json: `COSA_META_SCHEMA=<path to your schema>`
Or on the CLI: `cosa <cmd> --schema=none`

This should negate the immediate need of https://github.com/coreos/coreos-assembler/pull/1087