### PR TITLE
qemuvariants: add ibmcloud

### DIFF
--- a/src/cmd-buildextend-ibmcloud
+++ b/src/cmd-buildextend-ibmcloud
@@ -1,0 +1,1 @@
+cmd-artifact-disk

--- a/src/coreos-assembler
+++ b/src/coreos-assembler
@@ -43,7 +43,7 @@ cmd=${1:-}
 build_commands="init fetch build run prune clean"
 # commands more likely to be used in a prod pipeline only
 advanced_build_commands="buildprep buildupload oscontainer"
-buildextend_commands="qemu aws azure gcp openstack installer live vmware metal vultr"
+buildextend_commands="aws azure gcp ibmcloud installer live metal openstack qemu vmware vultr"
 utility_commands="tag sign compress koji-upload kola aws-replicate remote-prune"
 other_commands="shell meta"
 if [ -z "${cmd}" ]; then

--- a/src/cosalib/qemuvariants.py
+++ b/src/cosalib/qemuvariants.py
@@ -55,10 +55,6 @@ VARIANTS = {
         "image_suffix": "vhd",
         "platform": "azure",
     },
-    "openstack": {
-        "image_format": "qcow2",
-        "platform": "openstack",
-    },
     "gcp": {
         # See https://cloud.google.com/compute/docs/import/import-existing-image#requirements_for_the_image_file
         "image_format": "raw",
@@ -75,6 +71,14 @@ VARIANTS = {
             "-z",
             "--format=oldgnu"
         ]
+    },
+    "ibmcloud": {
+        "image_format": "qcow2",
+        "platform": "ibmcloud",
+    },
+    "openstack": {
+        "image_format": "qcow2",
+        "platform": "openstack",
     },
     "vmware_vmdk": {
         "image_format": "vmdk",


### PR DESCRIPTION
This adds a new qcow2-based image for the `ibmcloud` platform,
which can be booted on IBM Cloud VPC Generation 2.

Ref: https://github.com/coreos/fedora-coreos-tracker/issues/277
Closes: https://github.com/coreos/coreos-assembler/issues/1119