### PR TITLE
gf-mksquashfs: Use API to run+mount to fix RHCOS case

### DIFF
--- a/src/gf-mksquashfs
+++ b/src/gf-mksquashfs
@@ -31,10 +31,7 @@ set -x
 tmpd=$(mktemp -tdp "$(dirname "${dest}")" gf-mksquashfs.XXXXXX)
 tmp_dest=${tmpd}/image.squashfs
 
-coreos_gf_run "${src}" --ro
-
-root=$(coreos_gf findfs-label root)
-coreos_gf mount "${root}" /
+coreos_gf_run_mount "${src}" --ro
 
 coreos_gf mksquashfs / "${tmp_dest}" "compress:${compression}"
 


### PR DESCRIPTION
`cosa buildextend-live` was failing due to the LUKS container,
update `gf-mksquashfs` to use the new internal guestfish wrapper
which knows how to handle it.  Plus it's simpler.