### PR TITLE
qemuvariants: use correct Azure VMDK format

### DIFF
--- a/src/cosalib/build.py
+++ b/src/cosalib/build.py
@@ -96,7 +96,7 @@ class _Build:
 
         self._found_files = {}
         self._workdir = kwargs.pop("workdir", os.getcwd())
-        self._tmpdir = tempfile.mkdtemp(prefix="build_tmpd")
+        self._tmpdir = tempfile.mkdtemp(prefix="build_tmpd", dir=self._workdir)
         self._image_name = None
 
         # Setup the instance properties.


### PR DESCRIPTION
https://github.com/coreos/fedora-coreos-tracker/issues/361

Azure VMDK's require a fixed size. This change uses the qemu-img convert
required to produce a compliant disk.