### PR TITLE
Dockerfile: tickle Quay for rebuild

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /root/containerbuild
 # Only need a few of our scripts for the first few steps
 COPY ./src/print-dependencies.sh ./src/deps*.txt ./src/vmdeps*.txt ./src/build-deps.txt /root/containerbuild/src/
 COPY ./build.sh /root/containerbuild/
-RUN ./build.sh configure_yum_repos # nocache 20200601
+RUN ./build.sh configure_yum_repos # nocache 20200610
 RUN ./build.sh install_rpms
 
 # Ok copy in the rest of them for the next few steps


### PR DESCRIPTION
I think this might be the root cause behind CI failing in
https://github.com/coreos/rpm-ostree/pull/2122. It has a libdnf bump,
which relies on a bumped librepo for URL encoding/decoding of packages:

https://github.com/rpm-software-management/libdnf/commit/3e4997dd161a5be01fb78f0d9626fbd798b94360
https://github.com/rpm-software-management/librepo/commit/a283e9c087426542d45137b27569f11e40d440d4

But because Quay so aggressively re-uses layers, it's still using the
old librepo. One doesn't have to download cosa locally to check this.
The Bodhi update was pushed to the repos 5 days ago:

https://bodhi.fedoraproject.org/updates/FEDORA-2020-a943fde9ba

but none of the Quay.io build logs since longer than that have re-run
the package installs.