### PR TITLE
 mantle: Rework various bits to use new RpmArch() API

### DIFF
--- a/mantle/cmd/kola/kola.go
+++ b/mantle/cmd/kola/kola.go
@@ -275,7 +275,6 @@ func writeProps() error {
 		Platform:        kolaPlatform,
 		Distro:          kola.Options.Distribution,
 		IgnitionVersion: kola.Options.IgnitionVersion,
-		Board:           kola.QEMUOptions.Board,
 		OSContainer:     kola.Options.OSContainer,
 		AWS: AWS{
 			Region:       kola.AWSOptions.Region,

--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -30,7 +30,6 @@ import (
 var (
 	outputDir                   string
 	kolaPlatform                string
-	defaultTargetBoard          = sdk.DefaultBoard()
 	kolaArchitectures           = []string{"amd64"}
 	kolaPlatforms               = []string{"aws", "azure", "do", "esx", "gce", "openstack", "packet", "qemu", "qemu-unpriv"}
 	kolaDistros                 = []string{"fcos", "rhcos"}
@@ -133,7 +132,6 @@ func init() {
 	sv(&kola.PacketOptions.StorageURL, "packet-storage-url", "gs://users.developer.core-os.net/"+os.Getenv("USER")+"/mantle", "Google Storage base URL for temporary uploads")
 
 	// QEMU-specific options
-	sv(&kola.QEMUOptions.Board, "board", defaultTargetBoard, "target board")
 	sv(&kola.QEMUOptions.Firmware, "qemu-firmware", "bios", "Boot firmware: bios,uefi,uefi-secure")
 	sv(&kola.QEMUOptions.DiskImage, "qemu-image", "", "path to CoreOS disk image")
 	sv(&kola.QEMUOptions.DiskSize, "qemu-size", "", "Resize target disk via qemu-img resize [+]SIZE")

--- a/mantle/cmd/kola/qemuexec.go
+++ b/mantle/cmd/kola/qemuexec.go
@@ -57,7 +57,7 @@ func init() {
 func runQemuExec(cmd *cobra.Command, args []string) error {
 	var err error
 
-	builder := platform.NewBuilder(kola.QEMUOptions.Board, ignition, forceConfigInjection)
+	builder := platform.NewBuilder(ignition, forceConfigInjection)
 	if len(knetargs) > 0 {
 		builder.IgnitionNetworkKargs = knetargs
 	}

--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -84,7 +84,6 @@ func runTestIso(cmd *cobra.Command, args []string) error {
 		CosaBuildDir: kola.Options.CosaBuild,
 		CosaBuild:    kola.CosaBuild,
 
-		Board:    kola.QEMUOptions.Board,
 		Firmware: kola.QEMUOptions.Firmware,
 	}
 

--- a/mantle/kola/tests/ignition/mount.go
+++ b/mantle/kola/tests/ignition/mount.go
@@ -21,12 +21,12 @@ import (
 
 	ignconverter "github.com/coreos/ign-converter"
 	ignv3types "github.com/coreos/ignition/v2/config/v3_0/types"
-	"github.com/coreos/mantle/kola"
 	"github.com/coreos/mantle/kola/cluster"
 	"github.com/coreos/mantle/kola/register"
 	"github.com/coreos/mantle/platform"
 	"github.com/coreos/mantle/platform/conf"
 	"github.com/coreos/mantle/platform/machine/unprivqemu"
+	"github.com/coreos/mantle/system"
 	"github.com/coreos/mantle/util"
 )
 
@@ -181,7 +181,7 @@ func createClusterValidate(c cluster.TestCluster, options platform.MachineOption
 func setupIgnitionConfig() {
 	containerpartdeviceid := "by-partlabel/CONTR"
 	logpartdeviceid := "by-partlabel/LOG"
-	if kola.QEMUOptions.Board == "s390x-usr" {
+	if system.RpmArch() == "s390x" {
 		containerpartdeviceid = "by-partuuid/63194b49-e4b7-43f9-9a8b-df0fd8279bb7"
 		logpartdeviceid = "by-partuuid/6385b84e-2c7b-4488-a870-667c565e01a8"
 	}

--- a/mantle/platform/machine/unprivqemu/cluster.go
+++ b/mantle/platform/machine/unprivqemu/cluster.go
@@ -87,8 +87,7 @@ func (qc *Cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 		consolePath: filepath.Join(dir, "console.txt"),
 	}
 
-	board := qc.flight.opts.Board
-	builder := platform.NewBuilder(board, confPath, false)
+	builder := platform.NewBuilder(confPath, false)
 	defer builder.Close()
 	builder.Uuid = qm.id
 	builder.Firmware = qc.flight.opts.Firmware


### PR DESCRIPTION

Fedora/RHEL are *defined* to be self hosting; which means
cross compliation is not at all the default.  See also
https://blog.verbum.org/2012/10/13/building-everything-from-source-vs-self-hosting/

The mantle code was just using Portage architecture because
of CL; unifying on the RPM architecture names as are already used
by cosa will help consolidate things.

Further, we don't need to pass a "Board" all the way down
the stack; since we don't support cross compliation there's no
reason not to just call the new global API to get it.

