### PR TITLE
mantle/*/packet: rework for FCOS

### DIFF
--- a/mantle/cmd/kola/kola.go
+++ b/mantle/cmd/kola/kola.go
@@ -248,6 +248,8 @@ func writeProps() error {
 		Facility              string `json:"facility"`
 		Plan                  string `json:"plan"`
 		InstallerImageBaseURL string `json:"installer"`
+		Architecture          string `json:"architecture"`
+		IPXEURL               string `json:"ipxe"`
 		ImageURL              string `json:"image"`
 	}
 	type QEMU struct {
@@ -309,10 +311,11 @@ func writeProps() error {
 			Flavor: kola.OpenStackOptions.Flavor,
 		},
 		Packet: Packet{
-			Facility:              kola.PacketOptions.Facility,
-			Plan:                  kola.PacketOptions.Plan,
-			InstallerImageBaseURL: kola.PacketOptions.InstallerImageBaseURL,
-			ImageURL:              kola.PacketOptions.ImageURL,
+			Facility:     kola.PacketOptions.Facility,
+			Plan:         kola.PacketOptions.Plan,
+			Architecture: kola.PacketOptions.Architecture,
+			IPXEURL:      kola.PacketOptions.IPXEURL,
+			ImageURL:     kola.PacketOptions.ImageURL,
 		},
 		QEMU: QEMU{
 			Image:     kola.QEMUOptions.DiskImage,

--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -126,10 +126,10 @@ func init() {
 	sv(&kola.PacketOptions.ApiKey, "packet-api-key", "", "Packet API key (overrides config file)")
 	sv(&kola.PacketOptions.Project, "packet-project", "", "Packet project UUID (overrides config file)")
 	sv(&kola.PacketOptions.Facility, "packet-facility", "sjc1", "Packet facility code")
-	sv(&kola.PacketOptions.Plan, "packet-plan", "", "Packet plan slug (default board-dependent, e.g. \"t1.small.x86\")")
-	sv(&kola.PacketOptions.InstallerImageBaseURL, "packet-installer-image-base-url", "", "Packet installer image base URL, non-https (default board-dependent, e.g. \"http://stable.release.core-os.net/amd64-usr/current\")")
-	sv(&kola.PacketOptions.ImageURL, "packet-image-url", "", "Packet image URL (default board-dependent, e.g. \"https://alpha.release.core-os.net/amd64-usr/current/coreos_production_packet_image.bin.bz2\")")
-	sv(&kola.PacketOptions.StorageURL, "packet-storage-url", "gs://users.developer.core-os.net/"+os.Getenv("USER")+"/mantle", "Google Storage base URL for temporary uploads")
+	sv(&kola.PacketOptions.Plan, "packet-plan", "", "Packet plan slug (default arch-dependent, e.g. \"t1.small.x86\")")
+	sv(&kola.PacketOptions.Architecture, "packet-architecture", "x86_64", "Packet CPU architecture")
+	sv(&kola.PacketOptions.IPXEURL, "packet-ipxe-url", "", "iPXE script URL (default arch-dependent, e.g. \"https://raw.githubusercontent.com/coreos/coreos-assembler/master/mantle/platform/api/packet/fcos-x86_64.ipxe\")")
+	sv(&kola.PacketOptions.ImageURL, "packet-image-url", "", "image URL (default arch-dependent, e.g. \"https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200223.3.0/x86_64/fedora-coreos-31.20200223.3.0-metal.x86_64.raw.xz\")")
 
 	// QEMU-specific options
 	sv(&kola.QEMUOptions.Firmware, "qemu-firmware", "", "Boot firmware: bios,uefi,uefi-secure (default bios)")
@@ -142,9 +142,6 @@ func init() {
 
 // Sync up the command line options if there is dependency
 func syncOptionsImpl(useCosa bool) error {
-	kola.PacketOptions.Board = kola.QEMUOptions.Board
-	kola.PacketOptions.GSOptions = &kola.GCEOptions
-
 	validateOption := func(name, item string, valid []string) error {
 		for _, v := range valid {
 			if v == item {

--- a/mantle/cmd/ore/packet/create-device.go
+++ b/mantle/cmd/ore/packet/create-device.go
@@ -40,10 +40,10 @@ var (
 func init() {
 	Packet.AddCommand(cmdCreateDevice)
 	cmdCreateDevice.Flags().StringVar(&options.Facility, "facility", "sjc1", "facility code")
-	cmdCreateDevice.Flags().StringVar(&options.Plan, "plan", "", "plan slug (default board-dependent, e.g. \"t1.small.x86\")")
-	cmdCreateDevice.Flags().StringVar(&options.Board, "board", "amd64-usr", "Container Linux board")
-	cmdCreateDevice.Flags().StringVar(&options.InstallerImageBaseURL, "installer-image-base-url", "", "installer image base URL, non-https (default board-dependent, e.g. \"http://stable.release.core-os.net/amd64-usr/current\")")
-	cmdCreateDevice.Flags().StringVar(&options.ImageURL, "image-url", "", "image base URL (default board-dependent, e.g. \"https://alpha.release.core-os.net/amd64-usr/current/coreos_production_packet_image.bin.bz2\")")
+	cmdCreateDevice.Flags().StringVar(&options.Plan, "plan", "", "plan slug (default arch-dependent, e.g. \"t1.small.x86\")")
+	cmdCreateDevice.Flags().StringVar(&options.Architecture, "architecture", "x86_64", "CPU architecture")
+	cmdCreateDevice.Flags().StringVar(&options.IPXEURL, "ipxe-url", "", "iPXE script URL (default arch-dependent, e.g. \"https://raw.githubusercontent.com/coreos/coreos-assembler/master/mantle/platform/api/packet/fcos-x86_64.ipxe\")")
+	cmdCreateDevice.Flags().StringVar(&options.ImageURL, "image-url", "", "image URL (default arch-dependent, e.g. \"https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/31.20200223.3.0/x86_64/fedora-coreos-31.20200223.3.0-metal.x86_64.raw.xz\")")
 	cmdCreateDevice.Flags().StringVar(&hostname, "hostname", "", "hostname to assign to device")
 	cmdCreateDevice.Flags().StringVar(&userDataPath, "userdata-file", "", "path to file containing userdata")
 }

--- a/mantle/cmd/ore/packet/packet.go
+++ b/mantle/cmd/ore/packet/packet.go
@@ -16,11 +16,9 @@ package packet
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/coreos/mantle/auth"
 	"github.com/coreos/mantle/cli"
-	"github.com/coreos/mantle/platform/api/gcloud"
 	"github.com/coreos/mantle/platform/api/packet"
 	"github.com/coreos/pkg/capnslog"
 	"github.com/spf13/cobra"
@@ -34,16 +32,11 @@ var (
 		Short: "Packet machine utilities",
 	}
 
-	API       *packet.API
-	options   packet.Options
-	gsOptions gcloud.Options
+	API     *packet.API
+	options packet.Options
 )
 
 func init() {
-	options.GSOptions = &gsOptions
-	Packet.PersistentFlags().StringVar(&options.StorageURL, "storage-url", "gs://users.developer.core-os.net/"+os.Getenv("USER")+"/mantle", "Google Storage base URL for temporary uploads")
-	Packet.PersistentFlags().StringVar(&gsOptions.JSONKeyFile, "gs-json-key", "", "use a Google service account's JSON key to authenticate to Google Storage")
-	Packet.PersistentFlags().BoolVar(&gsOptions.ServiceAuth, "gs-service-auth", false, "use non-interactive Google auth when running within GCE")
 	Packet.PersistentFlags().StringVar(&options.ConfigPath, "config-file", "", "config file (default \"~/"+auth.PacketConfigPath+"\")")
 	Packet.PersistentFlags().StringVar(&options.Profile, "profile", "", "profile (default \"default\")")
 	Packet.PersistentFlags().StringVar(&options.ApiKey, "api-key", "", "API key (overrides config file)")

--- a/mantle/fcos/metadata.go
+++ b/mantle/fcos/metadata.go
@@ -199,3 +199,29 @@ func FetchAndParseStreamMetadata(url string) (*StreamMetadata, error) {
 func FetchAndParseCanonicalStreamMetadata(stream string) (*StreamMetadata, error) {
 	return FetchAndParseStreamMetadata(fmt.Sprintf(canonicalStreamMetadataLocation, stream))
 }
+
+func FetchCanonicalStreamArtifacts(stream, architecture string) (*StreamArtifacts, error) {
+	metadata, err := FetchAndParseCanonicalStreamMetadata(stream)
+	if err != nil {
+		return nil, fmt.Errorf("fetching stream metadata: %v", err)
+	}
+	arch, ok := metadata.Architectures[architecture]
+	if !ok {
+		return nil, fmt.Errorf("stream metadata missing architecture %q", architecture)
+	}
+	return &arch.Artifacts, nil
+}
+
+func GetPlatformDiskArtifact(platform *StreamMediaDetails, format string) (*ImageType, error) {
+	if platform == nil {
+		return nil, fmt.Errorf("stream metadata missing expected platform")
+	}
+	artifacts, ok := platform.Formats[format]
+	if !ok {
+		return nil, fmt.Errorf("stream metadata missing %q format", format)
+	}
+	if artifacts.Disk == nil {
+		return nil, fmt.Errorf("stream metadata missing %q disk image", format)
+	}
+	return artifacts.Disk, nil
+}

--- a/mantle/platform/api/packet/fcos-x86_64.ipxe
+++ b/mantle/platform/api/packet/fcos-x86_64.ipxe
@@ -1,0 +1,12 @@
+#!ipxe
+# By default, mantle fetches this file directly from the
+# coreos/coreos-assembler GitHub repo.  Changing this file in the master
+# branch will affect all deployed copies of mantle.
+
+set version 31.20200323.2.1
+# This URL is not a stable API.  We should be dynamically fetching URLs from
+# stream metadata instead.
+set base-url https://builds.coreos.fedoraproject.org/prod/streams/testing/builds/${version}/x86_64
+kernel ${base-url}/fedora-coreos-${version}-live-kernel-x86_64 ip=dhcp rd.neednet=1 initrd=fedora-coreos-${version}-live-initramfs.x86_64.img ignition.platform.id=packet ignition.firstboot console=ttyS1,115200n8
+initrd ${base-url}/fedora-coreos-${version}-live-initramfs.x86_64.img
+boot


### PR DESCRIPTION
Unlike CL, FCOS allows us to override the platform ID of the PXE image.  That allows us to put the installer Ignition config into userdata, which lets us drop the requirement to upload files to a remotely-accessible URL.  Instead, allow the user to pass an URL to an iPXE script (which references the installer kernel/initrd) and an URL to the image to be installed.

By default, mantle will use an iPXE script URL that points to the cosa GitHub repository, and an image URL fetched from FCOS stream metadata.  This means we'll use a static installer image, but that seems like a reasonable tradeoff in order to avoid implementing a webapp or requiring mantle to upload a file.

Drop the "board" abstraction within Packet code and use Fedora arch names.  This means we have to call amd64 "x86_64".

Drop various CL-specific workarounds.

This can be tested as:

```
bin/kola spawn -p packet --packet-ipxe-url https://raw.githubusercontent.com/bgilbert/coreos-assembler/packet/mantle/platform/api/packet/fcos-x86_64.ipxe
```
or:
```
bin/ore packet create-device --hostname <HOSTNAME> --ipxe-url https://raw.githubusercontent.com/bgilbert/coreos-assembler/packet/mantle/platform/api/packet/fcos-x86_64.ipxe --userdata-file <IGNITION-CONFIG>
```

Note that the installed system will incorrectly send console messages to `ttyS0`, not `ttyS1`.  That should probably be addressed directly in the distro.