### PR TITLE
cmd-build: Stop using RUNVM_NONET=1 for now

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -241,7 +241,8 @@ if [ ! -f "${workdir}"/builds/builds.json ] && [ ! -f "${fetch_stamp}" ] ; then
 fi
 # --cache-only is here since `fetch` is a separate verb
 # shellcheck disable=SC2086
-RUNVM_NONET=1 runcompose --cache-only ${FORCE} --add-metadata-from-json "${commitmeta_input_json}" \
+# XXX: use RUNVM_NONET=1 here once all issues are ironed out
+runcompose --cache-only ${FORCE} --add-metadata-from-json "${commitmeta_input_json}" \
            --write-composejson-to "${composejson}" \
            --ex-write-lockfile-to "${lockfile_out}".tmp \
            "${extra_compose_args[@]}"

--- a/src/cmd-build-fast
+++ b/src/cmd-build-fast
@@ -88,7 +88,8 @@ if [ -n "${projectdir}" ]; then
 fi
 tmpdir=${projectdir:-.}
 qemu-img create -f qcow2 -o backing_file="${previous_builddir}/${previous_qemu}" "${tmpdir}/${fastbuild_qemu}" 20G
-RUNVM_NONET=1 runvm -drive if=virtio,id=target,format=qcow2,file="${fastbuild_qemu}",cache=unsafe -- \
+# XXX: use RUNVM_NONET=1 here once all issues are ironed out
+runvm -drive if=virtio,id=target,format=qcow2,file="${fastbuild_qemu}",cache=unsafe -- \
     /usr/lib/coreos-assembler/offline-update-impl "${workdir}/tmp/repo" "${commit}"
 if [ -n "${projectdir}" ]; then
     echo "Created: ${fastbuild_qemu}"


### PR DESCRIPTION
This is hitting into some subtle issues with cosa overrides and
lockfiles. I'm working on an rpm-ostree patch to fix this, but for now,
let's unblock all the upstream CIs which currently use RPM overrides.