### PR TITLE
create_disk: put $ignition_firstboot last on kernel command line

### DIFF
--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -252,7 +252,7 @@ time ostree pull-local "$ostree" "$ref" --repo $rootfs/ostree/repo $remote_arg
 ostree admin os-init "$os_name" --sysroot $rootfs
 # Note that $ignition_firstboot is interpreted by grub at boot time,
 # *not* the shell here.  Hence the backslash escape.
-allkargs="\$ignition_firstboot $extrakargs"
+allkargs="$extrakargs \$ignition_firstboot"
 kargsargs=""
 for karg in $allkargs
 do


### PR DESCRIPTION
create_disk: put $ignition_firstboot last on kernel command line

Since $ignition_firstboot is expanded at runtime and also can be
used to add more kernel command line arguments [1] we should make it
last on the line so that it's possible to override other kargs. This
should fix the ordering issue mentioned in [2]

[1] https://github.com/coreos/coreos-assembler/blob/7f7965de5d6233b99c6a3f841d86be92dab6100e/src/grub.cfg#L43-L58
[2] https://github.com/coreos/fedora-coreos-tracker/issues/353#issuecomment-583165021
