### PR TITLE
[4.2] Changes to support F31 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:30
+FROM registry.fedoraproject.org/fedora:31
 WORKDIR /root/containerbuild
 
 # Only need a few of our scripts for the first few steps

--- a/build.sh
+++ b/build.sh
@@ -28,16 +28,13 @@ fi
 set -x
 srcdir=$(pwd)
 
-release="30"
-
 configure_yum_repos() {
-    if [ -n "${ISFEDORA}" ]; then
-        # Add continuous tag for latest build tools and mark as required so we
-        # can depend on those latest tools being available in all container
-        # builds.
-        echo -e "[f$release-coreos-continuous]\nenabled=1\nmetadata_expire=1m\nbaseurl=https://kojipkgs.fedoraproject.org/repos-dist/f$release-coreos-continuous/latest/\$basearch/\ngpgcheck=0\nskip_if_unavailable=False\n" > /etc/yum.repos.d/coreos.repo
-
-    fi
+    local version_id
+    version_id=$(. /etc/os-release && echo ${VERSION_ID})
+    # Add continuous tag for latest build tools and mark as required so we
+    # can depend on those latest tools being available in all container
+    # builds.
+    echo -e "[f${version_id}-coreos-continuous]\nenabled=1\nmetadata_expire=1m\nbaseurl=https://kojipkgs.fedoraproject.org/repos-dist/f${version_id}-coreos-continuous/latest/\$basearch/\ngpgcheck=0\nskip_if_unavailable=False\n" > /etc/yum.repos.d/coreos.repo
 }
 
 install_rpms() {

--- a/src/deps.txt
+++ b/src/deps.txt
@@ -56,4 +56,4 @@ ShellCheck
 python3-flake8 python3-pytest python3-pytest-cov
 
 # Support for Koji uploads.
-krb5-libs krb5-workstation python2-koji python2-krbv
+krb5-libs krb5-workstation koji-utils python3-koji python3-koji-cli-plugins


### PR DESCRIPTION
In the RHCOS world, a change to the spec file of `skopeo` caused `subscription-manager`, `dnf`, and all the associated dependencies to be dragged into the OS. [0]

While we investigate the impact of disabling `Recommends` for RHCOS builds, the workaround is to use the `exclude-packages` support[1] that was recently landed in `rpm-ostree`.  The most direct way to do this is to rebase the Dockerfile for `coreos-assembler` on F31.

[0] https://bugzilla.redhat.com/show_bug.cgi?id=1798278
[1] https://github.com/coreos/rpm-ostree/pull/1980