### PR TITLE
cmd-{build,fetch}: fix log message referencing wrong lockfile

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -185,7 +185,7 @@ lock_arg=
 for lock in "${manifest_lock}" "${manifest_lock_overrides}"; do
     if [ -f "${lock}" ]; then
         lock_arg+=" --ex-lockfile=${lock}"
-        echo "Building from lockfile: ${manifest_lock}"
+        echo "Building from lockfile: ${lock}"
     fi
 done
 if [ -n "${lock_arg}" ]; then

--- a/src/cmd-fetch
+++ b/src/cmd-fetch
@@ -73,7 +73,7 @@ else
     for lock in "${manifest_lock}" "${manifest_lock_overrides}"; do
         if [ -f "${lock}" ]; then
             args+=" --ex-lockfile=${lock}"
-            echo "Fetching RPMs from lockfile: ${manifest_lock}"
+            echo "Fetching RPMs from lockfile: ${lock}"
         fi
     done
     if [ -n "${args}" ]; then


### PR DESCRIPTION
Minor follow-up to #1233.