### PR TITLE
README.md: Add a note about `--net=host` here.

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,10 @@ currently `quay.io/coreos-assembler/coreos-assembler:latest`.
 See the [Hacking](#hacking) section below for examples of how to use these
 variables:
 
+### Containers and networking
+
+You may currently need to use `--net=host` if your host is connected to a VPN for example.
+
 ### Running persistently
 
 At this point, try `cosa shell` to start a shell inside the container.


### PR DESCRIPTION
This came from https://github.com/coreos/coreos-assembler/pull/282
which actually we don't strictly need for builds anymore because
we rely on 9p.

But some people may want it for e.g. kola.  It is tempting to
make `--net=host` the default particularly because SLIRP is a
performance hit but let's just document this for now.