### PR TITLE
build: Require an explicit fetch stage

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -231,7 +231,15 @@ composejson=${PWD}/tmp/compose.json
 # Put this under tmprepo so it gets automatically chown'ed if needed
 lockfile_out=${tmprepo}/tmp/manifest-lock.generated.${basearch}.json
 prepare_compose_overlays
-# --cache-only is here since `fetch` is a separate verb.
+# See https://github.com/coreos/coreos-assembler/pull/1379 - we want the local
+# dev case to explicitly fetch updates when they want them, plus CI pipelines
+# generally want to react to "changed or not" with a separate `fetch`.
+# The fetched-stamp is new, in order to not break existing workdirs we assume
+# a fetch was done if a successful build was done.
+if [ ! -f "${workdir}"/builds/builds.json ] && [ ! -f "${fetch_stamp}" ] ; then
+    fatal "Must fetch before building"
+fi
+# --cache-only is here since `fetch` is a separate verb
 # shellcheck disable=SC2086
 RUNVM_NONET=1 runcompose --cache-only ${FORCE} --add-metadata-from-json "${commitmeta_input_json}" \
            --write-composejson-to "${composejson}" \

--- a/src/cmd-fetch
+++ b/src/cmd-fetch
@@ -90,6 +90,9 @@ fi
 
 # shellcheck disable=SC2086
 runcompose --download-only ${args}
+# This stamp file signifies we successfully fetched once; it's
+# validated in cmd-build.
+touch "${fetch_stamp}"
 
 if [ -n "${UPDATE_LOCKFILE}" ]; then
     # Write out to the lockfile specified by the user or to the

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -186,8 +186,10 @@ prepare_build() {
     manifest=${configdir}/manifest.yaml
     manifest_lock=$(pick_yaml_or_else_json "${configdir}/manifest-lock.${basearch}")
     manifest_lock_overrides=$(pick_yaml_or_else_json "${configdir}/manifest-lock.overrides.${basearch}")
+    fetch_stamp="${workdir}"/cache/fetched-stamp
 
     export workdir configdir manifest manifest_lock manifest_lock_overrides
+    export fetch_stamp
 
     if ! [ -f "${manifest}" ]; then
         fatal "Failed to find ${manifest}"


### PR DESCRIPTION

The recent "no network for builds" change broke the case where
one hadn't done at least one fetch; previously this worked
because rpm-ostree would fall back to fetching, but it can't
without networking.

Explicitly error out if a fetch hasn't been done.