### PR TITLE
Dockerfile: Switch to f32

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:31
+FROM registry.fedoraproject.org/fedora:32
 WORKDIR /root/containerbuild
 
 # We split into multiple steps here so that local dev workflows which involve


### PR DESCRIPTION
Since the creation of the "buildroot" container derived from cosa
which we're using in CI, we really need cosa to somewhat match
the target system.

Also, we might as well do this on general principle.