### PR TITLE
osmet-pack: Mount RHCOS LUKS rootfs

### DIFF
--- a/src/osmet-pack
+++ b/src/osmet-pack
@@ -51,9 +51,23 @@ set -x
 /usr/sbin/udevadm trigger --settle
 
 rootfs=/dev/disk/by-id/virtio-osmet-part4
+# Also hardcoded in redhat-coreos/.../coreos-cryptfs
+rhcos_luks_header_size_sectors=32768
 
 mkdir -p /sysroot
-mount -o ro "${rootfs}" /sysroot
+roottype=$(blkid -s TYPE -o value "${rootfs}")
+real_rootdev=
+if [ "${roottype}" = "crypto_LUKS" ]; then
+  dev_size=$(($(blockdev --getsize ${rootfs}) - rhcos_luks_header_size_sectors))
+  # Unlike coreos-cryptfs we use the concise syntax which allows us to mark the blockdev
+  # as read-only, which is required for XFS to actually honor `-o ro` not replaying
+  # the journal.
+  dmsetup create --concise "rhcos-luks-root-nocrypt,,,ro,0 ${dev_size} linear ${rootfs} ${rhcos_luks_header_size_sectors}"
+  mount -o ro /dev/disk/by-label/root /sysroot
+  real_rootdev="${rootfs},${rhcos_luks_header_size_sectors}"
+else
+  mount -o ro "${rootfs}" /sysroot
+fi
 osname=$(ls /sysroot/ostree/deploy)
 deploydir=$(find "/sysroot/ostree/deploy/$osname/deploy" -mindepth 1 -maxdepth 1 -type d)
 # shellcheck disable=SC1090
@@ -66,4 +80,5 @@ fi
 RUST_BACKTRACE=full "${coreinst}" osmet pack /dev/disk/by-id/virtio-osmet \
     --description "${description}" \
     --checksum "${checksum}" \
+    ${real_rootdev:+--real-rootdev ${real_rootdev}} \
     --output "${osmet_dest}"


### PR DESCRIPTION
Prep for RHCOS osmet support.  This doesn't work on its own,
but gets us to the point where `coreos-installer osmet pack`
crashes trying to find the partition size.