### PR TITLE
Makefile: run `pylint -E` as part of `pycheck`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ check: ${src_checked} ${tests_checked} ${cwd_checked} flake8 pycheck mantle-chec
 
 pycheck:
 	python3 -m py_compile $(pysources)
+	pylint -E $(pysources)
 
 flake8:
 	python3 -m flake8 --ignore=$(PYIGNORE) $(pysources)

--- a/src/cmd-artifact-disk
+++ b/src/cmd-artifact-disk
@@ -101,8 +101,8 @@ def artifact_cli():
         if args.convert_options:
             kwargs["convert_options"] = {'-o': f'{args.convert_options}'}
 
-        builder = QVariants.QemuVariantImage(args.buildroot,
-                                             args.build,
+        builder = QVariants.QemuVariantImage(buildroot=args.buildroot,
+                                             build=args.build,
                                              **kwargs)
     else:
         raise Exception("please see --help for correct invocation")

--- a/src/cosalib/aliyun.py
+++ b/src/cosalib/aliyun.py
@@ -37,7 +37,7 @@ def aliyun_run_ore_replicate(build, args):
         log.info(("default: replicating to all regions. If this is not "
                  " desirable, use '--regions'"))
 
-    log.info("replicating to regions: ", args.region)
+    log.info("replicating to regions: %s", args.region)
 
     # only replicate to regions that don't already exist
     existing_regions = [item['name'] for item in aliyun_img_data]

--- a/src/cosalib/build.py
+++ b/src/cosalib/build.py
@@ -93,6 +93,11 @@ class _Build:
             basearch=kwargs.get("arch", BASEARCH)
         )
 
+        # This is a bit subtle; but essentially, we want to verify that the
+        # subclass has set a platform attribute; `getattr` will fail if not. We
+        # set it to itself to satisfy pylint.
+        self.platform = getattr(self, "platform")
+
         self._found_files = {}
         self._workdir = kwargs.pop("workdir", os.getcwd())
         tmpdir = os.path.join(self._workdir, "tmp")

--- a/src/deps.txt
+++ b/src/deps.txt
@@ -53,7 +53,7 @@ python3-tenacity
 ShellCheck
 
 # For python testing
-python3-flake8 python3-pytest python3-pytest-cov
+python3-flake8 python3-pytest python3-pytest-cov pylint
 
 # For encryption tests
 tang xinetd

--- a/src/deps.txt
+++ b/src/deps.txt
@@ -55,6 +55,9 @@ ShellCheck
 # For python testing
 python3-flake8 python3-pytest python3-pytest-cov pylint
 
+# For cmd-virt-install
+python3-libvirt
+
 # For encryption tests
 tang xinetd
 


### PR DESCRIPTION
pylint is pretty good in general at finding basic Python errors like
passing too many arguments to a function or referencing an unknown
variable, etc...

Let's make use of it.