### PR TITLE
Stop building fcct, add it as a dep instead

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,6 @@ RUN ./build.sh install_rpms
 COPY ./ /root/containerbuild/
 RUN ./build.sh write_archive_info
 RUN ./build.sh make_and_makeinstall
-RUN ./build.sh build_fcct
 RUN ./build.sh configure_user
 RUN ./build.sh install_tang
 

--- a/build.sh
+++ b/build.sh
@@ -75,21 +75,6 @@ install_rpms() {
     yum clean all
 }
 
-# Yes, this is a hack that loses sane auditing around what git commit
-# we used to build fcct, etc.  In the future we'll probably give in and package
-# it or something, see also https://github.com/coreos/fedora-coreos-tracker/issues/235
-build_fcct() {
-    cd /tmp
-    git clone https://github.com/coreos/fcct
-    cd fcct
-    git describe --tags --always > /usr/share/fcct-build.revision
-    ./build
-    fcct=$(find bin -type f -name fcct | head -1)
-    install -m 0755 -D -t /usr/bin "${fcct}"
-    cd /tmp
-    rm fcct -rf
-}
-
 install_tang() {
     install -m 0755 -T "$srcdir"/src/tang/tangdw /usr/libexec/tangdw
 }

--- a/src/deps.txt
+++ b/src/deps.txt
@@ -77,3 +77,6 @@ python3-jsonschema
 # general principle so people using cosa have it
 # automatically
 coreos-installer
+
+# For the ability to easily pass in an fcc to kola
+fcct


### PR DESCRIPTION
We ship fcct in Fedora now, so let's just add it as any other dep
instead of building it manually.