### PR TITLE
mantle: Add .gitattributes for vendor/

### DIFF
--- a/mantle/.gitattributes
+++ b/mantle/.gitattributes
@@ -1,0 +1,1 @@
+vendor/** linguist-generated=true


### PR DESCRIPTION
To hint that these are generated and shouldn't show up in Github
PR renderings.