### PR TITLE
kola/qemu: Revert swtpm for ppc64le for now

### DIFF
--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -452,7 +452,9 @@ func (builder *QemuBuilder) supportsFwCfg() bool {
 // supportsSwtpm if the target system supports a virtual TPM device
 func (builder *QemuBuilder) supportsSwtpm() bool {
 	switch system.RpmArch() {
-	case "s390x":
+	// add back ppc64le as f32/f31's qemu doesn't yet support tpm device emulation
+	// can be removed when cosa is rebased on top of f33/qemu5.0
+	case "s390x", "ppc64le":
 		return false
 	}
 	return true


### PR DESCRIPTION
f31/32's qemu doesn't yet support tpm emulation on ppc64le, missed that in my testing... This can be reverted after cosa will be using f33/qemu5.0 .