### PR TITLE
qemu: Ensure tmpdir is allocated for swtpm

### DIFF
--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -988,6 +988,10 @@ func (builder *QemuBuilder) Exec() (*QemuInstance, error) {
 
 	// Handle Software TPM
 	if builder.Swtpm && builder.supportsSwtpm() {
+		err = builder.ensureTempdir()
+		if err != nil {
+			return nil, err
+		}
 		swtpmSock := filepath.Join(builder.tempdir, "swtpm-sock")
 		swtpmdir := filepath.Join(builder.tempdir, "swtpm")
 		if err := os.Mkdir(swtpmdir, 0755); err != nil {


### PR DESCRIPTION
FCOS pipeline is seeing `swtpm/` directory in the working dir:
https://github.com/coreos/coreos-assembler/pull/1399#issuecomment-620179231

I didn't reproduce but this should fix it.