### PR TITLE
 buildextend-live: use `find . -mindepth 1` for cpio 

### DIFF
--- a/src/cmd-buildextend-installer
+++ b/src/cmd-buildextend-installer
@@ -134,12 +134,6 @@ def mkinitrd_pipe(tmproot, destf, compression=True):
     assert gzipproc.wait() == 0, f"gzip exited with {gzipproc.returncode}"
 
 
-def mkinitrd(tmproot, destpath, compression=True):
-    desttmp = destpath + '.tmp'
-    mkinitrd_pipe(tmproot, open(desttmp, 'w'), compression=compression)
-    shutil.move(desttmp, destpath)
-
-
 def extend_initrd(initramfs, tmproot, compression=True):
     with open(initramfs, 'ab') as fdst:
         mkinitrd_pipe(tmproot, fdst, compression=compression)

--- a/src/cmd-buildextend-installer
+++ b/src/cmd-buildextend-installer
@@ -121,7 +121,8 @@ initrd_ignition_padding = 256 * 1024
 
 # https://www.kernel.org/doc/html/latest/admin-guide/initrd.html#compressed-cpio-images
 def mkinitrd_pipe(tmproot, destf, compression=True):
-    findproc = subprocess.Popen(['find', '.', '-print0'], cwd=tmproot, stdout=subprocess.PIPE)
+    findproc = subprocess.Popen(['find', '.', '-mindepth', '1', '-print0'],
+                                cwd=tmproot, stdout=subprocess.PIPE)
     cpioproc = subprocess.Popen(['cpio', '-o', '-H', 'newc', '-R', 'root:root',
             '--quiet', '--reproducible', '--force-local', '--null',
             '-D', tmproot], stdin=findproc.stdout, stdout=subprocess.PIPE)


### PR DESCRIPTION
Super subtle but evil regression from #1423. By switching to `find` to
feed filenames to `cpio`, we were passing it `.`. And `cpio` dutifully
made note of the permissions of `.`, which at the time it is run are
those of the temporary directory we allocated, which is naturally 0700.

This in turn breaks Ignition's `files` stage, which purposely runs
things like adding SSH keys as the target user, and thus it can't even
access the directories in `/` when doing the equivalent of `mkdir -p
/sysroot/var/home/core/.ssh/...`.

Instead, use `-mindepth 1` here so we always skip the root of the
temporary directory itself.

This resolves coreos/fedora-coreos-tracker#496
but not marking as `Closes:` because we should really add a basic live
PXE + SSH key test.