### PR TITLE
cmd-build: add --strict for building in strict mode

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -23,7 +23,7 @@ pod(image: 'registry.fedoraproject.org/fedora:31', runAsUser: 0, kvm: true, memo
               // just split into separate invocations to make it easier to see where it fails
               cosa_cmd("init https://github.com/coreos/fedora-coreos-config")
               cosa_cmd("fetch")
-              cosa_cmd("build")
+              cosa_cmd("build --strict")
           }
           parallel kola: {
               try {

--- a/src/cmd-build
+++ b/src/cmd-build
@@ -8,7 +8,7 @@ dn=$(dirname "$0")
 print_help() {
     cat 1>&2 <<'EOF'
 Usage: coreos-assembler build --help
-       coreos-assembler build [--force] [--force-image] [--skip-prune] [--tag TAG] [--version VERSION] [TARGET...]
+       coreos-assembler build [--force] [--force-image] [--skip-prune] [--strict] [--tag TAG] [--version VERSION] [TARGET...]
 
   Build OSTree and image base artifacts from previously fetched packages.
   Accepted TARGET arguments:
@@ -30,8 +30,9 @@ SKIP_PRUNE=0
 VERSION=
 PARENT=
 TAG=
+STRICT=
 rc=0
-options=$(getopt --options hft: --longoptions tag:,help,force,version:,parent:,force-nocache,force-image,skip-prune -- "$@") || rc=$?
+options=$(getopt --options hft: --longoptions tag:,help,force,version:,parent:,force-nocache,force-image,skip-prune,strict -- "$@") || rc=$?
 [ $rc -eq 0 ] || {
     print_help
     exit 1
@@ -51,6 +52,9 @@ while true; do
             ;;
         --skip-prune)
             SKIP_PRUNE=1
+            ;;
+        --strict)
+            STRICT=1
             ;;
         --version)
             shift
@@ -194,23 +198,23 @@ EOF
 
 prepare_git_artifacts "${configdir_gitrepo}" "${PWD}/coreos-assembler-config.tar.gz" "${PWD}/coreos-assembler-config-git.json"
 
-lock_arg=
+extra_compose_args=()
+
 for lock in "${manifest_lock}" "${manifest_lock_overrides}"; do
     if [ -f "${lock}" ]; then
-        lock_arg+=" --ex-lockfile=${lock}"
-        echo "Building from lockfile: ${lock}"
+        extra_compose_args+=("--ex-lockfile=${lock}")
     fi
 done
-if [ -n "${lock_arg}" ]; then
-    sleep 1
+
+if [ -n "${STRICT}" ]; then
+    extra_compose_args+=("--ex-lockfile-strict")
 fi
 
 # We'll pass this directly to rpm-ostree instead of through
 # commitmeta_input_json since that one also gets injected into meta.json, where
 # there's already ostree-version.
-version_arg=
 if [ -n "${VERSION}" ]; then
-    version_arg="--add-metadata-string=version=${VERSION}"
+    extra_compose_args+=("--add-metadata-string=version=${VERSION}")
 fi
 
 # Builds are independent of each other. Higher-level pipelines may want to force
@@ -220,6 +224,7 @@ parent_arg=--no-parent
 if [ -n "${PARENT}" ]; then
     parent_arg="--parent=${PARENT}"
 fi
+extra_compose_args+=("$parent_arg")
 
 # These need to be absolute paths right now for rpm-ostree
 composejson=${PWD}/tmp/compose.json
@@ -231,7 +236,7 @@ prepare_compose_overlays
 runcompose --cache-only ${FORCE} --add-metadata-from-json "${commitmeta_input_json}" \
            --write-composejson-to "${composejson}" \
            --ex-write-lockfile-to "${lockfile_out}".tmp \
-           ${lock_arg} ${version_arg} ${parent_arg}
+           "${extra_compose_args[@]}"
 strip_out_lockfile_digests "$lockfile_out".tmp
 /usr/lib/coreos-assembler/finalize-artifact "${lockfile_out}"{.tmp,}
 # Very special handling for --write-composejson-to as rpm-ostree doesn't

--- a/src/cmd-fetch
+++ b/src/cmd-fetch
@@ -73,12 +73,8 @@ else
     for lock in "${manifest_lock}" "${manifest_lock_overrides}"; do
         if [ -f "${lock}" ]; then
             args+=" --ex-lockfile=${lock}"
-            echo "Fetching RPMs from lockfile: ${lock}"
         fi
     done
-    if [ -n "${args}" ]; then
-        sleep 1
-    fi
 fi
 
 if [ -n "${DRY_RUN}" ]; then
@@ -91,13 +87,9 @@ runcompose --download-only ${args}
 if [ -n "${UPDATE_LOCKFILE}" ]; then
     # Write out to the lockfile specified by the user or to the
     # existing manifest lockfile if none was specified by the user
-    if [ -n "${OUTPUT_LOCKFILE}" ]; then
-        # assume given path is relative to toplevel workdir
-        outfile="${workdir}/${OUTPUT_LOCKFILE}"
-    else
-        outfile=$manifest_lock
-    fi
+    outfile=${OUTPUT_LOCKFILE:-${manifest_lock}}
     strip_out_lockfile_digests "${tmprepo}/tmp/manifest-lock.json"
-    mv -f "${tmprepo}/tmp/manifest-lock.json" "${outfile}"
+    # cd back to workdir in case OUTPUT_LOCKFILE is relative
+    (cd "${workdir}" && mv -f "${tmprepo}/tmp/manifest-lock.json" "${outfile}")
     echo "Wrote out lockfile ${outfile}"
 fi

--- a/tests/test_pruning.sh
+++ b/tests/test_pruning.sh
@@ -9,9 +9,9 @@ set -xeuo pipefail
 # don't actually ask for a image rebuild since we use `ostree`.
 # FIXME: Add env COSA_BUILD_DUMMY=true or something instead of using this subtle
 # hack. Or better add `cosa build --shortcut=overrides` or so.
-cosa build ostree --force-image
-cosa build ostree --force-image
-cosa build ostree --force-image
+cosa build ostree --force-image --strict
+cosa build ostree --force-image --strict
+cosa build ostree --force-image --strict
 jq -e '.builds|length == 3' builds/builds.json
 jq -e '.builds[2].id | endswith("0-1")' builds/builds.json
 
@@ -21,10 +21,10 @@ cosa prune --build="${latest}"
 # And validate it
 cosa meta --get ostree-version>/dev/null
 # Another build to get back to previous state
-cosa build ostree --force-image
+cosa build ostree --force-image --strict
 
 # Test --skip-prune
-cosa build ostree --force-image --skip-prune
+cosa build ostree --force-image --skip-prune --strict
 jq -e '.builds|length == 4' builds/builds.json
 jq -e '.builds[3].id | endswith("0-1")' builds/builds.json
 


### PR DESCRIPTION
This makes use of rpm-ostree's new `--ex-lockfile-strict`. We really
want this for FCOS CI and release builds. For more background, see:

coreos/fedora-coreos-tracker#454

This also drops the printing of lockfiles and the `sleep 1` bit,
since... I think by now people should be pretty familiar with lockfiles
and rpm-ostree prints them already (and it's easily viewable while
libsolv is loading its cache).