### PR TITLE
kola: Rework scpKolet and dropFile to be generic APIs

### DIFF
--- a/mantle/kola/cluster/cluster.go
+++ b/mantle/kola/cluster/cluster.go
@@ -92,14 +92,14 @@ func (t *TestCluster) ListNativeFunctions() []string {
 }
 
 // DropFile places file from localPath to ~/ on every machine in cluster
-func (t *TestCluster) DropFile(localPath string) error {
+func DropFile(machines []platform.Machine, localPath string) error {
 	in, err := os.Open(localPath)
 	if err != nil {
 		return err
 	}
 	defer in.Close()
 
-	for _, m := range t.Machines() {
+	for _, m := range machines {
 		if _, err := in.Seek(0, 0); err != nil {
 			return err
 		}

--- a/mantle/kola/tests/crio/crio.go
+++ b/mantle/kola/tests/crio/crio.go
@@ -242,10 +242,10 @@ func genContainer(c cluster.TestCluster, m platform.Machine, podName, imageName 
 	if err != nil {
 		return "", "", err
 	}
-	if err = c.DropFile(configPathPod); err != nil {
+	if err = cluster.DropFile(c.Machines(), configPathPod); err != nil {
 		return "", "", err
 	}
-	if err = c.DropFile(configPathContainer); err != nil {
+	if err = cluster.DropFile(c.Machines(), configPathContainer); err != nil {
 		return "", "", err
 	}
 	// Create the crio image used for testing, only if it doesn't exist already

--- a/mantle/kola/tests/docker/docker.go
+++ b/mantle/kola/tests/docker/docker.go
@@ -382,7 +382,7 @@ func dockerOldClient(c cluster.TestCluster) {
 	if err != nil {
 		c.Fatal(err)
 	}
-	c.DropFile(oldclient)
+	cluster.DropFile(c.Machines(), oldclient)
 
 	genDockerContainer(c, m, "echo", []string{"echo"})
 

--- a/mantle/kola/tests/upgrade/basic.go
+++ b/mantle/kola/tests/upgrade/basic.go
@@ -121,7 +121,7 @@ func fcosUpgradeBasic(c cluster.TestCluster) {
 		// all. cloud testing should mostly be a pipeline thing, where the infra
 		// connection should be much faster
 		ostreeTarPath := filepath.Join(filepath.Dir(kola.Options.CosaBuild), kola.CosaBuild.BuildArtifacts.Ostree.Path)
-		if err := c.DropFile(ostreeTarPath); err != nil {
+		if err := cluster.DropFile(c.Machines(), ostreeTarPath); err != nil {
 			c.Fatal(err)
 		}
 


### PR DESCRIPTION
I'm trying to add `kola run-ext-bin` which doesn't quite
want `TestCluster` which is tied in with a `Harness` and a suite
of tests.  Lower these methods to functions that operate on
an array of machines.