### PR TITLE
ore,koji: Remove timestamps from Python log formats

### DIFF
--- a/src/cmd-koji-upload
+++ b/src/cmd-koji-upload
@@ -303,7 +303,7 @@ def set_logger(level):
     elif level == "info":
         sl = log.INFO
 
-    log.basicConfig(format='[%(asctime)s  %(levelname)s]: %(message)s',
+    log.basicConfig(format='[%(levelname)s]: %(message)s',
                     level=sl)
 
 

--- a/src/cmd-ore-wrapper
+++ b/src/cmd-ore-wrapper
@@ -18,7 +18,7 @@ from cosalib.qemuvariants import get_qemu_variant
 
 if __name__ == '__main__':
     log.basicConfig(
-        format='[%(asctime)s  %(levelname)s]: %(message)s',
+        format='[%(levelname)s]: %(message)s',
         level=log.INFO)
 
     parser = BuildCli(


### PR DESCRIPTION
coreos-assembler today is a mix of Go, Python (two different kinds)
and shell.

The Go and shell script don't output timestamps in logs, and neither
do other Python scripts.

Having just the newer Python code print timestamps looks odd.

Further, higher level tooling such as Jenkins and the systemd journal
already gather timestamps.  There's no need for us to do it here as
a general rule.

And we're realistically never going to have the whole code base
be just one form.

I think in general what would be nicer is if Python's logging
framework supported having `log.info()` => `print()`, and only
emit the log level if it's not INFO.