### PR TITLE
devshell: Don't print error on EOF from serial console

### DIFF
--- a/mantle/cmd/kola/devshell.go
+++ b/mantle/cmd/kola/devshell.go
@@ -187,7 +187,9 @@ WantedBy=multi-user.target`, readinessSignalChan)
 		for {
 			buf, _, err := bufr.ReadLine()
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "devshell reading serial console: %v\n", err)
+				if err != io.EOF {
+					fmt.Fprintf(os.Stderr, "devshell reading serial console: %v\n", err)
+				}
 				break
 			}
 			serialChan <- string(buf)


### PR DESCRIPTION
It's a normal thing on termination.