### PR TITLE
cosalib/build: Use workdir tmp/ as tempdir

### DIFF
--- a/src/cosalib/build.py
+++ b/src/cosalib/build.py
@@ -96,7 +96,12 @@ class _Build:
 
         self._found_files = {}
         self._workdir = kwargs.pop("workdir", os.getcwd())
-        self._tmpdir = tempfile.mkdtemp(prefix="build_tmpd")
+        tmpdir = os.path.join(self._workdir, "tmp")
+        os.environ['TMPDIR'] = tmpdir
+
+        # we need to make sure we allocate in tmp/ so we're on the same
+        # filesystem as builds/ and we can just `rename()` it there
+        self._tmpdir = tempfile.mkdtemp(dir=tmpdir)
         self._image_name = None
 
         # Setup the instance properties.
@@ -108,7 +113,6 @@ class _Build:
         }
 
         os.environ['workdir'] = self._workdir
-        os.environ['TMPDIR'] = os.path.join(self._workdir, "tmp")
 
         # Setup what is required for this Class.
         #   require_cosa means that the COSA information is need


### PR DESCRIPTION
We changed this behaviour during the refactor. There's quite a bit of
history here on why do this. But a major one at least is that we want to
be able to just `rename(2)` the final build artifacts into place. This
saves a bunch of time and I/O.

I noticed this due to the fact that we were losing sparsity from the
output of `qemu-img convert` because `shutil.move` doesn't do the
equivalent of `cp --sparse=auto`. This patch fixes that, though I think
we should also be able to change that call to a simple `os.rename()` in
a follow-up to make it explicit.

Related: https://github.com/coreos/fedora-coreos-tracker/issues/361