### PR TITLE
qemuvariants: simplify VMware OVA generation by using callback

### DIFF
--- a/src/cosalib/cmdlib.py
+++ b/src/cosalib/cmdlib.py
@@ -240,3 +240,14 @@ def get_timestamp(entry):
     # Older versions only had ostree-timestamp
     ts = j.get('coreos-assembler.build-timestamp') or j['ostree-timestamp']
     return parse_date_string(ts)
+
+
+def image_info(image):
+    try:
+        out = json.loads(run_verbose(
+            ['qemu-img', 'info', '--output=json', image],
+            capture_output=True).stdout
+        )
+        return out
+    except Exception as e:
+        raise Exception(f"failed to inspect {image} with qemu", e)

--- a/src/cosalib/vmware.py
+++ b/src/cosalib/vmware.py
@@ -48,6 +48,9 @@ class VmwareOVA(QemuVariantImage):
         variant = kwargs.pop("variant", "vmware")
         kwargs.update(VARIANTS.get(variant, {}))
         QemuVariantImage.__init__(self, *args, **kwargs)
+        # Set the QemuVariant mutate_callback so that OVA is called.
+        self.mutate_callback = self.write_ova
+        # Ensure that desc.ovf is included in the tar
         self.desc_ovf_path = os.path.join(self._tmpdir, "desc.ovf")
 
     def generate_ovf_parameters(self, vmdk, cpu=2,
@@ -104,18 +107,3 @@ class VmwareOVA(QemuVariantImage):
         log.debug(vmdk_xml)
         log.info("desc.ovf will be added to the tar file")
         self.tar_members.append(self.desc_ovf_path)
-
-    def mutate_image(self, *args, **kwargs):
-        """
-        mutate_image calls the QemuVariant.mutate_image with write_ova
-        as the callback unless callback=<func> is defined.
-
-        :param args: Non keyword arguments to pass to add_argument
-        :type args: list
-        :param kwargs: Keyword arguments to pass to add_argument
-        :type kwargs: dict
-        """
-        if kwargs.get("callback"):
-            super().mutate_image(*args, **kwargs)
-        else:
-            super().mutate_image(callback=self.write_ova)


### PR DESCRIPTION
cosalib.vmware overrode mutate_image and then called
QemuVariant.mutate_image with the callback. While working a seperate
issue, I started to define another class to use the call-back mechanism.
Rather than introduce another Class, this change allows for a class
attribute of "mutate_callback" to be defined which is used by default
unless `mutate_image(callback=foo)` is called.

The advantage to this approach is that VMware's OVA can be a bit
simpler.

Finally, a format check was added to ensure that the format is
appropriately changed. In some cases, 'qemu-img convert' will produce
'raw' images instead of compliant VHD's.