### PR TITLE
qemu: Lazily convert passed Ignition config

### DIFF
--- a/mantle/cmd/kola/devshell.go
+++ b/mantle/cmd/kola/devshell.go
@@ -154,9 +154,7 @@ WantedBy=multi-user.target`, readinessSignalChan)
 	}
 	readyReader := bufio.NewReader(readyChan)
 
-	if err := builder.SetConfig(*conf, kola.Options.IgnitionVersion == "v2"); err != nil {
-		return errors.Wrapf(err, "rendering config")
-	}
+	builder.SetConfig(*conf, kola.Options.IgnitionVersion == "v2")
 
 	serialPipe, err := builder.SerialPipe()
 	if err != nil {

--- a/mantle/cmd/kola/qemuexec.go
+++ b/mantle/cmd/kola/qemuexec.go
@@ -225,9 +225,7 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 		if directIgnition {
 			return fmt.Errorf("Cannot use fragments/mounts with direct ignition")
 		}
-		if err := builder.SetConfig(*config, kola.Options.IgnitionVersion == "v2"); err != nil {
-			return errors.Wrapf(err, "rendering config")
-		}
+		builder.SetConfig(*config, kola.Options.IgnitionVersion == "v2")
 	} else if directIgnition {
 		builder.ConfigFile = ignition
 	}


### PR DESCRIPTION
Today for architectures without `-fw-cfg` we end up rendering
the Ignition config when `SetPrimaryDisk()` is called.  This
is a confusing trap because it forces us to call `SetConfig()`
before that.

Rework the API to render the config lazily, which doesn't
fix the problem yet - but we can do so by then delaying
injecting the config to `Exec()` time which I'll do as a followup.

Also while we have the patient open, use the new
`conf.SerializeAndMaybeConvert()` API.