### PR TITLE
metal: don't redirect coreos-installer output to console

### DIFF
--- a/mantle/platform/metal.go
+++ b/mantle/platform/metal.go
@@ -597,8 +597,6 @@ OnFailureJobMode=isolate
 RemainAfterExit=yes
 Type=oneshot
 ExecStart=/usr/bin/coreos-installer install %s --ignition %s %s %s
-StandardOutput=kmsg+console
-StandardError=kmsg+console
 [Install]
 WantedBy=multi-user.target
 `, srcOpt, pointerIgnitionPath, insecureOpt, targetDevice)


### PR DESCRIPTION
In trying to debug why the pipeline metal4k offline install tests were
failing, neither the console nor the journal logs were very useful. The
first because ISO installs don't output to serial by default (and we
currently don't have an easy way to override that), the second because
we were redirecting `coreos-installer` to the console, which we can't
capture.

Drop the `StandardOutput`/`StandardError` overrides so that output goes
to the journal, where we can collect it over virtio.