### PR TITLE
kola: Avoid losing "external" tag

### DIFF
--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -585,7 +585,7 @@ RequiredBy=multi-user.target
 	} else {
 		t.Distros = strings.Fields(meta.Distros)
 	}
-	t.Tags = strings.Fields(meta.Tags)
+	t.Tags = append(t.Tags, strings.Fields(meta.Tags)...)
 
 	register.RegisterTest(t)
 


### PR DESCRIPTION
This is a regression from https://github.com/coreos/coreos-assembler/pull/1440
which is breaking the Ignition CI here
https://jenkins-coreos-ci.apps.ci.centos.org/job/github-ci/job/coreos/job/ignition/job/PR-968/35/console