### PR TITLE
build: Fix case with privileges and no cache

### DIFF
--- a/src/supermin-init-prelude.sh
+++ b/src/supermin-init-prelude.sh
@@ -30,7 +30,7 @@ if [ -L "${workdir}"/src/config ]; then
     mount -t 9p -o rw,trans=virtio,version=9p2000.L source "${workdir}"/src/config
 fi
 mkdir -p "${workdir}"/cache /host/container-work
-cachedev=$(blkid -lt LABEL=cosa-cache -o device)
+cachedev=$(blkid -lt LABEL=cosa-cache -o device || true)
 if [ -n "${cachedev}" ]; then
     mount "${cachedev}" "${workdir}"/cache
 else


### PR DESCRIPTION
Regression from: https://github.com/coreos/coreos-assembler/pull/1342
We'd die in pid 1 if the cache disk isn't found, which happens in
the privileged case.