### PR TITLE
testiso: Fix iso-install and iso-live-login for ppc64le

### DIFF
--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -477,8 +477,8 @@ func testLiveLogin() error {
 	builddir := kola.CosaBuild.Dir
 	isopath := filepath.Join(builddir, kola.CosaBuild.Meta.BuildArtifacts.LiveIso.Path)
 	builder := newBaseQemuBuilder()
-	// See AddInstallISO, but drop the bootindex bit; we want it to be the default
-	builder.Append("-drive", "file="+isopath+",format=raw,if=none,readonly=on,id=installiso", "-device", "ide-cd,drive=installiso")
+	// See AddInstallISO, but drop the bootindex bit (applicable to all arches except s390x and ppc64le); we want it to be the default
+	builder.AddInstallIso(isopath, "")
 
 	completionChannel, err := builder.VirtioChannelRead("coreos.liveiso-success")
 	if err != nil {

--- a/mantle/platform/metal.go
+++ b/mantle/platform/metal.go
@@ -669,7 +669,7 @@ WantedBy=multi-user.target
 	}
 
 	qemubuilder := inst.Builder
-	qemubuilder.AddInstallIso(isoEmbeddedPath)
+	qemubuilder.AddInstallIso(isoEmbeddedPath, "bootindex=2")
 
 	if offline {
 		qemubuilder.Append("-nic", "none")

--- a/src/cmd-buildextend-installer
+++ b/src/cmd-buildextend-installer
@@ -288,7 +288,7 @@ def generate_iso():
             run_verbose(['rm', '-rf', os.path.join(tmpisoroot, d)])
 
         # grub2-mkrescue is a wrapper around xorriso
-        genisoargs = ['grub2-mkrescue']
+        genisoargs = ['grub2-mkrescue', '-volid', volid]
     elif basearch == "s390x":
         # Reserve 32MB for the kernel, starting memory address of the initramfs
         # See https://github.com/weldr/lorax/blob/master/share/templates.d/99-generic/s390.tmpl


### PR DESCRIPTION
Few fixes to get the iso-install case working for ppc64le
 - add volid to grub2-mkrescue command
 - use -cdrom instead of ide-cd as ide-cd is not supported on ppc64le/s390x. It achieves the same effect as
   what was done using the ide-cd device.

Closes: #1463