### PR TITLE
Support passing kernel args to PXE installs

### DIFF
--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -59,6 +59,8 @@ var (
 
 	scenarios []string
 
+	pxeKernelArgs []string
+
 	console bool
 )
 
@@ -99,6 +101,7 @@ func init() {
 	cmdTestIso.Flags().BoolVarP(&nopxe, "no-pxe", "P", false, "Skip testing live installer PXE")
 	cmdTestIso.Flags().BoolVarP(&noiso, "no-iso", "", false, "Skip testing live installer ISO")
 	cmdTestIso.Flags().BoolVar(&console, "console", false, "Display qemu console to stdout")
+	cmdTestIso.Flags().StringSliceVar(&pxeKernelArgs, "pxe-kargs", nil, "Additional kernel arguments for PXE")
 	// FIXME move scenarioISOLiveLogin into the defaults once https://github.com/coreos/fedora-coreos-config/pull/339#issuecomment-613000050 is fixed
 	cmdTestIso.Flags().StringSliceVar(&scenarios, "scenarios", []string{scenarioPXEInstall, scenarioISOInstall}, fmt.Sprintf("Test scenarios (also available: %v)", []string{scenarioLegacyInstall, scenarioISOLiveLogin}))
 
@@ -323,7 +326,7 @@ func testPXE(inst platform.Install) error {
 		return err
 	}
 
-	mach, err := inst.PXE(nil, config)
+	mach, err := inst.PXE(pxeKernelArgs, config)
 	if err != nil {
 		return errors.Wrapf(err, "running PXE")
 	}

--- a/mantle/platform/metal.go
+++ b/mantle/platform/metal.go
@@ -460,6 +460,7 @@ func (inst *Install) runPXE(kern *kernelSetup, legacy bool) (*InstalledMachine, 
 	defer t.destroy()
 
 	kargs := renderBaseKargs()
+	kargs = append(kargs, inst.kargs...)
 	if !legacy {
 		kargs = append(kargs, liveKargs...)
 		kargs = append(kargs, fmt.Sprintf("ignition.config.url=%s/pxe-live.ign", t.baseurl))


### PR DESCRIPTION
So I can use e.g.
`kola testiso -S --scenarios=pxe-install --pxe-kargs rd.break=cmdline`
to debug things.

The metal API here already accepted kargs, it just didn't work
and wasn't exposed.