### PR TITLE
deps: Allow empty archful deps files

### DIFF
--- a/src/print-dependencies.sh
+++ b/src/print-dependencies.sh
@@ -6,5 +6,8 @@ srcdir="$(cd "$(dirname "$0")" && pwd)"
 arch="$(arch)"
 for x in deps vmdeps; do 
     grep -v '^#' "${srcdir}/${x}.txt"
-    grep -v '^#' "${srcdir}/${x}-${arch}.txt"
+    # There might not be any archful dependencies
+    if [ -s "${srcdir}/${x}-${arch}.txt" ]; then
+        grep -v '^#' "${srcdir}/${x}-${arch}.txt"
+    fi
 done


### PR DESCRIPTION
If no line is selected by grep, non-zero code is returned, ignore it for archful deps, allowing for empty archfull deps files. This fixes build of cosa image on aarch64.