### PR TITLE
cmd-oscontainer: put workdir in cache qcow2 in unprivileged path

### DIFF
--- a/src/cmd-oscontainer
+++ b/src/cmd-oscontainer
@@ -32,5 +32,8 @@ else
     else
         info "warning: No ~/.docker/config.json found, push will likely fail"
     fi
-    runvm -- env PYTHONUNBUFFERED=1 "${osc}" --authfile="${workdir}/tmp/docker-auth.json" --workdir /host/container-work "$@"
+    # we use the cache qcow2 here so that e.g. we cache the base image, and also
+    # so that buildah has a nice filesystem with space to work with instead of
+    # the tiny supermin ext2 root
+    runvm -- env PYTHONUNBUFFERED=1 "${osc}" --authfile="${workdir}/tmp/docker-auth.json" --workdir "${workdir}/cache/oscontainer-work" "$@"
 fi

--- a/src/cmd-upload-oscontainer
+++ b/src/cmd-upload-oscontainer
@@ -8,7 +8,6 @@
 import argparse
 import json
 import os
-import shutil
 import subprocess
 import sys
 
@@ -40,8 +39,6 @@ with open(metapath) as f:
     meta = json.load(f)
 
 print("Preparing to upload oscontainer for build: {}".format(latest_build))
-
-osc_workdir = "{}/tmp/oscontainer-work".format(os.getcwd())
 
 tmprepo = "{}/tmp/repo".format(os.getcwd())
 # if tmprepo is not a directory, but is unexpectedly a file,
@@ -91,6 +88,3 @@ metapath_new = f"{metapath}.new"
 with open(metapath_new, 'w') as f:
     json.dump(meta, f, sort_keys=True)
 os.rename(metapath_new, metapath)
-
-# Cleanup workdirs
-shutil.rmtree(osc_workdir, ignore_errors=True)

--- a/src/supermin-init-prelude.sh
+++ b/src/supermin-init-prelude.sh
@@ -39,7 +39,7 @@ if [ -L "${workdir}"/src/config ]; then
     mkdir -p "$(readlink "${workdir}"/src/config)"
     mount -t 9p -o rw,trans=virtio,version=9p2000.L source "${workdir}"/src/config
 fi
-mkdir -p "${workdir}"/cache /host/container-work
+mkdir -p "${workdir}"/cache
 cachedev=$(blkid -lt LABEL=cosa-cache -o device || true)
 if [ -n "${cachedev}" ]; then
     mount "${cachedev}" "${workdir}"/cache


### PR DESCRIPTION
We were passing `--workdir /host/container-work` to `oscontainer.py` in
the unprivileged case, but that path isn't actually mounted from the
host.

And actually, even if it were mounted, buildah wants to be able to
`chown` things in its container storage, which it won't be able to over
9p.

Instead, let's just point it at the cache qcow2 to do its work. That
way it can do whatever privileged operations it wants there, and plus we
get to cache the base `--from` image this way. Other temporary files are
nuked on exit, and otherwise, on the next run of `oscontainer.py` (in
practice, pipelines don't currently cache the qcow2 in between runs
anyway, but we should be nice to the unprivileged developer path).

(Again, we could also bump the supermin root instead, but I think as a
general pattern we should leave it tiny and do the real work in a
mounted disk which has lots of space and a more modern filesystem than
ext2.)