### PR TITLE
WIP: Enable parallel buildextend-* execution

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -38,8 +38,11 @@ pod(image: 'registry.fedoraproject.org/fedora:32', runAsUser: 0, kvm: true, memo
               shwrap("test -d /srv/tmp/kola")
           },
           buildextend: {
-              cosa_cmd("buildextend-metal")
-              cosa_cmd("buildextend-metal4k")
+              parallel metal: {
+                  cosa_cmd("buildextend-metal")
+              }, metal4k: {
+                  cosa_cmd("buildextend-metal4k")
+              }
               cosa_cmd("buildextend-live")
               cosa_cmd("buildextend-openstack")
               cosa_cmd("buildextend-vmware")

--- a/src/buildextend-rojig-impl
+++ b/src/buildextend-rojig-impl
@@ -36,5 +36,6 @@ if has_privileges; then
 else
     info "Required privileges not detected; running via supermin appliance"
     prepare_build
-    runvm -- "${0}" "${commit}" "${tmpdir}"
+    runvm -drive "if=none,id=cache,discard=unmap,file=${workdir}/cache/cache2.qcow2" \
+            -device virtio-blk,drive=cache -- "${0}" "${commit}" "${tmpdir}"
 fi

--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -270,7 +270,6 @@ runvm "${target_drive[@]}" -- \
             --rootfs "${rootfs_type}" \
             "${disk_args[@]}"
 /usr/lib/coreos-assembler/finalize-artifact "${path}.tmp" "${path}"
-echo "{}" > tmp/vm-iso-checksum.json
 
 # there's probably a jq one-liner for this...
 python3 -c "
@@ -282,7 +281,7 @@ j['images']['${image_type}'] = {
     'size': $(stat -c '%s' "${img}")
 }
 json.dump(j, sys.stdout, indent=4)
-" < "${builddir}/meta.json" | cat - tmp/vm-iso-checksum.json | jq -s add > meta.json.new
+" < "${builddir}/meta.json" > meta.json.new
 
 # and now the crucial bits
 /usr/lib/coreos-assembler/finalize-artifact meta.json.new "${builddir}/meta.json"

--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -271,18 +271,27 @@ runvm "${target_drive[@]}" -- \
             "${disk_args[@]}"
 /usr/lib/coreos-assembler/finalize-artifact "${path}.tmp" "${path}"
 
-# there's probably a jq one-liner for this...
-python3 -c "
+# calculate this ahead of time to reduce critical section timespan
+sha256=$(sha256sum_str < "${img}")
+
+# and now the crucial bits
+# shellcheck disable=SC2094
+(echo "Waiting for lock..."
+ flock 9
+ echo "Proceeding"
+
+ # there's probably a jq one-liner for this...
+ python3 -c "
 import sys, json
 j = json.load(sys.stdin)
 j['images']['${image_type}'] = {
-    'path': '${img}',
-    'sha256': '$(sha256sum_str < "${img}")',
-    'size': $(stat -c '%s' "${img}")
+ 'path': '${img}',
+ 'sha256': '${sha256}',
+ 'size': $(stat -c '%s' "${img}")
 }
 json.dump(j, sys.stdout, indent=4)
 " < "${builddir}/meta.json" > meta.json.new
 
-# and now the crucial bits
-/usr/lib/coreos-assembler/finalize-artifact meta.json.new "${builddir}/meta.json"
-/usr/lib/coreos-assembler/finalize-artifact "${img}" "${builddir}/${img}"
+ /usr/lib/coreos-assembler/finalize-artifact "${img}" "${builddir}/${img}"
+ /usr/lib/coreos-assembler/finalize-artifact meta.json.new "${builddir}/meta.json"
+) 9<"${builddir}/meta.json"

--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -231,11 +231,9 @@ else
     mkfs.xfs "${root_dev}" -L root -m reflink=1 -m uuid="${rootfs_uuid}"
 fi
 
-rootfs=$PWD/tmp/rootfs
+rootfs=$(mktemp -d -p $PWD/tmp rootfs-XXXXXX)
 
 # mount the partitions
-rm -rf ${rootfs}
-mkdir -p ${rootfs}
 mount -o discard "${root_dev}" ${rootfs}
 chcon $(matchpathcon -n /) ${rootfs}
 mkdir ${rootfs}/boot

--- a/src/osmet-pack
+++ b/src/osmet-pack
@@ -6,16 +6,16 @@ if [ ! -f /etc/cosa-supermin ]; then
     # shellcheck source=src/cmdlib.sh
     . "${dn}"/cmdlib.sh
 
-    img_src=$1; shift
+    img_src=$(realpath "$1"); shift
     sector_size=$1; shift
-    osmet_dest=$1; shift
+    osmet_dest=$(realpath "$1"); shift
     checksum=$1; shift
     coreinst=${1:-${OSMET_PACK_COREOS_INSTALLER:-}}
+    if [ -n "${coreinst:-}" ]; then
+        coreinst=$(realpath "${coreinst}")
+    fi
 
-    workdir=$(pwd)
-    TMPDIR=$(readlink -f tmp/tmp-osmet-pack)
-    rm -rf "${TMPDIR}"
-    mkdir -p "${TMPDIR}"
+    prepare_build
 
     if [[ $img_src == *.gz || $img_src == *.xz ]]; then
         img="$(basename "$img_src")"
@@ -39,8 +39,6 @@ if [ ! -f /etc/cosa-supermin ]; then
         /usr/lib/coreos-assembler/osmet-pack "$@"
 
     mv "${TMPDIR}/osmet.bin" "${osmet_dest}"
-    rm -rf "${TMPDIR}"
-
     exit 0
 fi
 


### PR DESCRIPTION
I really want to speed up the FCOS and RHCOS pipelines by parallelizing
things more. For example, all the simple "guestfish && tweak platform
id" buildextends could easily be parallelizable.

Really, the critical bits that need locking is updating `meta.json`.
Everything else can be done in parallel.

This starts the ball rolling for `buildextend-metal`. We adapt the bits
from `cmdlib.sh` and `create_disk.sh` which currently assume exclusive
access to some directories so that they can run in parallel, then add
locking in `buildextend-metal` at the crucial part where it needs to
write to the build directory.

With this, I can successfully run `buildextend-metal` and
`buildextend-metal4k` and `buildextend-qemu` in parallel.

If agreed on the model, I'll adapt the remaining commands for parallel
execution.

