### PR TITLE
mantle/kola: allow invalid meta.json as a user option

### DIFF
--- a/mantle/cosa/schema.go
+++ b/mantle/cosa/schema.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"strings"
 
 	"github.com/pkg/errors"
 
@@ -19,6 +20,9 @@ var (
 
 func init() {
 	runtimeSchemaPath := os.Getenv("COSA_META_SCHEMA")
+	if strings.ToLower(runtimeSchemaPath) == "none" {
+		return
+	}
 	if runtimeSchemaPath != "" {
 		f, err := os.Open(runtimeSchemaPath)
 		if err != nil {


### PR DESCRIPTION
In PR #1225, the schema was enforced by default, changing the behavior
in the handling of meta.json. To make the developer UX a little better,
this option allows for invalid meta.json to be consumed. By default, the
schema is still enforced.

Example:
       ` kola --cosa-build meta.json --enforce-schema=false ...`