### PR TITLE
kola: Support the Debian autopkgtest reboot API

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -37,6 +37,14 @@ pod(image: 'registry.fedoraproject.org/fedora:32', runAsUser: 0, kvm: true, memo
               // sanity check kola actually ran and dumped its output in tmp/
               shwrap("test -d /srv/tmp/kola")
           },
+          kolaself: {
+            try {
+              shwrap("cd /srv && ${env.WORKSPACE}/ci/run-kola-self-tests")
+            } finally {
+              shwrap("cd /srv && tar -cf - tmp/kolaself | xz -c9 > ${env.WORKSPACE}/kolaself.tar.xz")
+              archiveArtifacts allowEmptyArchive: true, artifacts: 'kolaself.tar.xz'
+            }
+          },
           buildextend: {
               cosa_cmd("buildextend-metal")
               cosa_cmd("buildextend-metal4k")

--- a/ci/run-kola-self-tests
+++ b/ci/run-kola-self-tests
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+dn=$(cd $(dirname $0) && pwd)
+toplevel=$(cd ${dn} && git rev-parse --show-toplevel)
+set -x
+kola run --output-dir tmp/kolaself -E ${toplevel}/tests/kola-ci-self 'ext.kola-ci-self*'
+log=$(find tmp/kolaself -type f -name kola-runext-autopkgtest-reboot.txt)
+test -n "${log}"
+if ! grep -qF -e 'ok autopkgtest rebooting' < "${log}"; then
+  echo "failed to validate autopkgtest rebooting test output"
+  exit 1
+fi

--- a/tests/kola-ci-self/tests/kola/autopkgtest-reboot
+++ b/tests/kola-ci-self/tests/kola/autopkgtest-reboot
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Copy of the reboot example from https://salsa.debian.org/ci-team/autopkgtest/raw/master/doc/README.package-tests.rst
+set -xeuo pipefail
+case "${AUTOPKGTEST_REBOOT_MARK:-}" in
+  "") echo "test beginning"; /tmp/autopkgtest-reboot mark1 ;;
+  mark1) echo "test in mark1"; /tmp/autopkgtest-reboot mark2 ;;
+  mark2) echo "test in mark2" ;;
+  *) echo "unexpected mark: ${AUTOPKGTEST_REBOOT_MARK}"; exit 1;;
+esac
+echo "ok autopkgtest rebooting"


### PR DESCRIPTION
As I was working on extending some of ostree's destructive
test suite to do reboots:
https://github.com/ostreedev/ostree/pull/2127

I realized that the Debian autopkgtest API for rebooting is
better, because it allows *saving state external to the host*.

Rather than having the test count boots as ostree is doing
today, the "mark" allows us to more reliably dispatch.
And further, becase we don't rely on writing anything to disk
on the target, we can add clean support for "forced reboots"
that might kill the OS before we write to persistent storage there.

The "between reboot" state lives in the test runner's memory instead.

We retain support for the previous (two!) reboot APIs here for now.

I tested this with basically the example script
from the Debian autopkgtest specification:

```
set -xeuo pipefail
case "${AUTOPKGTEST_REBOOT_MARK:-}" in
  "") echo "test beginning"; /tmp/autopkgtest-reboot mark1 ;;
  mark1) echo "test in mark1"; /tmp/autopkgtest-reboot mark2 ;;
  mark2) echo "test in mark2" ;;
  *) echo "unexpected mark: ${AUTOPKGTEST_REBOOT_MARK}"; exit 1;;
esac
echo "ok autopkgtest rebooting"
```

I think it will make sense actually to implement more of the autopkgtest
API - Debian has a nontrivial number of tests using this, and I
think there's even work upstream in e.g. systemd to bridge its
tests to autopkgtest.  Which would mean we gain "run systemd's tests in kola"
for free.