### PR TITLE
qemu: IgnoreOnIsolate=true for journal streaming

### DIFF
--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -892,6 +892,7 @@ func (builder *QemuBuilder) VirtioJournal(queryArguments string) (*v3types.Confi
 	}
 	var streamJournalUnit = fmt.Sprintf(`[Unit]
 	Requires=dev-virtio\\x2dports-mantlejournal.device
+	IgnoreOnIsolate=true
 	[Service]
 	Type=simple
 	StandardOutput=file:/dev/virtio-ports/mantlejournal


### PR DESCRIPTION
We want to keep it going as long as possible during shutdown or
if e.g. the system enters `emergency.target`.