### PR TITLE
kola/tests: Swith to expecting Networkmanager vs dhclient

### DIFF
--- a/mantle/kola/tests/misc/network.go
+++ b/mantle/kola/tests/misc/network.go
@@ -117,7 +117,7 @@ NextProcess:
 func NetworkListeners(c cluster.TestCluster) {
 	expectedListeners := []listener{
 		{"tcp", "22", "sshd"},
-		{"udp", "68", "dhclient"},
+		{"udp", "68", "NetworkManager"},
 		{"udp", "323", "chronyd"},
 	}
 	checkList := func() error {


### PR DESCRIPTION
We switched to NetworkManager and removed dhclient in
https://github.com/coreos/fedora-coreos-config/commit/90ce41141f9349432a0621c6f0e00748e20c840f