### PR TITLE
cli: always call startLogging in WrapPreRun

### DIFF
--- a/mantle/cli/cli.go
+++ b/mantle/cli/cli.go
@@ -102,6 +102,10 @@ func WrapPreRun(root *cobra.Command, f PreRunEFunc) {
 		if err := f(cmd, args); err != nil {
 			return err
 		}
+		// Always inject startLogging to commands that are wrapping the preRun
+		// due to github.com/spf13/cobra/issues/253 where parent command's
+		// preRun & preRunE functions are overwritten by children
+		startLogging(cmd)
 		if preRun != nil {
 			preRun(cmd, args)
 		} else if preRunE != nil {


### PR DESCRIPTION
There is an open issue in spf13/cobra where if a child possesses a
PreRun or PreRunE function the parent's functions are ignored. As we are
only starting logging at the top level command this causes the logging
parameters to be ignored in multiple commands today. Instead just always
call startLogging inside of the WrapPreRun function.

Closes #1321