### PR TITLE
Drop ostree-releng-scripts git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "ostree-releng-scripts"]
-	path = ostree-releng-scripts
-	url = https://github.com/ostreedev/ostree-releng-scripts

--- a/bottlecap
+++ b/bottlecap
@@ -6,7 +6,7 @@ set -euo pipefail
 usage() {
 	echo "usage:"
 	echo "bottlecap [--dev] [--dry-run] [--runtime $runtime] [--build-dir $build_dir] [--container $container] assemblerargs..."
-	echo "  --dev: rebuild and reinstall mantle, the build scripts, and the ostree-releng-scipts before running coreos-assembler"
+	echo "  --dev: rebuild and reinstall mantle and the build scripts before running coreos-assembler"
 	echo "  --dry-run: do not run CoreOS Assembler; print what commands would be executed instead"
 	echo "  --runtime: (auto) specify whether to use podman or docker. Defaults to podman if it is in \$PATH"
 	echo "  --build-dir: Where to put build artifacts, defaults to the current directory"

--- a/build.sh
+++ b/build.sh
@@ -71,18 +71,6 @@ install_rpms() {
     yum clean all
 }
 
-_prep_make_and_make_install() {
-    # TODO: install these as e.g.
-    # /usr/bin/ostree-releng-script-rsync-repos
-    mkdir -p /usr/app/
-    rsync -rlv "${srcdir}"/ostree-releng-scripts/ /usr/app/ostree-releng-scripts/
-
-    if git submodule status | grep -qEe '^-'; then
-        echo -e "\033[1merror: submodules not initialized. Run: git submodule update --init\033[0m" 1>&2
-        exit 1
-    fi
-}
-
 # Yes, this is a hack that loses sane auditing around what git commit
 # we used to build fcct, etc.  In the future we'll probably give in and package
 # it or something, see also https://github.com/coreos/fedora-coreos-tracker/issues/235
@@ -99,7 +87,6 @@ build_fcct() {
 }
 
 make_and_makeinstall() {
-    _prep_make_and_make_install
     make && make install
 }
 

--- a/src/deps.txt
+++ b/src/deps.txt
@@ -25,9 +25,11 @@ make git rpm-build
 # virt dependencies
 libguestfs-tools /usr/bin/qemu-img qemu-kvm swtpm
 
-# ostree-releng-scripts dependencies
+# Useful for moving files around
 rsync
-python2-gobject-base python3-gobject-base
+
+# For gobject-introspection
+python3-gobject-base
 
 # To support recursive containerization and manipulating images
 podman buildah skopeo

--- a/src/estimate-commit-disk-size
+++ b/src/estimate-commit-disk-size
@@ -1,7 +1,8 @@
 #!/usr/bin/python3
 #
 # Given an OSTree commit, estimate how much disk space it will take
-# Derived from ostree-releng-scripts/print-commitsize
+# Derived from: https://github.com/ostreedev/ostree-releng-scripts/blob/master/print-commitsize
+
 #
 # Copyright 2018 Red Hat, Inc
 # Licensed under the new-BSD license (http://www.opensource.org/licenses/bsd-license.php)


### PR DESCRIPTION
While we're in the mood for deleting git submodules, let's also delete
the ostree-releng-scripts. In practice, we don't use it in cosa itself,
and it's trivial for anyone who wants a script from there while e.g.
debugging from a cosa container to `git clone` it.

This also allows us to clean up the build script a bit.