### PR TITLE
kola: Use --cosa-build for Ignition version inference automatically

### DIFF
--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -223,7 +223,9 @@ func syncCosaOptions() error {
 	}
 
 	if kola.Options.IgnitionVersion == "" {
-		if kola.QEMUOptions.DiskImage != "" {
+		if kola.CosaBuild != nil {
+			kola.Options.IgnitionVersion = sdk.TargetIgnitionVersion(kola.CosaBuild)
+		} else if kola.QEMUOptions.DiskImage != "" {
 			kola.Options.IgnitionVersion = sdk.TargetIgnitionVersionFromName(kola.QEMUOptions.DiskImage)
 		}
 	}

--- a/mantle/sdk/ignversion.go
+++ b/mantle/sdk/ignversion.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+
+	"github.com/coreos/mantle/cosa"
 )
 
 // TargetIgnitionVersionFromName returns the Ignition spec version that should
@@ -36,4 +38,14 @@ func TargetIgnitionVersionFromName(artifact string) string {
 		}
 	}
 	return "v3"
+}
+
+func TargetIgnitionVersion(build *cosa.Build) string {
+	// Most cosa builds should have an "ostree"
+	for _, n := range []string{build.BuildArtifacts.Ostree.Path, build.BuildArtifacts.Qemu.Path, build.BuildArtifacts.Metal.Path} {
+		if n != "" {
+			return TargetIgnitionVersionFromName(n)
+		}
+	}
+	panic("TargetIgnitionVersion couldn't find artifact")
 }

--- a/src/cmd-kola
+++ b/src/cmd-kola
@@ -75,11 +75,6 @@ if not any([x in unknown_args for x in ["-b", "--distro"]]):
         kolaargs.extend(['-b', 'fcos'])
 
 print(f"qemu path: {qemupath}")
-ignition_version = cmdlib.disk_ignition_version(qemupath)
-print(f"Using ignition version {ignition_version}")
-
-if ignition_version == "2.2.0":
-    kolaargs.extend(["--ignition-version", "v2"])
 
 if os.getuid() != 0 and not ('-p' in unknown_args):
     kolaargs.extend(['-p', 'qemu-unpriv'])


### PR DESCRIPTION
This drains more code from assembler into mantle.