### PR TITLE
qemuvariants: produce fixed disks for Azure

### DIFF
--- a/src/cosalib/qemuvariants.py
+++ b/src/cosalib/qemuvariants.py
@@ -55,6 +55,9 @@ VARIANTS = {
         "image_format": "vpc",
         "image_suffix": "vhd",
         "platform": "azure",
+        "convert_options": {
+            '-o': 'force_size,subformat=fixed'
+        },
     },
     "gcp": {
         # See https://cloud.google.com/compute/docs/import/import-existing-image#requirements_for_the_image_file

--- a/tests/test_cosalib_cmdlib.py
+++ b/tests/test_cosalib_cmdlib.py
@@ -140,3 +140,14 @@ def test_import_ostree_commit(monkeypatch, tmpdir):
     monkeypatch.setattr(subprocess, 'call', monkeyspcall)
     # Test
     cmdlib.import_ostree_commit(tmpdir, 'commit', 'tarfile')
+
+
+def test_image_info(tmpdir):
+    cmdlib.run_verbose([
+        "qemu-img", "create", "-f", "qcow2", f"{tmpdir}/test.qcow2", "10M"])
+    assert cmdlib.image_info(f"{tmpdir}/test.qcow2").get('format') == "qcow2"
+    cmdlib.run_verbose([
+        "qemu-img", "create", "-f", "vpc",
+        '-o', 'force_size,subformat=fixed',
+        f"{tmpdir}/test.vpc", "10M"])
+    assert cmdlib.image_info(f"{tmpdir}/test.vpc").get('format') == "vpc"


### PR DESCRIPTION
Per [1] Azure VHD's require to be:
- size aligned to 1MB
- subformat of 'fixed'

In the docs, Microsoft indicates that the VHD must be 1MB aligned. Per
[2], "force_size" creates an aligned disk by calculating CHS values and
forcing the size to align. The "hack" for doing manually resizing to 1MB
is supperfulious in the case `force_size`. Further COSA creates MB
aligned disks too.

Confirmed that this produces bootable disk images for Azure.

[1] https://docs.microsoft.com/en-us/azure/virtual-machines/linux/create-upload-generic
[2] https://git.qemu.org/?p=qemu.git;a=commitdiff;h=fb9245c2610932d33ce14