### PR TITLE
Remove dead code relating to detecting Ignition version

### DIFF
--- a/mantle/cmd/kola/kola.go
+++ b/mantle/cmd/kola/kola.go
@@ -109,15 +109,6 @@ This can be useful for e.g. serving locally built OSTree repos to qemu.
 		RunE: runIgnitionConvert2,
 	}
 
-	cmdArtifactIgnitionVersion = &cobra.Command{
-		Use:    "artifact-ignition-version",
-		Short:  "Implementation detail of coreos-assembler",
-		RunE:   runArtifactIgnitionVersion,
-		Hidden: true,
-
-		SilenceUsage: true,
-	}
-
 	listJSON           bool
 	listPlatform       string
 	listDistro         string
@@ -148,9 +139,6 @@ func init() {
 	root.AddCommand(cmdRunUpgrade)
 	cmdRunUpgrade.Flags().BoolVar(&findParentImage, "find-parent-image", false, "automatically find parent image if not provided -- note on qemu, this will download the image")
 	cmdRunUpgrade.Flags().StringVar(&qemuImageDir, "qemu-image-dir", "", "directory in which to cache QEMU images if --fetch-parent-image is enabled")
-
-	// Implementation/hidden commands
-	root.AddCommand(cmdArtifactIgnitionVersion)
 }
 
 func main() {

--- a/src/cmd-meta
+++ b/src/cmd-meta
@@ -9,7 +9,6 @@ import sys
 
 COSA_PATH = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, COSA_PATH)
-from cosalib import cmdlib
 from cosalib.meta import GenericBuildMeta as Meta
 
 
@@ -28,8 +27,6 @@ def new_cli():
     sub_parser.add_argument('--set', help='set a field', action='append')
     sub_parser.add_argument(
         '--dump', help='dumps the entire structure', action='store_true')
-    sub_parser.add_argument(
-        '--ignition-version', help='Output the Ignition version used for a build', action='store_true')
     sub_parser.add_argument(
         '--image-path', help='Output path to artifact IMAGETYPE',
         action='store',
@@ -65,8 +62,6 @@ def new_cli():
         meta.write()
     elif args.dump is True:
         print(meta)
-    elif args.ignition_version:
-        print(cmdlib.disk_ignition_version(meta.get('images')['qemu']['path']))
     elif args.image_path is not None:
         print(os.path.join(os.path.dirname(meta.path), meta.get('images')[args.image_path]['path']))
 

--- a/src/cmd-virt-install
+++ b/src/cmd-virt-install
@@ -57,8 +57,6 @@ if args.instid is None:
 
 ignvol = f"{args.name}-ign-{args.instid}"
 ignsize = os.path.getsize(args.ignition)
-# TODO do conversion
-# ignition_version = cmdlib.disk_ignition_version(qemupath)
 
 vconn = libvirt.open(args.connect)
 if vconn is None:

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -113,18 +113,6 @@ preflight() {
     fi
 }
 
-
-disk_ignition_version() {
-    local path
-    path=$1
-    # yup, this is happening *again* (see below too)
-    python3 -c "
-import sys
-sys.path.insert(0, '${DIR}')
-from cosalib.cmdlib import disk_ignition_version
-print(disk_ignition_version('${path}}'))"
-}
-
 # Picks between yaml or json based on which version exists. Errors out if both
 # exists. If neither exist, prefers the extension in ${2}, or otherwise YAML.
 pick_yaml_or_else_json() {

--- a/src/cosalib/cmdlib.py
+++ b/src/cosalib/cmdlib.py
@@ -162,22 +162,6 @@ def rm_allow_noent(path):
         pass
 
 
-# Obviously this is a hack but...we need to know this before
-# launching, and I don't think we have structured metadata in e.g. qcow2.
-# There are other alternatives but we'll carry this hack for now.
-# But if you're reading this comment 10 years in the future, I won't be
-# too surprised either ;)  Oh and hey if you are please send me an email, it'll
-# be like a virtual time capsule!  If they still use email then...
-def disk_ignition_version(path):
-    v = subprocess.check_output(['kola', 'artifact-ignition-version', path], encoding='utf8').strip()
-    if v == "v2":
-        return "2.2.0"
-    elif v == "v3":
-        return "3.0.0"
-    else:
-        raise Exception(f"Unhandled: {v}")
-
-
 def import_ostree_commit(repo, commit, tarfile, force=False):
     # create repo in case e.g. tmp/ was cleared out; idempotent
     subprocess.check_call(['ostree', 'init', '--repo', repo, '--mode=archive'])


### PR DESCRIPTION
All of this is cruft now that lots of logic has moved into mantle.
We ended up with a pretty amazing chain where shell script would
load Python which in turn would exec kola.  No need for that
anymore.