### PR TITLE
disk/s390x: inject firstboot kargs (ignition-network-kcmdline)

### DIFF
--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -395,7 +395,7 @@ s390x)
 	# stage on s390x, either through zipl->grub2-emu or zipl standalone.
 	# See https://github.com/coreos/ignition-dracut/issues/84
 	# A similar hack is present in https://github.com/coreos/coreos-assembler/blob/master/src/gf-platformid#L55
-	echo "$(grep options $blsfile) ignition.firstboot" > $tmpfile
+	echo "$(grep options $blsfile) ignition.firstboot ${firstboot_kargs}" > $tmpfile
 
 	# ideally we want to invoke zipl with bls and zipl.conf but we might need
 	# to chroot to $rootfs/ to do so. We would also do that when FCOS boot on its own.

--- a/src/gf-platformid
+++ b/src/gf-platformid
@@ -52,7 +52,9 @@ coreos_gf upload "${tmpd}"/bls.conf "${blscfg_path}"
 if [ "$basearch" = "s390x" ] ; then
     # Before we re-run zipl make sure we have the firstboot options
     # A hack similar to https://github.com/coreos/coreos-assembler/blob/master/src/create_disk.sh#L381
-    sed -i -e 's,^\(options .*\),\1 ignition.firstboot,' "${tmpd}"/bls.conf
+    coreos_gf download /boot/ignition.firstboot "${tmpd}"/ignition.firstboot
+    IGN_NET_KARGS=$(sed 's/^set ignition_network_kcmdline=.\(.*\).$/\1/' "${tmpd}"/ignition.firstboot)
+    sed -i -e 's|^\(options .*\)|\1 ignition.firstboot '"${IGN_NET_KARGS}"'|' "${tmpd}"/bls.conf
     coreos_gf rename "${blscfg_path}" "${blscfg_path}.orig"
     coreos_gf upload "${tmpd}"/bls.conf "${blscfg_path}"
 


### PR DESCRIPTION
This somehow tries to forward firstboot kargs from a GRUB script
to a zipl configuration.

Ref: https://github.com/coreos/coreos-assembler/pull/1373#discussion_r430414499

/cc @jlebon 