### PR TITLE
buildroot: Remove libdnf's requirements in favor of rpm-ostree

### DIFF
--- a/src/buildroot-buildreqs.txt
+++ b/src/buildroot-buildreqs.txt
@@ -2,7 +2,6 @@
 # If you want to extend this, feel free to file a PR.
 ignition
 ostree
-libdnf
 librepo
 kernel
 systemd


### PR DESCRIPTION
Followup to https://github.com/coreos/coreos-assembler/pull/1154/commits/afbff9584cd1bf15076d7f3e861fc0083ad59d03

libdnf currently is pulling in the older one, and anyways we
should have its transitive dependencies from rpm-ostree.