### PR TITLE
 Drain autologin bits into mantle

### DIFF
--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -186,6 +186,10 @@ func syncOptionsImpl(useCosa bool) error {
 		}
 	}
 
+	if kola.Options.IgnitionVersion == "" && kola.QEMUOptions.DiskImage != "" {
+		kola.Options.IgnitionVersion = sdk.TargetIgnitionVersionFromName(kola.QEMUOptions.DiskImage)
+	}
+
 	units, _ := root.PersistentFlags().GetStringSlice("debug-systemd-units")
 	for _, unit := range units {
 		kola.Options.SystemdDropins = append(kola.Options.SystemdDropins, platform.SystemdDropin{
@@ -234,8 +238,6 @@ func syncCosaOptions() error {
 	if kola.Options.IgnitionVersion == "" {
 		if kola.CosaBuild != nil {
 			kola.Options.IgnitionVersion = sdk.TargetIgnitionVersion(kola.CosaBuild)
-		} else if kola.QEMUOptions.DiskImage != "" {
-			kola.Options.IgnitionVersion = sdk.TargetIgnitionVersionFromName(kola.QEMUOptions.DiskImage)
 		}
 	}
 

--- a/mantle/cmd/kola/qemuexec.go
+++ b/mantle/cmd/kola/qemuexec.go
@@ -17,11 +17,19 @@
 package main
 
 import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	ignconverter "github.com/coreos/ign-converter"
+	v3 "github.com/coreos/ignition/v2/config/v3_0"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/coreos/mantle/kola"
 	"github.com/coreos/mantle/platform"
+	"github.com/coreos/mantle/platform/conf"
 )
 
 var (
@@ -41,6 +49,8 @@ var (
 	ignition string
 	knetargs string
 
+	ignitionFragments []string
+
 	forceConfigInjection bool
 )
 
@@ -48,14 +58,91 @@ func init() {
 	root.AddCommand(cmdQemuExec)
 	cmdQemuExec.Flags().StringVarP(&knetargs, "knetargs", "", "", "Arguments for Ignition networking on kernel commandline")
 	cmdQemuExec.Flags().BoolVarP(&usernet, "usernet", "U", false, "Enable usermode networking")
+	cmdQemuExec.Flags().StringSliceVar(&ignitionFragments, "add-ignition", nil, "Append well-known Ignition fragment: [\"autologin\"]")
 	cmdQemuExec.Flags().StringVarP(&hostname, "hostname", "", "", "Set hostname via DHCP")
 	cmdQemuExec.Flags().IntVarP(&memory, "memory", "m", 0, "Memory in MB")
 	cmdQemuExec.Flags().StringVarP(&ignition, "ignition", "i", "", "Path to ignition config")
 	cmdQemuExec.Flags().BoolVarP(&forceConfigInjection, "inject-ignition", "", false, "Force injecting Ignition config using guestfs")
 }
 
+func renderFragments() (string, error) {
+	buf, err := ioutil.ReadFile(ignition)
+	if err != nil {
+		return "", err
+	}
+	config, _, err := v3.Parse(buf)
+	for _, fragtype := range ignitionFragments {
+		switch fragtype {
+		case "autologin":
+			newconf := v3.Merge(config, conf.GetAutologin())
+			config = newconf
+			break
+		default:
+			return "", fmt.Errorf("Unknown fragment: %s", fragtype)
+		}
+	}
+
+	newbuf, err := json.Marshal(config)
+	if err != nil {
+		return "", err
+	}
+	tmpf, err := ioutil.TempFile("", "qemuexec-ign")
+	if err != nil {
+		return "", err
+	}
+	if _, err := tmpf.Write(newbuf); err != nil {
+		return "", err
+	}
+
+	return tmpf.Name(), nil
+}
+
 func runQemuExec(cmd *cobra.Command, args []string) error {
 	var err error
+	cleanupIgnition := false
+	if len(ignitionFragments) > 0 {
+		newconfig, err := renderFragments()
+		if err != nil {
+			return errors.Wrapf(err, "rendering fragments")
+		}
+		ignition = newconfig
+		cleanupIgnition = true
+	}
+	if kola.Options.IgnitionVersion == "v2" {
+		buf, err := ioutil.ReadFile(ignition)
+		if err != nil {
+			return err
+		}
+		config, _, err := v3.Parse(buf)
+		if err != nil {
+			return errors.Wrapf(err, "parsing %s", ignition)
+		}
+		ignc2, err := ignconverter.Translate3to2(config)
+		if err != nil {
+			return err
+		}
+		ignc2buf, err := json.Marshal(ignc2)
+		if err != nil {
+			return err
+		}
+		tmpf, err := ioutil.TempFile("", "qemuexec-ign-conv")
+		if err != nil {
+			return err
+		}
+		if _, err := tmpf.Write(ignc2buf); err != nil {
+			return err
+		}
+		if cleanupIgnition {
+			os.Remove(ignition)
+		}
+		cleanupIgnition = true
+		ignition = tmpf.Name()
+	}
+	defer func() {
+		if cleanupIgnition {
+			os.Remove(ignition)
+		}
+	}()
 
 	builder := platform.NewBuilder(ignition, forceConfigInjection)
 	if len(knetargs) > 0 {

--- a/src/cmd-run
+++ b/src/cmd-run
@@ -183,16 +183,6 @@ EOF
 rowcol=$(stty -a | tr ';' '\n' | grep -e 'rows\|columns' | tr '\n' ' ' )
 rowcol=$(echo "stty ${rowcol}" | base64 --wrap 0)
 
-append_systemd_unit "{
-    \"name\": \"serial-getty@${DEFAULT_TERMINAL}.service\",
-    \"dropins\": [
-        {
-            \"name\": \"autologin-core.conf\",
-            \"contents\": \"[Service]\\nTTYVTDisallocate=no\\nExecStart=\\nExecStart=-/usr/sbin/agetty --autologin ${TARGET_USER} --noclear %I \$TERM\\n\"
-        }
-    ]
-}"
-
 f=$(mktemp)
 cat > "${f}" <<EOF
 {
@@ -279,4 +269,4 @@ case "${IMAGE_TYPE}" in
 esac
 
 set -x
-exec kola qemuexec -U --qemu-image "${VM_DISK}" --ignition "${IGNITION_CONFIG_FILE}" --memory "${VM_MEMORY}" "${kola_args[@]}" -- "$@"
+exec kola qemuexec --add-ignition=autologin -U --qemu-image "${VM_DISK}" --ignition "${IGNITION_CONFIG_FILE}" --memory "${VM_MEMORY}" "${kola_args[@]}" -- "$@"


### PR DESCRIPTION

I want to use this for live ISO testing, since being able to debug
on the console is super useful.

Also, this helps drain `cmd-run` into mantle.

`qemuexec` is slowly becoming something nontrivial...but most
of that mess is the Ignition conversion bits which are duplicated
around.