### PR TITLE
End schema complexity experiment; simplify the schema for x-lang support

### DIFF
--- a/mantle/cosa/cosa_v1.go
+++ b/mantle/cosa/cosa_v1.go
@@ -27,9 +27,9 @@ type Build struct {
 	Architecture              string                  `json:"coreos-assembler.basearch,omitempty"`
 	Azure                     Cloudartifact           `json:"azure,omitempty"`
 	BuildArtifacts            BuildArtifacts          `json:"images,omitempty"`
-	BuildID                   string                  `json:"buildid,omitempty"`
+	BuildID                   string                  `json:"buildid"`
 	BuildRef                  string                  `json:"ref,omitempty"`
-	BuildSummary              string                  `json:"summary,omitempty"`
+	BuildSummary              string                  `json:"summary"`
 	BuildTimeStamp            string                  `json:"coreos-assembler.build-timestamp,omitempty"`
 	BuildURL                  string                  `json:"build-url,omitempty"`
 	ConfigGitRev              string                  `json:"coreos-assembler.config-gitrev,omitempty"`
@@ -43,19 +43,19 @@ type Build struct {
 	Gcp                       Cloudartifact           `json:"gcp,omitempty"`
 	GitDirty                  string                  `json:"coreos-assembler.config-dirty,omitempty"`
 	ImageInputChecksum        string                  `json:"coreos-assembler.image-input-checksum,omitempty"`
-	InputHasOfTheRpmOstree    string                  `json:"rpm-ostree-inputhash,omitempty"`
-	Name                      string                  `json:"name,omitempty"`
+	InputHasOfTheRpmOstree    string                  `json:"rpm-ostree-inputhash"`
+	Name                      string                  `json:"name"`
 	Oscontainer               Image                   `json:"oscontainer,omitempty"`
-	OstreeCommit              string                  `json:"ostree-commit,omitempty"`
-	OstreeContentBytesWritten int                     `json:"ostree-content-bytes-written,omitempty"`
-	OstreeContentChecksum     string                  `json:"ostree-content-checksum,omitempty"`
-	OstreeNCacheHits          int                     `json:"ostree-n-cache-hits,omitempty"`
-	OstreeNContentTotal       int                     `json:"ostree-n-content-total,omitempty"`
-	OstreeNContentWritten     int                     `json:"ostree-n-content-written,omitempty"`
-	OstreeNMetadataTotal      int                     `json:"ostree-n-metadata-total,omitempty"`
-	OstreeNMetadataWritten    int                     `json:"ostree-n-metadata-written,omitempty"`
-	OstreeTimestamp           string                  `json:"ostree-timestamp,omitempty"`
-	OstreeVersion             string                  `json:"ostree-version,omitempty"`
+	OstreeCommit              string                  `json:"ostree-commit"`
+	OstreeContentBytesWritten int                     `json:"ostree-content-bytes-written"`
+	OstreeContentChecksum     string                  `json:"ostree-content-checksum"`
+	OstreeNCacheHits          int                     `json:"ostree-n-cache-hits"`
+	OstreeNContentTotal       int                     `json:"ostree-n-content-total"`
+	OstreeNContentWritten     int                     `json:"ostree-n-content-written"`
+	OstreeNMetadataTotal      int                     `json:"ostree-n-metadata-total"`
+	OstreeNMetadataWritten    int                     `json:"ostree-n-metadata-written"`
+	OstreeTimestamp           string                  `json:"ostree-timestamp"`
+	OstreeVersion             string                  `json:"ostree-version"`
 	OverridesActive           bool                    `json:"coreos-assembler.overrides-active,omitempty"`
 	PkgdiffBetweenBuilds      []PackageSetDifferences `json:"pkgdiff,omitempty"`
 }

--- a/src/schema/v1.json
+++ b/src/schema/v1.json
@@ -6,33 +6,27 @@
            "path": {
              "$id": "#/artifact/Path",
              "type":"string",
-             "title":"Path",
-             "default":"",
-             "pattern":"^(.*)$"
+             "title":"Path"
             },
            "sha256": {
              "$id": "#/artifact/sha256",
              "type":"string",
-             "title":"SHA256",
-             "pattern": "[A-Fa-f0-9]{64}"
+             "title":"SHA256"
             },
            "size": {
              "$id": "#/artifact/size",
              "type":"integer",
-             "title":"Size in bytes",
-             "default": 0
+             "title":"Size in bytes"
             },
            "uncompressed-sha256": {
              "$id": "#/artifact/uncompressed-sha256",
              "type":"string",
-             "title":"Uncompressed SHA256",
-             "pattern": "[A-Fa-f0-9]{64}"
+             "title":"Uncompressed SHA256"
             },
            "uncompressed-size": {
              "$id": "#/artifact/uncompressed-size",
              "type":"integer",
-             "title":"Uncompressed-size",
-             "default": 0
+             "title":"Uncompressed-size"
             }
           },
           "optional": [
@@ -55,14 +49,12 @@
            "digest": {
              "$id": "#/image/digest",
              "type":"string",
-             "title":"Digest",
-             "pattern":"sha256:[A-Fa-f0-9]{64}"
+             "title":"Digest"
             },
            "image": {
              "$id": "#/image/image",
              "type":"string",
-             "title":"Image",
-             "pattern":"^(?!\\s*$).+"
+             "title":"Image"
             }
           }
       },
@@ -76,22 +68,12 @@
            "image": {
              "$id":"#/cloudartifact/image",
              "type":"string",
-             "title":"Image",
-             "default":"",
-             "examples": [
-               "fcos-31-202001010000-0"
-              ],
-             "pattern":"^(?!\\s*$).+"
+             "title":"Image"
             },
            "url": {
              "$id":"#/cloudartifact/url",
              "type":"string",
-             "title":"URL",
-             "default":"",
-             "examples": [
-               "https://example.com/devel/devel/rhcos/fcos-31-202001010000-0.tar.gz"
-              ],
-             "pattern":"^(?!\\s*$).+"
+             "title":"URL"
             }
           }
      },
@@ -114,7 +96,7 @@
              "examples": [
                "HEAD"
               ],
-             "pattern":"^(?!\\s*$).+"
+             "minLength": 3
             },
            "commit": {
              "$id":"#/git/commit",
@@ -124,8 +106,8 @@
              "examples": [
                "742edc307e58f35824d906958b6493510e12b593"
               ],
-             "pattern":"\\b[0-9a-f]{5,40}\\b"
-            },
+             "minLength": 5
+           },
            "dirty": {
              "$id":"#/git/dirty",
              "type":"string",
@@ -134,8 +116,8 @@
              "examples": [
                "true"
               ],
-             "pattern":"^(?!\\s*$).+"
-            },
+             "minLength": 1
+           },
            "origin": {
              "$id":"#/git/origin",
              "type":"string",
@@ -144,7 +126,7 @@
              "examples": [
                "https://github.com/coreos/fedora-coreos-config"
               ],
-             "pattern":"^(?!\\s*$).+"
+             "minLength": 1
             }
           }
      }
@@ -153,88 +135,47 @@
  "$id":"http://github.com/coreos/coreos-assembler/blob/master/schema/v1.json",
  "type":"object",
  "title":"CoreOS Assember v1 meta.json schema",
- "allOf": [
-     {
-         "required": [
-             "buildid",
-             "name",
-             "ostree-commit",
-             "ostree-content-bytes-written",
-             "ostree-content-checksum",
-             "ostree-n-cache-hits",
-             "ostree-n-content-total",
-             "ostree-n-content-written",
-             "ostree-n-metadata-total",
-             "ostree-n-metadata-written",
-             "ostree-timestamp",
-             "ostree-version",
-             "rpm-ostree-inputhash",
-             "summary"
-         ],
-         "optional": [
-           "images",
-           "aliyun",
-           "amis",
-           "azure",
-           "build-url",
-           "gcp",
-           "exoscale",
-           "oscontainer",
-           "pkgdiff",
+ "required": [
+     "buildid",
+     "name",
+     "ostree-commit",
+     "ostree-content-bytes-written",
+     "ostree-content-checksum",
+     "ostree-n-cache-hits",
+     "ostree-n-content-total",
+     "ostree-n-content-written",
+     "ostree-n-metadata-total",
+     "ostree-n-metadata-written",
+     "ostree-timestamp",
+     "ostree-version",
+     "rpm-ostree-inputhash",
+     "summary"
+ ],
+ "optional": [
+   "images",
+   "aliyun",
+   "amis",
+   "azure",
+   "build-url",
+   "gcp",
+   "exoscale",
+   "oscontainer",
+   "pkgdiff",
 
-           "coreos-assembler.basearch",
-           "coreos-assembler.build-timestamp",
-           "coreos-assembler.code-source",
-           "coreos-assembler.config-dirty",
-           "coreos-assembler.config-gitrev",
-           "coreos-assembler.container-config-git",
-           "coreos-assembler.container-image-git",
-           "coreos-assembler.image-config-checksum",
-           "coreos-assembler.image-genver",
-           "coreos-assembler.image-input-checksum",
-           "coreos-assembler.overrides-active",
-           "fedora-coreos.parent-commit",
-           "fedora-coreos.parent-version",
-           "ref"
-          ]
-     },
-     {
-         "if": {
-             "properties": {
-                 "name": { "const": "fedora-coreos"  }
-             }
-         },
-         "then": {
-                "required": [
-                   "ref"
-                  ],
-                "optional": [
-                  "fedora-coreos.parent-commit",
-                  "fedora-coreos.parent-version"
-                ]
-         },
-         "else": {}
-    },
-    {
-         "if": {
-             "properties": {
-                 "name": { "pattern": "^(rhcos|fedora-coreos)$"  }
-             }
-         },
-         "then": {
-                "required": [
-                   "coreos-assembler.basearch",
-                   "coreos-assembler.build-timestamp",
-                   "coreos-assembler.code-source",
-                   "coreos-assembler.config-dirty",
-                   "coreos-assembler.config-gitrev",
-                   "coreos-assembler.image-config-checksum",
-                   "coreos-assembler.image-genver",
-                   "coreos-assembler.image-input-checksum"
-                  ]
-         },
-         "else": {}
-    }
+   "coreos-assembler.basearch",
+   "coreos-assembler.build-timestamp",
+   "coreos-assembler.code-source",
+   "coreos-assembler.config-dirty",
+   "coreos-assembler.config-gitrev",
+   "coreos-assembler.container-config-git",
+   "coreos-assembler.container-image-git",
+   "coreos-assembler.image-config-checksum",
+   "coreos-assembler.image-genver",
+   "coreos-assembler.image-input-checksum",
+   "coreos-assembler.overrides-active",
+   "fedora-coreos.parent-commit",
+   "fedora-coreos.parent-version",
+   "ref"
  ],
  "additionalProperties":false,
  "properties": {
@@ -243,80 +184,56 @@
      "type":"string",
      "title":"BuildRef",
      "default":"",
-     "examples": [
-       "fedora/x86_64/coreos/testing-devel"
-      ],
-     "pattern":"^(?!\\s*$).+"
+     "minLength": 1
     },
    "build-url": {
      "$id":"#/properties/build-url",
      "type":"string",
      "title":"Build URL",
      "default":"",
-     "examples": [
-       "https://jenkins-host.example.com/job/rhcos/5/"
-      ],
-     "pattern":"^(?!\\s*$).+"
+     "minLength": 1
     },
    "buildid": {
      "$id":"#/properties/buildid",
      "type":"string",
      "title":"BuildID",
      "default":"",
-     "examples": [
-       "31-202001010000-0"
-      ],
-     "pattern":"^(?!\\s*$).+"
+     "minLength": 1
     },
    "coreos-assembler.basearch": {
      "$id":"#/properties/coreos-assembler.basearch",
      "type":"string",
      "title":"Architecture",
      "default":"",
-     "examples": [
-       "x86_64"
-      ],
-     "pattern":"^(?!\\s*$).+"
+     "minLength": 1
     },
    "coreos-assembler.build-timestamp": {
      "$id":"#/properties/coreos-assembler.build-timestamp",
      "type":"string",
      "title":"Build Time Stamp",
      "default":"",
-     "examples": [
-       "2020-01-15T19:32:19Z"
-      ],
-     "pattern":"^(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\\.[0-9]+)?(Z)?$"
+     "minLength": 1
     },
    "coreos-assembler.code-source": {
      "$id":"#/properties/coreos-assembler.code-source",
      "type":"string",
      "title":"CoreOS Source",
      "default":"",
-     "examples": [
-       "container"
-      ],
-     "pattern":"^(?!\\s*$).+"
+     "minLength": 1
     },
    "coreos-assembler.config-dirty": {
      "$id":"#/properties/coreos-assembler.config-dirty",
      "type":"string",
      "title":"GitDirty",
      "default":"",
-     "examples": [
-       "true"
-      ],
-     "pattern":"^(?!\\s*$).+"
+     "minLength": 1
     },
    "coreos-assembler.config-gitrev": {
      "$id":"#/properties/coreos-assembler.config-gitrev",
      "type":"string",
      "title":"Config GitRev",
      "default":"",
-     "examples": [
-       "v3.1-728-g742edc307e58f35824d906958b6493510e12b593"
-      ],
-     "pattern":"^(?!\\s*$).+"
+     "minLength": 1
     },
    "coreos-assembler.container-config-git": {
      "$id":"#/properties/coreos-assembler.container-config-git",
@@ -335,10 +252,7 @@
      "type":"string",
      "title":"Fedora CoreOS Parent Version",
      "default":"",
-     "examples": [
-       "31.20200127.20.1"
-      ],
-     "pattern":"^(?!\\s*$).+"
+     "minLength": 12
     },
     "fedora-coreos.parent-commit": {
      "$id":"#/properties/fedora-coreos.parent-commit",
@@ -348,17 +262,14 @@
      "examples": [
        "f15f5b25cf138a7683e3d200c53ece2091bf71d31332135da87892ab72ff4ee3"
       ],
-      "pattern":"[A-Fa-f0-9]{64}$"
+     "minLength": 64
     },
    "coreos-assembler.image-config-checksum": {
      "$id":"#/properties/coreos-assembler.image-config-checksum",
      "type":"string",
      "title":"COSA image checksum",
      "default":"",
-     "examples": [
-       "f15f5b25cf138a7683e3d200c53ece2091bf71d31332135da87892ab72ff4ee3"
-      ],
-      "pattern":"[A-Fa-f0-9]{64}$"
+     "minLength": 64
     },
    "coreos-assembler.image-genver": {
      "$id":"#/properties/coreos-assembler.image-genver",
@@ -374,10 +285,7 @@
      "type":"string",
      "title":"Image input checksum",
      "default":"",
-     "examples": [
-       "59b0904f91aafcf55a66075b731476f802c9d60f17b0c670fb5c43d26333b876"
-      ],
-     "pattern":"^(?!\\s*$).+"
+     "minLength": 64
     },
    "coreos-assembler.overrides-active": {
      "$id":"#/properties/coreos-assembler.overrides-active",
@@ -529,74 +437,50 @@
      "type":"string",
      "title":"ostree-commit",
      "default":"",
-     "examples": [
-       "9665ab0cfd4a995cf70f1a3bb678d3515a03f7d3b5bb87d723ba06c26f0daa6e"
-      ],
-     "pattern":"[A-Fa-f0-9]{64}"
+     "minLength": 64
     },
    "ostree-content-bytes-written": {
      "$id":"#/properties/ostree-content-bytes-written",
      "type":"integer",
      "title":"ostree-content-bytes-written",
-     "default": 0,
-     "examples": [
-        156269945
-      ]
+     "default": 0
     },
    "ostree-content-checksum": {
      "$id":"#/properties/ostree-content-checksum",
      "type":"string",
      "title":"ostree-content-checksum",
      "default":"",
-     "examples": [
-       "e02647edba305ad68e2c7c5bb3a2c7765eb4ea6aadd1ebf8e538e459ebf99ed7"
-      ],
-     "pattern":"[A-Fa-f0-9]{64}"
+     "minLength": 64
     },
    "ostree-n-cache-hits": {
      "$id":"#/properties/ostree-n-cache-hits",
      "type":"integer",
      "title":"ostree-n-cache-hits",
-     "default": 0,
-     "examples": [
-        19185
-      ]
+     "default": 0
     },
    "ostree-n-content-total": {
      "$id":"#/properties/ostree-n-content-total",
      "type":"integer",
      "title":"ostree-n-content-total",
-     "default": 0,
-     "examples": [
-        3688
-      ]
+     "default": 0
     },
    "ostree-n-content-written": {
      "$id":"#/properties/ostree-n-content-written",
      "type":"integer",
      "title":"ostree-n-content-written",
-     "default": 0,
-     "examples": [
-        1210
-      ]
+     "default": 0
     },
    "ostree-n-metadata-total": {
      "$id":"#/properties/ostree-n-metadata-total",
      "type":"integer",
      "title":"ostree-n-metadata-total",
-     "default": 0,
-     "examples": [
-        9225
-      ]
+     "default": 0
     },
    "ostree-n-metadata-written": {
      "$id":"#/properties/ostree-n-metadata-written",
      "type":"integer",
      "title":"ostree-n-metadata-written",
-     "default": 0,
-     "examples": [
-        3015
-      ]
+     "default": 0
     },
    "ostree-timestamp": {
      "$id":"#/properties/ostree-timestamp",
@@ -606,17 +490,14 @@
      "examples": [
        "2020-01-15T19:31:31Z"
       ],
-     "pattern":"^(?!\\s*$).+"
+     "pattern":"\\d{4}-\\d{2}-\\d{2}T.*Z$"
     },
    "ostree-version": {
      "$id":"#/properties/ostree-version",
      "type":"string",
      "title":"ostree version",
      "default":"",
-     "examples": [
-       "31-202001010000-0"
-      ],
-     "pattern":"^(?!\\s*$).+"
+     "minLength": 1
     },
    "pkgdiff": {
      "$id":"#/properties/pkgdiff",
@@ -630,11 +511,7 @@
          "$id":"#/properties/pkgdiff/items/items",
          "title":"Items",
          "default":"",
-         "examples": [
-           "foo-bar",
-            2
-          ],
-         "pattern":"^(?!\\s*$).+"
+         "minLength": 1
         }
       }
     },
@@ -643,20 +520,14 @@
      "type":"string",
      "title":"input has of the rpm-ostree",
      "default":"",
-     "examples": [
-       "13de3656ed8f55f8b8bafeab7a2320496c247cf533063e3d3daa63a95592f1ac"
-      ],
-     "pattern":"[A-Fa-f0-9]{64}"
+     "minLength": 64
     },
    "summary": {
      "$id":"#/properties/summary",
      "type":"string",
      "title":"Build Summary",
      "default":"",
-     "examples": [
-       "FCOS 31"
-      ],
-     "pattern":"^(?!\\s*$).+"
+     "minLength": 1
     },
    "aliyun": {
      "$id":"#/properties/aliyun",
@@ -676,20 +547,14 @@
            "type":"string",
            "title":"Region",
            "default":"",
-           "examples": [
-             "us-west-1"
-            ],
-           "pattern":"^(?!\\s*$).+"
+           "minLength": 1
           },
          "id": {
            "$id":"#/properties/aliyun/items/properties/id",
            "type":"string",
            "title":"ImageID",
            "default":"",
-           "examples": [
-             "m-rj9d477fe8uxzai8d8zf"
-            ],
-           "pattern":"^(?!\\s*$).+"
+           "minLength": 1
           }
         }
       }
@@ -712,31 +577,19 @@
            "$id":"#/properties/amis/items/properties/name",
            "type":"string",
            "title":"Region",
-           "default":"",
-           "examples": [
-             "us-east-1"
-            ],
-           "pattern":"^(?!\\s*$).+"
+           "default":""
           },
          "hvm": {
            "$id":"#/properties/amis/items/properties/hvm",
            "type":"string",
            "title":"HVM",
-           "default":"",
-           "examples": [
-             "ami-0de107f30d290b9a1"
-            ],
-           "pattern":"^ami-(\\w{15,})$"
-          },
+           "default":""
+         },
          "snapshot": {
            "$id":"#/properties/amis/items/properties/snapshot",
            "type":"string",
            "title":"Snapshot",
-           "default":"",
-           "examples": [
-             "snap-006453e8b55eddb0e"
-            ],
-           "pattern":"^snap-(\\w{15,})$"
+           "default":""
           }
         }
       }


### PR DESCRIPTION
In looking to teach `ore` how to directly interact with the schema, I
found that there is a huge a problem with cross-language support for
"patterns" (the GoLang validators only support a subset) and then the
"anyOf" and "if/then/else" support is spotty at best.

Further, I came to find that the Python validator doesn't _really_ work
as we expected and is buggy.

In light of needing to support GoLang and Python, simplifying the schema
seems to be the best course for the time being.