### PR TITLE
kola/testiso: test that default path is fully offline

### DIFF
--- a/mantle/platform/metal.go
+++ b/mantle/platform/metal.go
@@ -552,7 +552,9 @@ func (inst *Install) InstallViaISOEmbed(kargs []string, liveIgnition, targetIgni
 	var srcOpt string
 	var serializedTargetConfig string
 	if offline {
-		srcOpt = "--offline"
+		// note we leave srcOpt as "" here; offline installs should now be the
+		// default!
+
 		// we want to test that a full offline install works; that includes the
 		// final installed host booting offline
 		serializedTargetConfig = dataurl.EncodeBytes([]byte(renderedTarget))


### PR DESCRIPTION
I'd like to get coverage for
https://github.com/coreos/coreos-installer/pull/197 before it merges and
we do a release with it.

To do that, I want to test that the default installation path no longer
requires Internet access. Here, "default" means we pass neither
`--offline` nor `--stream` nor `--image-url` to
`coreos-installer install`.

Change the new `iso-offline-install` scenario to cover this; all we need
to do is remove the explicit `--offline`.

This scenario will only pass for now if the build under test has that PR
and the live ISO has the osmet files (which right now is gated behind
`--osmet`).

Once that PR is in FCOS proper, we can make `--osmet` the default and
this test will then always pass.