### PR TITLE
Revert "mantle: Build binaries in parallel"

### DIFF
--- a/mantle/Makefile
+++ b/mantle/Makefile
@@ -3,13 +3,9 @@ DESTDIR ?=
 
 ARCH:=$(shell uname -m)
 
-BINS:=$(shell ls cmd)
-
-bin/%:
-	./build cmd/$*
-
 .PHONY: build test vendor clean
-build: $(patsubst %,bin/%,$(BINS))
+build:
+	./build cmd/*
 
 schema-update:
 	./build schema


### PR DESCRIPTION
This reverts commit afeb3c3f7dd80e5db4e55d1e8a213770f484d0ea - it
broke incremental builds.  I tried to fix it but just ran out
of Makefile-fu and want to work on more important things.