### PR TITLE
Allow having only an overrides lockfile

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -182,14 +182,13 @@ EOF
 prepare_git_artifacts "${configdir_gitrepo}" "${PWD}/coreos-assembler-config.tar.gz" "${PWD}/coreos-assembler-config-git.json"
 
 lock_arg=
-if [ -f "${manifest_lock}" ]; then
-    lock_arg="--ex-lockfile=${manifest_lock}"
-    echo -n "Building from lockfile ${manifest_lock}"
-    if [ -f "${manifest_lock_overrides}" ]; then
-        lock_arg="${lock_arg} --ex-lockfile=${manifest_lock_overrides}"
-        echo -n " and overrides ${manifest_lock_overrides}"
+for lock in "${manifest_lock}" "${manifest_lock_overrides}"; do
+    if [ -f "${lock}" ]; then
+        lock_arg+=" --ex-lockfile=${lock}"
+        echo "Building from lockfile: ${manifest_lock}"
     fi
-    echo
+done
+if [ -n "${lock_arg}" ]; then
     sleep 1
 fi
 

--- a/src/cmd-fetch
+++ b/src/cmd-fetch
@@ -69,15 +69,16 @@ if [ -n "${UPDATE_LOCKFILE}" ]; then
         echo "NB: ignoring overrides ${manifest_lock_overrides}"
         sleep 1
     fi
-elif [ -f "${manifest_lock}" ]; then
-    args="--ex-lockfile=${manifest_lock}"
-    echo -n "Fetching RPMs from lockfile ${manifest_lock}"
-    if [ -f "${manifest_lock_overrides}" ]; then
-        args="${args} --ex-lockfile=${manifest_lock_overrides}"
-        echo -n " and overrides ${manifest_lock_overrides}"
+else
+    for lock in "${manifest_lock}" "${manifest_lock_overrides}"; do
+        if [ -f "${lock}" ]; then
+            args+=" --ex-lockfile=${lock}"
+            echo "Fetching RPMs from lockfile: ${manifest_lock}"
+        fi
+    done
+    if [ -n "${args}" ]; then
+        sleep 1
     fi
-    echo
-    sleep 1
 fi
 
 if [ -n "${DRY_RUN}" ]; then


### PR DESCRIPTION
Right now, we ignore the override lockfile if a base lockfile isn't
present. This mostly works, but it prevents the case of bodhi-updates
where we want to override only some packages but leave the "base"
unlocked.

Tweak things so that both the base and override lockfiles can be used
independently.