### PR TITLE
kola: promote concept of sdk.LocalBuild throughout

### DIFF
--- a/mantle/cmd/kola/kola.go
+++ b/mantle/cmd/kola/kola.go
@@ -481,10 +481,10 @@ func runArtifactIgnitionVersion(cmd *cobra.Command, args []string) error {
 }
 
 func preRunUpgrade(cmd *cobra.Command, args []string) error {
-	// unlike `kola run`, we *require* the --cosa-build arg -- XXX: figure out
+	// unlike `kola run`, we *require* the --build arg -- XXX: figure out
 	// how to get this working using cobra's MarkFlagRequired()
-	if kola.Options.CosaBuild == "" {
-		errors.New("Error: missing required argument --cosa-build")
+	if kola.Options.CosaBuildId == "" {
+		errors.New("Error: missing required argument --build")
 	}
 
 	err := syncOptionsImpl(false)
@@ -592,15 +592,15 @@ func getParentFcosBuildBase() (string, error) {
 	// parse commitmeta.json for `fedora-coreos.stream`, then fetch the stream
 	// metadata for that stream, then fetch the release metadata
 
-	if kola.CosaBuild.BuildRef == "" {
+	if kola.CosaBuild.Meta.BuildRef == "" {
 		return "", errors.New("no ref in build metadata")
 	}
 
-	stream := filepath.Base(kola.CosaBuild.BuildRef)
+	stream := filepath.Base(kola.CosaBuild.Meta.BuildRef)
 
 	var parentVersion string
-	if kola.CosaBuild.FedoraCoreOsParentVersion != "" {
-		parentVersion = kola.CosaBuild.FedoraCoreOsParentVersion
+	if kola.CosaBuild.Meta.FedoraCoreOsParentVersion != "" {
+		parentVersion = kola.CosaBuild.Meta.FedoraCoreOsParentVersion
 	} else {
 		// ok, we're probably operating on a local dev build since the pipeline
 		// always injects the parent; just instead fetch the release index

--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -86,8 +86,7 @@ func runTestIso(cmd *cobra.Command, args []string) error {
 	}
 
 	baseInst := platform.Install{
-		CosaBuildDir: kola.Options.CosaBuild,
-		CosaBuild:    kola.CosaBuild,
+		CosaBuild: kola.CosaBuild,
 
 		Console:  console,
 		Firmware: kola.QEMUOptions.Firmware,
@@ -109,13 +108,13 @@ func runTestIso(cmd *cobra.Command, args []string) error {
 		"-device", "virtio-serial", "-device", "virtserialport,chardev=completion,name=completion",
 		"-chardev", "file,id=completion,path=" + completionfile}
 
-	if kola.CosaBuild.BuildArtifacts.Metal == nil {
-		return fmt.Errorf("Build %s must have a `metal` artifact", kola.CosaBuild.OstreeVersion)
+	if kola.CosaBuild.Meta.BuildArtifacts.Metal == nil {
+		return fmt.Errorf("Build %s must have a `metal` artifact", kola.CosaBuild.Meta.OstreeVersion)
 	}
 
 	ranTest := false
 
-	foundLegacy := baseInst.CosaBuild.BuildArtifacts.Kernel != nil
+	foundLegacy := baseInst.CosaBuild.Meta.BuildArtifacts.Kernel != nil
 	if foundLegacy {
 		if legacy {
 			ranTest = true
@@ -125,16 +124,16 @@ func runTestIso(cmd *cobra.Command, args []string) error {
 			if err := testPXE(inst, completionfile); err != nil {
 				return err
 			}
-			fmt.Printf("Successfully tested legacy installer for %s\n", kola.CosaBuild.OstreeVersion)
+			fmt.Printf("Successfully tested legacy installer for %s\n", kola.CosaBuild.Meta.OstreeVersion)
 		}
 	} else if legacy {
-		return fmt.Errorf("build %s has no legacy installer kernel", kola.CosaBuild.Name)
+		return fmt.Errorf("build %s has no legacy installer kernel", kola.CosaBuild.Meta.Name)
 	}
 
-	foundLive := kola.CosaBuild.BuildArtifacts.LiveKernel != nil
+	foundLive := kola.CosaBuild.Meta.BuildArtifacts.LiveKernel != nil
 	if !nolive {
 		if !foundLive {
-			return fmt.Errorf("build %s has no live installer kernel", kola.CosaBuild.Name)
+			return fmt.Errorf("build %s has no live installer kernel", kola.CosaBuild.Meta.Name)
 		}
 		if !nopxe {
 			ranTest = true
@@ -143,7 +142,7 @@ func runTestIso(cmd *cobra.Command, args []string) error {
 			if err := testPXE(instPxe, completionfile); err != nil {
 				return err
 			}
-			fmt.Printf("Successfully tested PXE live installer for %s\n", kola.CosaBuild.OstreeVersion)
+			fmt.Printf("Successfully tested PXE live installer for %s\n", kola.CosaBuild.Meta.OstreeVersion)
 		}
 
 		ranTest = true
@@ -151,7 +150,7 @@ func runTestIso(cmd *cobra.Command, args []string) error {
 		if err := testLiveIso(instIso, completionfile); err != nil {
 			return err
 		}
-		fmt.Printf("Successfully tested ISO live installer for %s\n", kola.CosaBuild.OstreeVersion)
+		fmt.Printf("Successfully tested ISO live installer for %s\n", kola.CosaBuild.Meta.OstreeVersion)
 	}
 
 	if !ranTest {
@@ -179,7 +178,7 @@ func testPXE(inst platform.Install, completionfile string) error {
 		},
 	}
 	var configStr string
-	if sdk.TargetIgnitionVersion(kola.CosaBuild) == "v2" {
+	if sdk.TargetIgnitionVersion(kola.CosaBuild.Meta) == "v2" {
 		ignc2, err := ignconverter.Translate3to2(config)
 		if err != nil {
 			return err

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -33,7 +33,6 @@ import (
 
 	ignv3 "github.com/coreos/ignition/v2/config/v3_0"
 	ignv3types "github.com/coreos/ignition/v2/config/v3_0/types"
-	"github.com/coreos/mantle/cosa"
 	"github.com/coreos/mantle/harness"
 	"github.com/coreos/mantle/harness/reporters"
 	"github.com/coreos/mantle/kola/cluster"
@@ -55,6 +54,7 @@ import (
 	"github.com/coreos/mantle/platform/machine/openstack"
 	"github.com/coreos/mantle/platform/machine/packet"
 	"github.com/coreos/mantle/platform/machine/unprivqemu"
+	"github.com/coreos/mantle/sdk"
 	"github.com/coreos/mantle/system"
 	"github.com/coreos/mantle/util"
 )
@@ -72,7 +72,7 @@ var (
 	PacketOptions    = packetapi.Options{Options: &Options}    // glue to set platform options from main
 	QEMUOptions      = unprivqemu.Options{Options: &Options}   // glue to set platform options from main
 
-	CosaBuild *cosa.Build // this is the parsed object of --cosa-build
+	CosaBuild *sdk.LocalBuild // this is a parsed cosa build
 
 	TestParallelism int    //glue var to set test parallelism from main
 	TAPFile         string // if not "", write TAP results here

--- a/mantle/kola/tests/upgrade/basic.go
+++ b/mantle/kola/tests/upgrade/basic.go
@@ -120,19 +120,19 @@ func fcosUpgradeBasic(c cluster.TestCluster) {
 		// optimized for qemu testing locally where this won't leave localhost at
 		// all. cloud testing should mostly be a pipeline thing, where the infra
 		// connection should be much faster
-		ostreeTarPath := filepath.Join(filepath.Dir(kola.Options.CosaBuild), kola.CosaBuild.BuildArtifacts.Ostree.Path)
+		ostreeTarPath := filepath.Join(kola.CosaBuild.Dir, kola.CosaBuild.Meta.BuildArtifacts.Ostree.Path)
 		if err := cluster.DropFile(c.Machines(), ostreeTarPath); err != nil {
 			c.Fatal(err)
 		}
 
-		c.MustSSHf(m, "tar -xf %s -C %s", kola.CosaBuild.BuildArtifacts.Ostree.Path, ostreeRepo)
+		c.MustSSHf(m, "tar -xf %s -C %s", kola.CosaBuild.Meta.BuildArtifacts.Ostree.Path, ostreeRepo)
 
 		graph.seedFromMachine(c, m)
-		graph.addUpdate(c, m, kola.CosaBuild.OstreeVersion, kola.CosaBuild.OstreeCommit)
+		graph.addUpdate(c, m, kola.CosaBuild.Meta.OstreeVersion, kola.CosaBuild.Meta.OstreeCommit)
 	})
 
 	c.Run("upgrade-from-previous", func(c cluster.TestCluster) {
-		waitForUpgradeToVersion(c, m, kola.CosaBuild.OstreeVersion)
+		waitForUpgradeToVersion(c, m, kola.CosaBuild.Meta.OstreeVersion)
 	})
 
 	// Now, synthesize an update and serve that -- this is similar to
@@ -141,9 +141,9 @@ func fcosUpgradeBasic(c cluster.TestCluster) {
 	// Zincati & HTTP). Essentially, this sanity-checks that old starting state
 	// + new content set can update.
 	c.Run("upgrade-from-current", func(c cluster.TestCluster) {
-		newVersion := kola.CosaBuild.OstreeVersion + ".kola"
+		newVersion := kola.CosaBuild.Meta.OstreeVersion + ".kola"
 		newCommit := c.MustSSHf(m, "ostree commit --repo %s -b %s --tree ref=%s --add-metadata-string version=%s",
-			ostreeRepo, kola.CosaBuild.BuildRef, kola.CosaBuild.OstreeCommit, newVersion)
+			ostreeRepo, kola.CosaBuild.Meta.BuildRef, kola.CosaBuild.Meta.OstreeCommit, newVersion)
 
 		graph.addUpdate(c, m, newVersion, string(newCommit))
 

--- a/mantle/platform/platform.go
+++ b/mantle/platform/platform.go
@@ -161,7 +161,8 @@ type Options struct {
 	IgnitionVersion string
 	SystemdDropins  []SystemdDropin
 
-	CosaBuild string
+	CosaWorkdir string
+	CosaBuildId string
 
 	NoTestExitError bool
 

--- a/mantle/sdk/repo.go
+++ b/mantle/sdk/repo.go
@@ -70,16 +70,11 @@ func RequireCosaRoot(root string) error {
 	return nil
 }
 
-func GetLatestLocalBuild() (*LocalBuild, error) {
-	return GetLocalBuild("latest")
+func GetLatestLocalBuild(root string) (*LocalBuild, error) {
+	return GetLocalBuild(root, "latest")
 }
 
-func GetLocalBuild(buildid string) (*LocalBuild, error) {
-	// Maybe in the future we support an environment variable or CLI switch
-	root, err := os.Getwd()
-	if err != nil {
-		return nil, err
-	}
+func GetLocalBuild(root, buildid string) (*LocalBuild, error) {
 	if err := RequireCosaRoot(root); err != nil {
 		return nil, err
 	}

--- a/src/cmd-kola
+++ b/src/cmd-kola
@@ -56,6 +56,8 @@ kolaargs = ['kola']
 if os.getuid() != 0 and not ('-p' in unknown_args):
     kolaargs.extend(['-p', 'qemu-unpriv'])
 
+if args.build is not None:
+    kolaargs.extend(['--build', args.build])
 outputdir = args.output_dir or default_output_dir
 kolaargs.extend(['--output-dir', outputdir])
 subargs = args.subargs or [default_cmd]


### PR DESCRIPTION
Instead of keeping separate the build metadata object and the build
directory, let's instead raise the visibility of `sdk.LocalBuild`, which
bundles those two things together already.

What I initially set out to solve was that `cosa kola --build ID` no
longer worked, because we weren't passing `--cosa-build` to kola
anymore. But even if we did, it's silly to have `cosa kola` dig into
build dirs to fetch the path to the `meta.json` when `kola` now knows
how to do that.

Concretely, this changes three things:
1. we add a `--cosa-workdir` to allow specifying a cosa dir other than
   the current working dir.
2. the `--cosa-build` argument is now a build ID, not a path to a
   `meta.json`.
3. `kola.CosaBuild` is now a `LocalBuild` so that we also have access to
   the build directory everywhere.
