### PR TITLE
mantle: Remove setenforce 1 by default

### DIFF
--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -748,7 +748,6 @@ func runTest(h *harness.H, t *register.Test, pltfrm string, flight platform.Flig
 		OutputDir:          h.OutputDir(),
 		NoSSHKeyInUserData: t.HasFlag(register.NoSSHKeyInUserData),
 		NoSSHKeyInMetadata: t.HasFlag(register.NoSSHKeyInMetadata),
-		NoEnableSelinux:    t.HasFlag(register.NoEnableSelinux),
 	}
 	c, err := flight.NewCluster(rconf)
 	if err != nil {

--- a/mantle/kola/register/register.go
+++ b/mantle/kola/register/register.go
@@ -29,7 +29,6 @@ const (
 	NoSSHKeyInUserData     Flag = iota // don't inject SSH key into Ignition/cloud-config
 	NoSSHKeyInMetadata                 // don't add SSH key to platform metadata
 	NoEmergencyShellCheck              // don't check console output for emergency shell invocation
-	NoEnableSelinux                    // don't enable selinux when starting or rebooting a machine
 	RequiresInternetAccess             // run the test only if the platform supports Internet access
 )
 

--- a/mantle/platform/platform.go
+++ b/mantle/platform/platform.go
@@ -185,7 +185,6 @@ type RuntimeConfig struct {
 
 	NoSSHKeyInUserData bool // don't inject SSH key into Ignition/cloud-config
 	NoSSHKeyInMetadata bool // don't add SSH key to platform metadata
-	NoEnableSelinux    bool // don't enable selinux when starting or rebooting a machine
 	AllowFailedUnits   bool // don't fail CheckMachine if a systemd unit has failed
 }
 

--- a/mantle/platform/util.go
+++ b/mantle/platform/util.go
@@ -86,15 +86,6 @@ func Manhole(m Machine) error {
 	return nil
 }
 
-// Enable SELinux on a machine (skip on machines without SELinux support)
-func EnableSelinux(m Machine) error {
-	_, stderr, err := m.SSH("if type -P setenforce; then sudo setenforce 1; fi")
-	if err != nil {
-		return fmt.Errorf("Unable to enable SELinux: %s: %s", err, stderr)
-	}
-	return nil
-}
-
 // Reboots a machine, stopping ssh first.
 // Afterwards run CheckMachine to verify the system is back and operational.
 func StartReboot(m Machine) error {
@@ -174,11 +165,6 @@ func StartMachineAfterReboot(m Machine, j *Journal, oldBootId string) error {
 	}
 	if err := CheckMachine(context.TODO(), m); err != nil {
 		return fmt.Errorf("machine %q failed basic checks: %v", m.ID(), err)
-	}
-	if !m.RuntimeConf().NoEnableSelinux {
-		if err := EnableSelinux(m); err != nil {
-			return fmt.Errorf("machine %q failed to enable selinux: %v", m.ID(), err)
-		}
 	}
 	return nil
 }


### PR DESCRIPTION
I saw this in the journal and wondered about it, it's a legacy
from CL which didn't have SELinux enabled by default.  FCOS/RHCOS
do, so let's stop pointlessly calling `setenforce 1`.