### PR TITLE
kola/fcos.users.shells: work-around root user NSS bug

### DIFF
--- a/mantle/kola/tests/misc/users.go
+++ b/mantle/kola/tests/misc/users.go
@@ -36,7 +36,6 @@ func CheckUserShells(c cluster.TestCluster) {
 	var badusers []string
 
 	ValidUsers := map[string]string{
-		"root":                 "/bin/bash",
 		"sync":                 "/bin/sync",
 		"shutdown":             "/sbin/shutdown",
 		"halt":                 "/sbin/halt",
@@ -58,7 +57,12 @@ func CheckUserShells(c cluster.TestCluster) {
 
 		username := userdata[0]
 		shell := userdata[6]
-		if shell != ValidUsers[username] && shell != "/sbin/nologin" {
+		if username == "root" {
+			// https://github.com/systemd/systemd/issues/15160
+			if shell != "/bin/bash" && shell != "/bin/sh" {
+				badusers = append(badusers, user)
+			}
+		} else if shell != ValidUsers[username] && shell != "/sbin/nologin" && shell != "/usr/sbin/nologin" {
 			badusers = append(badusers, user)
 		}
 	}


### PR DESCRIPTION
So, Fedora 32 systemd has a new interface for querying user databases so
that e.g. `getent passwd` can show dynamic users. Interestingly, this is
implemented via varlink:

https://systemd.io/USER_GROUP_API/

Anyway, there seems to be a bug right now where the `root` user shows up
twice:

https://github.com/systemd/systemd/issues/15160

And this is throwing off this test. Work around this.

While initially looking into this, I was tempted to just rip out this
test. Though it *did* catch a legitimate bug and in the process raised
awareness to an important change (I'm actually surprised this isn't
mentioned in https://fedoraproject.org/wiki/Releases/32/ChangeSet).