### PR TITLE
buildextend-live: Also filter out rhcos.root kernel argument

### DIFF
--- a/src/cmd-buildextend-installer
+++ b/src/cmd-buildextend-installer
@@ -35,6 +35,7 @@ live_exclude_kargs = set([
     'console',               # no serial console by default on ISO
     'ignition.platform.id',  # we hardcode "metal"
     'ostree',                # dracut finds the tree automatically
+    'rhcos.root',            # This one is set in RHCOS for the legacy LUKS path
 ])
 
 # Parse args and dispatch


### PR DESCRIPTION
We don't technically *need* this anymore; I've changed RHCOS
to fully use the `-diskful` targets.

But, filtering out that karg would have also fixed the core
bug of the LUKS bits trying to kick on the live system,
and it's just cleaner to have it filtered out.

(I wrote this before fixing RHCOS to use the `-diskful` targets)