### PR TITLE
ci: Run testiso before test_pruning.sh

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -49,13 +49,13 @@ pod(image: 'registry.fedoraproject.org/fedora:31', runAsUser: 0, kvm: true, memo
           }
       }
 
-      stage("More tests") {
-        parallel testiso: {
-          cosa_cmd("kola testiso -S")
-        },
-        clitests: {
-          shwrap("cd /srv && sudo -u builder ${env.WORKSPACE}/tests/test_pruning.sh")
-        }
+      stage("Image tests") {
+        cosa_cmd("kola testiso -S")
+      }
+
+      // Needs to be last because it's destructive
+      stage("CLI/build tests") {
+        shwrap("cd /srv && sudo -u builder ${env.WORKSPACE}/tests/test_pruning.sh")
       }
 }
 


### PR DESCRIPTION
This races because we were doing builds/pruning in
parallel with the testiso command trying to test a build.