### PR TITLE
kola: Port more main functions to Run*E*

### DIFF
--- a/mantle/cmd/kola/bootchart.go
+++ b/mantle/cmd/kola/bootchart.go
@@ -25,10 +25,10 @@ import (
 )
 
 var cmdBootchart = &cobra.Command{
-	Run:    runBootchart,
-	PreRun: preRun,
-	Use:    "bootchart > bootchart.svg",
-	Short:  "Boot performance graphing tool",
+	Run:     runBootchart,
+	PreRunE: preRun,
+	Use:     "bootchart > bootchart.svg",
+	Short:   "Boot performance graphing tool",
 	Long: `
 Boot a single instance and plot how the time was spent.
 

--- a/mantle/cmd/kola/kola.go
+++ b/mantle/cmd/kola/kola.go
@@ -61,8 +61,8 @@ If the glob pattern is exactly equal to the name of a single test, any
 restrictions on the versions of Container Linux supported by that test
 will be ignored.
 `,
-		RunE:   runRun,
-		PreRun: preRun,
+		RunE:    runRun,
+		PreRunE: preRun,
 	}
 
 	cmdRunUpgrade = &cobra.Command{
@@ -142,12 +142,10 @@ func main() {
 	cli.Execute(root)
 }
 
-func preRun(cmd *cobra.Command, args []string) {
+func preRun(cmd *cobra.Command, args []string) error {
 	err := syncOptions()
-
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		os.Exit(3)
+		return err
 	}
 
 	// Packet uses storage, and storage talks too much.
@@ -157,6 +155,8 @@ func preRun(cmd *cobra.Command, args []string) {
 			"storage": capnslog.WARNING,
 		})
 	}
+
+	return nil
 }
 
 func runRun(cmd *cobra.Command, args []string) error {

--- a/mantle/cmd/kola/qemuexec.go
+++ b/mantle/cmd/kola/qemuexec.go
@@ -17,9 +17,6 @@
 package main
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/spf13/cobra"
 
 	"github.com/coreos/mantle/kola"
@@ -28,10 +25,10 @@ import (
 
 var (
 	cmdQemuExec = &cobra.Command{
-		Run:    runQemuExec,
-		PreRun: preRun,
-		Use:    "qemuexec",
-		Short:  "Directly execute qemu on a CoreOS instance",
+		RunE:    runQemuExec,
+		PreRunE: preRun,
+		Use:     "qemuexec",
+		Short:   "Directly execute qemu on a CoreOS instance",
 	}
 
 	memory  int
@@ -47,14 +44,7 @@ func init() {
 	cmdQemuExec.Flags().StringVarP(&ignition, "ignition", "i", "", "Path to ignition config")
 }
 
-func runQemuExec(cmd *cobra.Command, args []string) {
-	if err := doQemuExec(cmd, args); err != nil {
-		fmt.Fprintf(os.Stderr, "%s\n", err)
-		os.Exit(1)
-	}
-}
-
-func doQemuExec(cmd *cobra.Command, args []string) error {
+func runQemuExec(cmd *cobra.Command, args []string) error {
 	var err error
 
 	builder := platform.NewBuilder(kola.QEMUOptions.Board, ignition)

--- a/mantle/cmd/kola/spawn.go
+++ b/mantle/cmd/kola/spawn.go
@@ -36,10 +36,10 @@ import (
 
 var (
 	cmdSpawn = &cobra.Command{
-		Run:    runSpawn,
-		PreRun: preRun,
-		Use:    "spawn",
-		Short:  "spawn a CoreOS instance",
+		RunE:    runSpawn,
+		PreRunE: preRun,
+		Use:     "spawn",
+		Short:   "spawn a CoreOS instance",
 	}
 
 	spawnNodeCount      int
@@ -70,14 +70,7 @@ func init() {
 	root.AddCommand(cmdSpawn)
 }
 
-func runSpawn(cmd *cobra.Command, args []string) {
-	if err := doSpawn(cmd, args); err != nil {
-		fmt.Fprintf(os.Stderr, "%s\n", err)
-		os.Exit(1)
-	}
-}
-
-func doSpawn(cmd *cobra.Command, args []string) error {
+func runSpawn(cmd *cobra.Command, args []string) error {
 	var err error
 
 	if spawnDetach {


### PR DESCRIPTION
We had the pattern of a "do" function wrapping a "run" function
that returned `error` in a few more places.