### PR TITLE
kola: add tags to test structure

### DIFF
--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -56,6 +56,7 @@ func init() {
 	ss("debug-systemd-unit", []string{}, "full-unit-name.service to enable SYSTEMD_LOG_LEVEL=debug on. Specify multiple times for multiple units.")
 	sv(&kola.Options.IgnitionVersion, "ignition-version", "", "Ignition version override: v2, v3")
 	ssv(&kola.BlacklistedTests, "blacklist-test", []string{}, "List of tests to blacklist")
+	ssv(&kola.Tags, "tags", []string{}, "List of tags to run")
 	bv(&kola.Options.SSHOnTestFailure, "ssh-on-test-failure", false, "SSH into a machine when tests fail")
 	sv(&kola.Options.CosaWorkdir, "workdir", "", "coreos-assembler working directory")
 	sv(&kola.Options.CosaBuildId, "build", "", "coreos-assembler build ID")

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -79,6 +79,7 @@ var (
 	TAPFile         string // if not "", write TAP results here
 
 	BlacklistedTests []string // tests which are blacklisted
+	Tags             []string // tags to be ran
 
 	consoleChecks = []struct {
 		desc     string
@@ -236,6 +237,7 @@ func filterTests(tests map[string]*register.Test, patterns []string, pltfrm stri
 	}
 
 	var blacklisted bool
+	noPattern := hasString("*", patterns)
 	for name, t := range tests {
 		// Drop anything which is blacklisted directly or by pattern
 		blacklisted = false
@@ -279,7 +281,16 @@ func filterTests(tests map[string]*register.Test, patterns []string, pltfrm stri
 		if err != nil {
 			return nil, err
 		}
-		if !match {
+
+		tagMatch := false
+		for _, tag := range Tags {
+			tagMatch = hasString(tag, t.Tags)
+			if tagMatch {
+				break
+			}
+		}
+
+		if (!noPattern && !match && !tagMatch) || (!tagMatch && noPattern && len(Tags) > 0) {
 			continue
 		}
 

--- a/mantle/kola/register/register.go
+++ b/mantle/kola/register/register.go
@@ -62,6 +62,7 @@ type Test struct {
 	Architectures        []string // whitelist of machine architectures supported -- defaults to all
 	ExcludeArchitectures []string // blacklist of architectures to ignore -- defaults to none
 	Flags                []Flag   // special-case options for this test
+	Tags                 []string // list of tags that can be matched against -- defaults to none
 
 	// ExternalTest is a path to a binary that will be uploaded
 	ExternalTest string

--- a/mantle/kola/tests/crio/crio.go
+++ b/mantle/kola/tests/crio/crio.go
@@ -184,6 +184,7 @@ func init() {
 		Flags:      []register.Flag{register.RequiresInternetAccess},
 		Distros:    []string{"rhcos"},
 		UserDataV3: enableCrioIgn,
+		Tags:       []string{"crio"},
 	})
 	register.RegisterTest(&register.Test{
 		Run:         crioNetwork,
@@ -192,6 +193,7 @@ func init() {
 		Flags:       []register.Flag{register.RequiresInternetAccess},
 		Distros:     []string{"rhcos"},
 		UserDataV3:  enableCrioIgn,
+		Tags:        []string{"crio"},
 		// qemu-unpriv machines cannot communicate between each other
 		ExcludePlatforms: []string{"qemu-unpriv"},
 	})

--- a/mantle/kola/tests/ignition/empty.go
+++ b/mantle/kola/tests/ignition/empty.go
@@ -31,6 +31,7 @@ func init() {
 		ExcludePlatforms: []string{"qemu", "esx"},
 		Distros:          []string{"fcos"},
 		UserData:         conf.Empty(),
+		Tags:             []string{"ignition"},
 	})
 	register.RegisterTest(&register.Test{
 		Name:             "fcos.ignition.v3.noop",
@@ -40,6 +41,7 @@ func init() {
 		Distros:          []string{"fcos"},
 		Flags:            []register.Flag{register.NoSSHKeyInUserData},
 		UserData:         conf.Ignition(`{"ignition":{"version":"3.0.0"}}`),
+		Tags:             []string{"ignition"},
 	})
 }
 

--- a/mantle/kola/tests/ignition/execution.go
+++ b/mantle/kola/tests/ignition/execution.go
@@ -25,6 +25,7 @@ func init() {
 		Name:        "coreos.ignition.once",
 		Run:         runsOnce,
 		ClusterSize: 1,
+		Tags:        []string{"ignition"},
 		UserDataV3: conf.Ignition(`{
                              "ignition": { "version": "3.0.0" },
                              "storage": {

--- a/mantle/kola/tests/ignition/mount.go
+++ b/mantle/kola/tests/ignition/mount.go
@@ -39,6 +39,7 @@ func init() {
 		Run:         testMountDisks,
 		ClusterSize: 0,
 		Platforms:   []string{"qemu"},
+		Tags:        []string{"ignition"},
 	})
 	// create new partiitons with disk `vda`
 	register.RegisterTest(&register.Test{
@@ -46,6 +47,7 @@ func init() {
 		Run:         testMountPartitions,
 		ClusterSize: 0,
 		Platforms:   []string{"qemu"},
+		Tags:        []string{"ignition"},
 	})
 }
 

--- a/mantle/kola/tests/ignition/passwd.go
+++ b/mantle/kola/tests/ignition/passwd.go
@@ -29,6 +29,7 @@ func init() {
 		Name:        "coreos.ignition.groups",
 		Run:         groups,
 		ClusterSize: 1,
+		Tags:        []string{"ignition"},
 		UserData: conf.Ignition(`{
 		             "ignition": { "version": "2.0.0" },
 		             "systemd": {
@@ -78,6 +79,7 @@ func init() {
 		Name:        "coreos.ignition.v2.users",
 		Run:         users,
 		ClusterSize: 1,
+		Tags:        []string{"ignition"},
 		UserData: conf.Ignition(`{
 		             "ignition": { "version": "2.0.0" },
 		             "passwd": {

--- a/mantle/kola/tests/ignition/qemufailure.go
+++ b/mantle/kola/tests/ignition/qemufailure.go
@@ -35,6 +35,7 @@ func init() {
 		Run:         runIgnitionFailure,
 		ClusterSize: 0,
 		Platforms:   []string{"qemu-unpriv"},
+		Tags:        []string{"ignition"},
 	})
 }
 

--- a/mantle/kola/tests/ignition/resource.go
+++ b/mantle/kola/tests/ignition/resource.go
@@ -103,6 +103,7 @@ func init() {
 		NativeFuncs: map[string]register.NativeFuncWrap{
 			"Serve": register.CreateNativeFuncWrap(Serve),
 		},
+		Tags: []string{"ignition"},
 		// https://github.com/coreos/bugs/issues/2205
 		ExcludePlatforms: []string{"do", "qemu-unpriv"},
 	})
@@ -111,6 +112,7 @@ func init() {
 		Run:         resourceRemote,
 		ClusterSize: 1,
 		Flags:       []register.Flag{register.RequiresInternetAccess},
+		Tags:        []string{"ignition"},
 		// https://github.com/coreos/bugs/issues/2205 for DO
 		ExcludePlatforms: []string{"do"},
 		UserData: conf.Ignition(`{
@@ -182,6 +184,7 @@ func init() {
 		Run:         resourceS3,
 		ClusterSize: 1,
 		Platforms:   []string{"aws"},
+		Tags:        []string{"ignition"},
 		UserData: conf.Ignition(`{
 		  "ignition": {
 		      "version": "2.1.0",
@@ -234,6 +237,7 @@ func init() {
 		Run:         resourceS3Versioned,
 		ClusterSize: 1,
 		Flags:       []register.Flag{register.RequiresInternetAccess},
+		Tags:        []string{"ignition"},
 		// https://github.com/coreos/bugs/issues/2205 for DO
 		ExcludePlatforms: []string{"do"},
 		UserData: conf.Ignition(`{

--- a/mantle/kola/tests/ignition/security.go
+++ b/mantle/kola/tests/ignition/security.go
@@ -77,6 +77,7 @@ func init() {
 			"TLSServe":   register.CreateNativeFuncWrap(TLSServe),
 			"TLSServeV3": register.CreateNativeFuncWrap(TLSServeV3),
 		},
+		Tags: []string{"ignition"},
 		// DO: https://github.com/coreos/bugs/issues/2205
 		// Packet & QEMU: https://github.com/coreos/ignition/issues/645
 		ExcludePlatforms: []string{"do", "packet", "qemu"},

--- a/mantle/kola/tests/ignition/sethostname.go
+++ b/mantle/kola/tests/ignition/sethostname.go
@@ -69,6 +69,7 @@ func init() {
 		UserData:         configV2,
 		UserDataV3:       configV3,
 		ExcludePlatforms: []string{"azure"},
+		Tags:             []string{"ignition"},
 	})
 }
 

--- a/mantle/kola/tests/ignition/ssh.go
+++ b/mantle/kola/tests/ignition/ssh.go
@@ -30,5 +30,6 @@ func init() {
 		Flags:            []register.Flag{register.NoSSHKeyInMetadata},
 		UserData:         conf.Ignition(`{"ignition":{"version":"2.0.0"}}`),
 		UserDataV3:       conf.Ignition(`{"ignition":{"version":"3.0.0"}}`),
+		Tags:             []string{"ignition"},
 	})
 }

--- a/mantle/kola/tests/ignition/systemd.go
+++ b/mantle/kola/tests/ignition/systemd.go
@@ -27,6 +27,7 @@ func init() {
 		Name:        "coreos.ignition.systemd.enable-service",
 		Run:         enableSystemdService,
 		ClusterSize: 1,
+		Tags:        []string{"ignition"},
 		// enable nfs-server, touch /etc/exports as it doesn't exist by default on Container Linux,
 		// and touch /var/lib/nfs/etab (https://bugzilla.redhat.com/show_bug.cgi?id=1394395) for RHCOS
 		UserDataV3: conf.Ignition(`{

--- a/mantle/kola/tests/ignition/units.go
+++ b/mantle/kola/tests/ignition/units.go
@@ -25,6 +25,7 @@ func init() {
 		Name:        "coreos.ignition.instantiated.enable-service",
 		Run:         enableSystemdInstantiatedService,
 		ClusterSize: 1,
+		Tags:        []string{"ignition"},
 		UserDataV3: conf.Ignition(`{
     "ignition": {"version": "3.0.0"},
     "systemd": {

--- a/mantle/kola/tests/ostree/basic.go
+++ b/mantle/kola/tests/ostree/basic.go
@@ -36,6 +36,7 @@ func init() {
 		Name:        "ostree.basic",
 		Distros:     []string{"rhcos"},
 		FailFast:    true,
+		Tags:        []string{"ostree"},
 	})
 
 	register.RegisterTest(&register.Test{
@@ -44,6 +45,7 @@ func init() {
 		Name:        "ostree.remote",
 		Flags:       []register.Flag{register.RequiresInternetAccess}, // need network to contact remote
 		FailFast:    true,
+		Tags:        []string{"ostree"},
 	})
 }
 

--- a/mantle/kola/tests/ostree/unlock.go
+++ b/mantle/kola/tests/ostree/unlock.go
@@ -30,6 +30,7 @@ func init() {
 		Name:        "ostree.unlock",
 		Flags:       []register.Flag{register.RequiresInternetAccess}, // need network to pull RPM
 		FailFast:    true,
+		Tags:        []string{"ostree"},
 	})
 	register.RegisterTest(&register.Test{
 		Run:         ostreeHotfixTest,
@@ -37,6 +38,7 @@ func init() {
 		Flags:       []register.Flag{register.RequiresInternetAccess}, // need network to pull RPM
 		Name:        "ostree.hotfix",
 		FailFast:    true,
+		Tags:        []string{"ostree"},
 	})
 
 }

--- a/mantle/kola/tests/rhcos/luks.go
+++ b/mantle/kola/tests/rhcos/luks.go
@@ -41,6 +41,7 @@ func init() {
 		Distros:              []string{"rhcos"},
 		Platforms:            []string{"qemu-unpriv"},
 		ExcludeArchitectures: []string{"s390x", "ppc64le"}, // no TPM support for s390x, ppc64le in qemu
+		Tags:                 []string{"luks", "tpm"},
 		UserData: conf.Ignition(`{
 			"ignition": {
 				"version": "2.2.0"
@@ -69,6 +70,7 @@ func init() {
 		Distros:              []string{"rhcos"},
 		Platforms:            []string{"qemu-unpriv"},
 		ExcludeArchitectures: []string{"s390x", "ppc64le"}, // no TPM support for s390x, ppc64le in qemu
+		Tags:                 []string{"luks", "tang"},
 	})
 	register.RegisterTest(&register.Test{
 		Run:                  luksSSST1Test,
@@ -78,6 +80,7 @@ func init() {
 		Distros:              []string{"rhcos"},
 		Platforms:            []string{"qemu-unpriv"},
 		ExcludeArchitectures: []string{"s390x", "ppc64le"}, // no TPM support for s390x, ppc64le in qemu
+		Tags:                 []string{"luks", "tpm", "tang", "sss"},
 	})
 	register.RegisterTest(&register.Test{
 		Run:                  luksSSST2Test,
@@ -87,6 +90,7 @@ func init() {
 		Distros:              []string{"rhcos"},
 		Platforms:            []string{"qemu-unpriv"},
 		ExcludeArchitectures: []string{"s390x", "ppc64le"}, // no TPM support for s390x, ppc64le in qemu
+		Tags:                 []string{"luks", "tpm", "tang", "sss"},
 	})
 }
 

--- a/mantle/kola/tests/rpmostree/deployments.go
+++ b/mantle/kola/tests/rpmostree/deployments.go
@@ -30,11 +30,13 @@ func init() {
 		ClusterSize: 1,
 		Name:        "rpmostree.upgrade-rollback",
 		FailFast:    true,
+		Tags:        []string{"rpm-ostree", "upgrade"},
 	})
 	register.RegisterTest(&register.Test{
 		Run:         rpmOstreeInstallUninstall,
 		ClusterSize: 1,
 		Name:        "rpmostree.install-uninstall",
+		Tags:        []string{"rpm-ostree"},
 		// this Ignition config lands the EPEL repo + key
 		UserDataV3: conf.Ignition(`{
   "ignition": {

--- a/mantle/kola/tests/rpmostree/status.go
+++ b/mantle/kola/tests/rpmostree/status.go
@@ -30,6 +30,7 @@ func init() {
 		Run:         rpmOstreeStatus,
 		ClusterSize: 1,
 		Name:        "rpmostree.status",
+		Tags:        []string{"rpm-ostree"},
 	})
 }
 

--- a/mantle/kola/tests/upgrade/basic.go
+++ b/mantle/kola/tests/upgrade/basic.go
@@ -47,6 +47,7 @@ func init() {
 		NativeFuncs: map[string]register.NativeFuncWrap{
 			"httpd": register.CreateNativeFuncWrap(httpd),
 		},
+		Tags:    []string{"upgrade"},
 		Distros: []string{"fcos"},
 		// This Ignition does a few things:
 		// 1. bumps Zincati verbosity


### PR DESCRIPTION
Adds the ability to tag tests with a list of strings that can be used as
an alternative to pattern matching.

With the current implementation a test can be valid to be ran if either
the pattern matches OR if a tag directly matches.

Originally discussed in https://github.com/coreos/rpm-ostree/pull/2061#discussion_r408985429