### PR TITLE
kola: add gce support for --find-parent-image 

### DIFF
--- a/mantle/cmd/kola/kola.go
+++ b/mantle/cmd/kola/kola.go
@@ -577,7 +577,7 @@ func syncFindParentImageOptions() error {
 			return err
 		}
 	default:
-		err = fmt.Errorf("--find-parent-image not yet supported for platform %s", kolaPlatform)
+		return fmt.Errorf("--find-parent-image not yet supported for platform %s", kolaPlatform)
 	}
 
 	return nil

--- a/mantle/cmd/kola/kola.go
+++ b/mantle/cmd/kola/kola.go
@@ -576,6 +576,11 @@ func syncFindParentImageOptions() error {
 		if err != nil {
 			return err
 		}
+	case "gce":
+		kola.GCEOptions.Image, err = parentCosaBuild.FindGCPImage()
+		if err != nil {
+			return err
+		}
 	default:
 		return fmt.Errorf("--find-parent-image not yet supported for platform %s", kolaPlatform)
 	}

--- a/mantle/cosa/build.go
+++ b/mantle/cosa/build.go
@@ -74,6 +74,20 @@ func (build *Build) FindAMI(region string) (string, error) {
 	return "", fmt.Errorf("no AMI found for region %s", region)
 }
 
+func (build *Build) FindGCPImage() (string, error) {
+	if build.Gcp != nil {
+		project := build.Gcp.ImageProject
+		if project == "" {
+			// Hack for when meta.json didn't include the project. We can
+			// probably drop this in the future. See:
+			// https://github.com/coreos/coreos-assembler/pull/1335
+			project = "fedora-coreos-cloud"
+		}
+		return fmt.Sprintf("projects/%s/global/images/%s", project, build.Gcp.ImageName), nil
+	}
+	return "", errors.New("no GCP image found")
+}
+
 func (build *Build) WriteMeta(path string, validate bool) error {
 	if validate {
 		if err := build.Validate(); len(err) != 0 {


### PR DESCRIPTION
We want to run upgrade tests in the pipeline now.