### PR TITLE
kola: Add --no-net flag

### DIFF
--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -57,6 +57,7 @@ func init() {
 	ss("debug-systemd-unit", []string{}, "full-unit-name.service to enable SYSTEMD_LOG_LEVEL=debug on. Can be specified multiple times.")
 	sv(&kola.Options.IgnitionVersion, "ignition-version", "", "Ignition version override: v2, v3")
 	ssv(&kola.BlacklistedTests, "blacklist-test", []string{}, "Test pattern to blacklist. Can be specified multiple times.")
+	bv(&kola.NoNet, "no-net", false, "Don't run tests that require an Internet connection")
 	ssv(&kola.Tags, "tag", []string{}, "Test tag to run. Can be specified multiple times.")
 	bv(&kola.Options.SSHOnTestFailure, "ssh-on-test-failure", false, "SSH into a machine when tests fail")
 	sv(&kola.Options.CosaWorkdir, "workdir", "", "coreos-assembler working directory")


### PR DESCRIPTION
The Docker Hub recently decided that us pulling the `nginx` image
over and over many times a day was abusive and started rate limiting
us.

For OSTree's test suite at least, there's no good reason for us
to run podman's tests at all.  Similarly for e.g. Ignition.

And just as a general rule I think it's useful to cleanly separate
tests that can be run fully offline from those that require
Internet access.