### PR TITLE
build: Run udevd in supermin appliance

### DIFF
--- a/src/offline-update-impl
+++ b/src/offline-update-impl
@@ -5,9 +5,6 @@ set -xeuo pipefail
 
 disk=/dev/vda
 
-udevadm trigger
-udevadm settle
-
 # We don't have systemd/udev running
 findlabel() {
     local label=$1

--- a/src/supermin-init-prelude.sh
+++ b/src/supermin-init-prelude.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# This script is our half-baked ad-hoc reimplementation of a minimal
+# Linux boot environment that we generate via `supermin`.  At some
+# point we will likely switch to using systemd.
+
 mount -t proc /proc /proc
 mount -t sysfs /sys /sys
 mount -t devtmpfs devtmpfs /dev
@@ -15,6 +19,10 @@ LANG=C /sbin/load_policy  -i
 
 # need fuse module for rofiles-fuse/bwrap during post scripts run
 /sbin/modprobe fuse
+
+# we want /dev/disk symlinks for coreos-installer
+/usr/lib/systemd/systemd-udevd --daemon
+/usr/sbin/udevadm trigger --settle
 
 # set up networking
 if [ -z "${RUNVM_NONET:-}" ]; then


### PR DESCRIPTION
A lot of our code wants things like `/dev/disk/by-X`.  Extracted
from https://github.com/coreos/coreos-assembler/pull/1244/