### PR TITLE
kola: Remove stray stdout logging

### DIFF
--- a/mantle/cmd/kolet/kolet.go
+++ b/mantle/cmd/kolet/kolet.go
@@ -148,7 +148,6 @@ func dispatchRunExtUnit(unitname string, sdconn *systemddbus.Conn) (bool, error)
 
 	switch state {
 	case "inactive":
-		fmt.Printf("Starting %s\n", unitname)
 		sdconn.StartUnit(unitname, "fail", nil)
 		return false, nil
 	case "activating":

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -632,7 +632,7 @@ ExecStart=%s
 					} else if expectingReboot {
 						err = errors.New("Got SIGTERM, but didn't see reboot indication")
 					} else if stdout != "" {
-						err = fmt.Errorf("Unexpected stdout %s", stdout)
+						plog.Warningf("Unexpected stdout %s", stdout)
 					}
 				}
 				// Other errors, just bomb out for now


### PR DESCRIPTION
This has broken a few recent kola runs, e.g.
https://jenkins-coreos-ci.apps.ci.centos.org/blue/organizations/jenkins/github-ci%2Fostreedev%2Fostree/detail/PR-2137/1/pipeline/202

Bug introduced in previous reboot handling.  The code is
a mess here (reboots are hard) and I hope to clean this up
after we can remove the previous reboot APIs.