### PR TITLE
mantle/ore: gcloud: add ability to attach license to image

### DIFF
--- a/mantle/cmd/ore/gcloud/upload.go
+++ b/mantle/cmd/ore/gcloud/upload.go
@@ -44,6 +44,7 @@ var (
 	uploadImageFamily      string
 	uploadImageDescription string
 	uploadCreateImage      bool
+	uploadImageLicense     string
 )
 
 func init() {
@@ -58,6 +59,7 @@ func init() {
 	cmdUpload.Flags().StringVar(&uploadImageFamily, "family", "", "GCP image family to attach image to")
 	cmdUpload.Flags().StringVar(&uploadImageDescription, "description", "", "The description that should be attached to the image")
 	cmdUpload.Flags().BoolVar(&uploadCreateImage, "create-image", true, "Create an image in GCP after uploading")
+	cmdUpload.Flags().StringVar(&uploadImageLicense, "license", "", "The license to attach to the image")
 	GCloud.AddCommand(cmdUpload)
 }
 
@@ -130,14 +132,16 @@ func runUpload(cmd *cobra.Command, args []string) {
 
 	if uploadCreateImage {
 		fmt.Printf("Creating image in GCE: %v...\n", imageNameGCE)
-
-		// create image on gce
-		_, pending, err := api.CreateImage(&gcloud.ImageSpec{
+		spec := &gcloud.ImageSpec{
 			Name:        imageNameGCE,
 			Family:      uploadImageFamily,
 			SourceImage: imageStorageURL,
 			Description: uploadImageDescription,
-		}, uploadForce)
+		}
+		if uploadImageLicense != "" {
+			spec.Licenses = []string{uploadImageLicense}
+		}
+		_, pending, err := api.CreateImage(spec, uploadForce)
 		if err == nil {
 			err = pending.Wait()
 		}
@@ -153,12 +157,7 @@ func runUpload(cmd *cobra.Command, args []string) {
 			switch ans {
 			case "y", "Y", "yes":
 				fmt.Println("Overriding existing image...")
-				_, pending, err = api.CreateImage(&gcloud.ImageSpec{
-					Name:        imageNameGCE,
-					Family:      uploadImageFamily,
-					SourceImage: imageStorageURL,
-					Description: uploadImageDescription,
-				}, true)
+				_, pending, err := api.CreateImage(spec, true)
 				if err == nil {
 					err = pending.Wait()
 				}

--- a/src/cosalib/gcp.py
+++ b/src/cosalib/gcp.py
@@ -67,6 +67,8 @@ def gcp_run_ore(build, args):
         ore_args.extend(['--description', args.description])
     if not args.create_image:
         ore_args.extend(['--create-image=false'])
+    if args.license:
+        ore_args.extend(['--license', args.license])
 
     run_verbose(ore_args)
     build.meta['gcp'] = {
@@ -119,4 +121,7 @@ def gcp_cli(parser):
                         type=boolean_string,
                         help="Whether or not to create an image in GCP after upload.",
                         default=True)
+    parser.add_argument("--license",
+                        help="The license that should be attached to the image",
+                        default=None)
     return parser


### PR DESCRIPTION
In order to get a dashboard with metrics and such we need to attach
our images to "licenses" in GCP. These aren't software licenses but
rather how billing and such is done for images that cost money. Ours
don't cost anything so it's purely for counting purposes.
