### PR TITLE
kola: Add Ignition spec 3 configs for RHCOS

### DIFF
--- a/mantle/kola/tests/fips/fips.go
+++ b/mantle/kola/tests/fips/fips.go
@@ -69,6 +69,70 @@ func init() {
 				]
 			}
 		}`),
+		UserDataV3: conf.Ignition(`{
+			"ignition": {
+			  "config": {
+				"replace": {
+				  "source": null,
+				  "verification": {}
+				}
+			  },
+			  "security": {
+				"tls": {}
+			  },
+			  "timeouts": {},
+			  "version": "3.0.0"
+			},
+			"passwd": {},
+			"storage": {
+			  "disks": [
+				{
+				  "device": "/dev/vda",
+				  "partitions": [
+					{
+					  "label": "CONTR",
+					  "sizeMiB": 0,
+					  "startMiB": 0
+					}
+				  ]
+				}
+			  ],
+			  "files": [
+				{
+				  "group": {
+					"name": "root"
+				  },
+				  "overwrite": true,
+				  "path": "/etc/ignition-machine-config-encapsulated.json",
+				  "user": {
+					"name": "root"
+				  },
+				  "contents": {
+					"source": "data:,%7B%22metadata%22%3A%7B%22name%22%3A%22rendered-worker-1cc576110e0cf8396831ce4016f63900%22%2C%22selfLink%22%3A%22%2Fapis%2Fmachineconfiguration.openshift.io%2Fv1%2Fmachineconfigs%2Frendered-worker-1cc576110e0cf8396831ce4016f63900%22%2C%22uid%22%3A%2248871c03-899d-4332-a5f5-bef94e54b23f%22%2C%22resourceVersion%22%3A%224168%22%2C%22generation%22%3A1%2C%22creationTimestamp%22%3A%222019-11-04T15%3A54%3A08Z%22%2C%22annotations%22%3A%7B%22machineconfiguration.openshift.io%2Fgenerated-by-controller-version%22%3A%22bd846958bc95d049547164046a962054fca093df%22%7D%2C%22ownerReferences%22%3A%5B%7B%22apiVersion%22%3A%22machineconfiguration.openshift.io%2Fv1%22%2C%22kind%22%3A%22MachineConfigPool%22%2C%22name%22%3A%22worker%22%2C%22uid%22%3A%223d0dee9e-c9d6-4656-a4a9-81785b9ab01a%22%2C%22controller%22%3Atrue%2C%22blockOwnerDeletion%22%3Atrue%7D%5D%7D%2C%22spec%22%3A%7B%22osImageURL%22%3A%22registry.svc.ci.openshift.org%2Focp%2F4.3-2019-11-04-125204%40sha256%3A8a344c5b157bd01c3ca1abfcef0004fc39f5d69cac1cdaad0fd8dd332ad8e272%22%2C%22config%22%3A%7B%22ignition%22%3A%7B%22config%22%3A%7B%7D%2C%22security%22%3A%7B%22tls%22%3A%7B%7D%7D%2C%22timeouts%22%3A%7B%7D%2C%22version%22%3A%223.0.0%22%7D%2C%22networkd%22%3A%7B%7D%2C%22passwd%22%3A%7B%7D%2C%22storage%22%3A%7B%7D%2C%22systemd%22%3A%7B%7D%7D%2C%22kernelArguments%22%3A%5B%5D%2C%22fips%22%3Atrue%7D%7D",
+					"verification": {}
+				  },
+				  "mode": 420
+				}
+			  ],
+			  "filesystems": [
+				{
+				  "device": "/dev/disk/by-partlabel/CONTR",
+				  "format": "xfs",
+				  "path": "/var/lib/containers",
+				  "wipeFilesystem": true
+				}
+			  ]
+			},
+			"systemd": {
+			  "units": [
+				{
+				  "contents": "[Mount]\nWhat=/dev/disk/by-partlabel/CONTR\nWhere=/var/lib/containers\nType=xfs\nOptions=defaults\n[Install]\nWantedBy=local-fs.target",
+				  "enabled": true,
+				  "name": "var-lib-containers.mount"
+				}
+			  ]
+			}
+		  }`),
 	})
 }
 

--- a/mantle/kola/tests/rhcos/luks.go
+++ b/mantle/kola/tests/rhcos/luks.go
@@ -41,6 +41,22 @@ func init() {
 				]
 			}
 		}`),
+		UserDataV3: conf.Ignition(`{
+			"ignition": {
+				"version": "3.0.0"
+			},
+			"storage": {
+				"files": [
+					{
+						"path": "/etc/clevis.json",
+						"contents": {
+							"source": "data:text/plain;base64,e30K"
+						},
+						"mode": 420
+					}
+				]
+			}
+		}`),
 	})
 	// Create 0 cluster size to allow starting and setup of Tang as needed per test
 	// See: https://github.com/coreos/coreos-assembler/pull/1310#discussion_r401908836
@@ -88,11 +104,20 @@ func setupTangMachine(c cluster.TestCluster) (string, string) {
 		},
 	}
 
-	ignition := conf.Ignition(`{
-		"ignition": {
-			"version": "2.2.0"
-		}
-	}`)
+	var ignition *conf.UserData
+	if c.IgnitionVersion() == "v2" {
+		ignition = conf.Ignition(`{
+			"ignition": {
+				"version": "2.2.0"
+			}
+		}`)
+	} else {
+		ignition = conf.Ignition(`{
+			"ignition": {
+				"version": "3.0.0"
+			}
+		}`)
+	}
 
 	switch pc := c.Cluster.(type) {
 	// These cases have to be separated because when put together to the same case statement
@@ -221,23 +246,46 @@ func luksTPMTest(c cluster.TestCluster) {
 func luksTangTest(c cluster.TestCluster) {
 	address, thumbprint := setupTangMachine(c)
 	encodedTangPin := getEncodedTangPin(c, address, thumbprint)
-	m, err := c.NewMachine(conf.Ignition(fmt.Sprintf(`{
-		"ignition": {
-			"version": "2.2.0"
-		},
-		"storage": {
-			"files": [
-				{
-					"filesystem": "root",
-					"path": "/etc/clevis.json",
-					"contents": {
-						"source": "data:text/plain;base64,%s"
-					},
-					"mode": 420
-				}
-			]
-		}
-	}`, encodedTangPin)))
+
+	var ignition *conf.UserData
+	if c.IgnitionVersion() == "v2" {
+		ignition = conf.Ignition(fmt.Sprintf(`{
+			"ignition": {
+				"version": "2.2.0"
+			},
+			"storage": {
+				"files": [
+					{
+						"filesystem": "root",
+						"path": "/etc/clevis.json",
+						"contents": {
+							"source": "data:text/plain;base64,%s"
+						},
+						"mode": 420
+					}
+				]
+			}
+		}`, encodedTangPin))
+	} else {
+		ignition = conf.Ignition(fmt.Sprintf(`{
+			"ignition": {
+				"version": "3.0.0"
+			},
+			"storage": {
+				"files": [
+					{
+						"path": "/etc/clevis.json",
+						"contents": {
+							"source": "data:text/plain;base64,%s"
+						},
+						"mode": 420
+					}
+				]
+			}
+		}`, encodedTangPin))
+	}
+
+	m, err := c.NewMachine(ignition)
 	if err != nil {
 		c.Fatalf("Unable to create test machine: %v", err)
 	}
@@ -248,23 +296,47 @@ func luksTangTest(c cluster.TestCluster) {
 func luksSSST1Test(c cluster.TestCluster) {
 	address, thumbprint := setupTangMachine(c)
 	encodedSSST1Pin := getEncodedSSSPin(c, 1, false, address, thumbprint)
-	m, err := c.NewMachine(conf.Ignition(fmt.Sprintf(`{
-		"ignition": {
-			"version": "2.2.0"
-		},
-		"storage": {
-			"files": [
-				{
-					"filesystem": "root",
-					"path": "/etc/clevis.json",
-					"contents": {
-						"source": "data:text/plain;base64,%s"
-					},
-					"mode": 420
-				}
-			]
-		}
-	}`, encodedSSST1Pin)))
+
+	var ignition *conf.UserData
+	if c.IgnitionVersion() == "v2" {
+		ignition = conf.Ignition(fmt.Sprintf(`{
+			"ignition": {
+				"version": "2.2.0"
+			},
+			"storage": {
+				"files": [
+					{
+						"filesystem": "root",
+						"path": "/etc/clevis.json",
+						"contents": {
+							"source": "data:text/plain;base64,%s"
+						},
+						"mode": 420
+					}
+				]
+			}
+		}`, encodedSSST1Pin))
+	} else {
+		ignition = conf.Ignition(fmt.Sprintf(`{
+			"ignition": {
+				"version": "3.0.0"
+			},
+			"storage": {
+				"files": [
+					{
+						"filesystem": "root",
+						"path": "/etc/clevis.json",
+						"contents": {
+							"source": "data:text/plain;base64,%s"
+						},
+						"mode": 420
+					}
+				]
+			}
+		}`, encodedSSST1Pin))
+	}
+
+	m, err := c.NewMachine(ignition)
 	if err != nil {
 		c.Fatalf("Unable to create test machine: %v", err)
 	}
@@ -275,23 +347,47 @@ func luksSSST1Test(c cluster.TestCluster) {
 func luksSSST2Test(c cluster.TestCluster) {
 	address, thumbprint := setupTangMachine(c)
 	encodedSSST2Pin := getEncodedSSSPin(c, 2, true, address, thumbprint)
-	m, err := c.NewMachine(conf.Ignition(fmt.Sprintf(`{
-		"ignition": {
-			"version": "2.2.0"
-		},
-		"storage": {
-			"files": [
-				{
-					"filesystem": "root",
-					"path": "/etc/clevis.json",
-					"contents": {
-						"source": "data:text/plain;base64,%s"
-					},
-					"mode": 420
-				}
-			]
-		}
-	}`, encodedSSST2Pin)))
+
+	var ignition *conf.UserData
+	if c.IgnitionVersion() == "v2" {
+		ignition = conf.Ignition(fmt.Sprintf(`{
+			"ignition": {
+				"version": "2.2.0"
+			},
+			"storage": {
+				"files": [
+					{
+						"filesystem": "root",
+						"path": "/etc/clevis.json",
+						"contents": {
+							"source": "data:text/plain;base64,%s"
+						},
+						"mode": 420
+					}
+				]
+			}
+		}`, encodedSSST2Pin))
+	} else {
+		ignition = conf.Ignition(fmt.Sprintf(`{
+			"ignition": {
+				"version": "3.0.0"
+			},
+			"storage": {
+				"files": [
+					{
+						"filesystem": "root",
+						"path": "/etc/clevis.json",
+						"contents": {
+							"source": "data:text/plain;base64,%s"
+						},
+						"mode": 420
+					}
+				]
+			}
+		}`, encodedSSST2Pin))
+	}
+
+	m, err := c.NewMachine(ignition)
 	if err != nil {
 		c.Fatalf("Unable to create test machine: %v", err)
 	}

--- a/mantle/kola/tests/rhcos/sssd.go
+++ b/mantle/kola/tests/rhcos/sssd.go
@@ -34,6 +34,11 @@ func init() {
 				"version": "2.2.0"
 			}
 		}`),
+		UserDataV3: conf.Ignition(`{
+			"ignition": {
+				"version": "3.0.0"
+			}
+		}`),
 	})
 }
 

--- a/mantle/kola/tests/rhcos/upgrade.go
+++ b/mantle/kola/tests/rhcos/upgrade.go
@@ -54,6 +54,22 @@ func init() {
 				]
 			}
 		}`),
+		UserDataV3: conf.Ignition(`{
+			"ignition": {
+				"version": "3.0.0"
+			},
+			"storage": {
+				"files": [
+					{
+						"path": "/etc/clevis.json",
+						"contents": {
+							"source": "data:text/plain;base64,e30K"
+						},
+						"mode": 420
+					}
+				]
+			}
+		}`),
 	})
 }
 


### PR DESCRIPTION
Split from https://github.com/coreos/coreos-assembler/pull/1532 that will keep only the revert that will be merged only when we are ready to commit to Ignition spec 3 in RHCOS.

This should be ready to merge.