### PR TITLE
qemu: Correctly check for ErrClosed on journal pipe

### DIFF
--- a/mantle/platform/machine/unprivqemu/machine.go
+++ b/mantle/platform/machine/unprivqemu/machine.go
@@ -62,9 +62,12 @@ func (m *machine) SSH(cmd string) ([]byte, []byte, error) {
 }
 
 func (m *machine) IgnitionError() error {
-	_, err := m.inst.WaitIgnitionError()
+	buf, err := m.inst.WaitIgnitionError()
 	if err != nil {
 		return err
+	}
+	if buf == "" {
+		return nil
 	}
 	// TODO render buf
 	return platform.ErrInitramfsEmergency

--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -157,7 +157,9 @@ func (inst *QemuInstance) WaitIgnitionError() (string, error) {
 		// It's normal to get EOF if we didn't catch an error and qemu
 		// is shutting down.  We also need to handle when the Destroy()
 		// function closes the journal FD on us.
-		if err == io.EOF || err == os.ErrClosed {
+		if e, ok := err.(*os.PathError); ok && e.Err == os.ErrClosed {
+			return "", nil
+		} else if err == io.EOF {
 			return "", nil
 		}
 		return "", errors.Wrapf(err, "Reading from journal")


### PR DESCRIPTION
This took a bit to figure out.

Closes: https://github.com/coreos/coreos-assembler/issues/1354