### PR TITLE
build: Don't auto-load qemu image when building

### DIFF
--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -205,7 +205,7 @@ func syncOptionsImpl(useCosa bool) error {
 			}
 		}
 
-		if kola.Options.CosaWorkdir != "" {
+		if kola.Options.CosaWorkdir != "" && kola.Options.CosaWorkdir != "none" {
 			localbuild, err := sdk.GetLatestLocalBuild(kola.Options.CosaWorkdir)
 			if err != nil {
 				return err

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -475,7 +475,7 @@ EOF
     rm -f "${workdir}/tmp/rc"
 
     #shellcheck disable=SC2086
-    kola qemuexec -m 2048 --auto-cpus -U -- -no-reboot -nodefaults -serial stdio \
+    kola qemuexec -m 2048 --auto-cpus -U --workdir none -- -no-reboot -nodefaults -serial stdio \
         -kernel "${vmbuilddir}/kernel" -initrd "${vmbuilddir}/initrd" \
         -drive "if=virtio,format=raw,snapshot=on,file=${vmbuilddir}/root,index=1" \
         "${cachedisk[@]}" \


### PR DESCRIPTION
Regression from https://github.com/coreos/coreos-assembler/pull/1289
that probably explains other mysterious problems I was seeing too.

Basically, if a qemu image already existed, we would auto-load it
with `kola qemuexec`.  In the case of builds, we absolutely do not
want to do that.

I probably didn't see this *initially* when working on this because
my build didn't have a qemu image yet.