### PR TITLE
 kola/tests/luks: Use separate machine as Tang server

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -16,7 +16,6 @@ if [ $# -gt 1 ]; then
   echo "    configure_yum_repos"
   echo "    install_rpms"
   echo "    make_and_makeinstall"
-  echo "    install_tang"
   exit 1
 fi
 
@@ -75,10 +74,6 @@ install_rpms() {
     yum clean all
 }
 
-install_tang() {
-    install -m 0755 -T "$srcdir"/src/tang/tangdw /usr/libexec/tangdw
-}
-
 make_and_makeinstall() {
     make && make install
 }
@@ -123,5 +118,4 @@ else
   write_archive_info
   make_and_makeinstall
   configure_user
-  install_tang
 fi

--- a/mantle/cmd/kola/qemuexec.go
+++ b/mantle/cmd/kola/qemuexec.go
@@ -216,7 +216,10 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 		builder.Processors = -1
 	}
 	if usernet {
-		builder.EnableUsermodeNetworking(22)
+		h := []platform.HostForwardPort{
+			{Service: "ssh", HostPort: 0, GuestPort: 22},
+		}
+		builder.EnableUsermodeNetworking(h)
 	}
 	builder.InheritConsole = true
 	builder.Append(args...)

--- a/mantle/platform/machine/unprivqemu/cluster.go
+++ b/mantle/platform/machine/unprivqemu/cluster.go
@@ -123,7 +123,15 @@ func (qc *Cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 			return nil, errors.Wrapf(err, "adding additional disk")
 		}
 	}
-	builder.EnableUsermodeNetworking(22)
+
+	if len(options.HostForwardPorts) > 0 {
+		builder.EnableUsermodeNetworking(options.HostForwardPorts)
+	} else {
+		h := []platform.HostForwardPort{
+			{Service: "ssh", HostPort: 0, GuestPort: 22},
+		}
+		builder.EnableUsermodeNetworking(h)
+	}
 
 	inst, err := builder.Exec()
 	if err != nil {

--- a/mantle/platform/platform.go
+++ b/mantle/platform/platform.go
@@ -35,7 +35,8 @@ import (
 )
 
 const (
-	sshRetries = 30
+	// Encryption takes a long time--retry more before failing
+	sshRetries = 60
 	sshTimeout = 10 * time.Second
 )
 

--- a/src/deps.txt
+++ b/src/deps.txt
@@ -58,9 +58,6 @@ python3-flake8 python3-pytest python3-pytest-cov pylint
 # For cmd-virt-install
 python3-libvirt
 
-# For encryption tests
-tang xinetd
-
 # Support for Koji uploads.
 krb5-libs krb5-workstation koji-utils python3-koji python3-koji-cli-plugins
 

--- a/src/tang/tangdw
+++ b/src/tang/tangdw
@@ -1,2 +1,0 @@
-#!/bin/bash
-/usr/libexec/tangd $1 2>>$2


### PR DESCRIPTION
~~This PR builds on top of #1405~~ Closed in favor of this PR.

Two main things in this PR:

-  Enable forwarding of multiple host ports.  Host port forwarding allows the host machine to communicate to the guest machine through the local host address. It also allows the guest machine to communicate with the host machine through the gateway address. With two guest machines, we can bridge the two guests through the host machine with port forwarding.  For example, Host A can run a webserver on port 8080 and Host B can access Host A's webserver through its gateway (host machine) address http://10.0.2.2:8080.

- Changing the Tang test to use host port forwarding to run Tang inside a contain on a separate machine.  This eliminates the need to have Tang in coreos-assembler itself and fixes races/issues with sharing the Tang server in core-assembler.