### PR TITLE
mantle/ore: gcloud: support specifying multiple image licenses

### DIFF
--- a/mantle/cmd/ore/gcloud/upload.go
+++ b/mantle/cmd/ore/gcloud/upload.go
@@ -44,7 +44,7 @@ var (
 	uploadImageFamily      string
 	uploadImageDescription string
 	uploadCreateImage      bool
-	uploadImageLicense     string
+	uploadImageLicenses    []string
 )
 
 func init() {
@@ -59,7 +59,9 @@ func init() {
 	cmdUpload.Flags().StringVar(&uploadImageFamily, "family", "", "GCP image family to attach image to")
 	cmdUpload.Flags().StringVar(&uploadImageDescription, "description", "", "The description that should be attached to the image")
 	cmdUpload.Flags().BoolVar(&uploadCreateImage, "create-image", true, "Create an image in GCP after uploading")
-	cmdUpload.Flags().StringVar(&uploadImageLicense, "license", "", "The license to attach to the image")
+	cmdUpload.Flags().StringSliceVar(
+		&uploadImageLicenses, "license", []string{},
+		"License to attach to image. Can be specified multiple times.")
 	GCloud.AddCommand(cmdUpload)
 }
 
@@ -138,8 +140,8 @@ func runUpload(cmd *cobra.Command, args []string) {
 			SourceImage: imageStorageURL,
 			Description: uploadImageDescription,
 		}
-		if uploadImageLicense != "" {
-			spec.Licenses = []string{uploadImageLicense}
+		if len(uploadImageLicenses) > 0 {
+			spec.Licenses = uploadImageLicenses
 		}
 		_, pending, err := api.CreateImage(spec, uploadForce)
 		if err == nil {

--- a/src/cosalib/gcp.py
+++ b/src/cosalib/gcp.py
@@ -51,8 +51,8 @@ def gcp_run_ore(build, args):
         '--json-key', args.json_key,
 
     ]
-    if args.log_level == "DEBUG":
-        ore_common_args.extend(['--log-level', "DEBUG"])
+    if args.log_level:
+        ore_common_args.extend(['--log-level', args.log_level])
 
     ore_upload_cmd = ore_common_args + [
         'upload',

--- a/src/cosalib/gcp.py
+++ b/src/cosalib/gcp.py
@@ -68,7 +68,8 @@ def gcp_run_ore(build, args):
     if not args.create_image:
         ore_upload_cmd.extend(['--create-image=false'])
     if args.license:
-        ore_upload_cmd.extend(['--license', args.license])
+        for license in args.license:
+            ore_upload_cmd.extend(['--license', license])
     run_verbose(ore_upload_cmd)
 
     # Run deprecate image to deprecate if requested
@@ -145,7 +146,8 @@ def gcp_cli(parser):
                         help="Whether or not to create an image in GCP after upload.",
                         default=True)
     parser.add_argument("--license",
-                        help="The license that should be attached to the image",
+                        action='append',
+                        help="The licenses that should be attached to the image",
                         default=None)
     parser.add_argument("--deprecated",
                         action="store_true",


### PR DESCRIPTION
This will allow us to specify our normal fedora-coreos-$stream
license as well as the nested virtualization license:

https://compute.googleapis.com/compute/v1/projects/vm-options/global/licenses/enable-vmx
