### PR TITLE
testiso: Add support for testing live path too

### DIFF
--- a/src/cmd-test-coreos-installer
+++ b/src/cmd-test-coreos-installer
@@ -14,4 +14,4 @@ arch=$(arch)
 builddir=builds/${build}/${arch}
 buildmeta=${builddir}/meta.json
 
-exec kola testiso --cosa-build "${buildmeta}"
+exec kola testiso --cosa-build "${buildmeta}" "$@"

--- a/src/gf-mksquashfs
+++ b/src/gf-mksquashfs
@@ -31,10 +31,7 @@ set -x
 tmpd=$(mktemp -tdp "$(dirname "${dest}")" gf-mksquashfs.XXXXXX)
 tmp_dest=${tmpd}/image.squashfs
 
-coreos_gf_run "${src}" --ro
-
-root=$(coreos_gf findfs-label root)
-coreos_gf mount "${root}" /
+coreos_gf_run_mount "${src}" --ro
 
 coreos_gf mksquashfs / "${tmp_dest}" "compress:${compression}"
 


### PR DESCRIPTION
The `testiso` command now supports testing both `live-initramfs`
and `initramfs` (legacy installer).

TODO:
- Support testing the "just run Live" case - maybe try to figure out
  how to have main `kola` tests apply?
- Test `coreos-install iso embed` path
