### PR TITLE
cmd-oc-adm-release: new tool for release origin/ocp payloads

### DIFF
--- a/src/cmd-oc-adm-release
+++ b/src/cmd-oc-adm-release
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+# NOTE: PYTHONUNBUFFERED is set in the entrypoint for unbuffered output
+#
+# Publish an oscontainer as the machine-os-content in an OpenShift release
+# series
+"""
+Example usage:
+    cosa release-ocp \
+        --to-url horcux.dev/rhcos/rhcos-ocp-test \
+        --authfile auth.json \
+        --fetch-bin
+"""
+
+import argparse
+import json
+import logging as log
+import os
+import shutil
+import sys
+import tarfile
+import tempfile
+import urllib.request
+
+
+COSA_PATH = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, COSA_PATH)
+from cosalib.meta import GenericBuildMeta as Meta
+from cosalib.cmdlib import (
+    get_basearch,
+    run_verbose
+)
+
+os.environ["PATH"] = f"{os.getcwd()}:{COSA_PATH}:{os.environ.get('PATH')}"
+OCP_SERVER = "https://api.ci.openshift.org"
+OCP_RELEASE_STREAM = "quay.io/openshift-release-dev/ocp-release"
+OCP_TOOL_MIRROR = "https://mirror.openshift.com/pub/openshift-v4/clients/oc/{ocp_ver}/linux/oc.tar.gz"
+
+log.basicConfig(
+    format='[%(levelname)s]: %(message)s',
+    level=log.INFO)
+
+
+def ocp_versions(meta):
+    """
+    Return the corresponding OCP version.
+    RHCOS is versioned <OCP MAJ><OCP MIN>.<RHEL MAJ><RHEL MIN>.
+    For example OCP version 4.6 with RHEL 8.1 would be 46.81
+    """
+
+    if "OpenShift" not in meta.get("summary", None):
+        return None, None
+    ostree_v = meta.get("ostree-version").split('.')
+    ocp_major, ocp_minor = list(ostree_v[0])
+    os_major, os_minor = list(ostree_v[1])
+    return (f"{ocp_major}.{ocp_minor}", f"{os_major}.{os_minor}")
+
+
+def fetch_ocp_bin(ocp_ver):
+    """
+    Download the specific release oc binary
+    """
+    ret = f"{os.getcwd()}/oc-{ocp_ver}"
+    if os.path.exists(ret):
+        log.warning(f"{ret} already exists, skipping download")
+        return ret
+
+    url = OCP_TOOL_MIRROR.format(ocp_ver=ocp_ver)
+    log.info(f"Downloading oc tool from {url}")
+
+    oc_gz = tempfile.NamedTemporaryFile()
+    oc_bin = tempfile.NamedTemporaryFile()
+
+    with urllib.request.urlopen(url) as data:
+        shutil.copyfileobj(data, oc_gz)
+
+    with tarfile.open(oc_gz.name, mode='r:gz') as td:
+        shutil.copyfileobj(td.extractfile("oc"), oc_bin)
+
+    shutil.copyfile(oc_bin.name, ret)
+    os.chmod(ret, 0o755)
+    return ret
+
+
+def release_stream(meta, args, ocp_ver):
+    """
+    Locate the release version based on the release streams.
+    If 'latest' look for the latest Z in the OCP series
+    """
+    if args.from_tag != "latest":
+        return args.from_tag
+
+    tag_cmd = ["skopeo", "list-tags"]
+    if args.authfile != "":
+        tag_cmd.extend(["--authfile", args.authfile])
+    tag_cmd.extend([f"docker://{args.from_url}"])
+    tags = json.loads(run_verbose(tag_cmd, capture_output=True).stdout)
+
+    log.info(f"Looking for latest release tag for {ocp_ver}")
+    ctags = []
+    for tag in tags["Tags"]:
+        if ocp_ver in tag and args.arch in tag:
+            ctags.append(tag)
+    sctags = sorted(ctags)
+    log.info(f"Generating release payload from tag {sctags[-1]}")
+    return f"{args.from_url}:{sctags[-1]}"
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--workdir', default=os.getcwd())
+    parser.add_argument('--build', default='latest')
+    parser.add_argument('--schema', help='location of meta.json schema',
+                        default=os.environ.get("COSA_META_SCHEMA",
+                                               f'{COSA_PATH}/schema/v1.json'))
+    parser.add_argument("--authfile", action="store", required=True,
+                        help="Pull secret")
+    parser.add_argument("--arch", action='store',
+                        default=get_basearch(),
+                        help="Architecture to use")
+    parser.add_argument("--from-url", action='store',
+                        default=OCP_RELEASE_STREAM)
+    parser.add_argument("--from-tag", action="store",
+                        default="latest",
+                        help="version to base release on; latest means latest in z stream")
+    parser.add_argument("--to-url", action='store', required=True)
+    parser.add_argument("--to-tag", action="store", default=None,
+                        help="release tag to use")
+    parser.add_argument('--content', action="store",
+                        default="machine-os-content",
+                        help="type release payload image")
+    parser.add_argument('--server', action="store",
+                        default=OCP_SERVER,
+                        help="server to get releases from")
+    parser.add_argument('--fetch-bin', action='store_true',
+                        help="download the oc binary, overrides --oc-bin"),
+    parser.add_argument('--oc-bin', action="store", default="",
+                        help="Openshift ocp binary")
+    parser.add_argument("--dry-run", default=False, action='store_true')
+
+    args = parser.parse_args()
+
+    meta = Meta(args.workdir, args.build, schema=args.schema)
+    oscontainer = meta.get("oscontainer")
+    if oscontainer is None:
+        raise Exception("oscontainer was not found in meta.json")
+
+    to_tag = args.to_tag
+    if to_tag is None:
+        to_tag = f"{meta['name']}-{meta.get('buildid')}"
+
+    ocp_ver, os_ver = ocp_versions(meta)
+    log.info(f"Generating payload for {ocp_ver} for OS Version {os_ver}")
+    from_release = release_stream(meta, args, ocp_ver)
+
+    oc_bin = args.oc_bin
+    if args.fetch_bin:
+        oc_bin = fetch_ocp_bin(ocp_ver)
+        log.info(f"Wrote {os.getcwd()}/{oc_bin}")
+    elif oc_bin == "":
+        oc_bin = shutil.which(f"oc-{ocp_ver}")
+
+    if oc_bin is None:
+        raise Exception("missing ocp binary: please use --fetch-bin, --ocp-bin "
+                        f"or add oc-{ocp_ver} to the path")
+
+    cmd = [oc_bin, "adm", "release", "new", "-a", args.authfile]
+    if ocp_ver:
+        cmd.extend(["-n", "ocp"])
+
+    payload_dest = f"{args.to_url}:{to_tag}"
+    cmd.extend([
+        "--from-release", from_release,
+        "--to-image", payload_dest,
+        f"{args.content}={oscontainer['image']}@{oscontainer['digest']}"
+    ])
+
+    log.info(f"Command: {' '.join(cmd)}")
+    if not args.dry_run:
+        run_verbose(cmd)
+        log.info(f"Payload released to: {payload_dest}")

--- a/src/coreos-assembler
+++ b/src/coreos-assembler
@@ -42,7 +42,7 @@ cmd=${1:-}
 # commands we'd expect to use in the local dev path
 build_commands="init fetch build run prune clean list"
 # commands more likely to be used in a prod pipeline only
-advanced_build_commands="buildprep buildupload oscontainer upload-oscontainer"
+advanced_build_commands="buildprep buildupload oscontainer upload-oscontainer oc-adm-release"
 buildextend_commands="aws azure digitalocean gcp ibmcloud installer live metal metal4k openstack qemu vmware vultr exoscale"
 utility_commands="tag sign compress koji-upload kola aws-replicate remote-prune"
 other_commands="shell meta"


### PR DESCRIPTION
This is specific to OpenShift, but should be extensible for OKD as well.
The intent of this script is to publish oscontent against a current
release for testing with updated content.

When running this in the context of a build, the corresponding CI
command might be:
```
        cosa release-ocp \
                --to-url horcux.dev/rhcos/rhcos-ocp-test
                --authfile auth.json \
                --fetch-bin
```
Signed-off-by: Ben Howard <ben.howard@redhat.com>