### PR TITLE
run: Set hostname to `cosarun`

### DIFF
--- a/src/cmd-run
+++ b/src/cmd-run
@@ -2,4 +2,4 @@
 set -euo pipefail
 # This used to contain a lot of its own custom logic.  All of the qemu code
 # now lives inside mantle/kola.
-exec kola qemuexec --add-ignition=autologin -U --auto-cpus "$@"
+exec kola qemuexec --hostname cosarun --add-ignition=autologin -U --auto-cpus "$@"


### PR DESCRIPTION
Let's provide a hostname by default, because the default
`ibm-p8-blah-blah-blah` is just too long.  This was a subtle
fallout from the `cmd-run` gutting.