### PR TITLE
qemu: Ignore journal fd closure in WaitIgnitionError

### DIFF
--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -154,7 +154,10 @@ func (inst *QemuInstance) WaitIgnitionError() (string, error) {
 	iscorrupted := false
 	_, err := b.Peek(1)
 	if err != nil {
-		if err == io.EOF {
+		// It's normal to get EOF if we didn't catch an error and qemu
+		// is shutting down.  We also need to handle when the Destroy()
+		// function closes the journal FD on us.
+		if err == io.EOF || err == os.ErrClosed {
 			return "", nil
 		}
 		return "", errors.Wrapf(err, "Reading from journal")


### PR DESCRIPTION
It's normal for this to happen on instance shutdown.

Closes: https://github.com/coreos/coreos-assembler/issues/1354