### PR TITLE
platform/{metal,qemu}: use bootindex=N instead of `-boot once=d`

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -39,6 +39,7 @@ pod(image: 'registry.fedoraproject.org/fedora:31', runAsUser: 0, kvm: true, memo
           },
           buildextend: {
               cosa_cmd("buildextend-metal")
+              cosa_cmd("buildextend-metal4k")
               cosa_cmd("buildextend-live")
               cosa_cmd("buildextend-openstack")
               cosa_cmd("buildextend-vmware")
@@ -50,7 +51,9 @@ pod(image: 'registry.fedoraproject.org/fedora:31', runAsUser: 0, kvm: true, memo
       }
 
       stage("Image tests") {
-        shwrap("cd /srv && env TMPDIR=\$(pwd)/tmp/ cosa kola testiso -S")
+        shwrap("cd /srv && env TMPDIR=\$(pwd)/tmp/ kola testiso -S")
+        // and again this time with the 4k image
+        shwrap("cd /srv && env TMPDIR=\$(pwd)/tmp/ kola testiso -S --qemu-native-4k --no-pxe")
       }
 
       // Needs to be last because it's destructive

--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -164,8 +164,13 @@ func syncOptionsImpl(useCosa bool) error {
 	if kola.QEMUOptions.Native4k && kola.QEMUOptions.Firmware == "bios" {
 		return fmt.Errorf("native 4k requires uefi firmware")
 	}
+	// default to BIOS, or UEFI for 4k
 	if kola.QEMUOptions.Firmware == "" {
-		kola.QEMUOptions.Firmware = "bios"
+		if kola.QEMUOptions.Native4k {
+			kola.QEMUOptions.Firmware = "uefi"
+		} else {
+			kola.QEMUOptions.Firmware = "bios"
+		}
 	}
 
 	if err := validateOption("platform", kolaPlatform, kolaPlatforms); err != nil {

--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -145,7 +145,7 @@ func runTestIso(cmd *cobra.Command, args []string) error {
 			if err := testPXE(instPxe, completionfile); err != nil {
 				return err
 			}
-			fmt.Printf("Successfully tested PXE live installer for %s\n", kola.CosaBuild.Meta.OstreeVersion)
+			printSuccess("PXE")
 		}
 
 		if !noiso {
@@ -154,7 +154,7 @@ func runTestIso(cmd *cobra.Command, args []string) error {
 			if err := testLiveIso(instIso, completionfile); err != nil {
 				return err
 			}
-			fmt.Printf("Successfully tested ISO live installer for %s\n", kola.CosaBuild.Meta.OstreeVersion)
+			printSuccess("ISO")
 		}
 	}
 
@@ -163,6 +163,14 @@ func runTestIso(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+func printSuccess(mode string) {
+	metaltype := "metal"
+	if kola.QEMUOptions.Native4k {
+		metaltype = "metal4k"
+	}
+	fmt.Printf("Successfully tested %s live installer for %s on %s (%s)\n", mode, kola.CosaBuild.Meta.OstreeVersion, kola.QEMUOptions.Firmware, metaltype)
 }
 
 func testPXE(inst platform.Install, completionfile string) error {

--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -90,6 +90,7 @@ func runTestIso(cmd *cobra.Command, args []string) error {
 
 		Console:  console,
 		Firmware: kola.QEMUOptions.Firmware,
+		Native4k: kola.QEMUOptions.Native4k,
 	}
 
 	if instInsecure {

--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -55,6 +55,7 @@ var (
 	legacy bool
 	nolive bool
 	nopxe  bool
+	noiso  bool
 
 	console bool
 )
@@ -75,6 +76,7 @@ func init() {
 	cmdTestIso.Flags().BoolVarP(&legacy, "legacy", "K", false, "Test legacy installer")
 	cmdTestIso.Flags().BoolVarP(&nolive, "no-live", "L", false, "Skip testing live installer (PXE and ISO)")
 	cmdTestIso.Flags().BoolVarP(&nopxe, "no-pxe", "P", false, "Skip testing live installer PXE")
+	cmdTestIso.Flags().BoolVarP(&noiso, "no-iso", "", false, "Skip testing live installer ISO")
 	cmdTestIso.Flags().BoolVar(&console, "console", false, "Display qemu console to stdout")
 
 	root.AddCommand(cmdTestIso)
@@ -146,12 +148,14 @@ func runTestIso(cmd *cobra.Command, args []string) error {
 			fmt.Printf("Successfully tested PXE live installer for %s\n", kola.CosaBuild.Meta.OstreeVersion)
 		}
 
-		ranTest = true
-		instIso := baseInst // Pretend this is Rust and I wrote .copy()
-		if err := testLiveIso(instIso, completionfile); err != nil {
-			return err
+		if !noiso {
+			ranTest = true
+			instIso := baseInst // Pretend this is Rust and I wrote .copy()
+			if err := testLiveIso(instIso, completionfile); err != nil {
+				return err
+			}
+			fmt.Printf("Successfully tested ISO live installer for %s\n", kola.CosaBuild.Meta.OstreeVersion)
 		}
-		fmt.Printf("Successfully tested ISO live installer for %s\n", kola.CosaBuild.Meta.OstreeVersion)
 	}
 
 	if !ranTest {

--- a/mantle/platform/metal.go
+++ b/mantle/platform/metal.go
@@ -187,7 +187,7 @@ func setupMetalImage(builddir, metalimg, destdir string) (string, error) {
 	metalIsCompressed := !strings.HasSuffix(metalimg, ".raw")
 	metalname := metalimg
 	if !metalIsCompressed {
-		fmt.Println("Compressing metal image")
+		fmt.Printf("Compressing %s\n", metalimg)
 		metalimgpath := filepath.Join(builddir, metalimg)
 		srcf, err := os.Open(metalimgpath)
 		if err != nil {

--- a/mantle/platform/metal.go
+++ b/mantle/platform/metal.go
@@ -225,7 +225,7 @@ func newQemuBuilder(firmware string, console bool, native4k bool) *QemuBuilder {
 		sectorSize = 4096
 	}
 
-	builder.AddDisk(&Disk{
+	builder.AddPrimaryDisk(&Disk{
 		Size: "12G", // Arbitrary
 
 		SectorSize: sectorSize,

--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -147,6 +147,7 @@ type QemuBuilder struct {
 	ConfigFile string
 	// ForceConfigInjection is useful for booting `metal` images directly
 	ForceConfigInjection bool
+	configInjected       bool
 
 	Memory     int
 	Processors int
@@ -527,6 +528,7 @@ func (builder *QemuBuilder) addDiskImpl(disk *Disk, primary bool) error {
 				dstFileName, disk.SectorSize); err != nil {
 				return errors.Wrapf(err, "ignition injection with guestfs failed")
 			}
+			builder.configInjected = true
 		}
 	}
 	fd, err := os.OpenFile(dstFileName, os.O_RDWR, 0)
@@ -706,7 +708,7 @@ func (builder *QemuBuilder) Exec() (*QemuInstance, error) {
 	argv = append(argv, "-nographic")
 
 	// Handle Ignition
-	if builder.ConfigFile != "" {
+	if builder.ConfigFile != "" && !builder.configInjected {
 		if builder.supportsFwCfg() {
 			builder.Append("-fw_cfg", "name=opt/com.coreos/config,file="+builder.ConfigFile)
 		} else if !builder.primaryDiskAdded {

--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -557,6 +557,11 @@ func (builder *QemuBuilder) addDiskImpl(disk *Disk, primary bool) error {
 	if disk.SectorSize != 0 {
 		diskOpts = append(diskOpts, fmt.Sprintf("physical_block_size=%[1]d,logical_block_size=%[1]d", disk.SectorSize))
 	}
+	// Primary disk gets bootindex 1, all other disks have unspecified
+	// bootindex, which means lower priority.
+	if primary {
+		diskOpts = append(diskOpts, "bootindex=1")
+	}
 	builder.addQcow2DiskFd(fd, channel, diskOpts)
 	return nil
 }
@@ -573,9 +578,14 @@ func (builder *QemuBuilder) AddDisk(disk *Disk) error {
 	return builder.addDiskImpl(disk, false)
 }
 
-// AddInstallIso adds an ISO image, configuring to boot from it once
+// AddInstallIso adds an ISO image
 func (builder *QemuBuilder) AddInstallIso(path string) error {
-	builder.Append("-boot", "once=d", "-cdrom", path)
+	// We use bootindex=2 here: the idea is that during an ISO install, the
+	// primary disk isn't bootable, so the bootloader will fall back to the ISO
+	// boot. On reboot when the system is installed, the primary disk is
+	// selected. This allows us to have "boot once" functionality on both UEFI
+	// and BIOS (`-boot once=d` OTOH doesn't work with OVMF).
+	builder.Append("-drive", "file="+path+",format=raw,if=none,readonly=on,id=installiso", "-device", "ide-cd,drive=installiso,bootindex=2")
 	return nil
 }
 


### PR DESCRIPTION
The `-boot once=d` technique only works with some bootloaders. OVMF is
not one of those. Instead, do what libvirt also does, which is to use
`bootindex=N` flags, which both SeaBIOS and OVMF understand. Though the
libvirt VM installation workflow goes one step further here and sets the
`bootindex=1` for the CD-ROM only on first boot, then turns off the
machine, changes the boot order (and ejects the CD media entirely), then
boots it back up. Here instead, we're just relying on the primary disk
being unbootable on first boot to avoid having to stop QEMU and starting
it again with slightly different args (which is totally possible for us
to do, just more complex).

This fixes `kola testiso -P --qemu-firmware=uefi` (and by extension,
`--qemu-native-4k` too). But note UEFI PXE booting still doesn't work,
will try to dig further into that.