### PR TITLE
osmet-pack: Remove unnecessary duplicate udev invocations

### DIFF
--- a/src/osmet-pack
+++ b/src/osmet-pack
@@ -52,12 +52,6 @@ coreinst=${1:-}
 
 set -x
 
-# we want /dev/disk symlinks for coreos-installer
-/usr/lib/systemd/systemd-udevd --daemon
-# mock systemd-udevd-trigger.service
-/usr/sbin/udevadm trigger --settle --type=subsystems --action=add
-/usr/sbin/udevadm trigger --settle --type=devices --action=add
-
 # Also hardcoded in redhat-coreos/.../coreos-cryptfs
 rhcos_luks_header_size_sectors=32768
 


### PR DESCRIPTION
We've had udev running inside `supermin-init-prelude.sh` for a
while.  I am seeing the udev calls hanging sometimes (often)
for me locally.

Removing them seems to make the process more reliable for me,
and is less code!