### PR TITLE
kola: Write ignition-virtio-dump.txt to test dir

### DIFF
--- a/mantle/platform/machine/unprivqemu/machine.go
+++ b/mantle/platform/machine/unprivqemu/machine.go
@@ -15,6 +15,7 @@
 package unprivqemu
 
 import (
+	"errors"
 	"io/ioutil"
 	"time"
 
@@ -69,8 +70,7 @@ func (m *machine) IgnitionError() error {
 	if buf == "" {
 		return nil
 	}
-	// TODO render buf
-	return platform.ErrInitramfsEmergency
+	return errors.New(buf)
 }
 
 func (m *machine) Reboot() error {

--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -133,6 +133,7 @@ func (inst *QemuInstance) WaitIgnitionError() (string, error) {
 			break
 		}
 		r.Write(line)
+		r.Write([]byte("\n"))
 	}
 	if iscorrupted {
 		return r.String(), fmt.Errorf("journal was truncated due to overly long line")

--- a/mantle/platform/util.go
+++ b/mantle/platform/util.go
@@ -19,7 +19,9 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"fmt"
+	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -187,8 +189,13 @@ func StartMachine(m Machine, j *Journal) error {
 	go func() {
 		err := m.IgnitionError()
 		if err != nil {
-			plog.Infof("machine %s entered emergency.target in initramfs: %v", m.ID(), err)
-			errchan <- err
+			msg := fmt.Sprintf("machine %s entered emergency.target in initramfs", m.ID())
+			plog.Info(msg)
+			path := filepath.Join(filepath.Dir(j.journalPath), "ignition-virtio-dump.txt")
+			if err := ioutil.WriteFile(path, []byte(err.Error()), 0644); err != nil {
+				plog.Errorf("Failed to write journal: %v", err)
+			}
+			errchan <- errors.New(msg)
 		}
 	}()
 	go func() {


### PR DESCRIPTION
We are seeing the `rhcos.fips` test fail occasionally; the
console is the usual mess of corrupted/overwritten text.

We have the new virtio dump stuff, but until now we have
been discarding the output.  Change the test framework to
save it.

(And in the future we should parse it and try to find
 actual error messages)