### PR TITLE
mantle/*: Add SilenceUsage to all CLI entrypoints

### DIFF
--- a/mantle/cmd/kola/bootchart.go
+++ b/mantle/cmd/kola/bootchart.go
@@ -37,7 +37,9 @@ systemd-bootchart since the latter requires setting a different
 init process.
 
 This must run as root!
-`}
+`,
+	SilenceUsage: true,
+}
 
 func init() {
 	root.AddCommand(cmdBootchart)

--- a/mantle/cmd/kola/console.go
+++ b/mantle/cmd/kola/console.go
@@ -36,7 +36,10 @@ Check console output for expressions matching failure messages logged
 by a Container Linux instance.
 
 If no files are specified as arguments, stdin is checked.
-`}
+`,
+
+		SilenceUsage: true,
+	}
 
 	checkConsoleVerbose bool
 )

--- a/mantle/cmd/kola/kola.go
+++ b/mantle/cmd/kola/kola.go
@@ -80,6 +80,8 @@ will be ignored.
 		Use:   "list",
 		Short: "List kola test names",
 		RunE:  runList,
+
+		SilenceUsage: true,
 	}
 
 	cmdHttpServer = &cobra.Command{
@@ -90,6 +92,8 @@ will be ignored.
 This can be useful for e.g. serving locally built OSTree repos to qemu.
 `,
 		RunE: runHttpServer,
+
+		SilenceUsage: true,
 	}
 
 	cmdIgnConvert = &cobra.Command{
@@ -107,6 +111,8 @@ This can be useful for e.g. serving locally built OSTree repos to qemu.
 		Short:  "Implementation detail of coreos-assembler",
 		RunE:   runArtifactIgnitionVersion,
 		Hidden: true,
+
+		SilenceUsage: true,
 	}
 
 	listJSON           bool

--- a/mantle/cmd/kola/qemuexec.go
+++ b/mantle/cmd/kola/qemuexec.go
@@ -29,6 +29,8 @@ var (
 		PreRunE: preRun,
 		Use:     "qemuexec",
 		Short:   "Directly execute qemu on a CoreOS instance",
+
+		SilenceUsage: true,
 	}
 
 	memory  int

--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -50,6 +50,8 @@ var (
 		PreRunE: preRun,
 		Use:     "testiso",
 		Short:   "Test a CoreOS PXE boot or ISO install path",
+
+		SilenceUsage: true,
 	}
 	// TODO expose this as an API that can be used by cosa too
 	consoleKernelArgument = map[string]string{

--- a/mantle/cmd/ore/aliyun/copy-image.go
+++ b/mantle/cmd/ore/aliyun/copy-image.go
@@ -31,6 +31,8 @@ var (
 After a successful run, the final line of output will be a line of JSON describing the resources created.
 `,
 		RunE: runCopyImage,
+
+		SilenceUsage: true,
 	}
 
 	sourceImageID        string

--- a/mantle/cmd/ore/aliyun/create-image.go
+++ b/mantle/cmd/ore/aliyun/create-image.go
@@ -32,6 +32,8 @@ var (
 After a successful run, the final line of output will be the ID of the image.
 `,
 		RunE: runCreate,
+
+		SilenceUsage: true,
 	}
 
 	bucket       string

--- a/mantle/cmd/ore/aliyun/delete.go
+++ b/mantle/cmd/ore/aliyun/delete.go
@@ -27,6 +27,8 @@ var (
 		Short: "Delete image on aliyun",
 		Long:  `Delete an image from aliyun.`,
 		RunE:  runDelete,
+
+		SilenceUsage: true,
 	}
 
 	deleteId    string

--- a/mantle/cmd/ore/aliyun/list-regions.go
+++ b/mantle/cmd/ore/aliyun/list-regions.go
@@ -27,6 +27,8 @@ var (
 		Short: "List enabled regions in the given aliyun account",
 		Long:  `List enabled regions in the given aliyun account.`,
 		RunE:  runListRegions,
+
+		SilenceUsage: true,
 	}
 )
 

--- a/mantle/cmd/ore/aws/copy-image.go
+++ b/mantle/cmd/ore/aws/copy-image.go
@@ -33,6 +33,8 @@ var (
 After a successful run, the final line of output will be a line of JSON describing the resources created.
 `,
 		RunE: runCopyImage,
+
+		SilenceUsage: true,
 	}
 
 	sourceImageID string

--- a/mantle/cmd/ore/aws/gc.go
+++ b/mantle/cmd/ore/aws/gc.go
@@ -28,6 +28,8 @@ var (
 		Short: "GC resources in AWS",
 		Long:  `Delete instances created over the given duration ago`,
 		RunE:  runGC,
+
+		SilenceUsage: true,
 	}
 
 	gcDuration time.Duration

--- a/mantle/cmd/ore/aws/initialize.go
+++ b/mantle/cmd/ore/aws/initialize.go
@@ -26,6 +26,8 @@ var (
 		Use:   "initialize",
 		Short: "initialize any uncreated resources for a given AWS region",
 		RunE:  runInitialize,
+
+		SilenceUsage: true,
 	}
 
 	bucket string

--- a/mantle/cmd/ore/aws/list-regions.go
+++ b/mantle/cmd/ore/aws/list-regions.go
@@ -30,6 +30,8 @@ var (
 		Long: `List enabled regions in the AWS account and partition implied by the
 specified credentials file, profile, and region.`,
 		RunE: runListRegions,
+
+		SilenceUsage: true,
 	}
 	disabledRegions bool
 	allRegions      bool

--- a/mantle/cmd/ore/aws/upload.go
+++ b/mantle/cmd/ore/aws/upload.go
@@ -44,6 +44,8 @@ After a successful run, the final line of output will be a line of JSON describi
 	  --file="/home/.../coreos_production_ami_vmdk_image.vmdk" \
 	  --tags="machine=production"`,
 		RunE: runUpload,
+
+		SilenceUsage: true,
 	}
 
 	uploadSourceObject    string

--- a/mantle/cmd/ore/azure/create-image-arm.go
+++ b/mantle/cmd/ore/azure/create-image-arm.go
@@ -28,6 +28,8 @@ var (
 		Short: "Create Azure image",
 		Long:  "Create Azure image from a blob url",
 		RunE:  runCreateImageARM,
+
+		SilenceUsage: true,
 	}
 
 	imageName     string

--- a/mantle/cmd/ore/azure/create-image.go
+++ b/mantle/cmd/ore/azure/create-image.go
@@ -28,6 +28,8 @@ var (
 		Short: "Create Azure image",
 		Long:  "Create Azure image from a local VHD file",
 		RunE:  runCreateImage,
+
+		SilenceUsage: true,
 	}
 
 	// create image options

--- a/mantle/cmd/ore/azure/delete-image.go
+++ b/mantle/cmd/ore/azure/delete-image.go
@@ -27,6 +27,8 @@ var (
 		Short: "Delete Azure image",
 		Long:  "Remove an image from Azure.",
 		RunE:  runDeleteImage,
+
+		SilenceUsage: true,
 	}
 )
 

--- a/mantle/cmd/ore/azure/gc.go
+++ b/mantle/cmd/ore/azure/gc.go
@@ -28,6 +28,8 @@ var (
 		Short: "GC resources in Azure",
 		Long:  `Delete instances created over the given duration ago`,
 		RunE:  runGC,
+
+		SilenceUsage: true,
 	}
 
 	gcDuration time.Duration

--- a/mantle/cmd/ore/azure/replicate-image.go
+++ b/mantle/cmd/ore/azure/replicate-image.go
@@ -26,6 +26,8 @@ var (
 		Use:   "replicate-image image",
 		Short: "Replicate an OS image in Azure",
 		RunE:  runReplicateImage,
+
+		SilenceUsage: true,
 	}
 
 	defaultRegions = []string{

--- a/mantle/cmd/ore/azure/share-image.go
+++ b/mantle/cmd/ore/azure/share-image.go
@@ -25,6 +25,8 @@ var (
 		Use:   "share-image image-name",
 		Short: "Set permissions on an azure OS image",
 		RunE:  runShareImage,
+
+		SilenceUsage: true,
 	}
 
 	sharePermission string

--- a/mantle/cmd/ore/azure/unreplicate-image.go
+++ b/mantle/cmd/ore/azure/unreplicate-image.go
@@ -25,6 +25,8 @@ var (
 		Use:   "unreplicate-image image",
 		Short: "Unreplicate an OS image in Azure",
 		RunE:  runUnreplicateImage,
+
+		SilenceUsage: true,
 	}
 )
 

--- a/mantle/cmd/ore/do/create-image.go
+++ b/mantle/cmd/ore/do/create-image.go
@@ -35,6 +35,8 @@ var (
 		Short: "Create image",
 		Long:  `Create an image.`,
 		RunE:  runCreateImage,
+
+		SilenceUsage: true,
 	}
 )
 

--- a/mantle/cmd/ore/do/delete-image.go
+++ b/mantle/cmd/ore/do/delete-image.go
@@ -28,6 +28,8 @@ var (
 		Short: "Delete image",
 		Long:  `Delete an image.`,
 		RunE:  runDeleteImage,
+
+		SilenceUsage: true,
 	}
 )
 

--- a/mantle/cmd/ore/do/delete-keys.go
+++ b/mantle/cmd/ore/do/delete-keys.go
@@ -27,6 +27,8 @@ var (
 		Use:   "delete-keys <key>...",
 		Short: "Delete DigitalOcean SSH keys",
 		RunE:  runDeleteKeys,
+
+		SilenceUsage: true,
 	}
 )
 

--- a/mantle/cmd/ore/do/gc.go
+++ b/mantle/cmd/ore/do/gc.go
@@ -29,6 +29,8 @@ var (
 		Short: "GC resources in DO",
 		Long:  `Delete droplets created over the given duration ago.`,
 		RunE:  runGC,
+
+		SilenceUsage: true,
 	}
 
 	gcDuration time.Duration

--- a/mantle/cmd/ore/do/list-keys.go
+++ b/mantle/cmd/ore/do/list-keys.go
@@ -27,6 +27,8 @@ var (
 		Use:   "list-keys",
 		Short: "List DigitalOcean SSH keys",
 		RunE:  runListKeys,
+
+		SilenceUsage: true,
 	}
 )
 

--- a/mantle/cmd/ore/esx/create-base.go
+++ b/mantle/cmd/ore/esx/create-base.go
@@ -32,6 +32,8 @@ var (
 After a successful run, the final line of output will be the name of the VM created.
 `,
 		RunE: runBaseCreate,
+
+		SilenceUsage: true,
 	}
 
 	ovaPath    string

--- a/mantle/cmd/ore/esx/remove-base.go
+++ b/mantle/cmd/ore/esx/remove-base.go
@@ -27,6 +27,8 @@ var (
 		Short: "Remove base vm on ESX",
 		Long:  `Remove base vm on ESX server.`,
 		RunE:  runBaseDelete,
+
+		SilenceUsage: true,
 	}
 
 	vmName string

--- a/mantle/cmd/ore/gcloud/gc.go
+++ b/mantle/cmd/ore/gcloud/gc.go
@@ -28,6 +28,8 @@ var (
 		Short: "GC resources in GCE",
 		Long:  `Delete instances created over the given duration ago.`,
 		RunE:  runGC,
+
+		SilenceUsage: true,
 	}
 
 	gcDuration time.Duration

--- a/mantle/cmd/ore/openstack/create.go
+++ b/mantle/cmd/ore/openstack/create.go
@@ -31,6 +31,8 @@ var (
 After a successful run, the final line of output will be the ID of the image.
 `,
 		RunE: runCreate,
+
+		SilenceUsage: true,
 	}
 
 	path string

--- a/mantle/cmd/ore/openstack/delete.go
+++ b/mantle/cmd/ore/openstack/delete.go
@@ -27,6 +27,8 @@ var (
 		Short: "Delete image on OpenStack",
 		Long:  `Delete an image from OpenStack.`,
 		RunE:  runDelete,
+
+		SilenceUsage: true,
 	}
 
 	id string

--- a/mantle/cmd/ore/openstack/gc.go
+++ b/mantle/cmd/ore/openstack/gc.go
@@ -28,6 +28,8 @@ var (
 		Short: "GC resources in OpenStack",
 		Long:  `Delete instances created over the given duration ago`,
 		RunE:  runGC,
+
+		SilenceUsage: true,
 	}
 
 	gcDuration time.Duration

--- a/mantle/cmd/ore/packet/delete-keys.go
+++ b/mantle/cmd/ore/packet/delete-keys.go
@@ -26,6 +26,8 @@ var (
 		Use:   "delete-keys <key>...",
 		Short: "Delete Packet SSH keys",
 		RunE:  runDeleteKeys,
+
+		SilenceUsage: true,
 	}
 )
 

--- a/mantle/cmd/ore/packet/gc.go
+++ b/mantle/cmd/ore/packet/gc.go
@@ -28,6 +28,8 @@ var (
 		Short: "GC resources in Packet",
 		Long:  `Delete devices created over the given duration ago.`,
 		RunE:  runGC,
+
+		SilenceUsage: true,
 	}
 
 	gcDuration time.Duration

--- a/mantle/cmd/ore/packet/list-keys.go
+++ b/mantle/cmd/ore/packet/list-keys.go
@@ -26,6 +26,8 @@ var (
 		Use:   "list-keys",
 		Short: "List Packet SSH keys",
 		RunE:  runListKeys,
+
+		SilenceUsage: true,
 	}
 )
 

--- a/mantle/cmd/plume/prerelease.go
+++ b/mantle/cmd/plume/prerelease.go
@@ -48,6 +48,8 @@ var (
 		Short: "Run pre-release steps for CoreOS",
 		Long:  "Runs pre-release steps for CoreOS, such as image uploading and OS image creation, and replication across regions.",
 		RunE:  runPreRelease,
+
+		SilenceUsage: true,
 	}
 
 	platforms = map[string]platform{


### PR DESCRIPTION
The cobra library made so many other good decisions, like
literally calling it cobra for commands which always summons
memories of GI Joe from my childhood.

This decision to print usage when an error is thrown is not
one of those good decisions; it spams output unnecessarily.

And holy cow do we have a lot of commmands.

Anyways, add `SilenceUsage` to all of them.