### PR TITLE
fcos.upgrade.basic: only force updates on if required

### DIFF
--- a/mantle/kola/tests/rpmostree/deployments.go
+++ b/mantle/kola/tests/rpmostree/deployments.go
@@ -177,7 +177,7 @@ func rpmOstreeUpgradeRollback(c cluster.TestCluster) {
 		}
 
 		// validate we are back to the original deployment by comparing the
-		// the two rpmOstreeDeployment structs
+		// the two RpmOstreeDeployment structs
 		if !reflect.DeepEqual(originalStatus.Deployments[0], rollbackStatus.Deployments[0]) {
 			c.Fatalf(`Differences found in "rpm-ostree status"; original %v, current: %v`, originalStatus.Deployments[0], rollbackStatus.Deployments[0])
 		}

--- a/mantle/kola/tests/util/rpmostree.go
+++ b/mantle/kola/tests/util/rpmostree.go
@@ -23,8 +23,8 @@ import (
 	"github.com/coreos/mantle/platform"
 )
 
-// rpmOstreeDeployment represents some of the data of an rpm-ostree deployment
-type rpmOstreeDeployment struct {
+// RpmOstreeDeployment represents some of the data of an rpm-ostree deployment
+type RpmOstreeDeployment struct {
 	Booted            bool     `json:"booted"`
 	Checksum          string   `json:"checksum"`
 	Origin            string   `json:"origin"`
@@ -34,11 +34,19 @@ type rpmOstreeDeployment struct {
 	Timestamp         int64    `json:"timestamp"`
 	Unlocked          string   `json:"unlocked"`
 	Version           string   `json:"version"`
+
+	// instead of making it a generic map of strings to "value", we just
+	// special-case the keys we're interested in for now
+	BaseCommitMeta rpmOstreeBaseCommitMeta `json:"base-commit-meta"`
+}
+
+type rpmOstreeBaseCommitMeta struct {
+	FedoraCoreOSStream string `json:"fedora-coreos.stream"`
 }
 
 // simplifiedRpmOstreeStatus contains deployments from rpm-ostree status
 type simplifiedRpmOstreeStatus struct {
-	Deployments []rpmOstreeDeployment
+	Deployments []RpmOstreeDeployment
 }
 
 // GetRpmOstreeStatusJSON returns an unmarshal'ed JSON object that contains
@@ -58,7 +66,7 @@ func GetRpmOstreeStatusJSON(c cluster.TestCluster, m platform.Machine) (simplifi
 	return target, nil
 }
 
-func GetBootedDeployment(c cluster.TestCluster, m platform.Machine) (*rpmOstreeDeployment, error) {
+func GetBootedDeployment(c cluster.TestCluster, m platform.Machine) (*RpmOstreeDeployment, error) {
 	s, err := GetRpmOstreeStatusJSON(c, m)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
On production streams, we should never have to force Zincati updates to
be on since that should already be the default. So remove that from the
Ignition config and dynamically check this when testing.

We check twice here because we need to account for the case where we're
first rebasing from e.g. `testing-devel` to `next` (where we do have to
force updates) and then an update on `next` itself (where we shouldn't
have to force updates).

This would have caught a regression in `next` where Zincati updates were
disabled: https://github.com/coreos/fedora-coreos-tracker/issues/473.