### PR TITLE
cosalib/build.py: fix invalid sha256sum key to sha256

### DIFF
--- a/src/cosalib/build.py
+++ b/src/cosalib/build.py
@@ -423,7 +423,7 @@ class _Build:
         log.info(f"Calculating metadata for {fname}")
         return {
             "path": fname,
-            "sha256sum": sha256sum_file(fpath),
+            "sha256": sha256sum_file(fpath),
             "size": int(fsize)
         }
 


### PR DESCRIPTION
Correct invalid key of 'sha256sum' to 'sha256', which was invalid per
the schema.