### PR TITLE
mantle: Stop cleaning every build

### DIFF
--- a/mantle/Makefile
+++ b/mantle/Makefile
@@ -10,7 +10,7 @@ else ifeq ($(GOARCH),aarch64)
 endif
 
 .PHONY: build test vendor clean
-build: clean
+build:
 	./build
 
 .PHONY: install


### PR DESCRIPTION
This really hurts the edit-compile-debug cycle; not sure why
we started doing that.