### PR TITLE
mantle/ore: glcoud: add ability to specify image description for gcp uploads

### DIFF
--- a/mantle/cmd/ore/gcloud/upload.go
+++ b/mantle/cmd/ore/gcloud/upload.go
@@ -36,13 +36,14 @@ var (
 		Run:   runUpload,
 	}
 
-	uploadBucket      string
-	uploadImageName   string
-	uploadFile        string
-	uploadFedora      bool
-	uploadForce       bool
-	uploadWriteUrl    string
-	uploadImageFamily string
+	uploadBucket           string
+	uploadImageName        string
+	uploadFile             string
+	uploadFedora           bool
+	uploadForce            bool
+	uploadWriteUrl         string
+	uploadImageFamily      string
+	uploadImageDescription string
 )
 
 func init() {
@@ -56,6 +57,7 @@ func init() {
 	cmdUpload.Flags().BoolVar(&uploadForce, "force", false, "overwrite existing GS and GCE images without prompt")
 	cmdUpload.Flags().StringVar(&uploadWriteUrl, "write-url", "", "output the uploaded URL to the named file")
 	cmdUpload.Flags().StringVar(&uploadImageFamily, "family", "", "GCP image family to attach image to")
+	cmdUpload.Flags().StringVar(&uploadImageDescription, "description", "", "The description that should be attached to the image")
 	GCloud.AddCommand(cmdUpload)
 }
 
@@ -132,6 +134,7 @@ func runUpload(cmd *cobra.Command, args []string) {
 		Name:        imageNameGCE,
 		Family:      uploadImageFamily,
 		SourceImage: storageSrc,
+		Description: uploadImageDescription,
 	}, uploadForce, uploadFedora)
 	if err == nil {
 		err = pending.Wait()
@@ -152,6 +155,7 @@ func runUpload(cmd *cobra.Command, args []string) {
 				Name:        imageNameGCE,
 				Family:      uploadImageFamily,
 				SourceImage: storageSrc,
+				Description: uploadImageDescription,
 			}, true, uploadFedora)
 			if err == nil {
 				err = pending.Wait()

--- a/mantle/cmd/ore/gcloud/upload.go
+++ b/mantle/cmd/ore/gcloud/upload.go
@@ -150,6 +150,7 @@ func runUpload(cmd *cobra.Command, args []string) {
 			fmt.Println("Overriding existing image...")
 			_, pending, err = api.CreateImage(&gcloud.ImageSpec{
 				Name:        imageNameGCE,
+				Family:      uploadImageFamily,
 				SourceImage: storageSrc,
 			}, true, uploadFedora)
 			if err == nil {

--- a/src/cosalib/gcp.py
+++ b/src/cosalib/gcp.py
@@ -70,6 +70,8 @@ def gcp_run_ore(build, args):
         ore_args.extend(['--fcos'])
     if args.family:
         ore_args.extend(['--family', args.family])
+    if args.description:
+        ore_args.extend(['--description', args.description])
 
     run_verbose(ore_args)
     build.meta['gcp'] = {
@@ -115,5 +117,8 @@ def gcp_cli(parser):
                         default=False)
     parser.add_argument("--family",
                         help="GCP image family to attach image to",
+                        default=None)
+    parser.add_argument("--description",
+                        help="The description that should be attached to the image",
                         default=None)
     return parser


### PR DESCRIPTION
GCP expects a certain image description to be attached to images in the
format of `DISTRO, DISTRO RELEASE, VERSION, INFO`. We need to be able to
specify a description for our images when they are created.

