### PR TITLE
qemu: Support monitoring for failures in the initramfs

### DIFF
--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -193,7 +193,7 @@ func runTestIso(cmd *cobra.Command, args []string) error {
 func awaitCompletion(inst *platform.QemuInstance, qchan *os.File, expected []string) error {
 	errchan := make(chan error)
 	go func() {
-		if err := inst.Wait(); err != nil {
+		if err := inst.WaitAll(); err != nil {
 			errchan <- err
 		}
 		time.Sleep(1 * time.Minute)

--- a/mantle/kola/tests/ignition/qemufailure.go
+++ b/mantle/kola/tests/ignition/qemufailure.go
@@ -1,0 +1,105 @@
+// Copyright 2020 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ignition
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	ignv3types "github.com/coreos/ignition/v2/config/v3_0/types"
+	"github.com/pkg/errors"
+
+	"github.com/coreos/mantle/kola"
+	"github.com/coreos/mantle/kola/cluster"
+	"github.com/coreos/mantle/kola/register"
+	"github.com/coreos/mantle/platform"
+	"github.com/coreos/mantle/util"
+)
+
+func init() {
+	register.RegisterTest(&register.Test{
+		Name:        "coreos.ignition.failure",
+		Run:         runIgnitionFailure,
+		ClusterSize: 0,
+		Platforms:   []string{"qemu-unpriv"},
+	})
+}
+
+func runIgnitionFailure(c cluster.TestCluster) {
+	if err := ignitionFailure(c); err != nil {
+		c.Fatal(err.Error())
+	}
+}
+
+func ignitionFailure(c cluster.TestCluster) error {
+	// TODO remove this once the feature lands
+	c.H.Skip("Needs https://github.com/coreos/ignition-dracut/pull/146")
+	// We can't create files in / due to the immutable bit OSTree creates, so
+	// this is a convenient way to test Ignition failure.
+	failConfig := ignv3types.Config{
+		Ignition: ignv3types.Ignition{
+			Version: "3.0.0",
+		},
+		Storage: ignv3types.Storage{
+			Files: []ignv3types.File{
+				{
+					Node: ignv3types.Node{
+						Path: "/notwritable.txt",
+					},
+					FileEmbedded1: ignv3types.FileEmbedded1{
+						Contents: ignv3types.FileContents{
+							Source: util.StrToPtr("data:,hello%20world%0A"),
+						},
+						Mode: util.IntToPtr(420),
+					},
+				},
+			},
+		},
+	}
+	builder := platform.NewBuilder()
+	builder.SetConfig(failConfig, kola.Options.IgnitionVersion == "v2")
+	builder.AddPrimaryDisk(&platform.Disk{
+		BackingFile: kola.QEMUOptions.DiskImage,
+	})
+	builder.Memory = 1024
+	inst, err := builder.Exec()
+	if err != nil {
+		return err
+	}
+	defer inst.Destroy()
+	errchan := make(chan error)
+	go func() {
+		err := inst.WaitAll()
+		if err == nil {
+			err = fmt.Errorf("Ignition unexpectedly succeeded")
+		} else if err == platform.ErrInitramfsEmergency {
+			// The expected case
+			err = nil
+		} else {
+			err = errors.Wrapf(err, "expected initramfs emergency.target error")
+		}
+		errchan <- err
+	}()
+	go func() {
+		time.Sleep(2 * time.Minute)
+		proc := os.Process{
+			Pid: inst.Pid(),
+		}
+		proc.Kill()
+		errchan <- errors.New("timed out waiting for initramfs error")
+	}()
+	return <-errchan
+}

--- a/mantle/platform/machine/aws/machine.go
+++ b/mantle/platform/machine/aws/machine.go
@@ -64,6 +64,10 @@ func (am *machine) SSH(cmd string) ([]byte, []byte, error) {
 	return am.cluster.SSH(am, cmd)
 }
 
+func (am *machine) IgnitionError() error {
+	return nil
+}
+
 func (am *machine) Reboot() error {
 	return platform.RebootMachine(am, am.journal)
 }

--- a/mantle/platform/machine/azure/machine.go
+++ b/mantle/platform/machine/azure/machine.go
@@ -74,6 +74,10 @@ func (am *machine) SSH(cmd string) ([]byte, []byte, error) {
 	return am.cluster.SSH(am, cmd)
 }
 
+func (am *machine) IgnitionError() error {
+	return nil
+}
+
 // Re-fetch the Public & Private IP address for the event that it's changed during the reboot
 func (am *machine) refetchIPs() error {
 	var err error

--- a/mantle/platform/machine/do/machine.go
+++ b/mantle/platform/machine/do/machine.go
@@ -61,6 +61,10 @@ func (dm *machine) SSH(cmd string) ([]byte, []byte, error) {
 	return dm.cluster.SSH(dm, cmd)
 }
 
+func (dm *machine) IgnitionError() error {
+	return nil
+}
+
 func (dm *machine) Reboot() error {
 	return platform.RebootMachine(dm, dm.journal)
 }

--- a/mantle/platform/machine/esx/machine.go
+++ b/mantle/platform/machine/esx/machine.go
@@ -62,6 +62,10 @@ func (em *machine) SSH(cmd string) ([]byte, []byte, error) {
 	return em.cluster.SSH(em, cmd)
 }
 
+func (em *machine) IgnitionError() error {
+	return nil
+}
+
 func (em *machine) Reboot() error {
 	return platform.RebootMachine(em, em.journal)
 }

--- a/mantle/platform/machine/gcloud/machine.go
+++ b/mantle/platform/machine/gcloud/machine.go
@@ -62,6 +62,10 @@ func (gm *machine) SSH(cmd string) ([]byte, []byte, error) {
 	return gm.gc.SSH(gm, cmd)
 }
 
+func (gm *machine) IgnitionError() error {
+	return nil
+}
+
 func (gm *machine) Reboot() error {
 	return platform.RebootMachine(gm, gm.journal)
 }

--- a/mantle/platform/machine/openstack/machine.go
+++ b/mantle/platform/machine/openstack/machine.go
@@ -83,6 +83,10 @@ func (om *machine) SSH(cmd string) ([]byte, []byte, error) {
 	return om.cluster.SSH(om, cmd)
 }
 
+func (om *machine) IgnitionError() error {
+	return nil
+}
+
 func (om *machine) Reboot() error {
 	return platform.RebootMachine(om, om.journal)
 }

--- a/mantle/platform/machine/packet/machine.go
+++ b/mantle/platform/machine/packet/machine.go
@@ -61,6 +61,10 @@ func (pm *machine) SSH(cmd string) ([]byte, []byte, error) {
 	return pm.cluster.SSH(pm, cmd)
 }
 
+func (pm *machine) IgnitionError() error {
+	return nil
+}
+
 func (pm *machine) Reboot() error {
 	return platform.RebootMachine(pm, pm.journal)
 }

--- a/mantle/platform/machine/unprivqemu/machine.go
+++ b/mantle/platform/machine/unprivqemu/machine.go
@@ -61,6 +61,15 @@ func (m *machine) SSH(cmd string) ([]byte, []byte, error) {
 	return m.qc.SSH(m, cmd)
 }
 
+func (m *machine) IgnitionError() error {
+	_, err := m.inst.WaitIgnitionError()
+	if err != nil {
+		return err
+	}
+	// TODO render buf
+	return platform.ErrInitramfsEmergency
+}
+
 func (m *machine) Reboot() error {
 	return platform.RebootMachine(m, m.journal)
 }

--- a/mantle/platform/platform.go
+++ b/mantle/platform/platform.go
@@ -51,6 +51,9 @@ type Machine interface {
 	// ID returns the plaform-specific machine identifier.
 	ID() string
 
+	// IgnitionError returns an error if the machine failed in Ignition
+	IgnitionError() error
+
 	// IP returns the machine's public IP.
 	IP() string
 


### PR DESCRIPTION
Pairs with https://github.com/coreos/ignition-dracut/pull/146

What we really want is to use this in kola, will do as a
separate followup.