### PR TITLE
mantle: Tweak schema generation script to use local cosa

### DIFF
--- a/mantle/generate
+++ b/mantle/generate
@@ -12,12 +12,9 @@ hash schematyper 2>/dev/null || {
 }
 
 schema_version="v1"
-schema_commit="25b788bf0a8d826db07830d11ee6105ea615814c"
-schema_url="https://raw.githubusercontent.com/coreos/coreos-assembler/${schema_commit}/src/schema/${schema_version}.json"
-echo "Generating COSA Schema ${schema_version} ${schema_commit}"
-curl -sL "${schema_url}" -o "cosa/${schema_version}.json"
+echo "Generating COSA Schema ${schema_version}"
 
-schematyper "cosa/${schema_version}.json" \
+schematyper "../src/schema/${schema_version}.json" \
     -o "cosa/cosa_${schema_version}.go" \
     --package="cosa" \
     --root-type=Build


### PR DESCRIPTION
Now that cosa/mantle are merged, we no longer need to awkwardly
have mantle fetch something from cosa.