### PR TITLE
cosalib/gcp: Add more gcp information to meta.json

### DIFF
--- a/mantle/cosa/cosa_v1.go
+++ b/mantle/cosa/cosa_v1.go
@@ -91,7 +91,7 @@ type Cloudartifact struct {
 type Gcp struct {
 	ImageFamily  string `json:"family,omitempty"`
 	ImageName    string `json:"image"`
-	ImageProject string `json:"project"`
+	ImageProject string `json:"project,omitempty"`
 	URL          string `json:"url"`
 }
 

--- a/mantle/cosa/cosa_v1.go
+++ b/mantle/cosa/cosa_v1.go
@@ -40,7 +40,7 @@ type Build struct {
 	CosaImageVersion          int                     `json:"coreos-assembler.image-genver,omitempty"`
 	FedoraCoreOsParentCommit  string                  `json:"fedora-coreos.parent-commit,omitempty"`
 	FedoraCoreOsParentVersion string                  `json:"fedora-coreos.parent-version,omitempty"`
-	Gcp                       *Cloudartifact          `json:"gcp,omitempty"`
+	Gcp                       *Gcp                    `json:"gcp,omitempty"`
 	GitDirty                  string                  `json:"coreos-assembler.config-dirty,omitempty"`
 	ImageInputChecksum        string                  `json:"coreos-assembler.image-input-checksum,omitempty"`
 	InputHasOfTheRpmOstree    string                  `json:"rpm-ostree-inputhash"`
@@ -86,6 +86,13 @@ type BuildArtifacts struct {
 type Cloudartifact struct {
 	Image string `json:"image"`
 	URL   string `json:"url"`
+}
+
+type Gcp struct {
+	ImageFamily  string `json:"family,omitempty"`
+	ImageName    string `json:"image"`
+	ImageProject string `json:"project"`
+	URL          string `json:"url"`
 }
 
 type Git struct {

--- a/mantle/cosa/schema_doc.go
+++ b/mantle/cosa/schema_doc.go
@@ -413,9 +413,9 @@ var generatedSchemaJSON = `{
          "$ref": "#/definitions/artifact"
         },
        "vultr": {
-         "$id":"#/properties/images/properties/vultr",
-         "type":"object",
-         "title":"Vultr",
+         "$id": "#/properties/images/properties/vultr",
+         "type": "object",
+         "title": "Vultr",
          "$ref": "#/definitions/artifact"
         },
        "aliyun": {
@@ -638,7 +638,36 @@ var generatedSchemaJSON = `{
      "$id":"#/properties/gcp",
      "type":"object",
      "title":"GCP",
-     "$ref": "#/definitions/cloudartifact"
+     "required": [
+         "image",
+         "url",
+         "project"
+     ],
+     "optional": [
+         "family"
+     ],
+     "properties": {
+       "image": {
+         "$id":"#/properties/gcp/image",
+         "type":"string",
+         "title":"Image Name"
+        },
+       "url": {
+         "$id":"#/properties/gcp/url",
+         "type":"string",
+         "title":"URL"
+        },
+       "project": {
+         "$id":"#/properties/gcp/project",
+         "type":"string",
+         "title":"Image Project"
+        },
+       "family": {
+         "$id":"#/properties/gcp/family",
+         "type":"string",
+         "title":"Image Family"
+        }
+      }
     }
   }
 }

--- a/mantle/cosa/schema_doc.go
+++ b/mantle/cosa/schema_doc.go
@@ -640,11 +640,11 @@ var generatedSchemaJSON = `{
      "title":"GCP",
      "required": [
          "image",
-         "url",
-         "project"
+         "url"
      ],
      "optional": [
-         "family"
+         "family",
+         "project"
      ],
      "properties": {
        "image": {

--- a/src/cosalib/gcp.py
+++ b/src/cosalib/gcp.py
@@ -93,8 +93,11 @@ def gcp_run_ore(build, args):
 
     build.meta['gcp'] = {
         'image': gcp_name,
+        'project': args.project,
         'url': open(urltmp).read().strip()
     }
+    if args.family:
+        build.meta['gcp']['family'] = args.family
     build.meta_write()
 
 

--- a/src/schema/v1.json
+++ b/src/schema/v1.json
@@ -633,7 +633,36 @@
      "$id":"#/properties/gcp",
      "type":"object",
      "title":"GCP",
-     "$ref": "#/definitions/cloudartifact"
+     "required": [
+         "image",
+         "url",
+         "project"
+     ],
+     "optional": [
+         "family"
+     ],
+     "properties": {
+       "image": {
+         "$id":"#/properties/gcp/image",
+         "type":"string",
+         "title":"Image Name"
+        },
+       "url": {
+         "$id":"#/properties/gcp/url",
+         "type":"string",
+         "title":"URL"
+        },
+       "project": {
+         "$id":"#/properties/gcp/project",
+         "type":"string",
+         "title":"Image Project"
+        },
+       "family": {
+         "$id":"#/properties/gcp/family",
+         "type":"string",
+         "title":"Image Family"
+        }
+      }
     }
   }
 }

--- a/src/schema/v1.json
+++ b/src/schema/v1.json
@@ -635,11 +635,11 @@
      "title":"GCP",
      "required": [
          "image",
-         "url",
-         "project"
+         "url"
      ],
      "optional": [
-         "family"
+         "family",
+         "project"
      ],
      "properties": {
        "image": {


### PR DESCRIPTION
When starting an image in GCP you need to specify the project associated
with the image. We should publish this information and also the image
family in case someone wants to just use the image family instead.