### PR TITLE
buildroot: support list of spec files to builddep

### DIFF
--- a/src/buildroot-buildreqs.txt
+++ b/src/buildroot-buildreqs.txt
@@ -2,7 +2,6 @@
 # If you want to extend this, feel free to file a PR.
 ignition
 ostree
-rpm-ostree
 libdnf
 librepo
 kernel

--- a/src/buildroot-specs.txt
+++ b/src/buildroot-specs.txt
@@ -1,0 +1,3 @@
+# for projects which have their canonical spec files upstream, use those instead
+# since they're more up to date
+https://raw.githubusercontent.com/coreos/rpm-ostree/master/packaging/rpm-ostree.spec.in

--- a/src/install-buildroot.sh
+++ b/src/install-buildroot.sh
@@ -8,4 +8,9 @@ echo "${deps}" | xargs yum -y install
 brs=$(grep -v '^#' "${dn}"/buildroot-buildreqs.txt)
 echo "Installing build dependencies of primary packages"
 echo "${brs}" | xargs yum -y builddep
+specs=$(grep -v '^#' "${dn}"/buildroot-specs.txt)
+echo "Installing build dependencies from canonical spec files"
+tmpd=$(mktemp -d) && trap 'rm -rf ${tmpd}' EXIT
+(cd "${tmpd}" && echo "${specs}" | xargs curl -L --remote-name-all)
+(cd "${tmpd}" && find . -type f -print0 | xargs -0 yum -y builddep --spec)
 echo 'Done!'


### PR DESCRIPTION
For rpm-ostree, we keep the canonical spec file upstream. Use that
instead of the latest deps of the last release since it's going to be
more up to date.