### PR TITLE
kola: Avoid SEGV if no qemu image

### DIFF
--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -230,7 +230,7 @@ func syncOptions() error {
 func syncCosaOptions() error {
 	switch kolaPlatform {
 	case "qemu-unpriv", "qemu":
-		if kola.QEMUOptions.DiskImage == "" {
+		if kola.QEMUOptions.DiskImage == "" && kola.CosaBuild.BuildArtifacts.Qemu != nil {
 			kola.QEMUOptions.DiskImage = filepath.Join(filepath.Dir(kola.Options.CosaBuild), kola.CosaBuild.BuildArtifacts.Qemu.Path)
 		}
 	}


### PR DESCRIPTION
I did a `cosa run` without a qemu image (had just done a
`cosa build metal`) and it crashed.