### PR TITLE
cosalib/aws: check for 'amis' key in buildmeta

### DIFF
--- a/src/cosalib/aws.py
+++ b/src/cosalib/aws.py
@@ -33,9 +33,9 @@ def delete_snapshot(snap_id, region):
 def aws_run_ore_replicate(build, args):
     build.refresh_meta()
     buildmeta = build.meta
-    if len(buildmeta['amis']) < 1:
+    if len(buildmeta.get('amis', [])) < 1:
         raise SystemExit(("buildmeta doesn't contain source AMIs."
-                         " Run buildextend-aws first"))
+                         " Run buildextend-aws --upload first"))
     if not args.region:
         args.region = subprocess.check_output([
             'ore', 'aws', 'list-regions'


### PR DESCRIPTION
Noticed this when I did `cosa buildextend-aws` (without `--upload`)
and then tried to do `cosa aws-replicate`.  Without this change, it
would blow up with a KeyError since the AMIs were never uploaded.