### PR TITLE
cosalib/builds: Fix get_local_builds for multiarch

### DIFF
--- a/src/cosalib/builds.py
+++ b/src/cosalib/builds.py
@@ -183,9 +183,11 @@ def get_local_builds(builds_dir):
                         multiarch_build = Build(id=entry.name, timestamp=ts,
                                                 basearches=[basearch_entry.name])
                     else:
-                        multiarch_build.basearches += [basearch_entry.name]
-                        multiarch_build.timestamp = max(
-                            multiarch_build.timestamp, ts)
+                        arches = [basearch_entry.name]
+                        arches.extend(multiarch_build.basearches)
+                        multiarch_build = Build(id=entry.name,
+                            timestamp=max(multiarch_build.timestamp, ts),
+                            basearches=arches)
                 if multiarch_build:
                     scanned_builds.append(multiarch_build)
     return scanned_builds


### PR DESCRIPTION
This fixes get_local_builds error, for cmd-prune and other possible uses of get_local_builds.
Traceback (most recent call last):
  File "/usr/lib/coreos-assembler/cmd-prune", line 45, in <module>
    scanned_builds = get_local_builds(builds_dir)
  File "/usr/lib/coreos-assembler/cosalib/builds.py", line 186, in get_local_builds
    multiarch_build.basearches += [basearch_entry.name]
AttributeError: can't set attribute
+ rc=1
+ set +x
Tuples are immutable ;)