### PR TITLE
deps: Add grub2-tools-extra on ppc64le for grub2-mkrescue

### DIFF
--- a/src/deps-ppc64le.txt
+++ b/src/deps-ppc64le.txt
@@ -1,3 +1,3 @@
 # To support pseries in anacondaless installs
-grub2 powerpc-utils xorriso
+grub2 grub2-tools-extra powerpc-utils xorriso
 


### PR DESCRIPTION
grub2 in f32 is not pulling in grub2-tools-extra on ppc64le anymore.
Other architectures get it via their platform specific grub sub-packages.