### PR TITLE
 kola: Test interactive ISO login without networking

### DIFF
--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -853,6 +853,19 @@ func (builder *QemuBuilder) VirtioChannelRead(name string) (*os.File, error) {
 	return r, nil
 }
 
+// SerialPipe reads the serial console output into a pipe
+func (builder *QemuBuilder) SerialPipe() (*os.File, error) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		return nil, errors.Wrapf(err, "virtioChannelRead creating pipe")
+	}
+	id := "serialpipe"
+	builder.Append("-chardev", fmt.Sprintf("file,id=%s,path=%s,append=on", id, builder.AddFd(w)))
+	builder.Append("-serial", fmt.Sprintf("chardev:%s", id))
+
+	return r, nil
+}
+
 func (builder *QemuBuilder) Exec() (*QemuInstance, error) {
 	builder.finalize()
 	var err error


### PR DESCRIPTION

I initially thought we could just scrape the text serial
console but the ISO doesn't output there by default cry

Instead, this now depends on coreos/fedora-coreos-config#339