### PR TITLE
mantle: Move the FCOS stream URL from kola into mantle

### DIFF
--- a/mantle/cmd/kola/kola.go
+++ b/mantle/cmd/kola/kola.go
@@ -640,9 +640,7 @@ func getParentFcosBuildBase(stream string) (string, error) {
 		parentVersion = index.Releases[n-1].Version
 	}
 
-	// XXX: multi-arch
-	// XXX: centralize URL and parameterize
-	return fmt.Sprintf("https://builds.coreos.fedoraproject.org/prod/streams/%s/builds/%s/x86_64/", stream, parentVersion), nil
+	return fcos.GetCosaBuildUrl(stream, parentVersion), nil
 }
 
 func runRunUpgrade(cmd *cobra.Command, args []string) error {

--- a/mantle/fcos/metadata.go
+++ b/mantle/fcos/metadata.go
@@ -19,10 +19,13 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+
+	"github.com/coreos/mantle/system"
 )
 
-const canonicalStreamIndexLocation = "https://builds.coreos.fedoraproject.org/prod/streams/%s/releases.json"
-const canonicalStreamMetadataLocation = "https://builds.coreos.fedoraproject.org/streams/%s.json"
+const buildHostUrl = "https://builds.coreos.fedoraproject.org/"
+const canonicalReleaseIndexLocation = "prod/streams/%s/releases.json"
+const canonicalStreamMetadataLocation = "streams/%s.json"
 
 // XXX: dedupe with fedora-coreos-stream-generator
 
@@ -179,7 +182,7 @@ func FetchAndParseReleaseIndex(url string) (*ReleaseIndex, error) {
 }
 
 func FetchAndParseCanonicalReleaseIndex(stream string) (*ReleaseIndex, error) {
-	return FetchAndParseReleaseIndex(fmt.Sprintf(canonicalStreamIndexLocation, stream))
+	return FetchAndParseReleaseIndex(buildHostUrl + fmt.Sprintf(canonicalReleaseIndexLocation, stream))
 }
 
 func FetchAndParseStreamMetadata(url string) (*StreamMetadata, error) {
@@ -197,7 +200,7 @@ func FetchAndParseStreamMetadata(url string) (*StreamMetadata, error) {
 }
 
 func FetchAndParseCanonicalStreamMetadata(stream string) (*StreamMetadata, error) {
-	return FetchAndParseStreamMetadata(fmt.Sprintf(canonicalStreamMetadataLocation, stream))
+	return FetchAndParseStreamMetadata(buildHostUrl + fmt.Sprintf(canonicalStreamMetadataLocation, stream))
 }
 
 func FetchCanonicalStreamArtifacts(stream, architecture string) (*StreamArtifacts, error) {
@@ -224,4 +227,9 @@ func GetPlatformDiskArtifact(platform *StreamMediaDetails, format string) (*Imag
 		return nil, fmt.Errorf("stream metadata missing %q disk image", format)
 	}
 	return artifacts.Disk, nil
+}
+
+// GetCosaBuildUrl returns a URL prefix for the coreos-assembler build.
+func GetCosaBuildUrl(stream, buildid string) string {
+	return buildHostUrl + fmt.Sprintf("prod/streams/%s/builds/%s/%s/", stream, buildid, system.RpmArch())
 }


### PR DESCRIPTION
Just a random side cleanup while looking at fetching builds
metadata for RHCOS upgrade testing.