### PR TITLE
gf-platformid: Add firstboot options before zipl rerun for s390x

### DIFF
--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -332,6 +332,7 @@ s390x)
 	# this is only a temporary solution until we are able to do firstboot check at bootloader
 	# stage on s390x, either through zipl->grub2-emu or zipl standalone.
 	# See https://github.com/coreos/ignition-dracut/issues/84
+	# A similar hack is present in https://github.com/coreos/coreos-assembler/blob/master/src/gf-platformid#L53
 	echo "$(grep options $blsfile) ignition.firstboot rd.neednet=1 ip=dhcp,dhcp6" > $tmpfile
 
 	# ideally we want to invoke zipl with bls and zipl.conf but we might need

--- a/src/gf-platformid
+++ b/src/gf-platformid
@@ -48,11 +48,19 @@ sed -i -e 's,^\(options .*\),\1 ignition.platform.id='"${platformid}"',' "${tmpd
 coreos_gf upload "${tmpd}"/bls.conf "${blscfg_path}"
 
 if [ "$basearch" = "s390x" ] ; then
+    # Before we re-run zipl make sure we have the firstboot options
+    # A hack similar to https://github.com/coreos/coreos-assembler/blob/master/src/create_disk.sh#L336
+    sed -i -e 's,^\(options .*\),\1 ignition.firstboot rd.neednet=1 ip=dhcp\,dhcp6,' "${tmpd}"/bls.conf
+    coreos_gf rename "${blscfg_path}" "${blscfg_path}.orig"
+    coreos_gf upload "${tmpd}"/bls.conf "${blscfg_path}"
+
     coreos_gf debug sh "mount -o bind /sysroot/boot /sysroot/${deploydir}/boot"
     # zipl wants /proc
     coreos_gf debug sh "mount -t proc none /sysroot/${deploydir}/proc"
     coreos_gf debug sh "chroot /sysroot/${deploydir} /usr/sbin/zipl"
     coreos_gf debug sh "umount /sysroot/${deploydir}/proc /sysroot/${deploydir}/boot"
+    # Remove firstboot options after running zipl as we don't want them to persist
+    coreos_gf rename "${blscfg_path}.orig" "${blscfg_path}"
 fi
 
 coreos_gf_shutdown


### PR DESCRIPTION
Recently it was noticed that the s390x openstack images don't run ignition
at all. This was because when zipl was rerun after changing the platformid
the firstboot options weren't included. This fixes the bug.

(cherry picked from commit 1d3d2ae46406c7c9c2039e9fd2248d340c9a75db)