### PR TITLE
Dockerfile: Inject a .built-via-container stamp file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN ./build.sh install_rpms
 COPY ./ /root/containerbuild/
 RUN ./build.sh write_archive_info
 RUN ./build.sh make_and_makeinstall
+RUN echo Dockerfile > /usr/lib/coreos-assembler/.built-via-container
 RUN ./build.sh build_fcct
 RUN ./build.sh configure_user
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -15,6 +15,7 @@ RUN rm -rfv /lib/coreos-assembler /usr/bin/coreos-assembler
 COPY ./src/print-dependencies.sh ./src/deps*.txt ./src/vmdeps*.txt ./src/build-deps.txt /root/containerbuild/src/
 COPY ./build.sh /root/containerbuild/
 RUN ./build.sh install_rpms
+RUN echo Dockerfile.dev > /usr/lib/coreos-assembler/.built-via-container
 
 COPY ./ /root/containerbuild/
 RUN ./build.sh write_archive_info


### PR DESCRIPTION
This helps us distinguish "running in official container" from
"make install inside existing dev container".