### PR TITLE
system/arch: Canonicalize ppc64, ppc64le => ppc64le

### DIFF
--- a/mantle/system/arch.go
+++ b/mantle/system/arch.go
@@ -27,10 +27,8 @@ func RpmArch() string {
 		return "x86_64"
 	case "arm64":
 		return "aarch64"
-	case "ppc64":
-		return "ppc64le"
-	case "s390x":
-		return "s390x"
+	case "ppc64le", "s390x":
+		return goarch
 	default:
 		panic(fmt.Sprintf("RpmArch: No mapping defined for GOARCH %s", goarch))
 	}


### PR DESCRIPTION
The previous code here wasn't right for ppc64.

https://github.com/coreos/coreos-assembler/pull/1257#issuecomment-603259804