### PR TITLE
cmd-fetch: add --strict for fetching in strict mode

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -22,7 +22,7 @@ pod(image: 'registry.fedoraproject.org/fedora:31', runAsUser: 0, kvm: true, memo
               shwrap("chown builder: /srv")
               // just split into separate invocations to make it easier to see where it fails
               cosa_cmd("init https://github.com/coreos/fedora-coreos-config")
-              cosa_cmd("fetch")
+              cosa_cmd("fetch --strict")
               cosa_cmd("build --strict")
           }
           parallel kola: {

--- a/src/cmd-fetch
+++ b/src/cmd-fetch
@@ -8,7 +8,7 @@ dn=$(dirname "$0")
 print_help() {
     cat 1>&2 <<'EOF'
 Usage: coreos-assembler fetch --help
-       coreos-assembler fetch [--update-lockfile] [--write-lockfile-to=file]
+       coreos-assembler fetch [--update-lockfile] [--write-lockfile-to=file] [--strict]
 
   Fetch and import the latest packages.
 EOF
@@ -17,8 +17,9 @@ EOF
 UPDATE_LOCKFILE=
 OUTPUT_LOCKFILE=
 DRY_RUN=
+STRICT=
 rc=0
-options=$(getopt --options h --longoptions help,update-lockfile,dry-run,write-lockfile-to: -- "$@") || rc=$?
+options=$(getopt --options h --longoptions help,update-lockfile,dry-run,write-lockfile-to:,strict -- "$@") || rc=$?
 [ $rc -eq 0 ] || {
     print_help
     exit 1
@@ -40,6 +41,9 @@ while true; do
             ;;
         --dry-run)
             DRY_RUN=1
+            ;;
+        --strict)
+            STRICT=1
             ;;
         --)
             shift
@@ -79,6 +83,9 @@ fi
 
 if [ -n "${DRY_RUN}" ]; then
     args="${args} --dry-run"
+fi
+if [ -n "${STRICT}" ]; then
+	args="${args} --ex-lockfile-strict"
 fi
 
 # shellcheck disable=SC2086


### PR DESCRIPTION
Similar to b2355e7 for `cosa build` let's add a --strict for
fetching in strict mode. Without this we were seeing issues where
fetching would fetch a different set of packages than "build" needed
in order to do the build.