### PR TITLE
Fixes related to kola/qemu on aarch64

### DIFF
--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -24,6 +24,7 @@ import (
 	"github.com/coreos/mantle/kola"
 	"github.com/coreos/mantle/platform"
 	"github.com/coreos/mantle/sdk"
+	"github.com/coreos/mantle/system"
 )
 
 var (
@@ -167,6 +168,8 @@ func syncOptionsImpl(useCosa bool) error {
 	// default to BIOS, or UEFI for 4k
 	if kola.QEMUOptions.Firmware == "" {
 		if kola.QEMUOptions.Native4k {
+			kola.QEMUOptions.Firmware = "uefi"
+		} else if system.RpmArch() == "aarch64" {
 			kola.QEMUOptions.Firmware = "uefi"
 		} else {
 			kola.QEMUOptions.Firmware = "bios"

--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -958,10 +958,13 @@ func (builder *QemuBuilder) Exec() (*QemuInstance, error) {
 	case "bios":
 		break
 	case "uefi":
-		builder.setupUefi(false)
+		if err := builder.setupUefi(false); err != nil {
+			return nil, err
+		}
 	case "uefi-secure":
-		builder.setupUefi(true)
-		break
+		if err := builder.setupUefi(true); err != nil {
+			return nil, err
+		}
 	default:
 		panic(fmt.Sprintf("Unknown firmware: %s", builder.Firmware))
 	}


### PR DESCRIPTION
Adds UEFI support in to kola/qemu for aarch64. Change a bit kola options around uefi and swtpm(default to off). I hope I have not missed any places. Tested on x86_64, aarch64 and ppc64le.