### PR TITLE
cmd-koji-upload: update to all kargs for _Build from cosalib

### DIFF
--- a/src/cmd-koji-upload
+++ b/src/cmd-koji-upload
@@ -99,13 +99,13 @@ class Build(_Build):
     """
     Koji implementation of Build.
     """
-    def __init__(self, *args, **kwargs):
+    def __init__(self, **kwargs):
         self._tmpdir = tempfile.mkdtemp(prefix="koji-build")
         kwargs.update({
             "require_commit": True,
             "require_cosa": True,
         })
-        _Build.__init__(self, *args, **kwargs)
+        _Build.__init__(self, **kwargs)
 
     def __del__(self):
         try:
@@ -649,7 +649,7 @@ Environment variables are supported:
 
     set_logger(args.log_level)
 
-    build = Build(args.buildroot, build=args.build, arch=args.arch)
+    build = Build(buildroot=args.buildroot, build=args.build, arch=args.arch)
     if args.auth:
         kinit(args.keytab, args.owner)
 


### PR DESCRIPTION
This is some fallout from 3c32c70. Convert cmd-koji-upload to
also use just kwargs for everything.