### PR TITLE
[4.5] upload-oscontainer: Automatically inject --display-name

### DIFF
--- a/src/cmd-upload-oscontainer
+++ b/src/cmd-upload-oscontainer
@@ -40,6 +40,7 @@ with open(metapath) as f:
     meta = json.load(f)
 
 print("Preparing to upload oscontainer for build: {}".format(latest_build))
+ostree_commit = meta['ostree-commit']
 
 osc_workdir = "{}/tmp/oscontainer-work".format(os.getcwd())
 
@@ -60,6 +61,20 @@ if not os.path.exists(tmprepo):
                            f'{latest_build_path}/{ostree_commit_tar}',
                            '-C', tmprepo])
 
+tmp_osreleasedir = 'tmp/usrlib-osrelease'
+cmdlib.run_verbose(['/usr/bin/ostree', 'checkout', '--repo', tmprepo,
+                    '--user-mode', '--subpath=/usr/lib/os-release', ostree_commit,
+                    tmp_osreleasedir])
+display_name = None
+with open(os.path.join(tmp_osreleasedir, "os-release")) as f:
+    for line in f.readlines():
+        if not line.startswith('NAME='):
+            continue
+        display_name = line.split('=', 2)[1]
+        break
+if display_name is None:
+    raise SystemExit(f"Failed to find NAME= in /usr/lib/os-release in commit {ostree_commit}")
+shutil.rmtree(tmp_osreleasedir)
 
 # The build ID is the container tag
 osc_name_and_tag = "{}:{}".format(args.name, latest_build)
@@ -74,6 +89,7 @@ if os.getuid != 0:
 cosa_argv.extend(['/usr/lib/coreos-assembler/oscontainer.py', '--workdir=./tmp', 'build',  f"--from={args.from_image}"])
 for d in args.add_directory:
     cosa_argv.append(f"--add-directory={d}")
+cosa_argv.append(f"--display-name={display_name}")
 subprocess.check_call(cosa_argv +
     [f'--digestfile={digestfile}',
         '--push', tmprepo,


### PR DESCRIPTION
At one point I was trying to drag the oscontainer code
out of the RHCOS pipeline, but stalled on that.
While I was doing that, we added `--display-name` logic
in the downstream version.

When I went to switch everything to upstream, that
change got lost.

The previous downstream change hardcoded passing
`--display-name=<osname>` in the pipeline.
Let's do better and automatically extract `os-release`
and use it.

(cherry picked from commit 53fd6a7edd20fc796e76f38f6c1a492f6282e88a)