### PR TITLE
Mark parent commit as partial and prune tmp/repo more aggressively

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -177,8 +177,12 @@ if [ -n "${PARENT_BUILD}" ]; then
     PARENT=$(jq -r '.["ostree-commit"]' < "${parent_builddir}/meta.json")
     # and copy the parent into the repo so that we can generate a pkgdiff below
     commitpath=${tmprepo}/objects/${PARENT::2}/${PARENT:2}.commit
-    mkdir -p "$(dirname "${commitpath}")"
-    cp "${parent_builddir}/ostree-commit-object" "${commitpath}"
+    commitpartial=${tmprepo}/state/${PARENT}.commitpartial
+    mkdir -p "$(dirname "${commitpath}")" "$(dirname "${commitpartial}")"
+    if [ ! -f "${commitpath}" ]; then
+        cp "${parent_builddir}/ostree-commit-object" "${commitpath}"
+        touch "${commitpartial}"
+    fi
 fi
 
 # Calculate image input checksum now and gather previous image build variables if any

--- a/src/cmd-build
+++ b/src/cmd-build
@@ -181,6 +181,7 @@ if [ -n "${PARENT_BUILD}" ]; then
     mkdir -p "$(dirname "${commitpath}")" "$(dirname "${commitpartial}")"
     if [ ! -f "${commitpath}" ]; then
         cp "${parent_builddir}/ostree-commit-object" "${commitpath}"
+        # and mark as partial since we only imported the commit object
         touch "${commitpartial}"
     fi
 fi
@@ -449,7 +450,9 @@ mv "${lockfile_out}" .
 saved_build_tmpdir="${workdir}/tmp/last-build-tmp"
 rm -rf "${saved_build_tmpdir}"
 mv -T tmp "${saved_build_tmpdir}"
-ostree prune --repo="${tmprepo}" --refs-only
+# just keep the last 3 commits as a rough guideline; this matches
+# DEFAULT_KEEP_LAST_N in `cmd-prune`
+ostree prune --repo="${tmprepo}" --refs-only --depth=2
 # Back to the toplevel work directory, so we can rename this one
 cd "${workdir}"
 # We create a .build-commit file to note that we're in the


### PR DESCRIPTION
```
commit 3fb5f99687ddd0981d2feb2333d01ef14a730265
Date:   Thu Jun 11 09:16:43 2020 -0400

    cmd-build: Only keep last three commits in tmp/repo

    The default otherwise is to keep all the commits, even if the associated
    builds were long gone.

commit ad2b096715a0ad8bc3189f25efb0f43e5a3cb662
Date:   Thu Jun 11 09:10:51 2020 -0400

    cmd-build: Mark parent commit as partial

    Otherwise, commands like `ostree prune` will think the full commit is
    present and try to traverse it.

    I hadn't hit this when originally adding `--parent-build` because I did
    have the full commits available in my `tmp/repo`. But the pipeline OTOH
    always starts from scratch.
```