### PR TITLE
grub: drop default `rd.neednet=1 ip=dhcp,dhcp6` kargs

### DIFF
--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -385,7 +385,7 @@ s390x)
 	# stage on s390x, either through zipl->grub2-emu or zipl standalone.
 	# See https://github.com/coreos/ignition-dracut/issues/84
 	# A similar hack is present in https://github.com/coreos/coreos-assembler/blob/master/src/gf-platformid#L55
-	echo "$(grep options $blsfile) ignition.firstboot rd.neednet=1 ip=dhcp,dhcp6" > $tmpfile
+	echo "$(grep options $blsfile) ignition.firstboot" > $tmpfile
 
 	# ideally we want to invoke zipl with bls and zipl.conf but we might need
 	# to chroot to $rootfs/ to do so. We would also do that when FCOS boot on its own.

--- a/src/gf-platformid
+++ b/src/gf-platformid
@@ -52,7 +52,7 @@ coreos_gf upload "${tmpd}"/bls.conf "${blscfg_path}"
 if [ "$basearch" = "s390x" ] ; then
     # Before we re-run zipl make sure we have the firstboot options
     # A hack similar to https://github.com/coreos/coreos-assembler/blob/master/src/create_disk.sh#L381
-    sed -i -e 's,^\(options .*\),\1 ignition.firstboot rd.neednet=1 ip=dhcp\,dhcp6,' "${tmpd}"/bls.conf
+    sed -i -e 's,^\(options .*\),\1 ignition.firstboot,' "${tmpd}"/bls.conf
     coreos_gf rename "${blscfg_path}" "${blscfg_path}.orig"
     coreos_gf upload "${tmpd}"/bls.conf "${blscfg_path}"
 

--- a/src/grub.cfg
+++ b/src/grub.cfg
@@ -44,8 +44,7 @@ fi
 # which is used in the kernel command line.
 set ignition_firstboot=""
 if [ -f "/ignition.firstboot" ]; then
-    # default to dhcp networking parameters to be used with ignition
-    set ignition_network_kcmdline='rd.neednet=1 ip=dhcp,dhcp6'
+    set ignition_network_kcmdline=''
 
     # source in the `ignition.firstboot` file which could override the
     # above $ignition_network_kcmdline with static networking config.


### PR DESCRIPTION
We want to move to a model where networking isn't unconditionally
brought up, but instead only if Ignition requires it.

But I think we'll still have to keep supporting
`ignition_network_kcmdline` since it's kind of part of our API now that
it can be overridden via `ignition.firstboot`.

Works with:
https://github.com/coreos/fedora-coreos-config/pull/321
https://github.com/coreos/ignition-dracut/pull/164
https://github.com/coreos/ignition/pull/956