### PR TITLE
dockerfile: drop install_tang step, cleanup after PR#1407

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,6 @@ COPY ./ /root/containerbuild/
 RUN ./build.sh write_archive_info
 RUN ./build.sh make_and_makeinstall
 RUN ./build.sh configure_user
-RUN ./build.sh install_tang
 
 RUN make check
 RUN make unittest


### PR DESCRIPTION
@mike-nguyen @cgwalters FYI ```build.sh intall_tang``` invocation has been forgotten(I assume) in the Dockerfile. It breaks the cosa image build. It is surprising this didn't get picked up by the CI.
```b8c73e7d1e42c20ec6d28786b79352f91d2cdd346c2bf0a32917566012f7801b
STEP 10: RUN ./build.sh configure_user
++ pwd
+ srcdir=/root/containerbuild
+ '[' 1 -ne 0 ']'
+ configure_user
+ groupadd -g 78 -o -r kvm78
+ groupadd -g 124 -o -r kvm124
+ groupadd -g 232 -o -r kvm232
+ useradd builder --uid 1000 -G wheel,kvm,kvm78,kvm124,kvm232
+ echo '%wheel ALL=(ALL) NOPASSWD: ALL'
+ chmod 600 /etc/sudoers.d/wheel-nopasswd
f9cf02abe21562c9d79f59f27e4cdf03559a2aa94e2b1b5145689757db1c581c
STEP 11: RUN ./build.sh install_tang
++ pwd
+ srcdir=/root/containerbuild
+ '[' 1 -ne 0 ']'
+ install_tang
./build.sh: line 113: install_tang: command not found
Error: error building at STEP "RUN ./build.sh install_tang": error while running runtime: exit status 127
```