### PR TITLE
buildextend-live: turn on osmet packing by default

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -52,6 +52,7 @@ pod(image: 'registry.fedoraproject.org/fedora:31', runAsUser: 0, kvm: true, memo
 
       stage("Image tests") {
         shwrap("cd /srv && env TMPDIR=\$(pwd)/tmp/ kola testiso -S")
+        shwrap("cd /srv && env TMPDIR=\$(pwd)/tmp/ kola testiso -S --scenarios iso-offline-install")
         // and again this time with the 4k image
         shwrap("cd /srv && env TMPDIR=\$(pwd)/tmp/ kola testiso -S --qemu-native-4k --no-pxe")
       }

--- a/src/cmd-buildextend-installer
+++ b/src/cmd-buildextend-installer
@@ -43,9 +43,6 @@ parser = argparse.ArgumentParser()
 parser.add_argument("--build", help="Build ID")
 parser.add_argument("--force", action='store_true', default=False,
                     help="Overwrite previously generated installer")
-# Temporary switch while we ratchet osmet in place
-parser.add_argument("--osmet", action='store_true', default=False,
-                    help="Generate osmet file")
 args = parser.parse_args()
 
 # Identify the builds and target the latest build if none provided
@@ -57,6 +54,10 @@ print(f"Targeting build: {args.build}")
 with open('src/config/image.yaml') as fh:
     image_yaml = yaml.safe_load(fh)
 squashfs_compression = image_yaml.get('squashfs-compression', 'zstd')
+
+# We make this a knob so that RHCOS can disable it until it supports osmet. See
+# https://github.com/coreos/coreos-installer/issues/224.
+osmet = image_yaml.get('osmet', True)
 
 # Hacky mode switch, until we can drop support for the installer images
 is_live = os.path.basename(sys.argv[0]).endswith('-live')
@@ -175,16 +176,17 @@ def generate_iso():
         tmp_cpio = os.path.join(tmpdir, 'root.cpio')
         tmp_initramfs = os.path.join(tmpdir, 'initramfs')
         cpio_input_files = [os.path.basename(tmp_squashfs)]
-        if args.osmet:
+        if osmet:
             tmp_osmet = os.path.join(tmpdir, img_metal_obj['path'] + '.osmet')
-            cpio_input_files += [os.path.basename(tmp_osmet)]
-            print(f'Generating osmet file')
+            print('Generating osmet file')
             run_verbose(['/usr/lib/coreos-assembler/osmet-pack',
                          img_metal, tmp_osmet, img_metal_checksum])
+            cpio_input_files += [os.path.basename(tmp_osmet)]
 
         print(f'Compressing squashfs with {squashfs_compression}')
         run_verbose(['/usr/lib/coreos-assembler/gf-mksquashfs',
                      img_metal, tmp_squashfs, squashfs_compression])
+
         # create a CPIO layer which holds the root squashfs and osmet binary
         run_verbose(['cpio', '-o', '-H', 'newc', '-R', 'root:root',
                 '--quiet', '--reproducible', '--force-local',


### PR DESCRIPTION
This is the final step in ratcheting osmet into place for offline
installs by default. We drop the `--osmet` optional flag and now always
perform osmet packing when generating the live ISO.

(We could leave the switch around for a while just for compatibility,
but meh... the only other place this exists right now is the
coreos-installer CI, where we can trivially update it once this merges.)

Though because RHCOS doesn't yet support osmet, we add support for an
`osmet` knob in `image.yaml` which the RHCOS pipeline can use to turn it
off for now.

Closes: https://github.com/coreos/fedora-coreos-tracker/issues/352
