### PR TITLE
kola/spawn: add --reconnect switch

### DIFF
--- a/mantle/cmd/kola/kola.go
+++ b/mantle/cmd/kola/kola.go
@@ -61,8 +61,9 @@ If the glob pattern is exactly equal to the name of a single test, any
 restrictions on the versions of Container Linux supported by that test
 will be ignored.
 `,
-		RunE:    runRun,
-		PreRunE: preRun,
+		RunE:         runRun,
+		PreRunE:      preRun,
+		SilenceUsage: true,
 	}
 
 	cmdRunUpgrade = &cobra.Command{

--- a/mantle/cmd/kola/spawn.go
+++ b/mantle/cmd/kola/spawn.go
@@ -36,10 +36,11 @@ import (
 
 var (
 	cmdSpawn = &cobra.Command{
-		RunE:    runSpawn,
-		PreRunE: preRun,
-		Use:     "spawn",
-		Short:   "spawn a CoreOS instance",
+		RunE:         runSpawn,
+		PreRunE:      preRun,
+		Use:          "spawn",
+		Short:        "spawn a CoreOS instance",
+		SilenceUsage: true,
 	}
 
 	spawnNodeCount      int

--- a/mantle/platform/util.go
+++ b/mantle/platform/util.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pkg/errors"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/terminal"
 )
@@ -69,15 +70,15 @@ func Manhole(m Machine) error {
 	}
 
 	if err = session.RequestPty(os.Getenv("TERM"), lines, cols, modes); err != nil {
-		return fmt.Errorf("failed to request pseudo terminal: %s", err)
+		return errors.Wrapf(err, "failed to request pseudo terminal")
 	}
 
 	if err := session.Shell(); err != nil {
-		return fmt.Errorf("failed to start shell: %s", err)
+		return errors.Wrapf(err, "failed to start shell")
 	}
 
 	if err := session.Wait(); err != nil {
-		return fmt.Errorf("failed to wait for session: %s", err)
+		return errors.Wrapf(err, "failed to wait for session")
 	}
 
 	return nil


### PR DESCRIPTION
Right now, `kola spawn` immediately kills the node once we leave the SSH
session. This is nice most of the time for quick testing. But it
basically throws out the window anything that requires rebooting (which
oddly makes it more limiting than `cosa run`, which does). And sure,
there's always libvirt for more persistence, but I think there's room
for another gradation level here.

Add a new `--reconnect` switch which can handle this. In this mode, we
constantly try to reconnect to the node after getting disconnected. One
can simply do Ctrl-C to kill the node.