### PR TITLE
create_disk: Explicitly unmount partitions and fsck /boot

### DIFF
--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -423,6 +423,11 @@ touch $rootfs/boot/ignition.firstboot
 chattr +i $rootfs
 
 fstrim -a -v
-umount -R $rootfs
+if [ ${EFIPN:+x} ]; then
+    umount $rootfs/boot/efi
+fi
+umount ${rootfs}/boot
+e2fsck -y "${disk}${BOOTPN}"
+umount $rootfs
 
 rmdir $rootfs


### PR DESCRIPTION
For reasons I don't fully understand, trying to use
`tune2fs -U random /dev/disk/by-label/boot` fails without
this explicit fsck step, even though the filesystem appears
cleanly unmounted.

This is for https://github.com/coreos/fedora-coreos-config/pull/354
to regenerate the UUID of `/boot` on firstboot.

Anyways, explicitly unmounting things seems better than relying
on `umount -R` to sort it, and having a `fsck` on `/boot` is
cheap.