### PR TITLE
testiso: Don't run iso-live-login scenario by default

### DIFF
--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -97,7 +97,8 @@ func init() {
 	cmdTestIso.Flags().BoolVarP(&nopxe, "no-pxe", "P", false, "Skip testing live installer PXE")
 	cmdTestIso.Flags().BoolVarP(&noiso, "no-iso", "", false, "Skip testing live installer ISO")
 	cmdTestIso.Flags().BoolVar(&console, "console", false, "Display qemu console to stdout")
-	cmdTestIso.Flags().StringSliceVar(&scenarios, "scenarios", []string{scenarioPXEInstall, scenarioISOInstall, scenarioISOLiveLogin}, fmt.Sprintf("Test scenarios (also available: %s)", scenarioLegacyInstall))
+	// FIXME move scenarioISOLiveLogin into the defaults once https://github.com/coreos/fedora-coreos-config/pull/339#issuecomment-613000050 is fixed
+	cmdTestIso.Flags().StringSliceVar(&scenarios, "scenarios", []string{scenarioPXEInstall, scenarioISOInstall}, fmt.Sprintf("Test scenarios (also available: %v)", []string{scenarioLegacyInstall, scenarioISOLiveLogin}))
 
 	root.AddCommand(cmdTestIso)
 }


### PR DESCRIPTION
I need to debug https://github.com/coreos/fedora-coreos-config/pull/339#issuecomment-613000050
and it's blocking CI on other projects right now:
https://github.com/coreos/coreos-installer/pull/216#issuecomment-615213338