### PR TITLE
cmd-koji-upload: set dummy platform attribute

### DIFF
--- a/src/cmd-koji-upload
+++ b/src/cmd-koji-upload
@@ -100,6 +100,10 @@ class Build(_Build):
     Koji implementation of Build.
     """
     def __init__(self, **kwargs):
+        # add a dummy platform to satisfy _Build; we're not actually building a
+        # new kind of image here, but _Build is geared towards that and has a
+        # image_name_base() member that wants a platform string to name stuff
+        self.platform = "koji"
         self._tmpdir = tempfile.mkdtemp(prefix="koji-build")
         kwargs.update({
             "require_commit": True,


### PR DESCRIPTION
Regression from #1384.

The koji upload code re-uses the `_Build` class, though the latter is
more geared towards actually building new artifacts. I was tempted to
just not make it use the `_Build` base class at all here and just write
out the procedural code for this (just like `cmd-buildupload`). But
let's go with a quick fix for now.