### PR TITLE
ci: Run --basic-qemu-scenarios

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -27,6 +27,7 @@ coreos.pod([image: 'registry.fedoraproject.org/fedora:31', runAsUser: 0, kvm: tr
           }
           parallel kola: {
               try {
+                cosa_cmd("kola --basic-qemu-scenarios")
                 cosa_cmd("kola run --parallel 8")
                 cosa_cmd("kola --upgrades")
               } finally {


### PR DESCRIPTION
Same rationale as https://github.com/coreos/fedora-coreos-pipeline/pull/187
Motivated by ensuring we're covering proposed changes like
https://github.com/coreos/coreos-assembler/pull/1105
in CI here too.