### PR TITLE
Move "detect host CPUs" into mantle

### DIFF
--- a/mantle/cmd/kola/qemuexec.go
+++ b/mantle/cmd/kola/qemuexec.go
@@ -42,8 +42,9 @@ var (
 		SilenceUsage: true,
 	}
 
-	memory  int
-	usernet bool
+	memory       int
+	usernet      bool
+	cpuCountHost bool
 
 	hostname string
 	ignition string
@@ -63,6 +64,7 @@ func init() {
 	cmdQemuExec.Flags().StringSliceVar(&ignitionFragments, "add-ignition", nil, "Append well-known Ignition fragment: [\"autologin\"]")
 	cmdQemuExec.Flags().StringVarP(&hostname, "hostname", "", "", "Set hostname via DHCP")
 	cmdQemuExec.Flags().IntVarP(&memory, "memory", "m", 0, "Memory in MB")
+	cmdQemuExec.Flags().BoolVar(&cpuCountHost, "auto-cpus", false, "Automatically set number of cpus to host count")
 	cmdQemuExec.Flags().StringVarP(&ignition, "ignition", "i", "", "Path to ignition config")
 	cmdQemuExec.Flags().BoolVarP(&forceConfigInjection, "inject-ignition", "", false, "Force injecting Ignition config using guestfs")
 }
@@ -174,6 +176,9 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 	builder.Hostname = hostname
 	if memory != 0 {
 		builder.Memory = memory
+	}
+	if cpuCountHost {
+		builder.Processors = -1
 	}
 	if usernet {
 		builder.EnableUsermodeNetworking(22)

--- a/mantle/system/nproc.go
+++ b/mantle/system/nproc.go
@@ -1,0 +1,57 @@
+// Copyright 2020 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package system
+
+import (
+	"io/ioutil"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	"github.com/coreos/mantle/system/exec"
+)
+
+// GetProcessors returns a count for number of cores we should use;
+// this value is appropriate to pass to e.g. make -J as well as
+// qemu -smp for example.
+func GetProcessors() (uint, error) {
+	// Note this code originated in cmdlib.sh; the git history there will
+	// have a bit more info.
+	proc1cgroup, err := ioutil.ReadFile("/proc/1/cgroup")
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return 0, err
+		}
+	} else {
+		// only use 1 core on kubernetes since we can't determine how much we can actually use
+		if strings.Contains(string(proc1cgroup), "kubepods") {
+			return 1, nil
+		}
+	}
+
+	nprocBuf, err := exec.Command("nproc").CombinedOutput()
+	if err != nil {
+		return 0, errors.Wrapf(err, "executing nproc")
+	}
+
+	nproc, err := strconv.ParseInt(strings.TrimSpace(string(nprocBuf)), 10, 32)
+	if err != nil {
+		return 0, errors.Wrapf(err, "parsing nproc output")
+	}
+
+	return uint(nproc), nil
+}

--- a/src/cmd-run
+++ b/src/cmd-run
@@ -20,7 +20,6 @@ VM_DISK=
 KARGS=
 DISK_CHANNEL=virtio
 VM_MEMORY=2048
-VM_NCPUS="${VM_NCPUS:-${QEMU_PROCS}}"
 VM_SRV_MNT=
 TARGET_USER=core
 FIRMWARE=bios
@@ -131,7 +130,7 @@ ignition_version=$(disk_ignition_version "${VM_DISK}")
 ign_validate="ignition-validate"
 
 # Set name to coreos to be shorter, and default CPUs to host
-set -- -name coreos -smp "${VM_NCPUS}" "$@"
+set -- -name coreos "$@"
 
 systemd_units=
 append_systemd_unit() {
@@ -277,4 +276,4 @@ case "${IMAGE_TYPE}" in
 esac
 
 set -x
-exec kola qemuexec --add-ignition=autologin -U --qemu-image "${VM_DISK}" --ignition "${IGNITION_CONFIG_FILE}" --memory "${VM_MEMORY}" "${kola_args[@]}" -- "$@"
+exec kola qemuexec --add-ignition=autologin -U --auto-cpus --qemu-image "${VM_DISK}" --ignition "${IGNITION_CONFIG_FILE}" --memory "${VM_MEMORY}" "${kola_args[@]}" -- "$@"


### PR DESCRIPTION
Today if you type `cosa run` you get the host CPUs, but
all invocations of `kola` (including `kola spawn` to log in
via SSH, as well as all tests) use exactly 1 processor.

This doesn't make sense - it's just a historical artifact.

This continues the move of cosa qemu logic into mantle so
we can use it for tests.  For now though, `kola qemuexec` learns a
`-C` argument to guess the number of CPUs.

Yes, the technical debt reduction from the mantle/cosa merger
is STILL GOING!

With a few more patches `cmd-run` will turn into just
`exec kola qemuexec [a few args]`.