### PR TITLE
kola: Use by-partlabel for mount tests except on s390x

### DIFF
--- a/mantle/util/common.go
+++ b/mantle/util/common.go
@@ -52,6 +52,10 @@ func BoolToPtr(b bool) *bool {
 	return &b
 }
 
+func IntToPtr(i int) *int {
+	return &i
+}
+
 func PathExists(path string) (bool, error) {
 	_, err := os.Stat(path)
 	if err != nil {


### PR DESCRIPTION
Revert to using by-partlabel for non s390x arches since that is the supported method. Required a bit
of refactoring to achieve this. This would probably also help mitigate https://bugzilla.redhat.com/show_bug.cgi?id=1812233
as we started seeing more failures with not being able to find the device after moving to partuuid.