### PR TITLE
grub: de-hardcode firstboot network configuration

### DIFF
--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -143,6 +143,18 @@ if [ "${image_type}" = dasd ] || [ "${image_type}" = metal4k ]; then
     ignition_platform_id=metal
 fi
 
+# Firstboot kernel arguments.
+firstboot_kargs="$(python3 -c '
+import sys, yaml
+LEGACY_DEFAULT = [ "rd.neednet=1", "ip=dhcp,dhcp6" ]
+args = yaml.safe_load(sys.stdin).get("ignition-network-kcmdline", LEGACY_DEFAULT)
+if not args:
+  # False-y value provided, e.g. empty array.
+  print("", end = "")
+else:
+  print(" ".join(args), end = "")
+' < "$configdir/image.yaml")"
+
 # bootfs
 bootfs_type="$(python3 -c 'import sys, yaml; print(yaml.safe_load(sys.stdin).get("bootfs", "ext4"))' < "$configdir/image.yaml")"
 
@@ -247,6 +259,7 @@ runvm "${target_drive[@]}" -- \
             --buildid "${build}" \
             --imgid "${img}" \
             --grub-script /usr/lib/coreos-assembler/grub.cfg \
+            --firstboot-kargs "\"${firstboot_kargs}\"" \
             --kargs "\"${kargs}\"" \
             --osname "${name}" \
             --ostree-ref "${ref_arg}" \

--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -28,6 +28,7 @@ Options:
     --disk: disk device to use
     --buildid: buildid
     --imgid: imageid
+    --firstboot-kargs: kernel args to be used on firstboot
     --grub-script: grub script to install
     --help: show this helper
     --kargs: kernel CLI args
@@ -51,6 +52,7 @@ rootfs_size="0"
 boot_verity=0
 rootfs_type="xfs"
 x86_bios_partition=1
+firstboot_kargs=""
 extrakargs=""
 
 while [ $# -gt 0 ];
@@ -60,6 +62,7 @@ do
         --disk)                  disk="${1}"; shift;;
         --buildid)               buildid="${1}"; shift;;
         --imgid)                 imgid="${1}"; shift;;
+        --firstboot-kargs)       firstboot_kargs="${1}"; shift;;
         --grub-script)           grub_script="${1}"; shift;;
         --help)                  usage; exit;;
         --kargs)                 extrakargs="${extrakargs} ${1}"; shift;;
@@ -392,7 +395,7 @@ s390x)
 	# stage on s390x, either through zipl->grub2-emu or zipl standalone.
 	# See https://github.com/coreos/ignition-dracut/issues/84
 	# A similar hack is present in https://github.com/coreos/coreos-assembler/blob/master/src/gf-platformid#L55
-	echo "$(grep options $blsfile) ignition.firstboot rd.neednet=1 ip=dhcp,dhcp6" > $tmpfile
+	echo "$(grep options $blsfile) ignition.firstboot" > $tmpfile
 
 	# ideally we want to invoke zipl with bls and zipl.conf but we might need
 	# to chroot to $rootfs/ to do so. We would also do that when FCOS boot on its own.
@@ -411,7 +414,7 @@ ostree config --repo $rootfs/ostree/repo set sysroot.bootloader "${bootloader_ba
 # https://github.com/ostreedev/ostree/issues/1265
 ostree config --repo $rootfs/ostree/repo set sysroot.readonly true
 
-touch $rootfs/boot/ignition.firstboot
+echo "set ignition_network_kcmdline='${firstboot_kargs}'" > $rootfs/boot/ignition.firstboot
 
 # Finally, add the immutable bit to the physical root; we don't
 # expect people to be creating anything there.  A use case for

--- a/src/gf-platformid
+++ b/src/gf-platformid
@@ -52,7 +52,7 @@ coreos_gf upload "${tmpd}"/bls.conf "${blscfg_path}"
 if [ "$basearch" = "s390x" ] ; then
     # Before we re-run zipl make sure we have the firstboot options
     # A hack similar to https://github.com/coreos/coreos-assembler/blob/master/src/create_disk.sh#L381
-    sed -i -e 's,^\(options .*\),\1 ignition.firstboot rd.neednet=1 ip=dhcp\,dhcp6,' "${tmpd}"/bls.conf
+    sed -i -e 's,^\(options .*\),\1 ignition.firstboot,' "${tmpd}"/bls.conf
     coreos_gf rename "${blscfg_path}" "${blscfg_path}.orig"
     coreos_gf upload "${tmpd}"/bls.conf "${blscfg_path}"
 

--- a/src/grub.cfg
+++ b/src/grub.cfg
@@ -44,14 +44,13 @@ fi
 # which is used in the kernel command line.
 set ignition_firstboot=""
 if [ -f "/ignition.firstboot" ]; then
-    # default to dhcp networking parameters to be used with ignition
-    set ignition_network_kcmdline='rd.neednet=1 ip=dhcp,dhcp6'
+    # Default networking parameters to be used with ignition.
+    set ignition_network_kcmdline=''
 
-    # source in the `ignition.firstboot` file which could override the
+    # Source in the `ignition.firstboot` file which could override the
     # above $ignition_network_kcmdline with static networking config.
-    # This override feature is primarily used by coreos-installer to
-    # persist static networking config provided during install to the
-    # first boot of the machine.
+    # This override feature is also by coreos-installer to persist static
+    # networking config provided during install to the first boot of the machine.
     source "/ignition.firstboot"
 
     set ignition_firstboot="ignition.firstboot ${ignition_network_kcmdline}"


### PR DESCRIPTION
This removes the hardcoded network configuration kargs from grub,
moving them into handling within initramfs by `dracut-cmdline.service`.

Ref: https://github.com/coreos/fedora-coreos-tracker/issues/460
Ref: https://github.com/coreos/fedora-coreos-config/pull/427