### PR TITLE
Revert "grub.cfg: set ip=dhcp,dhcp6"

### DIFF
--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -379,7 +379,7 @@ s390x)
 	# stage on s390x, either through zipl->grub2-emu or zipl standalone.
 	# See https://github.com/coreos/ignition-dracut/issues/84
 	# A similar hack is present in https://github.com/coreos/coreos-assembler/blob/master/src/gf-platformid#L55
-	echo "$(grep options $blsfile) ignition.firstboot rd.neednet=1 ip=dhcp,dhcp6" > $tmpfile
+	echo "$(grep options $blsfile) ignition.firstboot rd.neednet=1 ip=dhcp" > $tmpfile
 
 	# ideally we want to invoke zipl with bls and zipl.conf but we might need
 	# to chroot to $rootfs/ to do so. We would also do that when FCOS boot on its own.

--- a/src/gf-platformid
+++ b/src/gf-platformid
@@ -52,7 +52,9 @@ coreos_gf upload "${tmpd}"/bls.conf "${blscfg_path}"
 if [ "$basearch" = "s390x" ] ; then
     # Before we re-run zipl make sure we have the firstboot options
     # A hack similar to https://github.com/coreos/coreos-assembler/blob/master/src/create_disk.sh#L381
-    sed -i -e 's,^\(options .*\),\1 ignition.firstboot rd.neednet=1 ip=dhcp\,dhcp6,' "${tmpd}"/bls.conf
+    # Temporarily stop including dhcp6 (see https://github.com/coreos/coreos-assembler/pull/1148)
+    #sed -i -e 's,^\(options .*\),\1 ignition.firstboot rd.neednet=1 ip=dhcp\,dhcp6,' "${tmpd}"/bls.conf
+    sed -i -e 's,^\(options .*\),\1 ignition.firstboot rd.neednet=1 ip=dhcp,' "${tmpd}"/bls.conf
     coreos_gf rename "${blscfg_path}" "${blscfg_path}.orig"
     coreos_gf upload "${tmpd}"/bls.conf "${blscfg_path}"
 

--- a/src/grub.cfg
+++ b/src/grub.cfg
@@ -45,7 +45,7 @@ fi
 set ignition_firstboot=""
 if [ -f "/ignition.firstboot" ]; then
     # default to dhcp networking parameters to be used with ignition
-    set ignition_network_kcmdline='rd.neednet=1 ip=dhcp,dhcp6'
+    set ignition_network_kcmdline='rd.neednet=1 ip=dhcp'
 
     # source in the `ignition.firstboot` file which could override the
     # above $ignition_network_kcmdline with static networking config.


### PR DESCRIPTION
We need more patches in dracut for this to work properly. So just revert
it for now so that pure-IPv4 environments work correctly, which are much
more common than mixed IPv4/IPv6 setups.

This reverts commit d7329ab162277775e90c450a8fb37b60a57634a3.

See: https://bugzilla.redhat.com/show_bug.cgi?id=1803926