### PR TITLE
build.sh: preserve s390-base.rpm package from uninstalling

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -56,7 +56,8 @@ install_rpms() {
     # Commented out for now, see above
     #dnf remove -y ${builddeps}
     # can't remove grubby on el7 because libguestfs-tools depends on it
-    rpm -q grubby && yum remove -y grubby
+    # Add --exclude for s390utils-base because we need it to not get removed.
+    rpm -q grubby && yum remove --exclude=s390utils-base -y grubby
 
     # Allow Kerberos Auth to work from a keytab. The keyring is not
     # available in a Container.


### PR DESCRIPTION
During image generation 'grubby' package is getting uninstalled,
but this in turn also removes other 'dependent' packages.

Signed-off-by: Nikita Dubrovskii <nikita@linux.ibm.com>