### PR TITLE
aws: provide way to select source-region

### DIFF
--- a/src/cmd-ore-wrapper
+++ b/src/cmd-ore-wrapper
@@ -84,6 +84,7 @@ Each target has its own sub options. To access them us:
     parser.add_argument("--region", "--regions", dest="region",
                         help="Upload/replicate to specific regions",
                         nargs='+')
+    parser.add_argument("--source-region", help="Region to copy AMI from")
 
     parser.description = (
         f"'ore' interface for running ore commands for {target.upper()}"

--- a/src/cosalib/aws.py
+++ b/src/cosalib/aws.py
@@ -52,14 +52,25 @@ def aws_run_ore_replicate(build, args):
     if len(region_list) == 0:
         raise Exception("no new regions detected")
 
-    source_image = buildmeta['amis'][0]['hvm']
-    source_region = buildmeta['amis'][0]['name']
+    if not args.source_region:
+        args.source_region = buildmeta['amis'][0]['name']
+
+    source_image = None
+    for a in buildmeta['amis']:
+        if a['name'] == args.source_region:
+            source_image = a['hvm']
+            break
+
+    if source_image is None:
+        raise Exception(("Unable to find AMI ID for "
+                        f"{args.source_region} region"))
+
     ore_args = ['ore']
     if args.log_level:
         ore_args.extend(['--log-level', args.log_level])
     ore_args.extend([
         'aws', 'copy-image', '--image',
-        source_image, '--region', source_region
+        source_image, '--region', args.source_region
     ])
     ore_args.extend(region_list)
     print("+ {}".format(subprocess.list2cmdline(ore_args)))


### PR DESCRIPTION
When replicating AMIs across regions, the default is to use the first
region + AMI ID pair in the list of AMIs in `meta.json`.  This is
typically `us-east-1`.

When trying to replicate AMIs to AWS China regions, the RHCOS pipeline
uses a separate set of credentials that does not have the ability to
copy the AMI from `us-east-1`.  In this case, we want to be able to
specify a source region in AWS China where the AMI can be copied from.