### PR TITLE
devshell: Fatally error if there's no disk

### DIFF
--- a/mantle/cmd/kola/qemuexec.go
+++ b/mantle/cmd/kola/qemuexec.go
@@ -116,6 +116,9 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 		if directIgnition {
 			return fmt.Errorf("Cannot use devshell with direct ignition")
 		}
+		if kola.QEMUOptions.DiskImage == "" {
+			return fmt.Errorf("No disk image provided")
+		}
 		ignitionFragments = append(ignitionFragments, "autologin")
 		cpuCountHost = true
 		usernet = true


### PR DESCRIPTION
Previously if one had just `cosa build ostree` then
`cosa run`, qemu just stalls out confused.

(But this would be a bit better with
 https://github.com/coreos/coreos-assembler/pull/1380
 so someone review that please!)