### PR TITLE
metal/testiso: Also support installs via `coreos-installer iso embed`

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -50,7 +50,7 @@ pod(image: 'registry.fedoraproject.org/fedora:31', runAsUser: 0, kvm: true, memo
       }
 
       stage("Image tests") {
-        cosa_cmd("kola testiso -S")
+        shwrap("cd /srv && env TMPDIR=\$(pwd)/tmp/ cosa kola testiso -S")
       }
 
       // Needs to be last because it's destructive

--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -55,6 +55,8 @@ var (
 	legacy bool
 	nolive bool
 	nopxe  bool
+
+	console bool
 )
 
 var signalCompletionUnit = `[Unit]
@@ -73,6 +75,7 @@ func init() {
 	cmdTestIso.Flags().BoolVarP(&legacy, "legacy", "K", false, "Test legacy installer")
 	cmdTestIso.Flags().BoolVarP(&nolive, "no-live", "L", false, "Skip testing live installer (PXE and ISO)")
 	cmdTestIso.Flags().BoolVarP(&nopxe, "no-pxe", "P", false, "Skip testing live installer PXE")
+	cmdTestIso.Flags().BoolVar(&console, "console", false, "Display qemu console to stdout")
 
 	root.AddCommand(cmdTestIso)
 }
@@ -86,6 +89,7 @@ func runTestIso(cmd *cobra.Command, args []string) error {
 		CosaBuildDir: kola.Options.CosaBuild,
 		CosaBuild:    kola.CosaBuild,
 
+		Console:  console,
 		Firmware: kola.QEMUOptions.Firmware,
 	}
 

--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -519,6 +519,12 @@ func (builder *QemuBuilder) AddDisk(disk *Disk) error {
 	return builder.addDiskImpl(disk, false)
 }
 
+// AddInstallIso adds an ISO image, configuring to boot from it once
+func (builder *QemuBuilder) AddInstallIso(path string) error {
+	builder.Append("-boot", "once=d", "-cdrom", path)
+	return nil
+}
+
 func (builder *QemuBuilder) finalize() {
 	if builder.finalized {
 		return


### PR DESCRIPTION


Confusingly, the `testiso` command was (is) actually testing PXE installs.
It still does, but now the `platform/metal` infrastructure has a new
API to do an install via an ISO (scripting embedding an Ignition
config with `coreos-installer iso embed`).