### PR TITLE
mantle/platform/gcloud: drop SECURE_BOOT GuestOsFeature

### DIFF
--- a/mantle/platform/api/gcloud/image.go
+++ b/mantle/platform/api/gcloud/image.go
@@ -78,9 +78,6 @@ func (a *API) CreateImage(spec *ImageSpec, overwrite bool) (*compute.Operation, 
 		{
 			Type: "UEFI_COMPATIBLE",
 		},
-		{
-			Type: "SECURE_BOOT",
-		},
 	}
 
 	image := &compute.Image{


### PR DESCRIPTION
According to GCP, this feature flag is deprecated and does nothing.

cc @dustymabe 