### PR TITLE
Use sdk.TargetIgnitionVersionFromName() from mantle

### DIFF
--- a/mantle/cmd/kola/kola.go
+++ b/mantle/cmd/kola/kola.go
@@ -102,6 +102,13 @@ This can be useful for e.g. serving locally built OSTree repos to qemu.
 		RunE: runIgnitionConvert2,
 	}
 
+	cmdArtifactIgnitionVersion = &cobra.Command{
+		Use:    "artifact-ignition-version",
+		Short:  "Implementation detail of coreos-assembler",
+		RunE:   runArtifactIgnitionVersion,
+		Hidden: true,
+	}
+
 	listJSON           bool
 	listPlatform       string
 	listDistro         string
@@ -127,6 +134,9 @@ func init() {
 	root.AddCommand(cmdRunUpgrade)
 	cmdRunUpgrade.Flags().BoolVar(&findParentImage, "find-parent-image", false, "automatically find parent image if not provided -- note on qemu, this will download the image")
 	cmdRunUpgrade.Flags().StringVar(&qemuImageDir, "qemu-image-dir", "", "directory in which to cache QEMU images if --fetch-parent-image is enabled")
+
+	// Implementation/hidden commands
+	root.AddCommand(cmdArtifactIgnitionVersion)
 }
 
 func main() {
@@ -442,6 +452,12 @@ func runIgnitionConvert2(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	return nil
+}
+
+func runArtifactIgnitionVersion(cmd *cobra.Command, args []string) error {
+	artifact := args[0]
+	fmt.Printf("%s\n", sdk.TargetIgnitionVersionFromName(artifact))
 	return nil
 }
 

--- a/src/cosalib/cmdlib.py
+++ b/src/cosalib/cmdlib.py
@@ -169,17 +169,13 @@ def rm_allow_noent(path):
 # too surprised either ;)  Oh and hey if you are please send me an email, it'll
 # be like a virtual time capsule!  If they still use email then...
 def disk_ignition_version(path):
-    bn = os.path.basename(path)
-    ignition_spec2_openshift_releases = [1, 2, 3, 4]
-    # The output from the RHCOS pipeline names images like
-    # rhcos-42.81.$datestamp.  The images are renamed when
-    # placed at e.g. https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.2/4.2.0/
-    prefixes = [f"rhcos-4{x}" for x in ignition_spec2_openshift_releases] + \
-               [f"rhcos-4.{x}" for x in ignition_spec2_openshift_releases]
-    if bn.startswith(tuple(prefixes)):
+    v = subprocess.check_output(['kola', 'artifact-ignition-version', path], encoding='utf8').strip()
+    if v == "v2":
         return "2.2.0"
-    else:
+    elif v == "v3":
         return "3.0.0"
+    else:
+        raise Exception(f"Unhandled: {v}")
 
 
 def import_ostree_commit(repo, commit, tarfile, force=False):


### PR DESCRIPTION
Drop the duplication between mantle/cosa here.  Which - not
to totally beat this dead horse but - notice how trivial this is
as one nice single commit.

Also drains more Python into Go, continuing the crude but
straightforward "exec kola as subprocess" model.