### PR TITLE
schema: add metal4k to the schema

### DIFF
--- a/src/schema/v1.json
+++ b/src/schema/v1.json
@@ -314,6 +314,7 @@
        "live-initramfs",
        "live-iso",
        "metal",
+       "metal4k",
        "openstack",
        "qemu",
        "vmware"
@@ -347,6 +348,12 @@
          "$id":"#/properties/images/properties/metal",
          "type":"object",
          "title":"Metal",
+         "$ref": "#/definitions/artifact"
+        },
+       "metal4k": {
+         "$id":"#/properties/images/properties/metal4k",
+         "type":"object",
+         "title":"Metal (4K native)",
          "$ref": "#/definitions/artifact"
         },
        "iso": {


### PR DESCRIPTION
Now that metal4k is supported, add it to the schema

(Also noticed tests failing when metal4k image is present as it was missing from the schema)