### PR TITLE
ci: migrate to new coreos-ci project

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -1,10 +1,10 @@
-@Library('github.com/coreos/coreos-ci-lib@master') _
+// Documentation: https://github.com/coreos/coreos-ci/blob/master/README-upstream-ci.md
 
-coreos.pod([image: 'registry.fedoraproject.org/fedora:31', runAsUser: 0, kvm: true, memory: "9Gi"]) {
+pod(image: 'registry.fedoraproject.org/fedora:31', runAsUser: 0, kvm: true, memory: "9Gi") {
       checkout scm
 
       stage("Build") {
-          coreos.shwrap("""
+          shwrap("""
             dnf install -y git
             git submodule update --init
             ./build.sh
@@ -13,13 +13,13 @@ coreos.pod([image: 'registry.fedoraproject.org/fedora:31', runAsUser: 0, kvm: tr
 
       stage("Test") {
           parallel check: {
-              coreos.shwrap("""
+              shwrap("""
                 make check
                 make unittest
               """)
           },
           build: {
-              coreos.shwrap("chown builder: /srv")
+              shwrap("chown builder: /srv")
               // just split into separate invocations to make it easier to see where it fails
               cosa_cmd("init https://github.com/coreos/fedora-coreos-config")
               cosa_cmd("fetch")
@@ -31,11 +31,11 @@ coreos.pod([image: 'registry.fedoraproject.org/fedora:31', runAsUser: 0, kvm: tr
                 cosa_cmd("kola run --parallel 8")
                 cosa_cmd("kola --upgrades")
               } finally {
-                coreos.shwrap("cd /srv && tar -cf - tmp/kola/ | xz -c9 > ${env.WORKSPACE}/kola.tar.xz")
+                shwrap("cd /srv && tar -cf - tmp/kola/ | xz -c9 > ${env.WORKSPACE}/kola.tar.xz")
                 archiveArtifacts allowEmptyArchive: true, artifacts: 'kola.tar.xz'
               }
               // sanity check kola actually ran and dumped its output in tmp/
-              coreos.shwrap("test -d /srv/tmp/kola")
+              shwrap("test -d /srv/tmp/kola")
           },
           buildextend: {
               cosa_cmd("buildextend-metal")
@@ -50,10 +50,10 @@ coreos.pod([image: 'registry.fedoraproject.org/fedora:31', runAsUser: 0, kvm: tr
       }
 
       stage("CLI Tests") {
-          coreos.shwrap("cd /srv && sudo -u builder ${env.WORKSPACE}/tests/test_pruning.sh")
+          shwrap("cd /srv && sudo -u builder ${env.WORKSPACE}/tests/test_pruning.sh")
       }
 }
 
 def cosa_cmd(args) {
-    coreos.shwrap("cd /srv && sudo -u builder cosa ${args}")
+    shwrap("cd /srv && sudo -u builder cosa ${args}")
 }

--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -49,38 +49,8 @@ coreos.pod([image: 'registry.fedoraproject.org/fedora:31', runAsUser: 0, kvm: tr
           }
       }
 
-      stage("Pruning test") {
-          // Test that first build has been pruned
-          cosa_cmd("build ostree --force-image")
-          cosa_cmd("build ostree --force-image")
-          cosa_cmd("build ostree --force-image")
-          coreos.shwrap("cat /srv/builds/builds.json")
-          coreos.shwrap('jq -e ".builds|length == 3" /srv/builds/builds.json')
-          coreos.shwrap('jq -e ".builds[2].id | endswith(\\"0-1\\")" /srv/builds/builds.json')
-
-          // Test --skip-prune
-          cosa_cmd("build ostree --force-image --skip-prune")
-          coreos.shwrap("cat /srv/builds/builds.json")
-          coreos.shwrap('jq -e ".builds|length == 4" /srv/builds/builds.json')
-          coreos.shwrap('jq -e ".builds[3].id | endswith(\\"0-1\\")" /srv/builds/builds.json')
-
-          // Test prune --dry-run
-          cosa_cmd("prune --workdir /srv --dry-run")
-          coreos.shwrap("cat /srv/builds/builds.json")
-          coreos.shwrap('jq -e ".builds|length == 4" /srv/builds/builds.json')
-          coreos.shwrap('jq -e ".builds[3].id | endswith(\\"0-1\\")" /srv/builds/builds.json')
-
-          // Test --keep-last-n=0 skips pruning
-          cosa_cmd("prune --workdir /srv --keep-last-n=0")
-          coreos.shwrap("cat /srv/builds/builds.json")
-          coreos.shwrap('jq -e ".builds|length == 4" /srv/builds/builds.json')
-          coreos.shwrap('jq -e ".builds[3].id | endswith(\\"0-1\\")" /srv/builds/builds.json')
-
-          // Test prune --keep-last-n=1
-          cosa_cmd("prune --workdir /srv --keep-last-n=1")
-          coreos.shwrap("cat /srv/builds/builds.json")
-          coreos.shwrap('jq -e ".builds|length == 1" /srv/builds/builds.json')
-          coreos.shwrap('jq -e ".builds[0].id | endswith(\\"0-4\\")" /srv/builds/builds.json')
+      stage("CLI Tests") {
+          coreos.shwrap("cd /srv && sudo -u builder ${env.WORKSPACE}/tests/test_pruning.sh")
       }
 }
 

--- a/tests/test_pruning.sh
+++ b/tests/test_pruning.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -xeuo pipefail
+
+# This test isn't standalone for now. It's executed from the `.cci.jenkinsfile`.
+# It expects to be running in cosa workdir where a single fresh build was made.
+
+# Test that first build has been pruned
+cosa build ostree --force-image # this is a trick to get a no-op new build
+cosa build ostree --force-image
+cosa build ostree --force-image
+jq -e '.builds|length == 3' builds/builds.json
+jq -e '.builds[2].id | endswith("0-1")' builds/builds.json
+
+# Test --skip-prune
+cosa build ostree --force-image --skip-prune
+jq -e '.builds|length == 4' builds/builds.json
+jq -e '.builds[3].id | endswith("0-1")' builds/builds.json
+
+# Test prune --dry-run
+cosa prune --dry-run
+jq -e '.builds|length == 4' builds/builds.json
+jq -e '.builds[3].id | endswith("0-1")' builds/builds.json
+
+# Test --keep-last-n=0 skips pruning
+cosa prune --keep-last-n=0
+jq -e '.builds|length == 4' builds/builds.json
+jq -e '.builds[3].id | endswith("0-1")' builds/builds.json
+
+# Test prune --keep-last-n=1
+cosa prune --keep-last-n=1
+jq -e '.builds|length == 1' builds/builds.json
+jq -e '.builds[0].id | endswith("0-4")' builds/builds.json


### PR DESCRIPTION
Minor adjustments to move CI from the previous projectatomic-ci to the
new coreos-ci.

At the same time, split out the pruning tests into its own script to
clean things up a bit.

Requires: https://github.com/coreos/coreos-ci/pull/5