### PR TITLE
 cmdlib: Use kola qemuexec, delete qemu-kvm code

### DIFF
--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -234,20 +234,16 @@ if [ -n "${ref_is_temp}" ]; then
     ref_arg=${commit}
 fi
 
-target_drive=("-drive" "if=virtio,id=target,format=${image_format},file=${path}.tmp,cache=unsafe")
+target_device_opt="scsi-disk,drive=target,wwn=0x2a"
 # we need 4096 block size for ECKD DASD and (obviously) metal4k
 if [[ $image_type == dasd || $image_type == metal4k ]]; then
-    device_type=virtio-blk
-    if [[ $image_type == dasd ]]; then
-        device_type=virtio-blk-ccw
-    fi
-    target_drive=("-drive" "if=none,id=target,format=${image_format},file=${path}.tmp,cache=unsafe" \
-                    "-device" "${device_type},drive=target,physical_block_size=4096,logical_block_size=4096,scsi=off")
+  target_device_opt="${target_device_opt},physical_block_size=4096,logical_block_size=4096"
 fi
+target_drive=("-drive" "if=none,id=target,format=${image_format},file=${path}.tmp,cache=unsafe" \
+              "-device" "virtio-scsi-${devtype},id=scsitarget" "-device" "${target_device_opt}")
 
 runvm "${target_drive[@]}" -- \
         /usr/lib/coreos-assembler/create_disk.sh \
-            --disk /dev/vda \
             --buildid "${build}" \
             --imgid "${img}" \
             --grub-script /usr/lib/coreos-assembler/grub.cfg \

--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -42,6 +42,7 @@ run as part of 'coreos-assembler build'.
 EOC
 }
 
+disk=
 rootfs_size="0"
 boot_verity=0
 rootfs_type="xfs"
@@ -78,7 +79,25 @@ udevtrig() {
 
 export PATH=$PATH:/sbin:/usr/sbin
 arch="$(uname -m)"
-disk="${disk:?--disk must be defined}"
+
+if [ -z "${disk:-}" ]; then
+    # hex 0x2a = 42 in decimal; this is set in cmd-buildextend-metal.
+    # We use the WWN as an unambiguous way to identify our target disk,
+    # independent of other devices attached to the VM (caches, etc.)
+    wwn=000000000000002a
+    for dev in /sys/block/*; do
+        if grep -F -e "${wwn}" "${dev}/device/wwid" 2>/dev/null; then
+            disk="/dev/$(basename ${dev})"
+            break
+        fi
+    done
+    if [ -z "${disk:-}" ]; then
+        echo "failed to find disk with wwn ${wwn}" 1>&2
+        bash
+        exit 1
+    fi
+fi
+
 buildid="${buildid:?--buildid must be defined}"
 imgid="${imgid:?--imgid must be defined}"
 ostree="${ostree:?--ostree-repo must be defined}"


### PR DESCRIPTION

And this final commit gets rid of all of the qemu hardcoding in
cmdlib, so e.g. architecture specific changes only need to happen
in one place.

(Well, of course arch changes also end up in libvirt which we
 use indirectly too, but at least *we* only have one place)