### PR TITLE
Add `cosa list` to list basic info of local builds

### DIFF
--- a/src/cmd-list
+++ b/src/cmd-list
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+
+import datetime
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from cosalib.builds import Builds
+from cosalib.cmdlib import parse_date_string
+
+
+def main():
+    builds = Builds()
+    if len(builds.get_builds()) == 0:
+        print(f"No builds!")
+        return
+
+    tags = {}
+    for tag in builds.get_tags():
+        tags[tag['target']] = tags.get(tag['target'], []) + [tag['name']]
+
+    for build in builds.get_builds():
+        print(f"{build['id']}")
+        m = builds.get_build_meta(build['id'])
+        ts = m['coreos-assembler.build-timestamp']
+        d = parse_date_string(ts)
+        delta = datetime.datetime.now(datetime.timezone.utc) - d
+        # chop off the microseconds in the delta; don't need that precise
+        print(f"   Timestamp: {ts} ({str(delta).split('.')[0]} ago)")
+        print(f"   Artifacts: {' '.join(list(m['images']))}")
+        if build['id'] in tags:
+            print(f"   Tags: {' '.join(tags[build['id']])}")
+        print()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/coreos-assembler
+++ b/src/coreos-assembler
@@ -40,7 +40,7 @@ fi
 
 cmd=${1:-}
 # commands we'd expect to use in the local dev path
-build_commands="init fetch build run prune clean"
+build_commands="init fetch build run prune clean list"
 # commands more likely to be used in a prod pipeline only
 advanced_build_commands="buildprep buildupload oscontainer"
 buildextend_commands="aws azure gcp ibmcloud installer live metal openstack qemu vmware vultr"

--- a/src/cosalib/builds.py
+++ b/src/cosalib/builds.py
@@ -83,8 +83,16 @@ class Builds:  # pragma: nocover
             basearch = get_basearch()
         return self._path(f"builds/{build_id}/{basearch}")
 
+    def get_build_meta(self, build_id, basearch=None):
+        d = self.get_build_dir(build_id, basearch)
+        with open(os.path.join(d, 'meta.json')) as f:
+            return json.load(f)
+
     def get_tags(self):
         return self._data.get('tags', [])
+
+    def get_builds(self):
+        return self._data.get('builds', [])
 
     def insert_build(self, build_id, basearch=None):
         if not basearch:


### PR DESCRIPTION
This is useful in the dev workflow to quickly fetch the buildid of a
previous build, as well as just look at all the builds one has available
locally, how stale they are, and their associated tags. Kind of like a
`git status` or `rpm-ostree status` for `cosa`.