### PR TITLE
buildextend-installer: Remove unnecessary kargs exclusions

### DIFF
--- a/src/cmd-buildextend-installer
+++ b/src/cmd-buildextend-installer
@@ -35,9 +35,6 @@ live_exclude_kargs = set([
     'console',               # no serial console by default on ISO
     'ignition.platform.id',  # we hardcode "metal"
     'ostree',                # dracut finds the tree automatically
-    'root',                  # we use root.squashfs
-    'rootflags',             # not needed
-    'rw',                    # we have a read-only root
 ])
 
 # Parse args and dispatch


### PR DESCRIPTION
I was looking at this to figure out why `console` was omitted,
and noticed we could trim some cruft here.  We no longer use
`root` or `rootflags` etc. since we reworked rootfs discovery
in https://github.com/coreos/fedora-coreos-config/pull/187
etc.