### PR TITLE
Use shutil.move over os.rename in python code.

### DIFF
--- a/src/cmd-buildextend-installer
+++ b/src/cmd-buildextend-installer
@@ -137,7 +137,7 @@ def mkinitrd_pipe(tmproot, destf, compression=True):
 def mkinitrd(tmproot, destpath, compression=True):
     desttmp = destpath + '.tmp'
     mkinitrd_pipe(tmproot, open(desttmp, 'w'), compression=compression)
-    os.rename(desttmp, destpath)
+    shutil.move(desttmp, destpath)
 
 
 def extend_initrd(initramfs, tmproot, compression=True):
@@ -180,7 +180,7 @@ def generate_iso():
 
     initramfs = os.path.join(tmpisoimages, initramfs_img)
     base_initramfs = os.path.join(tmpdir, initramfs_img)
-    os.rename(initramfs, base_initramfs)
+    shutil.move(initramfs, base_initramfs)
     # Append the "stampfile initramfs" to the base which says
     # whether it's a live or legacy initramfs.
     with tempfile.TemporaryDirectory(prefix='initramfs', dir=tmpdir) as tmproot:
@@ -435,7 +435,7 @@ def generate_iso():
             'sha256': sha256sum_file(tmpisofile)
         }
     })
-    os.rename(tmpisofile, f"{builddir}/{iso_name}")
+    shutil.move(tmpisofile, f"{builddir}/{iso_name}")
 
     if not args.no_pxe:
         kernel_name = f'{base_name}-{args.build}-{image_type}-kernel-{basearch}'

--- a/src/cmd-compress
+++ b/src/cmd-compress
@@ -128,7 +128,7 @@ def compress_one_builddir(builddir):
             # Just flush out after every image type, but unlink after writing.
             # Then, we should be able to interrupt and restart from the last
             # type.
-            os.rename(tmpfile, filepath_with_ext)
+            shutil.move(tmpfile, filepath_with_ext)
             write_json(buildmeta_path, buildmeta)
             os.unlink(filepath)
             at_least_one = True

--- a/src/cmd-sign
+++ b/src/cmd-sign
@@ -181,7 +181,7 @@ def robosign_ostree(args, s3):
         ostree_image['sha256'] = sha256sum_file(commit_tarfile_new)
         # and the critical bits
         shutil.copymode(commit_tarfile, commit_tarfile_new)
-        os.rename(commit_tarfile_new, commit_tarfile)
+        shutil.move(commit_tarfile_new, commit_tarfile)
         build.write()
 
     # and finally add it to the tmprepo too so that buildextend-(qemu|metal)
@@ -245,7 +245,7 @@ def robosign_images(args, s3):
                     raise e
 
             # move into final location
-            os.rename(tmp_sig_path, f'{local_artifact}.sig')
+            shutil.move(tmp_sig_path, f'{local_artifact}.sig')
 
             # and make S3 object public (XXX: fix robosignatory for this?)
             s3.put_object_acl(Bucket=args.bucket, Key=sig_s3_key,

--- a/src/cmd-upload-oscontainer
+++ b/src/cmd-upload-oscontainer
@@ -8,6 +8,7 @@
 import argparse
 import json
 import os
+import shutil
 import subprocess
 import sys
 
@@ -87,4 +88,4 @@ meta['oscontainer'] = {'image': args.name,
 metapath_new = f"{metapath}.new"
 with open(metapath_new, 'w') as f:
     json.dump(meta, f, sort_keys=True)
-os.rename(metapath_new, metapath)
+shutil.move(metapath_new, metapath)

--- a/src/cosalib/cmdlib.py
+++ b/src/cosalib/cmdlib.py
@@ -5,6 +5,7 @@ Houses helper code for python based coreos-assembler commands.
 import hashlib
 import json
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -77,7 +78,7 @@ def write_json(path, data):
     f = tempfile.NamedTemporaryFile(mode='w', dir=dn, delete=False)
     json.dump(data, f, indent=4)
     os.fchmod(f.file.fileno(), 0o644)
-    os.rename(f.name, path)
+    shutil.move(f.name, path)
 
 
 def load_json(path):

--- a/src/cosalib/digitalocean.py
+++ b/src/cosalib/digitalocean.py
@@ -1,4 +1,4 @@
-import os
+import shutil
 
 from cosalib.cmdlib import (
     run_verbose
@@ -13,7 +13,7 @@ def mutate_digitalocean(path):
     temp_path = f"{path}.gz"
     with open(temp_path, "wb") as fh:
         run_verbose(['gzip', '-9c', path], stdout=fh)
-    os.rename(temp_path, path)
+    shutil.move(temp_path, path)
 
 
 def digitalocean_run_ore(build, args):

--- a/src/cosalib/qemuvariants.py
+++ b/src/cosalib/qemuvariants.py
@@ -249,7 +249,7 @@ class QemuVariantImage(_Build):
                 # match the default naming.
                 if member_name.endswith(('.raw', '.vmdk')):
                     if member_name != os.path.basename(work_img):
-                        os.rename(work_img, os.path.join(self._tmpdir, member_name))
+                        shutil.move(work_img, os.path.join(self._tmpdir, member_name))
                 tarlist.append(member_name)
 
             tar_cmd = ['tar', '--owner=0', '--group=0', '-C', self._tmpdir]


### PR DESCRIPTION
With RHCOS we need to place our builds on their own mount point.
os.rename is used by shutil when on the same file system. This change
allows for some directories to be hosted on another mount point.