### PR TITLE
testiso: lower install timeout to 10m

### DIFF
--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -67,7 +67,7 @@ var (
 )
 
 const (
-	installTimeout = 15 * time.Minute
+	installTimeout = 10 * time.Minute
 
 	scenarioPXEInstall = "pxe-install"
 	scenarioISOInstall = "iso-install"


### PR DESCRIPTION
We're hitting a `testiso` timeout right now in the FCOS pipeline and
it has to wait 15m each time before erroring and publishing artifacts.

Given that all our install tests transfer files within localhost to the
QEMU instance (or in the case of the offline tests, don't transfer files
at all), we really expect it to take much less time. There's still disk
I/O of course, but even so 10m should be enough.

We can revisit if we ever add `testiso` support for e.g. Packet or some
KNI setups where we're actually testing against real bare metal.