### PR TITLE
mantle/*: Use errors.Wrapf() in more places

### DIFF
--- a/mantle/cmd/kola/spawn.go
+++ b/mantle/cmd/kola/spawn.go
@@ -101,7 +101,7 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 	if spawnUserData != "" {
 		userbytes, err := ioutil.ReadFile(spawnUserData)
 		if err != nil {
-			return fmt.Errorf("Reading userdata failed: %v", err)
+			return errors.Wrapf(err, "Reading userdata failed")
 		}
 		userdata = conf.Unknown(string(userbytes))
 	}
@@ -127,12 +127,12 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 
 	outputDir, err = kola.SetupOutputDir(outputDir, kolaPlatform)
 	if err != nil {
-		return fmt.Errorf("Setup failed: %v", err)
+		return errors.Wrapf(err, "Setup failed")
 	}
 
 	flight, err := kola.NewFlight(kolaPlatform)
 	if err != nil {
-		return fmt.Errorf("Flight failed: %v", err)
+		return errors.Wrapf(err, "Flight failed")
 	}
 	if spawnRemove {
 		defer flight.Destroy()
@@ -143,7 +143,7 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 		AllowFailedUnits: true,
 	})
 	if err != nil {
-		return fmt.Errorf("Cluster failed: %v", err)
+		return errors.Wrapf(err, "Cluster failed")
 	}
 
 	if spawnRemove {
@@ -173,12 +173,12 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 			if spawnMachineOptions != "" {
 				b, err := ioutil.ReadFile(spawnMachineOptions)
 				if err != nil {
-					return fmt.Errorf("Could not read machine options: %v", err)
+					return errors.Wrapf(err, "Could not read machine options")
 				}
 
 				err = json.Unmarshal(b, &machineOpts)
 				if err != nil {
-					return fmt.Errorf("Could not unmarshal machine options: %v", err)
+					return errors.Wrapf(err, "Could not unmarshal machine options")
 				}
 			}
 
@@ -192,7 +192,7 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 			mach, err = cluster.NewMachine(userdata)
 		}
 		if err != nil {
-			return fmt.Errorf("Spawning instance failed: %v", err)
+			return errors.Wrapf(err, "Spawning instance failed")
 		}
 
 		if spawnVerbose {
@@ -211,7 +211,7 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 		if spawnRemove {
 			reader := strings.NewReader(`PS1="\[\033[0;31m\][bound]\[\033[0m\] $PS1"` + "\n")
 			if err := platform.InstallFile(reader, someMach, "/etc/profile.d/kola-spawn-bound.sh"); err != nil {
-				return fmt.Errorf("Setting shell prompt failed: %v", err)
+				return errors.Wrapf(err, "Setting shell prompt failed")
 			}
 		}
 		for {

--- a/mantle/harness/suite.go
+++ b/mantle/harness/suite.go
@@ -16,7 +16,6 @@
 package harness
 
 import (
-	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -29,6 +28,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/pkg/errors"
 
 	"github.com/coreos/mantle/harness/reporters"
 	"github.com/coreos/mantle/harness/testresult"
@@ -247,7 +248,7 @@ func (s *Suite) Run() (err error) {
 		}
 		defer f.Close()
 		if err := pprof.StartCPUProfile(f); err != nil {
-			return fmt.Errorf("harness: can't start cpu profile: %v", err)
+			return errors.Wrapf(err, "harness: can't start cpu profile")
 		}
 		defer pprof.StopCPUProfile() // flushes profile to disk
 	}
@@ -258,7 +259,7 @@ func (s *Suite) Run() (err error) {
 		}
 		defer f.Close()
 		if err := trace.Start(f); err != nil {
-			return fmt.Errorf("harness: can't start tacing: %v", err)
+			return errors.Wrapf(err, "harness: can't start tacing")
 		}
 		defer trace.Stop() // flushes trace to disk
 	}

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -450,18 +450,18 @@ func getClusterSemver(flight platform.Flight, outputDir string) (*semver.Version
 		OutputDir: testDir,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("creating cluster for semver check: %v", err)
+		return nil, errors.Wrapf(err, "creating cluster for semver check")
 	}
 	defer cluster.Destroy()
 
 	m, err := cluster.NewMachine(nil)
 	if err != nil {
-		return nil, fmt.Errorf("creating new machine for semver check: %v", err)
+		return nil, errors.Wrapf(err, "creating new machine for semver check")
 	}
 
 	out, stderr, err := m.SSH("grep ^VERSION_ID= /etc/os-release")
 	if err != nil {
-		return nil, fmt.Errorf("parsing /etc/os-release: %v: %s", err, stderr)
+		return nil, errors.Wrapf(err, "parsing /etc/os-release: %s", stderr)
 	}
 	ver := strings.Split(string(out), "=")[1]
 
@@ -479,7 +479,7 @@ func getClusterSemver(flight platform.Flight, outputDir string) (*semver.Version
 func parseCLVersion(input string) (*semver.Version, error) {
 	version, err := semver.NewVersion(input)
 	if err != nil {
-		return nil, fmt.Errorf("parsing os-release semver: %v", err)
+		return nil, errors.Wrapf(err, "parsing os-release semver")
 	}
 
 	return version, nil

--- a/mantle/platform/journal.go
+++ b/mantle/platform/journal.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 
 	"github.com/coreos/pkg/multierror"
+	"github.com/pkg/errors"
 
 	"github.com/coreos/mantle/network/journal"
 	"github.com/coreos/mantle/util"
@@ -117,7 +118,7 @@ func (j *Journal) Start(ctx context.Context, m Machine, oldBootId string) error 
 	// Retry for a while because this should be run before CheckMachine
 	if err := util.Retry(sshRetries, sshTimeout, start); err != nil {
 		cancel()
-		return fmt.Errorf("ssh journalctl failed: %v", err)
+		return errors.Wrapf(err, "ssh journalctl failed")
 	}
 
 	j.cancel = cancel
@@ -128,7 +129,7 @@ func (j *Journal) Start(ctx context.Context, m Machine, oldBootId string) error 
 func (j *Journal) Read() ([]byte, error) {
 	f, err := os.Open(j.journalPath)
 	if err != nil {
-		return nil, fmt.Errorf("reading journal: %v", err)
+		return nil, errors.Wrapf(err, "reading journal")
 	}
 	defer f.Close()
 	return ioutil.ReadAll(f)

--- a/mantle/platform/machine/azure/flight.go
+++ b/mantle/platform/machine/azure/flight.go
@@ -15,10 +15,9 @@
 package azure
 
 import (
-	"fmt"
-
 	ctplatform "github.com/coreos/container-linux-config-transpiler/config/platform"
 	"github.com/coreos/pkg/capnslog"
+	"github.com/pkg/errors"
 
 	"github.com/coreos/mantle/platform"
 	"github.com/coreos/mantle/platform/api/azure"
@@ -48,7 +47,7 @@ func NewFlight(opts *azure.Options) (platform.Flight, error) {
 	}
 
 	if err = api.SetupClients(); err != nil {
-		return nil, fmt.Errorf("setting up clients: %v", err)
+		return nil, errors.Wrapf(err, "setting up clients")
 	}
 
 	bf, err := platform.NewBaseFlight(opts.Options, Platform, ctplatform.Azure)

--- a/mantle/platform/machine/esx/machine.go
+++ b/mantle/platform/machine/esx/machine.go
@@ -15,7 +15,6 @@
 package esx
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"time"
@@ -24,6 +23,7 @@ import (
 
 	"github.com/coreos/mantle/platform"
 	"github.com/coreos/mantle/platform/api/esx"
+	"github.com/pkg/errors"
 )
 
 type machine struct {
@@ -109,7 +109,7 @@ func (em *machine) saveConsole() error {
 	defer f.Close()
 	_, err = f.WriteString(em.console)
 	if err != nil {
-		return fmt.Errorf("failed writing console to file: %v", err)
+		return errors.Wrapf(err, "failed writing console to file")
 	}
 
 	return nil

--- a/mantle/platform/platform.go
+++ b/mantle/platform/platform.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/coreos/pkg/capnslog"
+	"github.com/pkg/errors"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/net/context"
 
@@ -218,13 +219,13 @@ func TransferFile(src Machine, srcPath string, dst Machine, dstPath string) erro
 func ReadFile(m Machine, path string) (io.ReadCloser, error) {
 	client, err := m.SSHClient()
 	if err != nil {
-		return nil, fmt.Errorf("failed creating SSH client: %v", err)
+		return nil, errors.Wrapf(err, "failed creating SSH client")
 	}
 
 	session, err := client.NewSession()
 	if err != nil {
 		client.Close()
-		return nil, fmt.Errorf("failed creating SSH session: %v", err)
+		return nil, errors.Wrapf(err, "failed creating SSH session")
 	}
 
 	// connect session stdout
@@ -262,14 +263,14 @@ func InstallFile(in io.Reader, m Machine, to string) error {
 
 	client, err := m.SSHClient()
 	if err != nil {
-		return fmt.Errorf("failed creating SSH client: %v", err)
+		return errors.Wrapf(err, "failed creating SSH client")
 	}
 
 	defer client.Close()
 
 	session, err := client.NewSession()
 	if err != nil {
-		return fmt.Errorf("failed creating SSH session: %v", err)
+		return errors.Wrapf(err, "failed creating SSH session")
 	}
 
 	defer session.Close()
@@ -349,7 +350,7 @@ func CheckMachine(ctx context.Context, m Machine) error {
 	}
 
 	if err := util.Retry(sshRetries, sshTimeout, sshChecker); err != nil {
-		return fmt.Errorf("ssh unreachable: %v", err)
+		return errors.Wrapf(err, "ssh unreachable")
 	}
 
 	out, stderr, err := m.SSH(`. /etc/os-release && echo "$ID-$VARIANT_ID"`)


### PR DESCRIPTION
It's better since it avoids e.g. accidentally forgetting the `%v`
at the end and allows accessing the underlying error.

By porting some of the existing code we increase the likelihood
that people use it in new code.