### PR TITLE
AArch64 build fixes

### DIFF
--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -453,8 +453,8 @@ func (builder *QemuBuilder) supportsFwCfg() bool {
 func (builder *QemuBuilder) supportsSwtpm() bool {
 	switch system.RpmArch() {
 	// add back ppc64le as f32/f31's qemu doesn't yet support tpm device emulation
-	// can be removed when cosa is rebased on top of f33/qemu5.0
-	case "s390x", "ppc64le":
+	// can be removed when cosa is rebased on top of f33/qemu5.0 and also aarch64
+	case "s390x", "ppc64le", "aarch64":
 		return false
 	}
 	return true

--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"math"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -961,7 +960,10 @@ func (builder *QemuBuilder) Exec() (*QemuInstance, error) {
 		// cap qemu smp at some reasonable level; sometimes our tooling runs
 		// on 32-core servers (64 hyperthreads) and there's no reason to
 		// try to match that.
-		nproc = uint(math.Max(float64(nproc), float64(16)))
+		if nproc > 16 {
+			nproc = 16
+		}
+
 		builder.Processors = int(nproc)
 	} else if builder.Processors == 0 {
 		builder.Processors = 1


### PR DESCRIPTION
Disable the tpm emulation on aarch64 for now, with same reasons as on ppc64le(too much rawhide qemu for me). 

And improve the smp detection code so it is not using float casts and math package. Float casts are not generally safe as they are implementation/platform depended. For me it manifests, I assume, by seeing "16" cores on 8 core aarch64 box, resulting in qemu failure. This patch fixes it for me.
```
+ kola qemuexec -m 2048 --auto-cpus -U -- -no-reboot -nodefaults -serial stdio -kernel /srv/tmp/supermin.build/kernel -initrd /srv/tmp/supermin.build/initrd -drive if=virtio,format=raw,snapshot=on,file=/srv/tmp/supermin.build/root,index=1 -virtfs local,id=workdir,path=/srv,security_model=none,mount_tag=workdir -append 'root=/dev/vda console=ttyAMA0 selinux=1 enforcing=0 autorelabel=1' -drive if=none,id=target,format=qcow2,file=/srv/tmp/build/fedora-coreos-31.20200423.dev.0-qemu.aarch64.qcow2.tmp,cache=unsafe -device virtio-scsi-pci,id=scsitarget -device scsi-disk,drive=target,wwn=0x2a
qemu-system-aarch64: warning: Number of SMP cpus requested (16) exceeds the recommended cpus supported by KVM (8)
qemu-system-aarch64: warning: Number of hotpluggable cpus requested (16) exceeds the recommended cpus supported by KVM (8)
qemu-system-aarch64: Number of SMP CPUs requested (16) exceeds max CPUs supported by machine 'mach-virt' (8)
Error: exit status 1```