### PR TITLE
 qemu: Unlink non-multipath/nbd disks

### DIFF
--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -767,6 +767,13 @@ func (builder *QemuBuilder) addDiskImpl(disk *Disk, primary bool) error {
 				pId, disk.attachEndPoint))
 		}
 	} else {
+		if !disk.NbdDisk {
+			// In the non-multipath/nbd case we can just unlink the disk now
+			// and avoid leaking space if we get Ctrl-C'd (though it's best if
+			// higher level code catches SIGINT and cleans up the directory)
+			os.Remove(disk.dstFileName)
+		}
+		disk.dstFileName = ""
 		switch channel {
 		case "virtio":
 			builder.Append("-device", virtio("blk", fmt.Sprintf("drive=%s%s", id, opts)))


### PR DESCRIPTION
Reopened on top of https://github.com/coreos/coreos-assembler/pull/1399

---

I ran out of space in `/tmp` today and it turned out I had
a whole lot of `/tmp/mantle-qemu` files, including some
really big disk images.  This is a combination of changes
from #1338
and the multipath PR #1296

Basically if we get interrupted by Ctrl-C which is a lot more
likely now when qemu isn't owning the serial console from the
start, we will leak our tmpfiles.

We probably need to install a `SIGINT` handler but that's a whole
mess that's avoided if we just let the kernel clean up our
resources for us, which is what was happening before the multipath
PR (well, at least for files and not the swtpm tmpdir, but that's
small).

And actually
#1380
does install a `SIGINT` handler so someone please review that
and we can maybe fix this more after that lands.