### PR TITLE
Qemu: use nbd sockets for multipath disks

### DIFF
--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -135,6 +135,7 @@ func init() {
 	sv(&kola.QEMUOptions.Firmware, "qemu-firmware", "", "Boot firmware: bios,uefi,uefi-secure (default bios)")
 	sv(&kola.QEMUOptions.DiskImage, "qemu-image", "", "path to CoreOS disk image")
 	sv(&kola.QEMUOptions.DiskSize, "qemu-size", "", "Resize target disk via qemu-img resize [+]SIZE")
+	bv(&kola.QEMUOptions.NbdDisk, "qemu-nbd-socket", false, "Present the disks over NBD socket to qemu")
 	bv(&kola.QEMUOptions.MultiPathDisk, "qemu-multipath", false, "Enable multiple paths for the main disk")
 	bv(&kola.QEMUOptions.Native4k, "qemu-native-4k", false, "Force 4k sectors for main disk")
 	bv(&kola.QEMUOptions.Nvme, "qemu-nvme", false, "Use NVMe for main disk")

--- a/mantle/cmd/kola/qemuexec.go
+++ b/mantle/cmd/kola/qemuexec.go
@@ -170,6 +170,7 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 			Size:          kola.QEMUOptions.DiskSize,
 			SectorSize:    sectorSize,
 			MultiPathDisk: kola.QEMUOptions.MultiPathDisk,
+			NbdDisk:       kola.QEMUOptions.NbdDisk,
 		}); err != nil {
 			return errors.Wrapf(err, "adding primary disk")
 		}
@@ -192,6 +193,7 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	defer inst.Destroy()
 
 	// Ignore errors
 	_ = inst.Wait()

--- a/mantle/platform/machine/unprivqemu/flight.go
+++ b/mantle/platform/machine/unprivqemu/flight.go
@@ -35,6 +35,7 @@ type Options struct {
 
 	ForceConfigInjection bool
 
+	NbdDisk       bool
 	MultiPathDisk bool
 	Native4k      bool
 	Nvme          bool

--- a/mantle/system/exec/exec.go
+++ b/mantle/system/exec/exec.go
@@ -79,7 +79,6 @@ func (cmd *ExecCmd) Kill() error {
 			return nil
 		}
 	}
-
 	return err
 }
 

--- a/src/cmd-run
+++ b/src/cmd-run
@@ -17,6 +17,7 @@ BUILDID=latest
 IMAGE_TYPE=qemu
 HOSTNAME=
 MULTIPATH=
+NBD_SOCKET=
 VM_DISK=
 KARGS=
 DISK_CHANNEL=virtio
@@ -40,7 +41,8 @@ Options:
     --kargs               Append kernel arguments
     --uefi                Boot using uefi (x86_64 only, implied on arm)
     --uefi-secure         Boot using uefi with secure boot enabled (x86_64/arm only)
-    --multipath           Attach disks using two paths
+    --multipath           Attach disks using two paths, implies --nbd-socket
+    --nbd-socket          Attach disk using an nbd socket
 
 This script is a wrapper around qemu for starting CoreOS virtual machines,
 it will auto-log you into the console, and by default for read-only disk
@@ -96,6 +98,9 @@ while [ $# -ge 1 ]; do
             shift ;;
         --multipath)
             MULTIPATH=multipath
+            shift ;;
+        --nbd-socket)
+            NBD_SOCKET=nbd-socket
             shift ;;
         --kargs)
             KARGS="$2"
@@ -241,6 +246,10 @@ fi
 if [ -n "${MULTIPATH}" ]; then
     kola_args+=("--qemu-multipath")
 fi
+if [ -n "${NBD_SOCKET}" ]; then
+    kola_args+=("--qemu-nbd-socket")
+fi
+
 
 case "${FIRMWARE}" in
     bios) ;;


### PR DESCRIPTION
This changes up the multipath support by using a NBD server to open the
the qcow2 disks.

This was explored due to https://github.com/coreos/coreos-assembler/pull/1296#issuecomment-606956427
