### PR TITLE
 Handle Ignition spec2x conversion for metal

### DIFF
--- a/mantle/platform/conf/conf.go
+++ b/mantle/platform/conf/conf.go
@@ -104,6 +104,17 @@ func Ignition(data string) *UserData {
 	}
 }
 
+func IgnitionParsed(conf v3types.Config) *UserData {
+	buf, err := json.Marshal(conf)
+	if err != nil {
+		panic(err)
+	}
+	return &UserData{
+		kind: kindIgnition,
+		data: string(buf),
+	}
+}
+
 func Unknown(data string) *UserData {
 	u := &UserData{
 		data: data,
@@ -285,6 +296,17 @@ func (c *Conf) String() string {
 	}
 
 	return ""
+}
+
+// SerializeAndMaybeConvert serializes a config, and optionally
+// converts it to spec2x.
+func SerializeAndMaybeConvert(conf v3types.Config, spec2 bool) ([]byte, error) {
+	u := IgnitionParsed(conf)
+	c, err := u.Render("", spec2)
+	if err != nil {
+		return nil, err
+	}
+	return []byte(c.String()), nil
 }
 
 // MergeV3 merges a config with the ignitionV3 config via Ignition's merging function.

--- a/mantle/platform/metal.go
+++ b/mantle/platform/metal.go
@@ -260,6 +260,14 @@ func (inst *Install) setup(kern *kernelSetup) (*installerRun, error) {
 		return nil, err
 	}
 
+	pxeAutoLoginSerialized, err := conf.SerializeAndMaybeConvert(conf.GetAutologin(), inst.IgnitionSpec2)
+	if err != nil {
+		return nil, err
+	}
+	if err := ioutil.WriteFile(filepath.Join(tftpdir, "pxe-live.ign"), pxeAutoLoginSerialized, 0644); err != nil {
+		return nil, err
+	}
+
 	for _, name := range []string{kern.kernel, kern.initramfs} {
 		if err := absSymlink(filepath.Join(builddir, name), filepath.Join(tftpdir, name)); err != nil {
 			return nil, err
@@ -454,6 +462,7 @@ func (inst *Install) runPXE(kern *kernelSetup, legacy bool) (*InstalledMachine, 
 	kargs := renderBaseKargs()
 	if !legacy {
 		kargs = append(kargs, liveKargs...)
+		kargs = append(kargs, fmt.Sprintf("ignition.config.url=%s/pxe-live.ign", t.baseurl))
 	}
 
 	kargs = append(kargs, renderInstallKargs(t)...)


### PR DESCRIPTION

I think what happened here is I added conversion code for
PXE at one point, and had it in my head that all of the
paths supported it.

A few things going on here.  First, pass *parsed* Ignition types
into the `metal.go` APIs rather than strings - this is just generally
saner.

Push down Ignition conversion into `metal.go`, a lot like what
we did with `qemu.go`.

Add a helper to our handy "ignition abstraction" `conf.go` to
do what we need in a bunch of places in `metal.go` which is
to serialize and optionally convert in one go.