### PR TITLE
build-sys: Only build schema if source changed

### DIFF
--- a/mantle/Makefile
+++ b/mantle/Makefile
@@ -4,8 +4,11 @@ DESTDIR ?=
 ARCH:=$(shell uname -m)
 
 .PHONY: build test vendor clean
-build:
-	./build
+build: cosa/cosa_v1.go
+	./build cmd/*
+
+cosa/cosa_v1.go: ../src/schema/v1.json Makefile
+	./build schema
 
 .PHONY: install
 install: bin/ore bin/kola bin/plume bin/kolet

--- a/mantle/build
+++ b/mantle/build
@@ -7,7 +7,7 @@ cd $(dirname $0)
 source ./env
 
 if [[ $# -eq 0 ]]; then
-	set -- cmd/*
+	set -- cmd/* schema
 fi
 
 version=$(git describe --tags --always --dirty)
@@ -73,8 +73,11 @@ cross_build() {
 	done
 }
 
-schema_generate
-for cmd in "$@"; do
-	cmd=$(basename "${cmd}")
-	host_build "${cmd}"
+for arg in "$@"; do
+    if [ "${arg}" = "schema" ]; then
+        schema_generate
+    else
+	    cmd=$(basename "${arg}")
+	    host_build "${cmd}"
+    fi
 done


### PR DESCRIPTION
Previously we were generating the Go schema source each time
`make` is run, which forces the Go compiler to do more work
and slows down iteration.

`Makefile` rules are designed for this, so use that instead.