### PR TITLE
buildextend-installer: add metal4k osmet support

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -52,14 +52,15 @@ pod(image: 'registry.fedoraproject.org/fedora:32', runAsUser: 0, kvm: true, memo
 
       stage("Image tests") {
         try {
-          shwrap("cd /srv && rm tmp/kola -rf")
-          shwrap("cd /srv && env TMPDIR=\$(pwd)/tmp/ kola testiso -S")
-          shwrap("cd /srv && env TMPDIR=\$(pwd)/tmp/ kola testiso -S --scenarios iso-offline-install")
-          // and again this time with the 4k image
-          shwrap("cd /srv && env TMPDIR=\$(pwd)/tmp/ kola testiso -S --qemu-native-4k --no-pxe")
+          parallel metal: {
+              shwrap("cd /srv && env TMPDIR=\$(pwd)/tmp/ kola testiso -S --output-dir tmp/kola-testiso-metal")
+          }, metal4k: {
+              shwrap("cd /srv && env TMPDIR=\$(pwd)/tmp/ kola testiso -S --output-dir tmp/kola-testiso-metal4k --no-pxe")
+          }
         } finally {
-          shwrap("cd /srv && tar -cf - tmp/kola/ | xz -c9 > ${env.WORKSPACE}/kola-testiso.tar.xz")
-          archiveArtifacts allowEmptyArchive: true, artifacts: 'kola-testiso.tar.xz'
+          shwrap("cd /srv && tar -cf - tmp/kola-testiso-metal/ | xz -c9 > ${env.WORKSPACE}/kola-testiso-metal.tar.xz")
+          shwrap("cd /srv && tar -cf - tmp/kola-testiso-metal4k/ | xz -c9 > ${env.WORKSPACE}/kola-testiso-metal4k.tar.xz")
+          archiveArtifacts allowEmptyArchive: true, artifacts: 'kola-testiso*.tar.xz'
         }
       }
 

--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -71,9 +71,7 @@ const (
 
 	scenarioPXEInstall = "pxe-install"
 	scenarioISOInstall = "iso-install"
-	// this might just be iso-install eventually since the pxe install already
-	// tests the over-the-network case; we're making it separate for now to
-	// more easily ratchet osmet into place
+
 	scenarioISOOfflineInstall = "iso-offline-install"
 	scenarioISOLiveLogin      = "iso-live-login"
 	scenarioLegacyInstall     = "legacy-install"
@@ -110,7 +108,7 @@ func init() {
 	cmdTestIso.Flags().BoolVar(&debug, "debug", false, "Display qemu console to stdout, turn off automatic initramfs failure checking")
 	cmdTestIso.Flags().StringSliceVar(&pxeKernelArgs, "pxe-kargs", nil, "Additional kernel arguments for PXE")
 	// FIXME move scenarioISOLiveLogin into the defaults once https://github.com/coreos/fedora-coreos-config/pull/339#issuecomment-613000050 is fixed
-	cmdTestIso.Flags().StringSliceVar(&scenarios, "scenarios", []string{scenarioPXEInstall, scenarioISOInstall}, fmt.Sprintf("Test scenarios (also available: %v)", []string{scenarioLegacyInstall, scenarioISOLiveLogin, scenarioISOOfflineInstall}))
+	cmdTestIso.Flags().StringSliceVar(&scenarios, "scenarios", []string{scenarioPXEInstall, scenarioISOOfflineInstall}, fmt.Sprintf("Test scenarios (also available: %v)", []string{scenarioLegacyInstall, scenarioISOLiveLogin, scenarioISOInstall}))
 	cmdTestIso.Args = cobra.ExactArgs(0)
 
 	root.AddCommand(cmdTestIso)

--- a/src/cmd-buildextend-installer
+++ b/src/cmd-buildextend-installer
@@ -157,6 +157,11 @@ def generate_iso():
     img_metal = os.path.join(builddir, img_metal_obj['path'])
     img_metal_checksum = img_metal_obj['sha256']
 
+    img_metal4k_obj = buildmeta['images'].get('metal4k')
+    if img_metal4k_obj is not None:
+        img_metal4k = os.path.join(builddir, img_metal4k_obj['path'])
+        img_metal4k_checksum = img_metal4k_obj['sha256']
+
     # Find the directory under `/usr/lib/modules/<kver>` where the
     # kernel/initrd live. It will be the 2nd entity output by
     # `ostree ls <commit> /usr/lib/modules`
@@ -191,9 +196,15 @@ def generate_iso():
     if is_live and osmet:
         with tempfile.TemporaryDirectory(prefix='initramfs', dir=tmpdir) as tmproot:
             tmp_osmet = os.path.join(tmproot, img_metal_obj['path'] + '.osmet')
-            print(f'Generating osmet file')
+            print(f'Generating osmet file for 512b metal image')
             run_verbose(['/usr/lib/coreos-assembler/osmet-pack',
-                        img_metal, tmp_osmet, img_metal_checksum])
+                         img_metal, '512', tmp_osmet, img_metal_checksum])
+            if img_metal4k_obj is not None:
+                tmp_osmet4k = os.path.join(tmproot, img_metal4k_obj['path'] + '.osmet')
+                print(f'Generating osmet file for 4k metal image')
+                run_verbose(['/usr/lib/coreos-assembler/osmet-pack',
+                             img_metal4k, '4096', tmp_osmet4k,
+                             img_metal4k_checksum])
             extend_initrd(base_initramfs, tmproot, compression=False)
 
     # The base_initramfs from here is shared between the ISO and PXE paths

--- a/src/osmet-pack
+++ b/src/osmet-pack
@@ -7,6 +7,7 @@ if [ ! -f /etc/cosa-supermin ]; then
     . "${dn}"/cmdlib.sh
 
     img_src=$1; shift
+    sector_size=$1; shift
     osmet_dest=$1; shift
     checksum=$1; shift
     coreinst=${1:-${OSMET_PACK_COREOS_INSTALLER:-}}
@@ -27,9 +28,14 @@ if [ ! -f /etc/cosa-supermin ]; then
         set -- "$@" "${TMPDIR}/coreos-installer"
     fi
 
+    device_opts=
+    if [ "$sector_size" != 512 ]; then
+        device_opts=",physical_block_size=${sector_size},logical_block_size=${sector_size}"
+    fi
+
     # stamp it with "osmet" serial so we find it easily in the VM
     runvm -drive "if=none,id=osmet,format=raw,readonly=on,file=${img_src}" \
-        -device virtio-blk,serial=osmet,drive=osmet -- \
+        -device "virtio-blk,serial=osmet,drive=osmet${device_opts}" -- \
         /usr/lib/coreos-assembler/osmet-pack "$@"
 
     mv "${TMPDIR}/osmet.bin" "${osmet_dest}"


### PR DESCRIPTION
Start building and shipping osmet files for metal4k images so that those
users can also do offline installs.

This completes the osmet work.