### PR TITLE
[4.2] Dockerfile: blow out quay.io cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /root/containerbuild
 
 # Only need a few of our scripts for the first few steps
 COPY ./src/cmdlib.sh ./build.sh ./deps*.txt ./vmdeps*.txt ./build-deps.txt /root/containerbuild/
-RUN ./build.sh configure_yum_repos
+RUN ./build.sh configure_yum_repos # nocache 20200211
 RUN ./build.sh install_rpms
 
 # Ok copy in the rest of them for the next few steps


### PR DESCRIPTION
We want to pull in the v2020.1 version of `rpm-ostree` for the
`exclude-packages` support[0].  @jlebon was nice enough to rebuild
`rpm-ostree` with that support in F30, so blow out the cache to make
sure we pick it up.

[0] https://github.com/coreos/rpm-ostree/pull/1980