### PR TITLE
supermin-shell: Support passing through qemu arguments

### DIFF
--- a/src/cmd-supermin-shell
+++ b/src/cmd-supermin-shell
@@ -7,4 +7,4 @@ dn=$(dirname "$0")
 
 prepare_build
 
-RUNVM_SHELL=1 runvm -- bash
+RUNVM_SHELL=1 runvm "$@" -- bash


### PR DESCRIPTION
So I can more easily debug an attached disk image via e.g.:
```
$ cosa supermin-shell -drive if=virtio,read-only,file=(pwd)/builds/latest/x86_64/rhcos-46.82.202005261954-0-qemu.x86_64.qcow2,format=qcow2
```