### PR TITLE
mantle/ore: gcloud: clean up upload.go, stop mutating image name

### DIFF
--- a/mantle/cmd/ore/gcloud/upload.go
+++ b/mantle/cmd/ore/gcloud/upload.go
@@ -82,10 +82,10 @@ func runUpload(cmd *cobra.Command, args []string) {
 	}
 
 	uploadBucket = gsURL.Host
-	uploadImageName = strings.TrimPrefix(gsURL.Path+"/"+uploadImageName, "/")
-	// create equivalent image names for GS and GCE
+	imageNameGS := strings.TrimPrefix(gsURL.Path+"/"+uploadImageName, "/") + ".tar.gz"
+
+	// Sanitize the image name for GCE
 	imageNameGCE := gceSanitize(uploadImageName)
-	imageNameGS := uploadImageName + ".tar.gz"
 
 	storageAPI, err := storage.New(api.Client())
 	if err != nil {

--- a/src/cosalib/gcp.py
+++ b/src/cosalib/gcp.py
@@ -54,7 +54,6 @@ def gcp_run_ore(build, args):
         '--basename', build.build_name,
         'upload',
         '--force',  # We want to support restarting the pipeline
-        '--board=""',
         '--bucket', f'gs://{args.bucket}/{build.build_name}',
         '--json-key', args.json_key,
         '--name', gcp_name,


### PR DESCRIPTION
Some cleanup in here to remove CL specific bits and change the code from mutating the image name on upload. See the individual commit messages for more info.

- mantle/ore: gcloud: clean up a lot of CL specific bits in upload.go
- mantle/ore: gcloud: remove bucket subpath from GCE image name