### PR TITLE
Revert "libguestfish.sh: actually use --ro for read-only runs"

### DIFF
--- a/src/libguestfish.sh
+++ b/src/libguestfish.sh
@@ -56,7 +56,6 @@ coreos_gf_run_mount() {
     if [ "$1" = ro ]; then
         mntarg=mount-ro
         shift
-        set -- "$@" --ro
     fi
     coreos_gf_run "$@"
     # Detect the RHCOS LUKS case; first check if there's


### PR DESCRIPTION
This reverts commit 42e429332448c0ca364bb00a4892bf8b50136062.
It's causing at least one of our images (aws) to not get the
right platform.id set in the BLS configs that grub sources.
This means AWS doesn't look in the right place for the user-data
and no ignition config gets applied.