### PR TITLE
mantle/qemu: Rework API to allow setting Config after creation

### DIFF
--- a/mantle/cmd/kola/qemuexec.go
+++ b/mantle/cmd/kola/qemuexec.go
@@ -96,9 +96,9 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 		}
 		config = *newconfig
 	}
-	builder, err := platform.NewBuilderFromParsed(config, kola.Options.IgnitionVersion == "v2")
-	if err != nil {
-		return errors.Wrapf(err, "creating qemu builder")
+	builder := platform.NewBuilder()
+	if err := builder.SetConfig(config, kola.Options.IgnitionVersion == "v2"); err != nil {
+		return errors.Wrapf(err, "rendering config")
 	}
 	builder.ForceConfigInjection = forceConfigInjection
 	if len(knetargs) > 0 {

--- a/mantle/platform/machine/unprivqemu/cluster.go
+++ b/mantle/platform/machine/unprivqemu/cluster.go
@@ -87,7 +87,8 @@ func (qc *Cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 		consolePath: filepath.Join(dir, "console.txt"),
 	}
 
-	builder := platform.NewBuilder(confPath, false)
+	builder := platform.NewBuilder()
+	builder.ConfigFile = confPath
 	defer builder.Close()
 	builder.Uuid = qm.id
 	builder.Firmware = qc.flight.opts.Firmware

--- a/mantle/platform/metal.go
+++ b/mantle/platform/metal.go
@@ -216,7 +216,7 @@ func setupMetalImage(builddir, metalimg, destdir string) (string, error) {
 }
 
 func newQemuBuilder(firmware string, console bool) *QemuBuilder {
-	builder := NewBuilder("", false)
+	builder := NewBuilder()
 	builder.Firmware = firmware
 	builder.AddDisk(&Disk{
 		Size: "12G", // Arbitrary


### PR DESCRIPTION
First, we don't hard require a config, so there's no reason
to force people to pass the empty string if they don't want one.

Second, this is prep for further work on 9p mounts which want
to build up a config and qemu arguments simultaneously.