### PR TITLE
 run/kola-qemuexec: Add DHCP hostname support

### DIFF
--- a/mantle/cmd/kola/qemuexec.go
+++ b/mantle/cmd/kola/qemuexec.go
@@ -34,12 +34,14 @@ var (
 	memory  int
 	usernet bool
 
+	hostname string
 	ignition string
 )
 
 func init() {
 	root.AddCommand(cmdQemuExec)
 	cmdQemuExec.Flags().BoolVarP(&usernet, "usernet", "U", false, "Enable usermode networking")
+	cmdQemuExec.Flags().StringVarP(&hostname, "hostname", "", "", "Set hostname via DHCP")
 	cmdQemuExec.Flags().IntVarP(&memory, "memory", "m", 0, "Memory in MB")
 	cmdQemuExec.Flags().StringVarP(&ignition, "ignition", "i", "", "Path to ignition config")
 }
@@ -61,6 +63,7 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 			Size:        kola.QEMUOptions.DiskSize,
 		})
 	}
+	builder.Hostname = hostname
 	if memory != 0 {
 		builder.Memory = memory
 	}

--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -148,6 +148,8 @@ type QemuBuilder struct {
 	Pdeathsig  bool
 	Argv       []string
 
+	Hostname   string
+
 	InheritConsole bool
 
 	primaryDiskAdded bool
@@ -220,11 +222,16 @@ func (builder *QemuBuilder) ConsoleToFile(path string) {
 }
 
 func (builder *QemuBuilder) EnableUsermodeNetworking(forwardedPort uint) {
-	var forward string
+	netdev := "user,id=eth0"
 	if forwardedPort != 0 {
-		forward = fmt.Sprintf(",hostfwd=tcp:127.0.0.1:0-:%d", forwardedPort)
+		netdev += fmt.Sprintf(",hostfwd=tcp:127.0.0.1:0-:%d", forwardedPort)
 	}
-	builder.Append("-netdev", "user,id=eth0"+forward, "-device", virtio(builder.Board, "net", "netdev=eth0"))
+
+	if builder.Hostname != "" {
+		netdev += fmt.Sprintf(",hostname=%s", builder.Hostname)
+	}
+
+	builder.Append("-netdev", netdev, "-device", virtio(builder.Board, "net", "netdev=eth0"))
 }
 
 // supportsFwCfg if the target system supports injecting

--- a/src/cmd-run
+++ b/src/cmd-run
@@ -15,6 +15,7 @@ dn=$(dirname "$0")
 
 BUILDID=latest
 IMAGE_TYPE=qemu
+HOSTNAME=
 VM_DISK=
 DISK_CHANNEL=virtio
 VM_MEMORY=2048
@@ -31,6 +32,7 @@ Options:
     -i FILE               File containing an Ignition config to merge into the default config
     --srv src             Mount (via 9p) src on the host as /var/srv in guest
     -m MB                 RAM size in MB (2048)
+    --hostname NAME       Set hostname via DHCP
     --size GB             Disk size in GB (matches base by default)
     --user USERNAME       Create user USERNAME via Ignition (if not already extant) and log in as that user
     -h                    this ;-)
@@ -76,6 +78,9 @@ while [ $# -ge 1 ]; do
             shift 2 ;;
         --user)
             TARGET_USER="$2"
+            shift 2 ;;
+        --hostname)
+            HOSTNAME="$2"
             shift 2 ;;
         -v|--verbose)
             set -x
@@ -258,5 +263,9 @@ case "${FIRMWARE}" in
     bios) ;;
     *) kola_args+=("--qemu-firmware=${FIRMWARE}")
 esac
+
+if [ -n "${HOSTNAME}" ]; then
+    kola_args+=("--hostname=${HOSTNAME}")
+fi
 
 exec kola qemuexec -U --qemu-image "${VM_DISK}" --ignition "${IGNITION_CONFIG_FILE}" --memory "${VM_MEMORY}" "${kola_args[@]}" -- "$@"


### PR DESCRIPTION

Add support for explicitly configuring the hostname as provided
from DHCP - prep for testing this.