### PR TITLE
qemu: Propagate errors from disk attachment

### DIFF
--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -649,7 +649,9 @@ func (disk *Disk) prepare(builder *QemuBuilder) error {
 }
 
 func (builder *QemuBuilder) addDiskImpl(disk *Disk, primary bool) error {
-	disk.prepare(builder)
+	if err := disk.prepare(builder); err != nil {
+		return err
+	}
 	if primary {
 		// If the board doesn't support -fw_cfg or we were explicitly
 		// requested, inject via libguestfs on the primary disk.


### PR DESCRIPTION
I passed `--qemu-image /path/to/nofile.qcow2` and got a confusing
error because we weren't propagating errors here.  One of those
things that I miss from Rust where the compiler knows to
warn about unused results.