### PR TITLE
Use better terms for exclusion/inclusion

### DIFF
--- a/mantle/README.md
+++ b/mantle/README.md
@@ -79,18 +79,18 @@ runs any tests whose registered names matches a glob pattern.
 
 `kola run <glob pattern>`
 
-`--blacklist-test` can be used if one or more tests in the pattern should be skipped.
+`--denylist-test` can be used if one or more tests in the pattern should be skipped.
 This switch may be provided once:
 
-`kola --blacklist-test linux.nfs.v3 run`
+`kola --denylist-test linux.nfs.v3 run`
 
 multiple times:
 
-`kola --blacklist-test linux.nfs.v3 --blacklist-test linux.nfs.v4 run`
+`kola --denylist-test linux.nfs.v3 --denylist-test linux.nfs.v4 run`
 
 and can also be used with glob patterns:
 
-`kola --blacklist-test linux.nfs* --blacklist-test crio.* run`
+`kola --denylist-test linux.nfs* --denylist-test crio.* run`
 
 #### kola list
 The list command lists all of the available tests.

--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -56,7 +56,7 @@ func init() {
 	sv(&kola.Options.BaseName, "basename", "kola", "Cluster name prefix")
 	ss("debug-systemd-unit", []string{}, "full-unit-name.service to enable SYSTEMD_LOG_LEVEL=debug on. Can be specified multiple times.")
 	sv(&kola.Options.IgnitionVersion, "ignition-version", "", "Ignition version override: v2, v3")
-	ssv(&kola.BlacklistedTests, "blacklist-test", []string{}, "Test pattern to blacklist. Can be specified multiple times.")
+	ssv(&kola.DenylistedTests, "denylist-test", []string{}, "Test pattern to add to denylist. Can be specified multiple times.")
 	bv(&kola.NoNet, "no-net", false, "Don't run tests that require an Internet connection")
 	ssv(&kola.Tags, "tag", []string{}, "Test tag to run. Can be specified multiple times.")
 	bv(&kola.Options.SSHOnTestFailure, "ssh-on-test-failure", false, "SSH into a machine when tests fail")

--- a/mantle/kola/register/register.go
+++ b/mantle/kola/register/register.go
@@ -54,12 +54,12 @@ type Test struct {
 	UserData             *conf.UserData
 	UserDataV3           *conf.UserData
 	ClusterSize          int
-	Platforms            []string // whitelist of platforms to run test against -- defaults to all
-	ExcludePlatforms     []string // blacklist of platforms to ignore -- defaults to none
-	Distros              []string // whitelist of distributions to run test against -- defaults to all
-	ExcludeDistros       []string // blacklist of distributions to ignore -- defaults to none
-	Architectures        []string // whitelist of machine architectures supported -- defaults to all
-	ExcludeArchitectures []string // blacklist of architectures to ignore -- defaults to none
+	Platforms            []string // allowlist of platforms to run test against -- defaults to all
+	ExcludePlatforms     []string // denylist of platforms to ignore -- defaults to none
+	Distros              []string // allowlist of distributions to run test against -- defaults to all
+	ExcludeDistros       []string // denylist of distributions to ignore -- defaults to none
+	Architectures        []string // allowlist of machine architectures supported -- defaults to all
+	ExcludeArchitectures []string // denylist of architectures to ignore -- defaults to none
 	Flags                []Flag   // special-case options for this test
 	Tags                 []string // list of tags that can be matched against -- defaults to none
 

--- a/mantle/kola/tests/misc/files.go
+++ b/mantle/kola/tests/misc/files.go
@@ -37,7 +37,7 @@ func Filesystem(c cluster.TestCluster) {
 	c.Run("writablefiles", WritableFiles)
 	c.Run("writabledirs", WritableDirs)
 	c.Run("stickydirs", StickyDirs)
-	c.Run("blacklist", Blacklist)
+	c.Run("denylist", Denylist)
 }
 
 func sugidFiles(c cluster.TestCluster, validfiles []string, mode string) {
@@ -161,7 +161,7 @@ func StickyDirs(c cluster.TestCluster) {
 	}
 }
 
-func Blacklist(c cluster.TestCluster) {
+func Denylist(c cluster.TestCluster) {
 	m := c.Machines()[0]
 
 	skip := []string{
@@ -175,7 +175,7 @@ func Blacklist(c cluster.TestCluster) {
 		"/usr/lib/firmware",
 	}
 
-	blacklist := []string{
+	denylist := []string{
 		// Things excluded from the image that might slip in
 		"/usr/bin/perl",
 		"/usr/bin/python",
@@ -196,9 +196,9 @@ func Blacklist(c cluster.TestCluster) {
 		"*\x7f*",
 	}
 
-	output := c.MustSSH(m, fmt.Sprintf("sudo find / -ignore_readdir_race -path %s -prune -o -path '%s' -print", strings.Join(skip, " -prune -o -path "), strings.Join(blacklist, "' -print -o -path '")))
+	output := c.MustSSH(m, fmt.Sprintf("sudo find / -ignore_readdir_race -path %s -prune -o -path '%s' -print", strings.Join(skip, " -prune -o -path "), strings.Join(denylist, "' -print -o -path '")))
 
 	if string(output) != "" {
-		c.Fatalf("Blacklisted files or directories found:\n%s", output)
+		c.Fatalf("Denylisted files or directories found:\n%s", output)
 	}
 }

--- a/src/cmd-kola
+++ b/src/cmd-kola
@@ -36,18 +36,23 @@ else:
     default_cmd = 'run'
     default_output_dir = "tmp/kola"
 
-# automatically add blacklisted tests specified in the src config
-blacklist_args = []
-blacklist_path = "src/config/kola-blacklist.yaml"
-if os.path.isfile(blacklist_path):
-    with open(blacklist_path) as f:
-        blacklist = yaml.safe_load(f)
-        for obj in (blacklist or []):
+# automatically add tests from denylist specified in the src config
+denylist_args = []
+denylist_path = "src/config/kola-denylist.yaml"
+old_denylist_path = "src/config/kola-blacklist.yaml"
+if os.path.isfile(old_denylist_path):
+    print(f"⛔ Detected an old filename for denylist; please update your filename to `kola-denylist.yaml`")
+    denylist_path = old_denylist_path
+
+if os.path.isfile(denylist_path):
+    with open(denylist_path) as f:
+        denylist = yaml.safe_load(f)
+        for obj in (denylist or []):
             # if there are any arches specified, skip tests only for those arches. if not skip unconditionally.
             if basearch in obj.get('arches', [basearch]):
                 print(f"⚠️  Skipping kola test pattern \"{obj['pattern']}\":")
                 print(f"⚠️  {obj['tracker']}")
-                blacklist_args += ['--blacklist-test', obj['pattern']]
+                denylist_args += ['--denylist-test', obj['pattern']]
 
 # XXX: teach to kola to auto-detect based on prefix; see discussions in
 # https://github.com/coreos/coreos-assembler/pull/85
@@ -67,7 +72,7 @@ subargs = args.subargs or [default_cmd]
 kolaargs.extend(subargs)
 kolaargs.extend(unknown_args)
 
-kolaargs.extend(blacklist_args)
+kolaargs.extend(denylist_args)
 
 if args.basic_qemu_scenarios:
     for scenario in BASIC_SCENARIOS:


### PR DESCRIPTION
The use of the term "blacklist" to describe things we want to exclude
is archaic and not representative of the social values we want to
support in this project.  Similarly, "whitelist" as a term for
inclusion has the same problems.

This changes the code to use a format of `denylist` and `allowlist`
across the project.  It does not attempt to change any of the
vendored modules.