### PR TITLE
cmd-run: print kola qemuexec command before running

### DIFF
--- a/src/cmd-run
+++ b/src/cmd-run
@@ -274,4 +274,5 @@ case "${IMAGE_TYPE}" in
     *) kola_args+=('--inject-ignition');;
 esac
 
+set -x
 exec kola qemuexec -U --qemu-image "${VM_DISK}" --ignition "${IGNITION_CONFIG_FILE}" --memory "${VM_MEMORY}" "${kola_args[@]}" -- "$@"


### PR DESCRIPTION
This helps debugging when trying to figure out what `cosa run` is
actually doing, and if one wants to drop down to `kola qemuexec`
directly.