### PR TITLE
devshell: Print serial console as status line, dump when interrupted

### DIFF
--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -42,13 +42,6 @@ var (
 	ErrInitramfsEmergency = errors.New("entered emergency.target in initramfs")
 )
 
-const (
-	StateInitial    = "qemu"
-	StateKernel     = "kernel"
-	StateInitramfs  = "initramfs"
-	StateTargetRoot = "root"
-)
-
 type MachineOptions struct {
 	AdditionalDisks []Disk
 }
@@ -149,44 +142,6 @@ func (inst *QemuInstance) Wait() error {
 		return err
 	}
 	return nil
-}
-
-func runParseSerialConsoleState(r io.Reader, schan chan<- string, echan chan<- error) {
-	bufr := bufio.NewReader(r)
-	state := StateInitial
-	for {
-		buf, _, err := bufr.ReadLine()
-		if err != nil {
-			echan <- err
-			break
-		}
-		line := string(buf)
-		switch state {
-		case StateInitial:
-			// Yes, all this is heuristic.  But it's just informational.
-			if strings.Contains(line, "Hypervisor detected: KVM") {
-				state = StateKernel
-				schan <- state
-			}
-		case StateKernel:
-			if strings.Contains(line, "Running in initial RAM disk.") {
-				state = StateInitramfs
-				schan <- state
-			}
-		case StateInitramfs:
-			if strings.Contains(line, "initrd-switch-root.service: Succeeded.") {
-				state = StateTargetRoot
-				schan <- state
-			}
-		}
-	}
-}
-
-func (inst *QemuInstance) ParseSerialConsoleState(r io.Reader) (<-chan string, <-chan error) {
-	schan := make(chan string)
-	echan := make(chan error)
-	go runParseSerialConsoleState(r, schan, echan)
-	return schan, echan
 }
 
 // WaitIgnitionError will only return if the instance


### PR DESCRIPTION
This is a followup to the previous progress status for
https://github.com/coreos/coreos-assembler/issues/1367

Rather than trying to parse the serial console, just print it as
is, except strip control characters/newlines so that it becomes
effectively a progress bar.  This way, we don't corrupt the terminal,
and we don't fill up its history either.

And, go a step farther and dump the whole serial console in the
case where we get Ctrl-C before a successful login.  This aids
in debugging.