### PR TITLE
mantle/api: gcloud: remove FCOS specific image GuestOSFeatures

### DIFF
--- a/mantle/cmd/ore/gcloud/create-image.go
+++ b/mantle/cmd/ore/gcloud/create-image.go
@@ -41,7 +41,6 @@ var (
 	createImageRoot    string
 	createImageName    string
 	createImageForce   bool
-	createImageFcos    bool
 )
 
 func init() {
@@ -60,7 +59,6 @@ func init() {
 		"Storage image name")
 	cmdCreateImage.Flags().BoolVar(&createImageForce, "force",
 		false, "overwrite existing GCE images without prompt")
-	cmdCreateImage.Flags().BoolVar(&uploadFedora, "fcos", false, "Flag this is Fedora CoreOS (or a derivative); currently enables SECURE_BOOT and UEFI_COMPATIBLE")
 	GCloud.AddCommand(cmdCreateImage)
 }
 
@@ -118,7 +116,7 @@ func runCreateImage(cmd *cobra.Command, args []string) {
 	_, pending, err := api.CreateImage(&gcloud.ImageSpec{
 		Name:        imageNameGCE,
 		SourceImage: storageSrc,
-	}, createImageForce, createImageFcos)
+	}, createImageForce)
 	if err == nil {
 		err = pending.Wait()
 	}

--- a/mantle/cmd/ore/gcloud/upload.go
+++ b/mantle/cmd/ore/gcloud/upload.go
@@ -39,7 +39,6 @@ var (
 	uploadBucket           string
 	uploadImageName        string
 	uploadFile             string
-	uploadFedora           bool
 	uploadForce            bool
 	uploadWriteUrl         string
 	uploadImageFamily      string
@@ -53,7 +52,6 @@ func init() {
 	cmdUpload.MarkFlagRequired("name")
 	cmdUpload.Flags().StringVar(&uploadFile, "file", "", "path to image .tar.gz file to upload")
 	cmdUpload.MarkFlagRequired("file")
-	cmdUpload.Flags().BoolVar(&uploadFedora, "fcos", false, "Flag this is Fedora CoreOS (or a derivative); currently enables SECURE_BOOT and UEFI_COMPATIBLE")
 	cmdUpload.Flags().BoolVar(&uploadForce, "force", false, "overwrite existing GS and GCE images without prompt")
 	cmdUpload.Flags().StringVar(&uploadWriteUrl, "write-url", "", "output the uploaded URL to the named file")
 	cmdUpload.Flags().StringVar(&uploadImageFamily, "family", "", "GCP image family to attach image to")
@@ -135,7 +133,7 @@ func runUpload(cmd *cobra.Command, args []string) {
 		Family:      uploadImageFamily,
 		SourceImage: storageSrc,
 		Description: uploadImageDescription,
-	}, uploadForce, uploadFedora)
+	}, uploadForce)
 	if err == nil {
 		err = pending.Wait()
 	}
@@ -156,7 +154,7 @@ func runUpload(cmd *cobra.Command, args []string) {
 				Family:      uploadImageFamily,
 				SourceImage: storageSrc,
 				Description: uploadImageDescription,
-			}, true, uploadFedora)
+			}, true)
 			if err == nil {
 				err = pending.Wait()
 			}

--- a/mantle/cmd/plume/release.go
+++ b/mantle/cmd/plume/release.go
@@ -140,7 +140,7 @@ func gceUploadImage(spec *channelSpec, api *gcloud.API, obj *gs.Object, name, de
 		Name:        name,
 		Description: desc,
 		Licenses:    spec.GCE.Licenses,
-	}, false, selectedDistro == "fcos")
+	}, false)
 	if err != nil {
 		plog.Fatalf("GCE image creation failed: %v", err)
 	}

--- a/mantle/platform/api/gcloud/image.go
+++ b/mantle/platform/api/gcloud/image.go
@@ -42,7 +42,7 @@ type ImageSpec struct {
 // CreateImage creates an image on GCE and returns operation details and
 // a Pending. If overwrite is true, an existing image will be overwritten
 // if it exists.
-func (a *API) CreateImage(spec *ImageSpec, overwrite, fedora bool) (*compute.Operation, *Pending, error) {
+func (a *API) CreateImage(spec *ImageSpec, overwrite bool) (*compute.Operation, *Pending, error) {
 	licenses := make([]string, len(spec.Licenses))
 	for i, l := range spec.Licenses {
 		license, err := a.compute.Licenses.Get(a.options.Project, l).Do()
@@ -75,15 +75,12 @@ func (a *API) CreateImage(spec *ImageSpec, overwrite, fedora bool) (*compute.Ope
 		{
 			Type: "VIRTIO_SCSI_MULTIQUEUE",
 		},
-	}
-	if fedora {
-		features = append(features,
-			&compute.GuestOsFeature{
-				Type: "UEFI_COMPATIBLE",
-			},
-			&compute.GuestOsFeature{
-				Type: "SECURE_BOOT",
-			})
+		{
+			Type: "UEFI_COMPATIBLE",
+		},
+		{
+			Type: "SECURE_BOOT",
+		},
 	}
 
 	image := &compute.Image{

--- a/src/cosalib/gcp.py
+++ b/src/cosalib/gcp.py
@@ -61,8 +61,6 @@ def gcp_run_ore(build, args):
         '--write-url', urltmp,
     ])
 
-    if args.fcos:
-        ore_args.extend(['--fcos'])
     if args.family:
         ore_args.extend(['--family', args.family])
     if args.description:
@@ -105,11 +103,6 @@ def gcp_cli(parser):
     parser.add_argument("--project",
                         help="GCP Project name",
                         default=os.environ.get("GCP_PROJECT_NAME"))
-    parser.add_argument("--fcos",
-                        help="""Flag this is Fedora CoreOS (or a derivative);
-                                Currently enables SECURE_BOOT and UEFI_COMPATIBLE""",
-                        action="store_true",
-                        default=False)
     parser.add_argument("--family",
                         help="GCP image family to attach image to",
                         default=None)


### PR DESCRIPTION
We consider the VIRTIO_SCSI_MULTIQUEUE, UEFI_COMPATIBLE,
and SECURE_BOOT flags to be standard now so we can
unconditionally add them to GCP images we create and get
rid of the --fcos option.