### PR TITLE
kola: Add option to configure RAM

### DIFF
--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -136,6 +136,7 @@ func init() {
 	sv(&kola.QEMUOptions.Firmware, "qemu-firmware", "", "Boot firmware: bios,uefi,uefi-secure (default bios)")
 	sv(&kola.QEMUOptions.DiskImage, "qemu-image", "", "path to CoreOS disk image")
 	sv(&kola.QEMUOptions.DiskSize, "qemu-size", "", "Resize target disk via qemu-img resize [+]SIZE")
+	sv(&kola.QEMUOptions.Memory, "qemu-memory", "", "Default memory size in MB")
 	bv(&kola.QEMUOptions.NbdDisk, "qemu-nbd-socket", false, "Present the disks over NBD socket to qemu")
 	bv(&kola.QEMUOptions.MultiPathDisk, "qemu-multipath", false, "Enable multiple paths for the main disk")
 	bv(&kola.QEMUOptions.Native4k, "qemu-native-4k", false, "Force 4k sectors for main disk")

--- a/mantle/platform/machine/unprivqemu/cluster.go
+++ b/mantle/platform/machine/unprivqemu/cluster.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 
 	"sync"
 	"time"
@@ -95,6 +96,14 @@ func (qc *Cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 	builder.Swtpm = qc.flight.opts.Swtpm
 	builder.Hostname = fmt.Sprintf("qemu%d", qc.BaseCluster.AllocateMachineSerial())
 	builder.ConsoleToFile(qm.consolePath)
+
+	if qc.flight.opts.Memory != "" {
+		memory, err := strconv.ParseInt(qc.flight.opts.Memory, 10, 32)
+		if err != nil {
+			return nil, errors.Wrapf(err, "parsing memory option")
+		}
+		builder.Memory = int(memory)
+	}
 
 	channel := "virtio"
 	if qc.flight.opts.Nvme {

--- a/mantle/platform/machine/unprivqemu/flight.go
+++ b/mantle/platform/machine/unprivqemu/flight.go
@@ -32,6 +32,7 @@ type Options struct {
 	DiskSize string
 	Board    string
 	Firmware string
+	Memory   string
 
 	ForceConfigInjection bool
 


### PR DESCRIPTION
Currently we default to 1024MiB for tests, but trying out this
patch with:
```
$ cosa kola run -- --parallel 8 --qemu-memory 512
```

The *only* test which fails is `rpmostree.install-uninstall`, probably
because the Fedora package metadata is enormous.

The main thing limiting test parallelism in our CI pipeline is RAM,
so if we can e.g. use 512 by default then that would nearly double test execution
speed.

This is prep for a future patch which will try to assign "instance type requests"
to tests, so both qemu and other platforms like AWS can use smaller instances.
For example in AWS we could use `t2.nano` for some tests instead of `m4.large`;
the pricing difference is large.  `t2.nano` in `us-east-2` is $0.0058, and
`m4.large` is $0.10, a savings of 95%.