### PR TITLE
kola/spawn: restrict --reconnect to qemu platform

### DIFF
--- a/mantle/cmd/kola/spawn.go
+++ b/mantle/cmd/kola/spawn.go
@@ -93,6 +93,10 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Cluster Failed: nodecount must be one or more")
 	}
 
+	if spawnReconnect && !strings.HasPrefix(kolaPlatform, "qemu") {
+		return fmt.Errorf("Cannot use --reconnect on non-qemu platforms %v", kolaPlatform)
+	}
+
 	var userdata *conf.UserData
 	if spawnUserData != "" {
 		userbytes, err := ioutil.ReadFile(spawnUserData)


### PR DESCRIPTION
Follow-up to #1214.

Otherwise, exiting with Ctrl-C can cause cloud instances to leak. (We
could install signal handlers for this... but really we should have
stronger binding with the underlying resource so that one doesn't have
to Ctrl-C at all).