### PR TITLE
ci: run on Fedora 32 image

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -1,6 +1,6 @@
 // Documentation: https://github.com/coreos/coreos-ci/blob/master/README-upstream-ci.md
 
-pod(image: 'registry.fedoraproject.org/fedora:31', runAsUser: 0, kvm: true, memory: "9Gi") {
+pod(image: 'registry.fedoraproject.org/fedora:32', runAsUser: 0, kvm: true, memory: "9Gi") {
       checkout scm
 
       stage("Build") {


### PR DESCRIPTION
Now that we've bumped cosa to f32, we want to make sure CI is also
targeting that. (Ideally, we'd just build from the Dockerfile and run
tests on the resulting image. That's something we can easily do with
Prow, though we should be able to do this via the OpenShift Jenkins
plugin too.)