### PR TITLE
build: Downgrade cryptsetup to 2.2.1-1.fc31

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -55,6 +55,9 @@ install_rpms() {
     # Process our base dependencies + build dependencies and install
     (echo "${builddeps}" && "${srcdir}"/src/print-dependencies.sh) | xargs yum -y install
 
+    # https://github.com/coreos/coreos-assembler/issues/1496
+    yum -y downgrade cryptsetup-2.2.1-1.fc31
+
     # Commented out for now, see above
     #dnf remove -y ${builddeps}
     # can't remove grubby on el7 because libguestfs-tools depends on it


### PR DESCRIPTION
The cryptsetup upstream maintainers seem to be telling
us to stop doing what we're doing.  Which, hopefully
we will soon!  But for now let's downgrade.

I thought about hardcoding the header, but I worry that
there might e.g. be differences across architectures.

Closes: https://github.com/coreos/coreos-assembler/issues/1496

Adjusted backport of #1497 for Fedora 31 - the newer cryptsetup does
cause issues with builds on ppc64le and s390x. 2.2.1-1 is the version
that is available to downgrade to.