### PR TITLE
buildinitramfs-fast: New command to iterate on initramfs quickly

### DIFF
--- a/src/cmd-buildinitramfs-fast
+++ b/src/cmd-buildinitramfs-fast
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Tool for hacking on the initramfs quickly.  Like
+# `cosa build-fast`, this takes content just from an "overrides"
+# directory, in this case overrides/initramfs (relative to the cosa workdir).
+# Note that this does a literal overlay onto the initramfs,
+# which bypasses dracut modules - so if you're e.g. hacking
+# on a systemd unit or binary, you'll need to do so directly.
+# Example usage:
+# ```
+# $ cd /src/ignition
+# $ make 
+# $ install -D -d -m 0755 bin/amd64/ignition /srv/fcos/overrides/initramfs
+# $ cd /srv/fcos
+# $ cosa buildinitramfs-fast
+# ```
+# 
+# Now you can e.g. log into it:
+# $ cosa run --devshell-console --qemu-image tmp/fastbuild/fastbuildinitrd*.qcow2
+# Or run tests:
+# $ cosa kola run --qemu-image tmp/fastbuild/fastbuildinitrd*.qcow2 basic
+
+dn=$(dirname "$0")
+# shellcheck source=src/cmdlib.sh
+. "${dn}"/cmdlib.sh
+# shellcheck source=src/cmdlib.sh
+. "${dn}"/libguestfish.sh
+
+prepare_build
+
+initramfs_overridedir=${workdir}/overrides/initramfs
+if ! [ -d "${initramfs_overridedir}" ]; then
+    fatal "Must have overrides/initramfs to use this command"
+fi
+
+previous_build=$(get_latest_build)
+previous_qemu=
+if [ -z "${previous_build}" ]; then
+    fatal "previous build required for a fast build"
+fi
+previous_builddir=$(get_build_dir "${previous_build}")
+previous_commit=$(jq -r '.["ostree-commit"]' < "${previous_builddir}/meta.json")
+previous_qemu=$(jq -r '.["images"]["qemu"]["path"]' < "${previous_builddir}/meta.json")
+if [ "${previous_qemu}" = "null" ]; then
+    fatal "A previous qemu build is required"
+fi
+echo "Basing on: ${previous_qemu}"
+
+set -x
+moddir="$(ostree ls --repo "${tmprepo}" "${previous_commit}" /usr/lib/modules | awk '{ print $5 }' | tail -1)"
+
+ostree --repo="${tmprepo}" checkout -U --force-copy --subpath="${moddir}/initramfs.img" "${previous_commit}" .
+
+initramfs=initramfs.img
+test -f "${initramfs}" || fatal "missing ${initramfs}"
+(cd "${initramfs_overridedir}"
+ find . -print0 | cpio -o -H newc -R root:root --null \
+                --quiet --reproducible --force-local \
+                -D . | gzip -1) >>"${initramfs}"
+
+fastbuild_qemu="fastbuildinitrd-${name}-qemu.qcow2"
+qemu-img create -f qcow2 -o backing_file="${previous_builddir}/${previous_qemu}" "${fastbuild_qemu}" 20G
+
+coreos_gf_run_mount ro "${fastbuild_qemu}"
+coreos_gf remount /boot rw:true
+destinitramfs=$(coreos_gf glob-expand /boot/ostree/*/initramfs*)
+coreos_gf upload "${initramfs}" "${destinitramfs}"
+coreos_gf_shutdown
+cd "${workdir}"
+rm "${fastbuilddir}" -rf
+mv -nT "${tmp_builddir}" "${fastbuilddir}"
+echo "Created: ${fastbuilddir}/${fastbuild_qemu}"


### PR DESCRIPTION
This is parallel to [build-fast](https://github.com/coreos/coreos-assembler/pull/1371)
which is about quickly iterating on userspace.

Here is the opposite - we just want to take our new code and
get it into the initramfs as fast as possible.  An example use
is demonstrated in the comment at the top of the file.

Here this takes about 5 seconds to run, which is fast enough
that at least I would probably stay at the terminal and not e.g.
context switch to code review or check Twitter or whatever.