### PR TITLE
kola/qemu: Use max supported gic version on the aarch64 host

### DIFF
--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -568,7 +568,7 @@ func baseQemuArgs() []string {
 	case "aarch64":
 		return []string{
 			"qemu-system-aarch64",
-			"-machine", "virt,accel=kvm,gic-version=3",
+			"-machine", "virt,accel=kvm,gic-version=max",
 			"-cpu", "host",
 		}
 	case "s390x":


### PR DESCRIPTION
Switching to version "max" will pick the highest correct version, allowing running test suite on wider range of aarch64 hosts.