### PR TITLE
mantle/ore: gcloud: fix error detection, add some error checking

### DIFF
--- a/mantle/cmd/ore/gcloud/upload.go
+++ b/mantle/cmd/ore/gcloud/upload.go
@@ -171,16 +171,20 @@ func runUpload(cmd *cobra.Command, args []string) {
 				fmt.Println("Skipped GCE image creation")
 			}
 		}
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Creating GCE image failed: %v\n", err)
+			os.Exit(1)
+		}
 	}
 
 	if uploadWriteUrl != "" {
 		err = ioutil.WriteFile(uploadWriteUrl, []byte(imageStorageURL), 0644)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Writing file (%v) failed: %v\n", uploadWriteUrl, err)
+			os.Exit(1)
+		}
 	}
 
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Creating GCE image failed: %v\n", err)
-		os.Exit(1)
-	}
 }
 
 // Converts an image name from Google Storage to an equivalent GCE image


### PR DESCRIPTION
Previously we could miss detecting errors because err != nil was only
checked properly for the "already exists" error case. It then wasn't
checked again until after err was overwritten again by `err = ioutil.WriteFile`.

While going in to work on this I found the entire logic a bit confusing
so I refactored it to first identify if the image exists before ever
calling api.createImage.