### PR TITLE
mantle/system: Add RpmArch API

### DIFF
--- a/mantle/system/arch.go
+++ b/mantle/system/arch.go
@@ -15,8 +15,26 @@
 package system
 
 import (
+	"fmt"
 	"runtime"
 )
+
+// RpmArch returns the architecture in RPM terms.
+func RpmArch() string {
+	goarch := runtime.GOARCH
+	switch goarch {
+	case "amd64":
+		return "x86_64"
+	case "arm64":
+		return "aarch64"
+	case "ppc64":
+		return "ppc64le"
+	case "s390x":
+		return "s390x"
+	default:
+		panic(fmt.Sprintf("RpmArch: No mapping defined for GOARCH %s", goarch))
+	}
+}
 
 func PortageArch() string {
 	arch := runtime.GOARCH


### PR DESCRIPTION
A lot of our code uses the portage architecture, which no longer
makes sense.  Now, the more correct code for this is part of
rpm-ostree but I'm not sure we want to go to forking off that yet.
Since the build system only supports this set of architectures
currently, let's just inline the Go -> RPM translation here.