### PR TITLE
Add RUNVM_NONET which skips dhclient in helper VM

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -228,7 +228,7 @@ lockfile_out=${tmprepo}/tmp/manifest-lock.generated.${basearch}.json
 prepare_compose_overlays
 # --cache-only is here since `fetch` is a separate verb.
 # shellcheck disable=SC2086
-runcompose --cache-only ${FORCE} --add-metadata-from-json "${commitmeta_input_json}" \
+RUNVM_NONET=1 runcompose --cache-only ${FORCE} --add-metadata-from-json "${commitmeta_input_json}" \
            --write-composejson-to "${composejson}" \
            --ex-write-lockfile-to "${lockfile_out}".tmp \
            ${lock_arg} ${version_arg} ${parent_arg}

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -469,7 +469,7 @@ workdir=${workdir}
 # use the builder user's id, otherwise some operations like
 # chmod will set ownership to root, not builder
 export USER=$(id -u)
-
+export RUNVM_NONET=${RUNVM_NONET:-}
 $(cat "${DIR}"/supermin-init-prelude.sh)
 rc=0
 sh ${TMPDIR}/cmd.sh || rc=\$?

--- a/src/supermin-init-prelude.sh
+++ b/src/supermin-init-prelude.sh
@@ -17,7 +17,9 @@ LANG=C /sbin/load_policy  -i
 /sbin/modprobe fuse
 
 # set up networking
-/usr/sbin/dhclient eth0
+if [ -z "${RUNVM_NONET:-}" ]; then
+    /usr/sbin/dhclient eth0
+fi
 
 # set the umask so that anyone in the group can rwx
 umask 002


### PR DESCRIPTION
This is part of speeding up `cosa build-fast`; here the `dhclient`
run takes about a second out of 11 (after other speedups) so
that's a 9% win.  After rebasing on
https://github.com/coreos/coreos-assembler/pull/1289
I'll also drop out the virtio-net NIC entirely which will help
us ensure tasks that shouldn't pull external content don't.