### PR TITLE
cmdlib: Lower cost of cosa RPM overrides repo

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -353,6 +353,7 @@ EOF
 name=coreos-assembler-local-overrides
 baseurl=file://${workdir}/overrides/rpm
 gpgcheck=0
+cost=500
 EOF
     fi
     rootfs_overrides="${overridesdir}/rootfs"


### PR DESCRIPTION
Surprisingly, AFAICT there is nothing in libdnf today which
automatically lowers the cost of local repos vs remote ones. Let's give
it some help by adding a `cost=500` here (the default is 1000). This
will allow libsolv to always pick the RPM from the overrides repo, even
if the same NEVRA is available from a remote repo.