### PR TITLE
grub: extend boot prompt timeout to 5 seconds

### DIFF
--- a/src/grub.cfg
+++ b/src/grub.cfg
@@ -33,11 +33,11 @@ terminal_input serial console
 terminal_output serial console
 if [ x$feature_timeout_style = xy ] ; then
   set timeout_style=menu
-  set timeout=1
+  set timeout=5
 # Fallback normal timeout code in case the timeout_style feature is
 # unavailable.
 else
-  set timeout=1
+  set timeout=5
 fi
 
 # Determine if this is a first boot and set the ${ignition_firstboot} variable


### PR DESCRIPTION
At 1 second it's almost impossible to catch the boot prompt if you need
to change the kernel command line parameters. Let's extend it to 5
seconds so users have a fighting chance to catch the prompt.

This follows from a similar change made to the Live ISO:
https://github.com/coreos/fedora-coreos-config/pull/281