### PR TITLE
fcos.upgrade.basic: sync after untarring OSTree tarball

### DIFF
--- a/mantle/kola/tests/upgrade/basic.go
+++ b/mantle/kola/tests/upgrade/basic.go
@@ -125,7 +125,11 @@ func fcosUpgradeBasic(c cluster.TestCluster) {
 			c.Fatal(err)
 		}
 
-		c.MustSSHf(m, "tar -xf %s -C %s", kola.CosaBuild.Meta.BuildArtifacts.Ostree.Path, ostreeRepo)
+		// XXX: Note the '&& sync' here; this is to work around sysroot
+		// remounting in libostree forcing a cache flush and blocking D-Bus.
+		// Should drop this once we fix it more properly in {rpm-,}ostree.
+		// https://github.com/coreos/coreos-assembler/issues/1301
+		c.MustSSHf(m, "tar -xf %s -C %s && sync", kola.CosaBuild.Meta.BuildArtifacts.Ostree.Path, ostreeRepo)
 
 		graph.seedFromMachine(c, m)
 		graph.addUpdate(c, m, kola.CosaBuild.Meta.OstreeVersion, kola.CosaBuild.Meta.OstreeCommit)


### PR DESCRIPTION
This works around a subtle issue in rpm-ostree/libostree dropping D-Bus
transactions due to `mount` causing a cache flush and hanging for a
while due to slow I/O.

As mentioned in the comment there, we should drop this in the future and
rework things in the stack proper instead so we're not susceptible to
this.

See https://github.com/coreos/coreos-assembler/issues/1301.