### PR TITLE
vmware: Several fixes and cleanups

### DIFF
--- a/src/cosalib/qemuvariants.py
+++ b/src/cosalib/qemuvariants.py
@@ -227,16 +227,16 @@ class QemuVariantImage(_Build):
         if self.tar_members:
             # Python does not create sparse Tarfiles, so we have do it via
             # the CLI here.
-            base_name = self.tar_members.pop(0)
-            tarlist = [base_name]
-            # in the case of several clouds, the disk is named `disk.raw` or
-            # `disk.vmdk`. When creating a tarball, we rename the disk to
-            # the in-tar name if the name does not match the defaulting naming.
-            if base_name != os.path.basename(work_img):
-                os.rename(work_img, os.path.join(self._tmpdir, base_name))
-
+            tarlist = []
             for member in self.tar_members:
                 member_name = os.path.basename(member)
+                # In the case of several clouds, the disk is named
+                # `disk.raw` or `disk.vmdk`.  When creating a tarball, we
+                # rename the disk to the in-tar name if the name does not
+                # match the default naming.
+                if member_name.endswith(('.raw', '.vmdk')):
+                    if member_name != os.path.basename(work_img):
+                        os.rename(work_img, os.path.join(self._tmpdir, member_name))
                 tarlist.append(member_name)
 
             tar_cmd = ['tar', '-C', self._tmpdir]

--- a/src/cosalib/vmware.py
+++ b/src/cosalib/vmware.py
@@ -110,4 +110,6 @@ class VmwareOVA(QemuVariantImage):
 
         log.debug(vmdk_xml)
         log.info("desc.ovf will be added to the tar file")
-        self.tar_members.append(self.desc_ovf_path)
+        # OVF descriptor must come first, then the manifest, then
+        # References in order
+        self.tar_members.insert(0, self.desc_ovf_path)

--- a/src/cosalib/vmware.py
+++ b/src/cosalib/vmware.py
@@ -32,7 +32,9 @@ VARIANTS = {
             "disk.vmdk"
         ],
         "tar_flags": [
-            "-c",
+            # DEFAULT_TAR_FLAGS has -S, which isn't suppported by ustar
+            '-ch',
+            # Required by OVF spec
             "--format=ustar"
         ]
     },

--- a/src/cosalib/vmware.py
+++ b/src/cosalib/vmware.py
@@ -58,8 +58,8 @@ class VmwareOVA(QemuVariantImage):
         QemuVariantImage.__init__(self, *args, **kwargs)
         # Set the QemuVariant mutate_callback so that OVA is called.
         self.mutate_callback = self.write_ova
-        # Ensure that desc.ovf is included in the tar
-        self.desc_ovf_path = os.path.join(self._tmpdir, "desc.ovf")
+        # Ensure that coreos.ovf is included in the tar
+        self.ovf_path = os.path.join(self._tmpdir, "coreos.ovf")
 
     def generate_ovf_parameters(self, vmdk, cpu=2,
                                 memory=4096, system_type="vmx-13",
@@ -103,13 +103,12 @@ class VmwareOVA(QemuVariantImage):
 
         with open(OVA_TEMPLATE_FILE) as f:
             template = f.read()
-        vmdk_xml = template.format(**ovf_params)
+        ovf_xml = template.format(**ovf_params)
 
-        with open(self.desc_ovf_path, "w") as ovf:
-            ovf.write(vmdk_xml)
+        with open(self.ovf_path, "w") as ovf:
+            ovf.write(ovf_xml)
 
-        log.debug(vmdk_xml)
-        log.info("desc.ovf will be added to the tar file")
+        log.debug(ovf_xml)
         # OVF descriptor must come first, then the manifest, then
         # References in order
-        self.tar_members.insert(0, self.desc_ovf_path)
+        self.tar_members.insert(0, self.ovf_path)

--- a/src/cosalib/vmware.py
+++ b/src/cosalib/vmware.py
@@ -70,6 +70,7 @@ class VmwareOVA(QemuVariantImage):
         based on the qemu, vmdk, and info from the build metadata
         """
         disk_info = image_info(vmdk)
+        vmdk_size = os.stat(vmdk).st_size
         image = self.summary
         product = f'{self.meta["name"]} {self.summary}'
         vendor = self.meta['name']
@@ -86,8 +87,8 @@ class VmwareOVA(QemuVariantImage):
             'vsphere_os_type':                  os_type,
             'vsphere_scsi_controller_type':     scsi,
             'vsphere_network_controller_type':  network,
-            'virtual_disk_size':                disk_info.get("virtual-size"),
-            'vmdk_size':                        disk_info.get("actual-size"),
+            'vmdk_capacity':                    disk_info.get("virtual-size"),
+            'vmdk_size':                        str(vmdk_size),
         }
 
         return params

--- a/src/vmware-template.xml
+++ b/src/vmware-template.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0"?>
 <Envelope xmlns="http://schemas.dmtf.org/ovf/envelope/1" xmlns:cim="http://schemas.dmtf.org/wbem/wscim/1/common" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" vmw:buildId="build-880146">
   <References>
-	  <File ovf:href="disk.vmdk" ovf:id="file1" ovf:size="{virtual_disk_size}"/>
+	  <File ovf:href="disk.vmdk" ovf:id="file1" ovf:size="{vmdk_size}"/>
   </References>
   <DiskSection>
     <Info>Virtual disk information</Info>
-    <Disk ovf:capacity="{virtual_disk_size}" ovf:capacityAllocationUnits="byte" ovf:diskId="vmdisk1" ovf:fileRef="file1" ovf:format="http://www.vmware.com/interfaces/specifications/vmdk.html#streamOptimized" ovf:populatedSize="{vmdk_size}"/>
+    <Disk ovf:capacity="{vmdk_capacity}" ovf:capacityAllocationUnits="byte" ovf:diskId="vmdisk1" ovf:fileRef="file1" ovf:format="http://www.vmware.com/interfaces/specifications/vmdk.html#streamOptimized" ovf:populatedSize="{vmdk_size}"/>
   </DiskSection>
   <NetworkSection>
     <Info>The list of logical networks</Info>


### PR DESCRIPTION
Addresses wrong VMDK file size and `Did not find an .ovf file at the beginning of the OVA package` from https://github.com/coreos/fedora-coreos-tracker/issues/391.

Tested on VMware Workstation 15.5.1 and vSphere 6.7.0.

I also have a commit (not in this PR) that generates a manifest file, but it doesn't work.  `ovftool` correctly parses the VMDK hash out of the manifest, but then concludes that the digest of the actual VMDK has some other value.  Manual verification of the VMDK from the tarball shows that the manifest is correct.  I'm not sure why this is happening, and absent other ideas I'm planning to file a draft PR and ignore for now.