### PR TITLE
Use an explicit `cosa-cache` label for cache2.qcow2

### DIFF
--- a/src/supermin-init-prelude.sh
+++ b/src/supermin-init-prelude.sh
@@ -30,8 +30,11 @@ if [ -L "${workdir}"/src/config ]; then
     mount -t 9p -o rw,trans=virtio,version=9p2000.L source "${workdir}"/src/config
 fi
 mkdir -p "${workdir}"/cache /host/container-work
-if [ -b /dev/sdb1 ]; then
-    mount /dev/sdb1 "${workdir}"/cache
+cachedev=$(blkid -lt LABEL=cosa-cache -o device)
+if [ -n "${cachedev}" ]; then
+    mount "${cachedev}" "${workdir}"/cache
+else
+    echo "No cosa-cache filesystem found!"
 fi
 
 if [ -f "${workdir}/tmp/supermin/supermin.env" ]; then


### PR DESCRIPTION
I'd like to rework our build process to use `kola qemuexec`
and complete the move all the core qemu logic into mantle.

Today our build logic ends up hardcoding specific devices like
`/dev/sdb1` which is extremely fragile.  Let's use labels instead,
and start with the cache device.

Rename the cache to `cache2.qcow2` and remove the old one so we
can reliably find the label.