### PR TITLE
schema: Fix duplicate key in overrides-active

### DIFF
--- a/src/schema/v1.json
+++ b/src/schema/v1.json
@@ -381,7 +381,6 @@
     },
    "coreos-assembler.overrides-active": {
      "$id":"#/properties/coreos-assembler.overrides-active",
-     "type":"string",
      "title":"Overrides Active",
      "default":"",
      "type": "boolean"


### PR DESCRIPTION
It's a boolean, not a string (the former was overriding the latter).
Noticed this in VS Code which has a generic "duplicate key in JSON"
linter.