### PR TITLE
tests: Enforce no Internet in qemu unless flagged

### DIFF
--- a/mantle/kola/tests/podman/podman.go
+++ b/mantle/kola/tests/podman/podman.go
@@ -24,6 +24,7 @@ import (
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/net/context"
 
+	"github.com/coreos/mantle/kola"
 	"github.com/coreos/mantle/kola/cluster"
 	"github.com/coreos/mantle/kola/register"
 	tutil "github.com/coreos/mantle/kola/tests/util"
@@ -53,7 +54,9 @@ func init() {
 		Run:         podmanNetworksReliably,
 		ClusterSize: 1,
 		Name:        `podman.network-single`,
-		Distros:     []string{"fcos"},
+		// Not really but podman blows up if there's no /etc/resolv.conf
+		Tags:    []string{kola.NeedsInternetTag},
+		Distros: []string{"fcos"},
 	})
 	// https://github.com/coreos/mantle/pull/1080
 	// register.RegisterTest(&register.Test{

--- a/mantle/platform/machine/unprivqemu/cluster.go
+++ b/mantle/platform/machine/unprivqemu/cluster.go
@@ -142,6 +142,9 @@ func (qc *Cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 		}
 		builder.EnableUsermodeNetworking(h)
 	}
+	if !qc.RuntimeConf().InternetAccess {
+		builder.RestrictNetworking = true
+	}
 
 	inst, err := builder.Exec()
 	if err != nil {

--- a/mantle/platform/platform.go
+++ b/mantle/platform/platform.go
@@ -186,6 +186,9 @@ type RuntimeConfig struct {
 	NoSSHKeyInUserData bool // don't inject SSH key into Ignition/cloud-config
 	NoSSHKeyInMetadata bool // don't add SSH key to platform metadata
 	AllowFailedUnits   bool // don't fail CheckMachine if a systemd unit has failed
+
+	// InternetAccess is true if the cluster should be Internet connected
+	InternetAccess bool
 }
 
 // Wrap a StdoutPipe as a io.ReadCloser


### PR DESCRIPTION

In https://github.com/coreos/coreos-assembler/pull/1478 we
discussed Internet access and tests, adding a flag to disable
tests which are flagged as requiring it.

This flips things around and *enforces* no Internet access for
qemu tests by default unless the test is flagged as requiring
it.

Unsurprisingly it turns out several tests are missing the flag.
(And we also don't presently have a way to flag external tests
 as requiring Internet, which is another issue)
