### PR TITLE
kola/harness: log external test journal output to file

### DIFF
--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -516,6 +516,7 @@ RequiredBy=multi-user.target
 		ClusterSize:   1, // Hardcoded for now
 		ExternalTest:  executable,
 		DependencyDir: dependencydir,
+		Tags:          []string{"external"},
 
 		Run: func(c cluster.TestCluster) {
 			mach := c.Machines()[0]


### PR DESCRIPTION
Adds a new log file for external tests containing the journal output of
the unit under test.

Additionally contains another minor patch to tag external tests with
the `external` tag.

Closes #1408