### PR TITLE
[4.1] start using F30 coreos-continuous repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /root/containerbuild
 
 # Only need a few of our scripts for the first few steps
 COPY ./src/cmdlib.sh ./build.sh ./deps*.txt ./vmdeps.txt ./build-deps.txt /root/containerbuild/
-RUN ./build.sh configure_yum_repos
+RUN ./build.sh configure_yum_repos # nocache 20200211
 RUN ./build.sh install_rpms
 
 # Ok copy in the rest of them for the next few steps

--- a/build.sh
+++ b/build.sh
@@ -30,8 +30,10 @@ release="30"
 
 configure_yum_repos() {
     if [ -n "${ISFEDORA}" ]; then
-        # Add continuous tag for latest build tools
-        echo -e "[f$release-coreos-continuous]\nenabled=1\nmetadata_expire=1m\nbaseurl=https://kojipkgs.fedoraproject.org/repos-dist/f$release-coreos-continuous/latest/\$basearch/\ngpgcheck=0\n" > /etc/yum.repos.d/coreos.repo
+        # Add continuous tag for latest build tools and mark as required so we
+        # can depend on those latest tools being available in all container
+        # builds.
+        echo -e "[f$release-coreos-continuous]\nenabled=1\nmetadata_expire=1m\nbaseurl=https://kojipkgs.fedoraproject.org/repos-dist/f$release-coreos-continuous/latest/\$basearch/\ngpgcheck=0\nskip_if_unavailable=False\n" > /etc/yum.repos.d/coreos.repo
 
     fi
 }

--- a/build.sh
+++ b/build.sh
@@ -26,11 +26,11 @@ fi
 set -x
 srcdir=$(pwd)
 
-release="29"
+release="30"
 
 configure_yum_repos() {
     if [ -n "${ISFEDORA}" ]; then
-        # Add f29-coreos-continuous tag for latest build tools
+        # Add continuous tag for latest build tools
         echo -e "[f$release-coreos-continuous]\nenabled=1\nmetadata_expire=1m\nbaseurl=https://kojipkgs.fedoraproject.org/repos-dist/f$release-coreos-continuous/latest/\$basearch/\ngpgcheck=0\n" > /etc/yum.repos.d/coreos.repo
 
     fi
@@ -104,6 +104,10 @@ _prep_make_and_make_install() {
     fi
 }
 
+# For now keep using the f29 anaconda. There's no golden f30 image yet and it
+# doesn't support the installclass stuff and hopefully we'll stop using it soon.
+installer_release=29
+
 arch=$(uname -m)
 # Download url is different for primary and secondary fedora
 # Primary Fedora - https://download.fedoraproject.org/pub/fedora/linux/releases/
@@ -117,8 +121,8 @@ repository_dirs[ppc64le]=fedora-secondary
 repository_dirs[s390x]=fedora-secondary
 
 repository_dir=${repository_dirs[$arch]}
-INSTALLER=https://download.fedoraproject.org/pub/$repository_dir/releases/$release/Everything/$arch/iso/Fedora-Everything-netinst-$arch-$release-1.2.iso
-INSTALLER_CHECKSUM=https://download.fedoraproject.org/pub/$repository_dir/releases/$release/Everything/$arch/iso/Fedora-Everything-$release-1.2-$arch-CHECKSUM
+INSTALLER=https://download.fedoraproject.org/pub/$repository_dir/releases/$installer_release/Everything/$arch/iso/Fedora-Everything-netinst-$arch-$installer_release-1.2.iso
+INSTALLER_CHECKSUM=https://download.fedoraproject.org/pub/$repository_dir/releases/$installer_release/Everything/$arch/iso/Fedora-Everything-$installer_release-1.2-$arch-CHECKSUM
 
 install_anaconda() {
     # Overriding install URL

--- a/build.sh
+++ b/build.sh
@@ -26,16 +26,13 @@ fi
 set -x
 srcdir=$(pwd)
 
+release="29"
+
 configure_yum_repos() {
     if [ -n "${ISFEDORA}" ]; then
-        # Add FAHC https://pagure.io/fedora-atomic-host-continuous
-        # but as disabled.  Today FAHC isn't multi-arch.  But let's
-        # add it so that anyone on x86_64 who wants to test the latest
-        # ostree/rpm-ostree can easily do so.
-        # NOTE: The canonical copy of this code lives in rpm-ostree's CI:
-        # https://github.com/projectatomic/rpm-ostree/blob/d2b0e42bfce972406ac69f8e2136c98f22b85fb2/ci/build.sh#L13
-        # Please edit there first
-        echo -e '[fahc]\nenabled=0\nmetadata_expire=1m\nbaseurl=https://ci.centos.org/artifacts/sig-atomic/fahc/rdgo/build/\ngpgcheck=0\n' > /etc/yum.repos.d/fahc.repo
+        # Add f29-coreos-continuous tag for latest build tools
+        echo -e "[f$release-coreos-continuous]\nenabled=1\nmetadata_expire=1m\nbaseurl=https://kojipkgs.fedoraproject.org/repos-dist/f$release-coreos-continuous/latest/\$basearch/\ngpgcheck=0\n" > /etc/yum.repos.d/coreos.repo
+
     fi
 }
 
@@ -108,7 +105,6 @@ _prep_make_and_make_install() {
 }
 
 arch=$(uname -m)
-release="29"
 # Download url is different for primary and secondary fedora
 # Primary Fedora - https://download.fedoraproject.org/pub/fedora/linux/releases/
 # Secondary Fedora - https://download.fedoraproject.org/pub/fedora-secondary/releases/

--- a/src/cmd-koji-upload
+++ b/src/cmd-koji-upload
@@ -37,9 +37,11 @@ import koji_cli.lib as klib
 try:
     # Available in Koji v1.17, https://pagure.io/koji/issue/975
     from koji_cli.lib import unique_path
-    from koji_cli.lib import progress_callback as cb
 except ImportError:
     from koji_cli.lib import _unique_path as unique_path
+try:
+    from koji_cli.lib import progress_callback as cb
+except ImportError:
     from koji_cli.lib import _progress_callback as cb
 
 try:


### PR DESCRIPTION
We want to pull in the v2020.1 version of `rpm-ostree` for the
`exclude-packages` support[0].  @jlebon was nice enough to rebuild
`rpm-ostree` with that support in F30, so pull in the necessary commits for us to us the F30 coreos-continuous repo.

[0] https://github.com/coreos/rpm-ostree/pull/1980