### PR TITLE
testiso: Accept zero args

### DIFF
--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -101,6 +101,7 @@ func init() {
 	cmdTestIso.Flags().BoolVar(&console, "console", false, "Display qemu console to stdout")
 	// FIXME move scenarioISOLiveLogin into the defaults once https://github.com/coreos/fedora-coreos-config/pull/339#issuecomment-613000050 is fixed
 	cmdTestIso.Flags().StringSliceVar(&scenarios, "scenarios", []string{scenarioPXEInstall, scenarioISOInstall}, fmt.Sprintf("Test scenarios (also available: %v)", []string{scenarioLegacyInstall, scenarioISOLiveLogin}))
+	cmdTestIso.Args = cobra.ExactArgs(0)
 
 	root.AddCommand(cmdTestIso)
 }


### PR DESCRIPTION
I added `--pxe-kargs` and then accidentally edited my command
history to omit it but passed a value, and was confused
why it wasn't working.