### PR TITLE
cmd-build: create object dir before copying parent commit

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -176,7 +176,9 @@ if [ -n "${PARENT_BUILD}" ]; then
     parent_builddir=$(get_build_dir "${PARENT_BUILD}")
     PARENT=$(jq -r '.["ostree-commit"]' < "${parent_builddir}/meta.json")
     # and copy the parent into the repo so that we can generate a pkgdiff below
-    cp "${parent_builddir}/ostree-commit-object" "${tmprepo}/objects/${PARENT::2}/${PARENT:2}.commit"
+    commitpath=${tmprepo}/objects/${PARENT::2}/${PARENT:2}.commit
+    mkdir -p "$(dirname "${commitpath}")"
+    cp "${parent_builddir}/ostree-commit-object" "${commitpath}"
 fi
 
 # Calculate image input checksum now and gather previous image build variables if any


### PR DESCRIPTION
Regression from #1507. We need to make sure we create the parent
directory before copying.