### PR TITLE
cmd-kola: also detect --platform=

### DIFF
--- a/src/cmd-kola
+++ b/src/cmd-kola
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import re
 import subprocess
 import os
 import sys
@@ -52,7 +53,10 @@ if os.path.isfile(blacklist_path):
 # https://github.com/coreos/coreos-assembler/pull/85
 kolaargs = ['kola']
 
-if os.getuid() != 0 and not ('-p' in unknown_args):
+r = re.compile("-p(=.+)?|--platform(=.+)?")
+platformargs = list(filter(r.match, unknown_args))
+
+if os.getuid() != 0 and len(platformargs) == 0:
     kolaargs.extend(['-p', 'qemu-unpriv'])
 
 if args.build is not None:


### PR DESCRIPTION
This fixes it so that passing --platform= also works.