### PR TITLE
testiso: Tweak qemu memory for s390x

### DIFF
--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -124,8 +124,9 @@ func newBaseQemuBuilder() *platform.QemuBuilder {
 	// https://github.com/coreos/fedora-coreos-docs/pull/46
 	builder.Memory = 4096
 	if system.RpmArch() == "s390x" {
-		// FIXME - determine why this is
-		builder.Memory = int(math.Max(float64(builder.Memory), 16384))
+		// After some trial and error looks like we need at least 10G on s390x
+		// Recorded an issue to investigate this: https://github.com/coreos/coreos-assembler/issues/1489
+		builder.Memory = int(math.Max(float64(builder.Memory), 10240))
 	}
 
 	builder.InheritConsole = debug


### PR DESCRIPTION
After a bit of trial and error it looks like the minimum needed is 10G for
the legacy-install to run successfully. I will continue investigating this
through https://github.com/coreos/coreos-assembler/issues/1489, but looks like
with anything less than 10G, the qemu process gets killed abruptly during the
start of the reboot phase.