### PR TITLE
 kola/qemu: Support injecting kernel network arguments

### DIFF
--- a/mantle/cmd/kola/qemuexec.go
+++ b/mantle/cmd/kola/qemuexec.go
@@ -38,10 +38,12 @@ var (
 
 	hostname string
 	ignition string
+	knetargs string
 )
 
 func init() {
 	root.AddCommand(cmdQemuExec)
+	cmdQemuExec.Flags().StringVarP(&knetargs, "knetargs", "", "", "Arguments for Ignition networking on kernel commandline")
 	cmdQemuExec.Flags().BoolVarP(&usernet, "usernet", "U", false, "Enable usermode networking")
 	cmdQemuExec.Flags().StringVarP(&hostname, "hostname", "", "", "Set hostname via DHCP")
 	cmdQemuExec.Flags().IntVarP(&memory, "memory", "m", 0, "Memory in MB")
@@ -52,6 +54,9 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 	var err error
 
 	builder := platform.NewBuilder(kola.QEMUOptions.Board, ignition)
+	if len(knetargs) > 0 {
+		builder.IgnitionNetworkKargs = knetargs
+	}
 	defer builder.Close()
 	builder.Firmware = kola.QEMUOptions.Firmware
 	if kola.QEMUOptions.DiskImage != "" {

--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -282,8 +282,8 @@ func setupIgnition(confPath string, diskImagePath string) error {
 	// Set guestfish backend to direct in order to avoid libvirt as backend.
 	// Using libvirt can lead to permission denied issues if it does not have access
 	// rights to the qcow image
-	os.Setenv("LIBGUESTFS_BACKEND", "direct")
 	cmd := exec.Command("guestfish", "--listen", "-a", diskImagePath)
+	cmd.Env = append(os.Environ(), "LIBGUESTFS_BACKEND=direct")
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return fmt.Errorf("getting stdout pipe: %v", err)


### PR DESCRIPTION

This is useful for quickly testing static IP addresses on the
kernel cmdline without actually having to catch the GRUB
prompt or go through a whole series of `coreos-installer iso embed`
etc.

