### PR TITLE
kola: Support inline metadata JSON

### DIFF
--- a/mantle/kola/README-kola-ext.md
+++ b/mantle/kola/README-kola-ext.md
@@ -95,3 +95,15 @@ The reason to use a single string (instead of a native JSON list)
 is that by providing `!` at the front of the string, the value instead
 declares exclusions (`ExclusiveArchitectures` instead of `Architectures` in
 reference to kola internals.
+
+More recently, you can also (useful for shell scripts) include the JSON file
+inline per test, like this:
+
+```sh
+#!/bin/bash
+set -xeuo pipefail
+# kola: { "architectures": "x86_64", "platforms": ["aws", "gcp"] }
+test code here
+```
+
+This metadata stanza must start with `# kola: ` and have a single line of JSON.


### PR DESCRIPTION
Having a separate JSON file for the metadata is annoying, let's
support it inline.

(This is of course somewhat tricky for compiled binaries to support,
 but we'll deal with that when we get there)