### PR TITLE
Exclude rhcos distro from the journaldEntry test

### DIFF
--- a/mantle/kola/tests/ignition/journaldEntry.go
+++ b/mantle/kola/tests/ignition/journaldEntry.go
@@ -29,6 +29,8 @@ func init() {
 		Name:        "coreos.ignition.journald-log",
 		Run:         sendJournaldLog,
 		ClusterSize: 1,
+		// Since RHCOS uses the 2x spec and not 3x.
+		ExcludeDistros: []string{"rhcos"},
 	})
 }
 


### PR DESCRIPTION
[context] --- FAIL: coreos.ignition.journald-log (22.90s)
        journaldEntry.go:44: Ignition didn't write 57124006b5c94805b77ce473e92a8aeb
/cc @ashcrow 