### PR TITLE
kola: Add RHCOS LUKS upgrade test

### DIFF
--- a/mantle/kola/tests/rhcos/upgrade.go
+++ b/mantle/kola/tests/rhcos/upgrade.go
@@ -1,0 +1,101 @@
+// Copyright 2020 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rhcos
+
+import (
+	"path/filepath"
+
+	"github.com/coreos/pkg/capnslog"
+
+	"github.com/coreos/mantle/kola"
+	"github.com/coreos/mantle/kola/cluster"
+	"github.com/coreos/mantle/kola/register"
+	"github.com/coreos/mantle/kola/tests/util"
+	"github.com/coreos/mantle/platform/conf"
+)
+
+var plog = capnslog.NewPackageLogger("github.com/coreos/mantle", "kola/tests/upgrade")
+
+func init() {
+	register.RegisterUpgradeTest(&register.Test{
+		Run:         rhcosUpgradeLuks,
+		ClusterSize: 1,
+		// if renaming this, also rename the command in kolet-httpd.service below
+		Name:     "rhcos.upgrade.luks",
+		FailFast: true,
+		Tags:     []string{"upgrade"},
+		Distros:  []string{"rhcos"},
+		UserData: conf.Ignition(`{
+			"ignition": {
+				"version": "2.2.0"
+			},
+			"storage": {
+				"files": [
+					{
+						"filesystem": "root",
+						"path": "/etc/clevis.json",
+						"contents": {
+							"source": "data:text/plain;base64,e30K"
+						},
+						"mode": 420
+					}
+				]
+			}
+		}`),
+	})
+}
+
+// Ensure that we can still boot into a system with LUKS rootfs after
+// an upgrade.
+func rhcosUpgradeLuks(c cluster.TestCluster) {
+	m := c.Machines()[0]
+	ostreeCommit := kola.CosaBuild.Meta.OstreeCommit
+	ostreeTarName := kola.CosaBuild.Meta.BuildArtifacts.Ostree.Path
+	// See tests/upgrade/basic.go for some more information on this; in the future
+	// we should optimize this to use virtio-fs for qemu.
+	c.Run("setup", func(c cluster.TestCluster) {
+		ostreeTarPath := filepath.Join(kola.CosaBuild.Dir, ostreeTarName)
+		if err := cluster.DropFile(c.Machines(), ostreeTarPath); err != nil {
+			c.Fatal(err)
+		}
+
+		// XXX: Note the '&& sync' here; this is to work around sysroot
+		// remounting in libostree forcing a cache flush and blocking D-Bus.
+		// Should drop this once we fix it more properly in {rpm-,}ostree.
+		// https://github.com/coreos/coreos-assembler/issues/1301
+		// Also we should really add a streaming import for this
+		c.MustSSHf(m, "sudo tar -xf %s -C /var/srv && sudo rm %s", ostreeTarName, ostreeTarName)
+		c.MustSSHf(m, "sudo ostree --repo=/sysroot/ostree/repo pull-local /var/srv %s && sudo rm -rf /var/srv/* && sudo sync", ostreeCommit)
+	})
+
+	c.Run("upgrade-from-previous", func(c cluster.TestCluster) {
+		c.MustSSHf(m, "sudo rpm-ostree rebase :%s", ostreeCommit)
+		err := m.Reboot()
+		if err != nil {
+			c.Fatalf("Failed to reboot machine: %v", err)
+		}
+	})
+
+	c.Run("verify", func(c cluster.TestCluster) {
+		d, err := util.GetBootedDeployment(c, m)
+		if err != nil {
+			c.Fatal(err)
+		}
+		if d.Checksum != kola.CosaBuild.Meta.OstreeCommit {
+			c.Fatalf("Got booted checksum=%s expected=%s", d.Checksum, kola.CosaBuild.Meta.OstreeCommit)
+		}
+		// And we should also like systemctl --failed here and stuff
+	})
+}


### PR DESCRIPTION
I really think osmet is key for the RHCOS Live ISO experience and
we don't have that right now because of the LUKS container
thing.

I thought then about putting the LUKS header in `/boot`
and dropping the LUKS container by default
(that came up before) so we could also skip the dm-linear
thing.  That way it'd be the same as FCOS.

I started looking at that code but then I was reminded of a
moment of fear I had when something related came up last week -
we have absolutely no testing of upgrades around it, and that
is *highly* likely to break if we start trying to make any
fundamental changes.

This paves some of the infrastructure for a bit more "real" upgrade
testing where we boot the old OS with a target Ignition (in
this case the LUKS config), then reboot into the new OSTree
commit.  This is in contrast to the "synthetic" `offline-upgrade`
which directly overlays the new OSTree commit.

Run this test via e.g.:
`kola run-upgrade --ignition-version v2 -b rhcos -v --find-parent-image --qemu-image-dir tmp/`
which needs to be plumbed into the pipeline.