### PR TITLE
cmd-build-fast: New command to iterate on content quickly

### DIFF
--- a/src/cmd-build-fast
+++ b/src/cmd-build-fast
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# This command can be run in two different ways.  If COSA_DIR is unset, it
+# must be run from a coreos-assembler working directory.  It will takes new
+# files from overrides/rootfs and applies them
+# on top of a previously built qemu image.  It creates a new deployment.
+# If COSA_DIR is set, it's assumed instead that you are developing on *one*
+# project - it will take the output of `make && make install DESTDIR=` as
+# an overlay on top of the build from COSA_DIR.  Notably, the qcow2 image
+# will end up in the project's working directory - so you can effectively
+# have independent CoreOS builds for each project.
+# This model is likely preferable if you are developing on an individual
+# project - you should turn to the main `cosa build/cosa build-fast` when
+# working on multiple projects.
+
+dn=$(dirname "$0")
+# shellcheck source=src/cmdlib.sh
+. "${dn}"/cmdlib.sh
+
+projectdir=
+projectname=
+if [ -n "${COSA_DIR:-}" ]; then
+    projectdir=$(pwd)
+    projectname=$(basename "${projectdir}")
+    cd "${COSA_DIR}"
+fi
+
+prepare_build
+
+previous_build=$(get_latest_build)
+previous_qemu=
+if [ -z "${previous_build}" ]; then
+    fatal "previous build required for a fast build"
+fi
+previous_builddir=$(get_build_dir "${previous_build}")
+previous_commit=$(jq -r '.["ostree-commit"]' < "${previous_builddir}/meta.json")
+previous_qemu=$(jq -r '.["images"]["qemu"]["path"]' < "${previous_builddir}/meta.json")
+if [ "${previous_qemu}" = "null" ]; then
+    fatal "--shortcut requires a previous build with qemu"
+fi
+echo "Basing on previous build: ${previous_build:-none}"
+
+version="fastbuild-$(date +"%s")"
+if [ -n "${projectdir}" ]; then
+    cd "${projectdir}"
+    rm _install -rf
+    make
+    make install DESTDIR="$(pwd)/_install"
+    rootfsoverrides="${projectdir}/_install"
+else
+    rootfsoverrides="${workdir}/overrides/rootfs"
+fi
+etcdir="${rootfsoverrides}/etc"
+usretcdir="${rootfsoverrides}/usr/etc"
+etcmoved=0
+# FIXME add `ostree commit --rename=etc,usr/etc`
+if [ -d "${etcdir}" ]; then
+    mv -nT "${etcdir}" "${usretcdir}"
+    etcmoved=1
+fi
+restore_etc() {
+    if [ "${etcmoved}" = 1 ]; then
+        mv -nT "${usretcdir}" "${etcdir}"
+    fi
+}
+set -x
+ref=fastbuild
+commit_args=()
+if [ -n "${projectdir}" ]; then
+    ref=fastbuild-${projectname}
+    commit_args+=('--consume')  # nom nom nom
+fi
+# Depends https://github.com/ostreedev/ostree/pull/2041/commits/b3bbbd154225e81980546b2c0b5ed98714830696
+if ! ostree --repo="${tmprepo}" commit -b "${ref}" --base="${previous_commit}" --tree=dir="${rootfsoverrides}" \
+    --owner-uid 0 --owner-gid 0 --selinux-policy-from-base --link-checkout-speedup --no-bindings --no-xattrs \
+    --add-metadata-string=version="${version}" --fsync=0 "${commit_args[@]}"; then
+    restore_etc
+    exit 1
+fi
+set +x
+commit=$(ostree --repo="${tmprepo}" rev-parse "${ref}")
+if [ -z "${projectdir}" ]; then
+    restore_etc
+fi
+fastbuild_qemu="fastbuild-${name}-qemu.qcow2"
+if [ -n "${projectdir}" ]; then
+    fastbuild_qemu="fastbuild-${name}-${projectname}-qemu.qcow2"
+fi
+tmpdir=${projectdir:-.}
+qemu-img create -f qcow2 -o backing_file="${previous_builddir}/${previous_qemu}" "${tmpdir}/${fastbuild_qemu}" 20G
+RUNVM_NONET=1 runvm -drive if=virtio,id=target,format=qcow2,file="${fastbuild_qemu}",cache=unsafe -- \
+    /usr/lib/coreos-assembler/offline-update-impl "${workdir}/tmp/repo" "${commit}"
+if [ -n "${projectdir}" ]; then
+    echo "Created: ${fastbuild_qemu}"
+else
+    cd "${workdir}"
+    rm "${fastbuilddir}" -rf
+    mv -nT "${tmp_builddir}" "${fastbuilddir}"
+    echo "Created: ${fastbuilddir}/${fastbuild_qemu}"
+fi

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -254,6 +254,11 @@ prepare_build() {
     # This dir is no longer used
     rm builds/work -rf
 
+    # Place for cmd-build-fast
+    mkdir -p tmp/fastbuilds
+    fastbuilddir=$(pwd)/tmp/fastbuild
+    export fastbuilddir
+
     # Allocate temporary space for this build
     tmp_builddir=${workdir}/tmp/build
     rm "${tmp_builddir}" -rf


### PR DESCRIPTION
Part of the implementation of
https://github.com/coreos/coreos-assembler/issues/1341

This is useful for me hacking on ostree/rpm-ostree.  Here we
don't need to regenerate the initramfs (usually), we just want
new ostree binaries in `/usr`.  But we *do* want the OS to be
set up as a "proper" OSTree commit, i.e. not `rpm-ostree usroverlay`.

Here this completes a qemu image (overlaid on previous) in 13 seconds,
compared to 147 seconds for a full build; 11x faster *and* we're
not writing `O(sizeof(coreos))` bytes to my SSD, but
`O(sizeof(change) + sizeof(metadata(coreos))`.

With this a workflow looks like:
```
$ cd /src/ostree
$ make && make install DESTDIR=/path/to/cosa/overrides/rootfs
$ cd /path/to/cosa
$ cosa build-fast
$ cosa run --qemu-image tmp/fastbuild/fastbuild-qemu.qcow2
```

(Or, instead of `cosa run`, `cosa kola run --qemu-image  tmp/fastbuild/fastbuild-qemu.qcow2 -E /src/ostree ext.ostree.*`)