### PR TITLE
kola/cluster: use "write to separate file then rename" pattern

### DIFF
--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -815,16 +815,8 @@ func scpKolet(machines []platform.Machine) error {
 	} {
 		kolet := filepath.Join(d, "kolet")
 		if _, err := os.Stat(kolet); err == nil {
-			if err := cluster.DropFile(machines, kolet); err != nil {
+			if err := cluster.DropLabeledFile(machines, kolet, "bin_t"); err != nil {
 				return errors.Wrapf(err, "dropping kolet binary")
-			}
-			// If in the future we want to care about machines without SELinux, let's
-			// do basically test -d /sys/fs/selinux or run `getenforce`.
-			for _, machine := range machines {
-				out, stderr, err := machine.SSH("sudo chcon -t bin_t kolet")
-				if err != nil {
-					return errors.Wrapf(err, "running chcon on kolet: %s: %s", out, stderr)
-				}
 			}
 			return nil
 		}


### PR DESCRIPTION
See individual commit messages.

The motivation for this is that there's a race in upgrade testing on AWS where we try to start the kolet httpd service *before* we actually had time to `chcon -t bin_t`. The service of course then fails to start due to SELinux violations.