### PR TITLE
mantle: Build binaries in parallel

### DIFF
--- a/mantle/Makefile
+++ b/mantle/Makefile
@@ -3,9 +3,13 @@ DESTDIR ?=
 
 ARCH:=$(shell uname -m)
 
+BINS:=$(shell ls cmd)
+
+bin/%:
+	./build cmd/$*
+
 .PHONY: build test vendor clean
-build:
-	./build cmd/*
+build: $(patsubst %,bin/%,$(BINS))
 
 schema-update:
 	./build schema


### PR DESCRIPTION
One really terrible thing about Go is there's no standard build
system - contrast with Rust's cargo.  Here our hand-rolled
`Makefile` + shell script inhibits parallelism.

Rework the binaries to be separate jobs; this cuts a clean build
from 9s here to 5s.