### PR TITLE
qemuvariants: always ship tarfiles with uid/gid=0

### DIFF
--- a/src/cosalib/qemuvariants.py
+++ b/src/cosalib/qemuvariants.py
@@ -239,7 +239,7 @@ class QemuVariantImage(_Build):
                 member_name = os.path.basename(member)
                 tarlist.append(member_name)
 
-            tar_cmd = ['tar', '-C', self._tmpdir]
+            tar_cmd = ['tar', '--owner=0', '--group=0', '-C', self._tmpdir]
             tar_cmd.extend(self.tar_flags)
             tar_cmd.extend(['-f', final_img])
             tar_cmd.extend(tarlist)


### PR DESCRIPTION
Minor regression from #1136. The `ustar` format only supports uids up to
2097151. This of course blows up in OpenShift where we run with much
higher uids.

Really though, we don't want to encode the OpenShift uid either anyway.
Instead just canonicalize to uid and gid 0. On extraction, tar defaults
to extracting files as the running user.