### PR TITLE
 Drain more logic from cmd-kola into kola

### DIFF
--- a/mantle/cmd/kola/kola.go
+++ b/mantle/cmd/kola/kola.go
@@ -77,9 +77,10 @@ will be ignored.
 	}
 
 	cmdList = &cobra.Command{
-		Use:   "list",
-		Short: "List kola test names",
-		RunE:  runList,
+		Use:     "list",
+		Short:   "List kola test names",
+		PreRunE: preRun,
+		RunE:    runList,
 
 		SilenceUsage: true,
 	}

--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -285,5 +285,7 @@ func syncCosaOptions() error {
 		kola.Options.Distribution = distro
 	}
 
+	runExternals = append(runExternals, filepath.Join(kola.Options.CosaWorkdir, "src/config"))
+
 	return nil
 }

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -37,6 +37,7 @@ import (
 	"github.com/coreos/mantle/harness/reporters"
 	"github.com/coreos/mantle/kola/cluster"
 	"github.com/coreos/mantle/kola/register"
+	"github.com/coreos/mantle/network"
 	"github.com/coreos/mantle/platform"
 	awsapi "github.com/coreos/mantle/platform/api/aws"
 	azureapi "github.com/coreos/mantle/platform/api/azure"
@@ -855,7 +856,13 @@ func CheckConsole(output []byte, t *register.Test) []string {
 
 func SetupOutputDir(outputDir, platform string) (string, error) {
 	defaulted := outputDir == ""
-	defaultBaseDirName := "_kola_temp"
+
+	var defaultBaseDirName string
+	if defaulted && Options.CosaWorkdir != "" {
+		defaultBaseDirName = filepath.Join(Options.CosaWorkdir, "tmp/kola")
+	} else {
+		defaultBaseDirName = "_kola_temp"
+	}
 	defaultDirName := fmt.Sprintf("%s-%s-%d", platform, time.Now().Format("2006-01-02-1504"), os.Getpid())
 
 	if defaulted {
@@ -865,6 +872,8 @@ func SetupOutputDir(outputDir, platform string) (string, error) {
 			}
 		}
 		outputDir = filepath.Join(defaultBaseDirName, defaultDirName)
+		// FIXME pass this down better than global state
+		network.DefaultSSHDir = defaultBaseDirName
 	}
 
 	outputDir, err := harness.CleanOutputDir(outputDir)

--- a/mantle/network/ssh.go
+++ b/mantle/network/ssh.go
@@ -33,6 +33,10 @@ const (
 	rsaKeySize  = 2048
 )
 
+// DefaultSSHDir is a process-global path that can be set, and
+// currently is by kola.
+var DefaultSSHDir string
+
 // Dialer is an interface for anything compatible with net.Dialer
 type Dialer interface {
 	Dial(network, address string) (net.Conn, error)
@@ -71,13 +75,15 @@ func NewSSHAgent(dialer Dialer) (*SSHAgent, error) {
 
 	var sockDir string
 	var ok, sockdirOwned bool
-	// This will be set by at least `coreos-assembler kola` since
-	// we have an implicit workdir.
 	if sockDir, ok = os.LookupEnv("MANTLE_SSH_DIR"); !ok {
-		sockDir, err = ioutil.TempDir("", "mantle-ssh-")
-		sockdirOwned = true
-		if err != nil {
-			return nil, err
+		if DefaultSSHDir == "" {
+			sockDir, err = ioutil.TempDir("", "mantle-ssh-")
+			sockdirOwned = true
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			sockDir = DefaultSSHDir
 		}
 	}
 

--- a/src/cmd-kola
+++ b/src/cmd-kola
@@ -4,7 +4,6 @@ import argparse
 import subprocess
 import os
 import sys
-import shutil
 import yaml
 
 # Just test these boot to start with.  In the future we should at least
@@ -64,22 +63,7 @@ subargs = args.subargs or [default_cmd]
 kolaargs.extend(subargs)
 kolaargs.extend(unknown_args)
 
-# FIXME drain into kola once it understands cosa
-if 'run' in subargs or 'list' in subargs:
-    if os.path.isdir('src/config/tests/kola'):
-        kolaargs.extend(['-E', 'src/config'])
-
 kolaargs.extend(blacklist_args)
-
-env = dict(os.environ)
-# By default, store ssh agent in tmp/ too so it can be
-# conveniently found.
-if args.output_dir is None:
-    kola_ssh_dir = 'tmp/kola-ssh'
-    if os.path.isdir(kola_ssh_dir):
-        shutil.rmtree(kola_ssh_dir)
-    os.mkdir(kola_ssh_dir)
-    env['MANTLE_SSH_DIR'] = kola_ssh_dir
 
 if args.basic_qemu_scenarios:
     for scenario in BASIC_SCENARIOS:
@@ -92,8 +76,8 @@ elif args.upgrades:
         kolaargs.extend(['--qemu-image-dir', 'tmp/kola-qemu-cache'])
     kolaargs.extend(['-v', '--find-parent-image'])
     print(subprocess.list2cmdline(kolaargs), flush=True)
-    os.execvpe('kola', kolaargs, env)
+    os.execvp('kola', kolaargs)
 else:
     # flush before exec; see https://docs.python.org/3.7/library/os.html#os.execvpe
     print(subprocess.list2cmdline(kolaargs), flush=True)
-    os.execvpe('kola', kolaargs, env)
+    os.execvp('kola', kolaargs)


### PR DESCRIPTION

If we have a cosa workdir active, use it.  This makes
things consistent so directly running `kola` does the same
thing as `cosa kola`.