### PR TITLE
mantle: change vsmt default value for Power

### DIFF
--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -823,7 +823,7 @@ func baseQemuArgs() []string {
 	case "ppc64le":
 		return []string{
 			"qemu-system-ppc64",
-			"-machine", "pseries,accel=kvm,kvm-type=HV",
+			"-machine", "pseries,accel=kvm,kvm-type=HV,vsmt=8",
 		}
 	default:
 		panic(fmt.Sprintf("RpmArch %s combo not supported for qemu ", system.RpmArch()))


### PR DESCRIPTION
- POWER8 with RHEL7 does not support vsmt change causing the error:
"On PPC, a VM with 1 threads/core on a host with 8 threads/core requires the use of VSMT mode 1. This KVM seems to be too old to support VSMT."

On POWER8 the vsmt default is 8, when on POWER9 it is 1.
This patch change the vsmt=8 in order to restore the default value for
POWER8. It is also compatible with POWER9