### PR TITLE
libguestfish.sh: actually use --ro for read-only runs

### DIFF
--- a/src/libguestfish.sh
+++ b/src/libguestfish.sh
@@ -56,6 +56,7 @@ coreos_gf_run_mount() {
     if [ "$1" = ro ]; then
         mntarg=mount-ro
         shift
+        set -- "$@" --ro
     fi
     coreos_gf_run "$@"
     # Detect the RHCOS LUKS case; first check if there's


### PR DESCRIPTION
We were using `mount-ro`, but weren't passing `--ro` to guestfish
itself, so it would still try to reopen all disk images passed to it as
rw. This will fail of course if the image file is read-only.