### PR TITLE
build: Identify target disk by wwn

### DIFF
--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -234,20 +234,16 @@ if [ -n "${ref_is_temp}" ]; then
     ref_arg=${commit}
 fi
 
-target_drive=("-drive" "if=virtio,id=target,format=${image_format},file=${path}.tmp,cache=unsafe")
+target_device_opt="scsi-disk,drive=target,wwn=0x2a"
 # we need 4096 block size for ECKD DASD and (obviously) metal4k
 if [[ $image_type == dasd || $image_type == metal4k ]]; then
-    device_type=virtio-blk
-    if [[ $image_type == dasd ]]; then
-        device_type=virtio-blk-ccw
-    fi
-    target_drive=("-drive" "if=none,id=target,format=${image_format},file=${path}.tmp,cache=unsafe" \
-                    "-device" "${device_type},drive=target,physical_block_size=4096,logical_block_size=4096,scsi=off")
+  target_device_opt="${target_device_opt},physical_block_size=4096,logical_block_size=4096"
 fi
+target_drive=("-drive" "if=none,id=target,format=${image_format},file=${path}.tmp,cache=unsafe" \
+              "-device" "virtio-scsi-${devtype},id=scsitarget" "-device" "${target_device_opt}")
 
 runvm "${target_drive[@]}" -- \
         /usr/lib/coreos-assembler/create_disk.sh \
-            --disk /dev/vda \
             --buildid "${build}" \
             --imgid "${img}" \
             --grub-script /usr/lib/coreos-assembler/grub.cfg \

--- a/src/supermin-init-prelude.sh
+++ b/src/supermin-init-prelude.sh
@@ -30,7 +30,7 @@ if [ -L "${workdir}"/src/config ]; then
     mount -t 9p -o rw,trans=virtio,version=9p2000.L source "${workdir}"/src/config
 fi
 mkdir -p "${workdir}"/cache /host/container-work
-cachedev=$(blkid -lt LABEL=cosa-cache -o device)
+cachedev=$(blkid -lt LABEL=cosa-cache -o device || true)
 if [ -n "${cachedev}" ]; then
     mount "${cachedev}" "${workdir}"/cache
 else


### PR DESCRIPTION
This is a followup to:
https://github.com/coreos/coreos-assembler/pull/1342
which is part of:
https://github.com/coreos/coreos-assembler/pull/1289

Our builds right now run qemu in a way that's highly sensitive
to changes in device ordering.

SCSI hardware supports a [world wide name](https://en.wikipedia.org/wiki/World_Wide_Name);
change our qemu invocation to use `42` (in decimal) for that.

Unfortunately because we're not using udev in our supermin
VM right now we don't get the nice `/dev/disk/by-id` symlink
to it.  Instead just walk `/sys/block` manually.