### PR TITLE
testiso: If iso-install is excluded, also exclude iso-live-login

### DIFF
--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -158,6 +158,7 @@ func runTestIso(cmd *cobra.Command, args []string) error {
 	}
 	if noiso || nolive {
 		delete(targetScenarios, scenarioISOInstall)
+		delete(targetScenarios, scenarioISOLiveLogin)
 	}
 
 	if len(targetScenarios) == 0 {


### PR DESCRIPTION
The RHCOS pipeline is failing because it uses `-SKL` which
excludes the first two but not the `iso-live-login` case.  Make
excluding `iso-install` also exclude `iso-live-login`.