### PR TITLE
Move distribution detection into mantle

### DIFF
--- a/mantle/sdk/distros.go
+++ b/mantle/sdk/distros.go
@@ -47,3 +47,26 @@ func TargetIgnitionVersion(build *cosa.Build) string {
 	// Most cosa builds should have an "ostree"
 	return TargetIgnitionVersionFromName(build.BuildArtifacts.Ostree.Path)
 }
+
+// TargetDistroFromName returns the distribution given
+// the path to an artifact (usually a disk image).
+func TargetDistroFromName(artifact string) string {
+	basename := filepath.Base(artifact)
+	if strings.HasPrefix(basename, "rhcos-") {
+		return "rhcos"
+	}
+	// For now, just assume fcos
+	return "fcos"
+}
+
+// TargetDistro returns the distribution of a cosa build
+func TargetDistro(build *cosa.Build) (string, error) {
+	switch build.Name {
+	case "rhcos":
+		return "rhcos", nil
+	case "fedora-coreos":
+		return "fcos", nil
+	default:
+		return "", fmt.Errorf("Unknown distribution: %s", build.Name)
+	}
+}

--- a/src/cmd-kola
+++ b/src/cmd-kola
@@ -68,12 +68,6 @@ qemupath = os.path.join(builddir, qemuimg['path'])
 # https://github.com/coreos/coreos-assembler/pull/85
 kolaargs = ['kola']
 bn = os.path.basename(qemupath)
-if not any([x in unknown_args for x in ["-b", "--distro"]]):
-    if bn.startswith("rhcos-"):
-        kolaargs.extend(['-b', 'rhcos'])
-    else:
-        kolaargs.extend(['-b', 'fcos'])
-
 print(f"qemu path: {qemupath}")
 
 if os.getuid() != 0 and not ('-p' in unknown_args):


### PR DESCRIPTION
This way `cosa kola` thins out even more; helps running
`kola` directly and will also be useful for tests.