### PR TITLE
cmd-prune: fix use of add_mutually_exclusive_group

### DIFF
--- a/src/cmd-prune
+++ b/src/cmd-prune
@@ -27,7 +27,7 @@ strategy = parser.add_mutually_exclusive_group()
 strategy.add_argument("--keep-last-n", type=int, metavar="N",
                       default=DEFAULT_KEEP_LAST_N,
                       help="Number of untagged builds to keep (0 for all)")
-strategy.add_argument("--prune", metavar="BUILDID", action='append',
+strategy.add_argument("--build", metavar="BUILDID", action='append',
                       default=[], help="Explicitly prune BUILDID")
 args = parser.parse_args()
 
@@ -58,9 +58,9 @@ builds_to_delete = []
 # Don't prune known builds
 if skip_pruning:
     new_builds = scanned_builds
-elif len(args.prune) > 0:
+elif len(args.build) > 0:
     builds_to_delete_map = {}
-    for bid in args.prune:
+    for bid in args.build:
         build = scanned_builds_map.get(bid)
         if build is None:
             raise Exception(f"Failed to find build ID: {bid}")

--- a/src/cmd-prune
+++ b/src/cmd-prune
@@ -23,13 +23,12 @@ parser = argparse.ArgumentParser(prog="coreos-assembler prune")
 parser.add_argument("--workdir", default='.', help="Path to workdir")
 parser.add_argument("--dry-run", help="Don't actually delete anything",
                     action='store_true')
-keep_options = parser.add_mutually_exclusive_group()
-keep_options.add_argument("--keep-last-n", type=int, metavar="N",
-                          default=DEFAULT_KEEP_LAST_N,
-                          help="Number of untagged builds to keep (0 for all)")
-exactdelete_options = parser.add_mutually_exclusive_group()
-exactdelete_options.add_argument("--prune", metavar="BUILDID", action='append',
-                          default=[], help="Explicitly prune BUILDID")
+strategy = parser.add_mutually_exclusive_group()
+strategy.add_argument("--keep-last-n", type=int, metavar="N",
+                      default=DEFAULT_KEEP_LAST_N,
+                      help="Number of untagged builds to keep (0 for all)")
+strategy.add_argument("--prune", metavar="BUILDID", action='append',
+                      default=[], help="Explicitly prune BUILDID")
 args = parser.parse_args()
 
 skip_pruning = (args.keep_last_n == 0)

--- a/tests/test_pruning.sh
+++ b/tests/test_pruning.sh
@@ -17,7 +17,7 @@ jq -e '.builds[2].id | endswith("0-1")' builds/builds.json
 
 # Test pruning latest via explicit buildid
 latest="$(readlink builds/latest)"
-cosa prune --prune="${latest}"
+cosa prune --build="${latest}"
 # And validate it
 cosa meta --get ostree-version>/dev/null
 # Another build to get back to previous state

--- a/tests/test_pruning.sh
+++ b/tests/test_pruning.sh
@@ -4,9 +4,11 @@ set -xeuo pipefail
 # This test isn't standalone for now. It's executed from the `.cci.jenkinsfile`.
 # It expects to be running in cosa workdir where a single fresh build was made.
 
-# Test that first build has been pruned; create a few builds for testing.
-# FIXME: Add env COSA_BUILD_DUMMY=true or something since this test is very
-# expensive in CI; or better add `cosa build --shortcut=overrides` or so.
+# Test that first build has been pruned; create a few builds for testing. Note
+# these builds are cheap to make because we invalidate the image input data, but
+# don't actually ask for a image rebuild since we use `ostree`.
+# FIXME: Add env COSA_BUILD_DUMMY=true or something instead of using this subtle
+# hack. Or better add `cosa build --shortcut=overrides` or so.
 cosa build ostree --force-image
 cosa build ostree --force-image
 cosa build ostree --force-image


### PR DESCRIPTION
Using `add_mutually_exclusive_group` only makes sense if there are
multiple options within the group. The `keep_options` one actually
should've been dropped as part of #943.

But we do want it now anyway to make `--keep-last-n` conflict with
`--prune`. (One could easily imagine using both options being valid,
though the code doesn't support that right now, so let's reflect that on
the CLI).