### PR TITLE
koji-upload: Use builds/ for tempdir

### DIFF
--- a/src/cmd-koji-upload
+++ b/src/cmd-koji-upload
@@ -104,7 +104,8 @@ class Build(_Build):
         # new kind of image here, but _Build is geared towards that and has a
         # image_name_base() member that wants a platform string to name stuff
         self.platform = "koji"
-        self._tmpdir = tempfile.mkdtemp(prefix="koji-build")
+        # Use a tempdir in builds/ because we want to use large scratch space
+        self._tmpdir = tempfile.mkdtemp(prefix="koji-build", dir="builds/")
         kwargs.update({
             "require_commit": True,
             "require_cosa": True,


### PR DESCRIPTION
Koji/Brew forces us to recompress files which uses a lot of
space and is exacerbating disk space issues with the RHCOS pipeline.

We want a broader fix where we generally write directly into `builds/`
for images but for now, this quick hack should get us using
a larger PVC for the RHCOS pipeline.