### PR TITLE
Dockerfile: blow cache for new coreos-installer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /root/containerbuild
 # Only need a few of our scripts for the first few steps
 COPY ./src/print-dependencies.sh ./src/deps*.txt ./src/vmdeps*.txt ./src/build-deps.txt /root/containerbuild/src/
 COPY ./build.sh /root/containerbuild/
-RUN ./build.sh configure_yum_repos # nocache 20200420
+RUN ./build.sh configure_yum_repos # nocache 20200601
 RUN ./build.sh install_rpms
 
 # Ok copy in the rest of them for the next few steps

--- a/build.sh
+++ b/build.sh
@@ -29,10 +29,6 @@ configure_yum_repos() {
     # can depend on those latest tools being available in all container
     # builds.
     echo -e "[f${version_id}-coreos-continuous]\nenabled=1\nmetadata_expire=1m\nbaseurl=https://kojipkgs.fedoraproject.org/repos-dist/f${version_id}-coreos-continuous/latest/\$basearch/\ngpgcheck=0\nskip_if_unavailable=False\n" > /etc/yum.repos.d/coreos.repo
-    # We have a few packages that we currently import from f32, so explicitly
-    # add the f32 repo temporarily.
-    echo -e "[f32-coreos-continuous]\nenabled=1\nmetadata_expire=1m\nbaseurl=https://kojipkgs.fedoraproject.org/repos-dist/f32-coreos-continuous/latest/\$basearch/\ngpgcheck=0\nskip_if_unavailable=False\n" >> /etc/yum.repos.d/coreos.repo
-
 }
 
 install_rpms() {


### PR DESCRIPTION
Just tagged coreos-installer-0.2.1-2.fc32 into f32-coreos-continuous to
unblock upgrade testing (we now sign `testing-devel` images with the f32
key, but the public key was added in 0.2.1 so it's failing to verify).

Let's blow the Quay.io cache to force it to re-install the RPMs.