### PR TITLE
testiso: add ssh key info in ignition config for testing live ISO/PXE artifacts

### DIFF
--- a/mantle/cmd/kola/devshell.go
+++ b/mantle/cmd/kola/devshell.go
@@ -94,23 +94,17 @@ func runDevShellSSH(builder *platform.QemuBuilder, conf *v3types.Config) error {
 	if !terminal.IsTerminal(0) {
 		return fmt.Errorf("stdin is not a tty")
 	}
-
 	tmpd, err := ioutil.TempDir("", "kola-devshell")
 	if err != nil {
 		return err
 	}
+	sshPubKeyBuf, sshKeyPath, err := util.CreateSSHAuthorizedKey(tmpd)
+	if err != nil {
+		return err
+	}
+
 	defer os.RemoveAll(tmpd)
 
-	sshKeyPath := filepath.Join(tmpd, "ssh.key")
-	sshPubKeyPath := sshKeyPath + ".pub"
-	err = exec.Command("ssh-keygen", "-N", "", "-t", "ed25519", "-f", sshKeyPath).Run()
-	if err != nil {
-		return errors.Wrapf(err, "running ssh-keygen")
-	}
-	sshPubKeyBuf, err := ioutil.ReadFile(sshPubKeyPath)
-	if err != nil {
-		return errors.Wrapf(err, "reading pubkey")
-	}
 	sshPubKey := v3types.SSHAuthorizedKey(strings.TrimSpace(string(sshPubKeyBuf)))
 
 	// Await sshd startup;

--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -26,6 +26,7 @@ import (
 	"io/ioutil"
 	"math"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -394,10 +395,48 @@ func printSuccess(mode string) {
 	fmt.Printf("Successfully tested scenario %s for %s on %s (%s)\n", mode, kola.CosaBuild.Meta.OstreeVersion, kola.QEMUOptions.Firmware, metaltype)
 }
 
+// createSSHAuthorizedKey generates a public key to sanity check
+// that Ignition accepts it. This is added to address
+// https://github.com/coreos/fedora-coreos-tracker/issues/515
+func createSSHAuthorizedKey() ([]byte, error) {
+	tmpd, err := ioutil.TempDir("", "kola-testiso")
+	if err != nil {
+		return nil, err
+	}
+	defer os.RemoveAll(tmpd)
+
+	sshKeyPath := filepath.Join(tmpd, "ssh.key")
+	sshPubKeyPath := sshKeyPath + ".pub"
+	err = exec.Command("ssh-keygen", "-N", "", "-t", "ed25519", "-f", sshKeyPath).Run()
+	if err != nil {
+		return nil, errors.Wrapf(err, "running ssh-keygen")
+	}
+	sshPubKeyBuf, err := ioutil.ReadFile(sshPubKeyPath)
+	if err != nil {
+		return nil, errors.Wrapf(err, "reading pubkey")
+	}
+	return sshPubKeyBuf, nil
+}
+
 func testPXE(inst platform.Install, outdir string) error {
+	sshPubKeyBuf, err := createSSHAuthorizedKey()
+	if err != nil {
+		return err
+	}
+	sshPubKey := ignv3types.SSHAuthorizedKey(strings.TrimSpace(string(sshPubKeyBuf)))
 	config := ignv3types.Config{
 		Ignition: ignv3types.Ignition{
 			Version: "3.0.0",
+		},
+		Passwd: ignv3types.Passwd{
+			Users: []ignv3types.PasswdUser{
+				{
+					Name: "core",
+					SSHAuthorizedKeys: []ignv3types.SSHAuthorizedKey{
+						sshPubKey,
+					},
+				},
+			},
 		},
 		Systemd: ignv3types.Systemd{
 			Units: []ignv3types.Unit{
@@ -458,9 +497,24 @@ func testLiveIso(inst platform.Install, outdir string, offline bool) error {
 	RequiredBy=multi-user.target
 	`, liveOKSignal)
 
+	sshPubKeyBuf, err := createSSHAuthorizedKey()
+	if err != nil {
+		return err
+	}
+	sshPubKey := ignv3types.SSHAuthorizedKey(strings.TrimSpace(string(sshPubKeyBuf)))
 	liveConfig := ignv3types.Config{
 		Ignition: ignv3types.Ignition{
 			Version: "3.0.0",
+		},
+		Passwd: ignv3types.Passwd{
+			Users: []ignv3types.PasswdUser{
+				{
+					Name: "core",
+					SSHAuthorizedKeys: []ignv3types.SSHAuthorizedKey{
+						sshPubKey,
+					},
+				},
+			},
 		},
 		Systemd: ignv3types.Systemd{
 			Units: []ignv3types.Unit{
@@ -477,6 +531,16 @@ func testLiveIso(inst platform.Install, outdir string, offline bool) error {
 	targetConfig := ignv3types.Config{
 		Ignition: ignv3types.Ignition{
 			Version: "3.0.0",
+		},
+		Passwd: ignv3types.Passwd{
+			Users: []ignv3types.PasswdUser{
+				{
+					Name: "core",
+					SSHAuthorizedKeys: []ignv3types.SSHAuthorizedKey{
+						sshPubKey,
+					},
+				},
+			},
 		},
 		Systemd: ignv3types.Systemd{
 			Units: []ignv3types.Unit{


### PR DESCRIPTION
Fixes https://github.com/coreos/fedora-coreos-tracker/issues/515 
This fix will add a test in CI for live ISO/PXE artifacts to validate if an ssh key is setting up appropriately for the `core` user when provided via ignition config.