### PR TITLE
mantle/qemu: Set a short hostname

### DIFF
--- a/mantle/platform/cluster.go
+++ b/mantle/platform/cluster.go
@@ -34,6 +34,7 @@ import (
 
 type BaseCluster struct {
 	machlock   sync.Mutex
+	machserial uint
 	machmap    map[string]Machine
 	consolemap map[string]string
 
@@ -164,6 +165,14 @@ func (bc *BaseCluster) DelMach(m Machine) {
 	defer bc.machlock.Unlock()
 	delete(bc.machmap, m.ID())
 	bc.consolemap[m.ID()] = m.ConsoleOutput()
+}
+
+func (bc *BaseCluster) AllocateMachineSerial() uint {
+	bc.machlock.Lock()
+	defer bc.machlock.Unlock()
+	r := bc.machserial
+	bc.machserial += 1
+	return r
 }
 
 func (bc *BaseCluster) Keys() ([]*agent.Key, error) {

--- a/mantle/platform/machine/unprivqemu/cluster.go
+++ b/mantle/platform/machine/unprivqemu/cluster.go
@@ -93,6 +93,7 @@ func (qc *Cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 	builder.Uuid = qm.id
 	builder.Firmware = qc.flight.opts.Firmware
 	builder.Swtpm = qc.flight.opts.Swtpm
+	builder.Hostname = fmt.Sprintf("qemu%d", qc.BaseCluster.AllocateMachineSerial())
 	builder.ConsoleToFile(qm.consolePath)
 
 	channel := "virtio"


### PR DESCRIPTION
Similarly to https://github.com/coreos/coreos-assembler/pull/1324
I was reading a systemd journal from kola and the `ibm-p8-blah-blah-blah`
is just too long.  Set a hostname so we have less to read.