### PR TITLE
create_disk: Ensure filesystem journal on rootfs is clean

### DIFF
--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -426,6 +426,9 @@ echo "set ignition_network_kcmdline='${firstboot_kargs}'" > $rootfs/boot/ignitio
 chattr +i $rootfs
 
 fstrim -a -v
+# Ensure the filesystem journal is flushed
+mount -o remount,ro $rootfs
+xfs_freeze -f $rootfs
 umount -R $rootfs
 
 rmdir $rootfs


### PR DESCRIPTION
Trying to get osmet to work with RHCOS, I kept being unable to
mount the rootfs and it turned out that while the code I'd added
to unpack the LUKS bits was working fine, mounting the rootfs
was failing because the block device was read-only, but XFS
wanted to replay the journal.

And for some reason I haven't traced through yet, this apparently
isn't affecting FCOS, but the unclean journal is breaking osmet
w/RHCOS.

This of course is the *second* time I've hit this problem of
"ext4 flushes the journal on umount, XFS doesn't" - see
also https://github.com/ostreedev/ostree/pull/1049/

Adding the necessary invocation of `xfs_freeze` ensures
that our firstboot has a clean XFS journal for `/` which
is just a good idea anyways.