### PR TITLE
 tree: delete Dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,7 +1,0 @@
-version: 1
-
-update_configs:
-  - package_manager: "submodules"
-    directory: "/"
-    update_schedule: "daily"
-


### PR DESCRIPTION
We don't use git submodules anymore, so drop this.

Closes: #1186