### PR TITLE
kola: switch qemuoptions to bios for all arches except aarch64 and x86 for metal 4k

### DIFF
--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -167,11 +167,11 @@ func syncOptionsImpl(useCosa bool) error {
 	if kola.QEMUOptions.Native4k && kola.QEMUOptions.Firmware == "bios" {
 		return fmt.Errorf("native 4k requires uefi firmware")
 	}
-	// default to BIOS, or UEFI for 4k
+	// default to BIOS, UEFI for aarch64 and x86(only for 4k)
 	if kola.QEMUOptions.Firmware == "" {
-		if kola.QEMUOptions.Native4k {
+		if system.RpmArch() == "aarch64" {
 			kola.QEMUOptions.Firmware = "uefi"
-		} else if system.RpmArch() == "aarch64" {
+		} else if system.RpmArch() == "x86_64" && kola.QEMUOptions.Native4k {
 			kola.QEMUOptions.Firmware = "uefi"
 		} else {
 			kola.QEMUOptions.Firmware = "bios"

--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -220,8 +220,10 @@ func runTestIso(cmd *cobra.Command, args []string) error {
 		delete(targetScenarios, scenarioISOLiveLogin)
 	}
 
+	// just make it a normal print message so pipelines don't error out for ppc64le and s390x
 	if len(targetScenarios) == 0 {
-		return fmt.Errorf("No scenarios specified!")
+		fmt.Println("No valid scenarios specified!")
+		return nil
 	}
 	scenarios = []string{}
 	for scenario, _ := range targetScenarios {


### PR DESCRIPTION
The pipeline for ppc64le fails on the metal4k tests as UEFI is not supported.
Change to use UEFI only for aarch64 and x86 metal 4k test.For s390x, this test is
skipped but in the pipeline it fails because there are no scenarios to test.
Change that message to just a print.

Thanks @cgwalters for the suggestion to fix the test for ppc64le!