### PR TITLE
Teach mantle/kola how to automatically find cosa builds

### DIFF
--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -174,15 +174,32 @@ func syncOptionsImpl(useCosa bool) error {
 		return err
 	}
 
-	if kola.Options.CosaBuild != "" {
+	foundCosa := false
+	if kola.Options.CosaBuild == "" {
+		isroot, err := sdk.IsCosaRoot(".")
+		if err != nil {
+			return err
+		}
+		if isroot {
+			localbuild, err := sdk.GetLatestLocalBuild()
+			if err != nil {
+				return err
+			}
+
+			kola.Options.CosaBuild = filepath.Join(localbuild.Dir, "meta.json")
+			kola.CosaBuild = localbuild.Meta
+			foundCosa = true
+		}
+	} else {
 		kola.CosaBuild, err = cosa.ParseBuild(kola.Options.CosaBuild)
 		if err != nil {
 			return err
 		}
-		if useCosa {
-			if err := syncCosaOptions(); err != nil {
-				return err
-			}
+		foundCosa = true
+	}
+	if foundCosa && useCosa {
+		if err := syncCosaOptions(); err != nil {
+			return err
 		}
 	}
 

--- a/src/cmd-kola
+++ b/src/cmd-kola
@@ -2,7 +2,6 @@
 
 import argparse
 import subprocess
-import json
 import os
 import sys
 import shutil
@@ -17,7 +16,6 @@ cosa_dir = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, cosa_dir)
 
 from cosalib import cmdlib
-from cosalib.builds import Builds
 
 basearch = cmdlib.get_basearch()
 
@@ -38,14 +36,6 @@ else:
     default_cmd = 'run'
     default_output_dir = "tmp/kola"
 
-builds = Builds()
-if args.build is None:
-    args.build = builds.get_latest()
-builddir = builds.get_build_dir(args.build)
-buildmeta_path = os.path.join(builddir, "meta.json")
-with open(buildmeta_path) as f:
-    buildmeta = json.load(f)
-
 # automatically add blacklisted tests specified in the src config
 blacklist_args = []
 blacklist_path = "src/config/kola-blacklist.yaml"
@@ -59,22 +49,13 @@ if os.path.isfile(blacklist_path):
                 print(f"⚠️  {obj['tracker']}")
                 blacklist_args += ['--blacklist-test', obj['pattern']]
 
-qemuimg = buildmeta['images'].get('qemu')
-if qemuimg is None:
-    raise SystemExit(f"No qemu image in build: {args.build}")
-qemupath = os.path.join(builddir, qemuimg['path'])
-
 # XXX: teach to kola to auto-detect based on prefix; see discussions in
 # https://github.com/coreos/coreos-assembler/pull/85
 kolaargs = ['kola']
-bn = os.path.basename(qemupath)
-print(f"qemu path: {qemupath}")
 
 if os.getuid() != 0 and not ('-p' in unknown_args):
     kolaargs.extend(['-p', 'qemu-unpriv'])
 
-# shellcheck disable=SC2086
-kolaargs.extend(['--cosa-build', buildmeta_path])
 outputdir = args.output_dir or default_output_dir
 kolaargs.extend(['--output-dir', outputdir])
 subargs = args.subargs or [default_cmd]


### PR DESCRIPTION
The current `mantle/cosa` directory is a bit circular, we
basically have `cosa/mantle/cosa` then.  It made sense before
the projects were merged but less so now I think.

Second, the `mantle/cosa/builds.go` is really about the `meta.json`
file but we also need the *directory* for a build.  What's
going on in kola is quite weird because we basically need
to keep around the pair of (directory, parsed meta).

Enhance the `mantle/sdk` to learn about a `LocalBuild` struct
and teach kola how to use it to synthesize the other two if
`.` looks like a coreos-assembler root.

This drains more logic from `cmd-kola` in cosa, trending
towards removing it!
