### PR TITLE
 Move 9p mount logic into QemuBuilder/qemuexec

### DIFF
--- a/mantle/go.mod
+++ b/mantle/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/aws/aws-sdk-go v1.25.14
 	github.com/coreos/container-linux-config-transpiler v0.8.0
 	github.com/coreos/go-semver v0.3.0
+	github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
 	github.com/coreos/go-systemd/v22 v22.0.0
 	github.com/coreos/ign-converter v0.0.0-20200228175238-237c8512310a
 	github.com/coreos/ignition v0.35.0

--- a/src/cmd-run
+++ b/src/cmd-run
@@ -137,17 +137,6 @@ append_systemd_unit() {
     fi
 }
 
-if [ -n "${VM_SRV_MNT}" ]; then
-    set -- --fsdev local,id=var-srv,path="${VM_SRV_MNT}",security_model=mapped,readonly \
-        -device virtio-9p-"${devtype}",fsdev=var-srv,mount_tag=/var/srv "$@"
-    # The dependency changes are hacks around https://github.com/coreos/fedora-coreos-tracker/issues/223
-    append_systemd_unit '{
-"name": "var-srv.mount",
-"enabled": true,
-"contents": "[Unit]\nDefaultDependencies=no\nAfter=systemd-tmpfiles-setup.service\nBefore=basic.target\n[Mount]\nWhat=/var/srv\nWhere=/var/srv\nType=9p\nOptions=ro,trans=virtio,version=9p2000.L\n[Install]\nWantedBy=multi-user.target\n"
-}'
-fi
-
 if [ -n "${IGNITION_CONFIG_FILE:-}" ]; then
     user_config=$(base64 --wrap 0 "${IGNITION_CONFIG_FILE}")
     user_config=$(cat << EOF
@@ -237,6 +226,10 @@ case "${DISK_CHANNEL}" in
     nvme) kola_args+=('--qemu-nvme');;
     *) die "Invalid --disk-channel ${DISK_CHANNEL}" ;;
 esac
+
+if [ -n "${VM_SRV_MNT}" ]; then
+    kola_args+=("--bind-ro=${VM_SRV_MNT},/var/srv")
+fi
 
 if [ "${IMAGE_TYPE}" == metal4k ]; then
     kola_args+=("--qemu-native-4k")


### PR DESCRIPTION

Drain another thing out of `cmd-run`.  This is prep for making
`cmd-run` be a tiny wrapper around `kola qemuexec`.

Also, using 9p mounts can be very useful for testing; i.e. this
helps unlock having qemu-specific tests that bind mount in data
without copying.

(One thing I'm thinking for example is that we support pulling
container images from the host)