### PR TITLE
testiso: fix legacy-install scenario

### DIFF
--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -493,7 +493,14 @@ func testPXE(inst platform.Install, outdir string) error {
 	}
 	defer mach.Destroy()
 
-	return awaitCompletion(mach.QemuInst, outdir, completionChannel, []string{liveOKSignal, signalCompleteString})
+	var signals []string
+	// the legacy installer doesn't have a live environment, so we only expect
+	// the signal from the installed machine
+	if !inst.LegacyInstaller {
+		signals = append(signals, liveOKSignal)
+	}
+	signals = append(signals, signalCompleteString)
+	return awaitCompletion(mach.QemuInst, outdir, completionChannel, signals)
 }
 
 func testLiveIso(inst platform.Install, outdir string, offline bool) error {


### PR DESCRIPTION
In the legacy path, we never boot into a live environment, so the only
signal we should expect is the completion signal from the installed
system.

Regression from #1524.