### PR TITLE
WIP: build: Add support for "variants"

### DIFF
--- a/src/buildextend-rojig-impl
+++ b/src/buildextend-rojig-impl
@@ -5,6 +5,8 @@ dn=$(dirname "$0")
 # shellcheck source=src/cmdlib.sh
 . "${dn}"/cmdlib.sh
 
+manifest=$1
+shift
 commit=$1
 shift
 tmpdir=$1
@@ -27,7 +29,7 @@ if has_privileges; then
         tmpdir=$(mktemp -d -p /var/tmp)
     fi
     sudo rpm-ostree ex commit2rojig --repo="$(pwd)/tmp/repo" --pkgcache-repo="$(pwd)/cache/pkgcache-repo" \
-        "${commit}" "$(pwd)/src/config/manifest.yaml" "${tmpdir}"
+        "${commit}" "$(pwd)/src/config/${manifest}.yaml" "${tmpdir}"
     if ! [ -f /etc/cosa-supermin ]; then
         sudo chown -R -h "${USER}:${USER}" "${tmpdir}"
     else

--- a/src/cmd-build
+++ b/src/cmd-build
@@ -8,7 +8,7 @@ dn=$(dirname "$0")
 print_help() {
     cat 1>&2 <<'EOF'
 Usage: coreos-assembler build --help
-       coreos-assembler build [--force] [--force-image] [--skip-prune] [--strict] [--tag TAG] [--version VERSION] [TARGET...]
+       coreos-assembler build [--force] [--force-image] [--skip-prune] [--strict] [--tag TAG] [--version VERSION] [-O/--variant VARIANT] [TARGET...]
 
   Build OSTree and image base artifacts from previously fetched packages.
   Accepted TARGET arguments:
@@ -30,9 +30,10 @@ SKIP_PRUNE=0
 VERSION=
 PARENT=
 TAG=
+VARIANT=
 STRICT=
 rc=0
-options=$(getopt --options hft: --longoptions tag:,help,force,version:,parent:,force-nocache,force-image,skip-prune,strict -- "$@") || rc=$?
+options=$(getopt --options hftO: --longoptions tag:,help,force,version:,parent:,variant:,force-nocache,force-image,skip-prune,strict -- "$@") || rc=$?
 [ $rc -eq 0 ] || {
     print_help
     exit 1
@@ -63,6 +64,10 @@ while true; do
         --parent)
             shift
             PARENT=$1
+            ;;
+        -O | --variant)
+            shift
+            VARIANT=$1
             ;;
         -t | --tag)
             shift
@@ -107,6 +112,13 @@ build_followup_targets() {
 }
 
 prepare_build
+if [ -n "${VARIANT}" ]; then
+    manifest=${workdir}/src/config/${VARIANT}.yaml
+    if ! [ -f "${manifest}" ]; then
+        fatal "Failed to find variant manifest ${manifest}"
+    fi
+    echo "Using variant manifest: ${manifest}"
+fi
 
 ostree --version
 rpm-ostree --version
@@ -357,12 +369,17 @@ fi
 #
 # notice need to backslash escape double quotes in summary since the
 # summary could have double quotes: https://github.com/coreos/coreos-assembler/issues/327
+variantmeta=
+if [ -n "${VARIANT}" ]; then
+    variantmeta='"variant": "'"${VARIANT}"'",'
+fi
 #
 # shellcheck disable=SC2046 disable=SC2086
 cat > tmp/buildmeta.json <<EOF
 {
  "name": "${name}",
  "summary": "${summary//\"/\\\"}",
+ ${variantmeta}
  "coreos-assembler.build-timestamp": "${build_timestamp}",
  "coreos-assembler.image-config-checksum": "${image_config_checksum}",
  "coreos-assembler.image-input-checksum": "${image_input_checksum}",

--- a/src/cmd-buildextend-rojig
+++ b/src/cmd-buildextend-rojig
@@ -30,13 +30,14 @@ print(f"Targeting build: {args.build}")
 buildmeta_path = os.path.join(builddir, 'meta.json')
 with open(buildmeta_path) as f:
     buildmeta = json.load(f)
+manifest = buildmeta.get('variant', 'manifest')
 # Grab the commit hash for this build
 buildmeta_commit = buildmeta['ostree-commit']
 repo = os.path.join(workdir, 'tmp/repo')
 pkgcache_repo = os.path.join(workdir, 'cache/pkgcache-repo')
 
 with tempfile.TemporaryDirectory(prefix='rojig-', dir=f"{workdir}/tmp") as tmpd:
-    run_verbose(['/usr/lib/coreos-assembler/buildextend-rojig-impl', buildmeta_commit, os.path.abspath(tmpd)])
+    run_verbose(['/usr/lib/coreos-assembler/buildextend-rojig-impl', manifest, buildmeta_commit, os.path.abspath(tmpd)])
     rojig_path = None
     arch_destdir = os.path.join(tmpd, get_basearch())
     if not os.path.isdir(arch_destdir):


### PR DESCRIPTION
My immediate goal here is to change
https://github.com/cgwalters/centos-coreos-stream-config
into something more like "openshift/coreos-config" that
can be built in multiple ways.

We'd have `rhcos` and `cscos` as "build variants".  And
actually while we're here potentially `rhbasecos` which would
be "just stuff from RHEL".

Another use case for this is the "alternative desktops" for
Silverblue.

And yet another use case is something like a "debug" build
for FCOS where e.g. we swap in `kernel-debug` and potentially
turn on other userspace debugging too.