### PR TITLE
src/cosalib: don't always force uploads for aws & aliyun

### DIFF
--- a/src/cosalib/aliyun.py
+++ b/src/cosalib/aliyun.py
@@ -96,6 +96,9 @@ def aliyun_run_ore(build, args):
     if args.log_level:
         ore_args.extend(['--log-level', args.log_level])
 
+    if args.force:
+        ore_args.extend(['--force'])
+
     region = "us-west-1"
     if args.region is not None:
         region = args.region[0]
@@ -113,8 +116,7 @@ def aliyun_run_ore(build, args):
         '--file', f"{build.image_path}",
         '--description', f'{build.summary} {build.build_id}',
         '--architecture', build.basearch,
-        '--disk-size-inspect',
-        '--force'
+        '--disk-size-inspect'
     ])
 
     print(ore_args)

--- a/src/cosalib/aws.py
+++ b/src/cosalib/aws.py
@@ -94,6 +94,9 @@ def aws_run_ore(build, args):
     if args.log_level:
         ore_args.extend(['--log-level', args.log_level])
 
+    if args.force:
+        ore_args.extend(['--force'])
+
     region = "us-east-1"
     if args.region is not None and len(args.region) > 0:
         region = args.region[0]
@@ -107,8 +110,7 @@ def aws_run_ore(build, args):
         '--ami-description', f'{build.summary} {build.build_id}',
         '--file', f"{build.image_path}",
         '--disk-size-inspect',
-        '--delete-object',
-        '--force'
+        '--delete-object'
     ])
     for user in args.grant_user:
         ore_args.extend(['--grant-user', user])


### PR DESCRIPTION
On both AWS & Aliyun `ore` can resume in the middle of the process.
Switch up the logic to default to not passing force.