### PR TITLE
mantle: update Ignition spec detection for RHCOS 4.5

### DIFF
--- a/mantle/sdk/ignversion.go
+++ b/mantle/sdk/ignversion.go
@@ -25,7 +25,7 @@ import (
 // be a disk image or the "name" of a coreos-assembler stream.
 func TargetIgnitionVersionFromName(artifact string) string {
 	basename := filepath.Base(artifact)
-	ignition_spec2_openshift_releases := []int{1, 2, 3, 4}
+	ignition_spec2_openshift_releases := []int{1, 2, 3, 4, 5}
 	// The output from the RHCOS pipeline names images like
 	// rhcos-42.81.$datestamp.  The images are renamed when
 	// placed at e.g. https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.2/4.2.0/

--- a/src/cmd-run
+++ b/src/cmd-run
@@ -115,6 +115,8 @@ fi
 vmdiskdir=$(dirname "${VM_DISK}")
 VM_DISK=$(realpath "${vmdiskdir}")/$(basename "${VM_DISK}")
 
+# For future me: if you are in here wondering where this value is ultimately
+# derived from, it exists in mantle/sdk/ignversion.go via `TargetIgnitionVersionFromName()`
 ignition_version=$(disk_ignition_version "${VM_DISK}")
 ign_validate="ignition-validate"
 


### PR DESCRIPTION
We're still carrying Ignition spec v2 for RHCOS 4.5, so update the
code appropriately.