### PR TITLE
cmd-fetch: include overrides when updating lockfile

### DIFF
--- a/src/cmd-fetch
+++ b/src/cmd-fetch
@@ -70,8 +70,10 @@ if [ -n "${UPDATE_LOCKFILE}" ]; then
     # Put this under tmprepo so it gets automatically chown'ed if needed
     args="--ex-write-lockfile-to=${tmprepo}/tmp/manifest-lock.json"
     if [ -f "${manifest_lock_overrides}" ]; then
-        echo "NB: ignoring overrides ${manifest_lock_overrides}"
-        sleep 1
+        # Include the overrides in the resulting lockfile here; otherwise, we
+        # might not even be able to get a depsolve solely from the non-lockfile
+        # repos.
+        args+=" --ex-lockfile=${manifest_lock_overrides}"
     fi
 else
     for lock in "${manifest_lock}" "${manifest_lock_overrides}"; do


### PR DESCRIPTION
I'm working on a lockfile updater[1], and I'd like it to just be able to
do `cosa fetch --update-lockfile` the same way a human would. This
normally would run `rpm-ostree compose tree` without passing any
lockfiles and blocking out the pool so that all packages come from the
base repo.

Sadly, that doesn't currently work for FCOS right now because we have an
override for crypto-policies from f32 so that we don't pull in Python.
And because we also have an `exclude-packages` for Python, without the
f32 crypto-policies, we can't get a depsolve from just the base f31
repos. (This is the same issue that killed bodhi-updates[2].)

As a short-term hack, just include the overrides for now. This dillutes
the meaning of a "base" lockfile of course, because it will now include
the packages from the overrides. I don't think this really matters for
now though (it does make the checking for whether overrides are still
needed harder, but I'd like to automate dropping overrides eventually
too).

Anyway, we can drop this hack once we move to f32, though I have some
ideas too on how to solve this more correctly.

[1] https://github.com/coreos/fedora-coreos-tracker/issues/293
[2] https://github.com/coreos/fedora-coreos-config/pull/335#issuecomment-610634917