### PR TITLE
mantle/build: explicitly specify schematyper binary name

### DIFF
--- a/mantle/build
+++ b/mantle/build
@@ -19,10 +19,9 @@ schema_generate() {
     mkdir -p ${GOBIN}
     if [ ! -x "${GOBIN}/schematyper" ]; then
         (
-            mkdir -p ${GOBIN}
             echo "Building schematyper"
             cd schematyper &&
-                go build -mod vendor -o "${GOBIN}" .
+                go build -mod vendor -o "${GOBIN}/schematyper" .
         )
     fi
 


### PR DESCRIPTION
My pet container is currently based on F30 (yeah, I know...) and only
has `golang` 1.12 available.  When trying to `mantle/build ore`, the
build failed because the binary name was missing.

Adding the name of the binary to the parameters of `go build` fixed it
for me.  And `golang` 1.13 doesn't seem to mind the change, either.