### PR TITLE
kola: Bump default instance type to m5.large

### DIFF
--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -76,7 +76,8 @@ func init() {
 	sv(&kola.AWSOptions.Region, "aws-region", defaultRegion, "AWS region")
 	sv(&kola.AWSOptions.Profile, "aws-profile", "default", "AWS profile name")
 	sv(&kola.AWSOptions.AMI, "aws-ami", "alpha", `AWS AMI ID, or (alpha|beta|stable) to use the latest image`)
-	sv(&kola.AWSOptions.InstanceType, "aws-type", "m4.large", "AWS instance type")
+	// See https://github.com/openshift/installer/issues/2919 for example
+	sv(&kola.AWSOptions.InstanceType, "aws-type", "m5.large", "AWS instance type")
 	sv(&kola.AWSOptions.SecurityGroup, "aws-sg", "kola", "AWS security group name")
 	sv(&kola.AWSOptions.IAMInstanceProfile, "aws-iam-profile", "kola", "AWS IAM instance profile name")
 

--- a/mantle/platform/api/aws/network.go
+++ b/mantle/platform/api/aws/network.go
@@ -304,18 +304,22 @@ func (a *API) createSubnets(vpcId, routeTableId string) error {
 	return nil
 }
 
-// getSubnetID gets a subnet for the given VPC.
-func (a *API) getSubnetID(vpc string) (string, error) {
+// getSubnetID gets a subnet for the given VPC and availability zone
+func (a *API) getSubnetID(vpc string, zone string) (string, error) {
 	subIds, err := a.ec2.DescribeSubnets(&ec2.DescribeSubnetsInput{
 		Filters: []*ec2.Filter{
 			{
 				Name:   aws.String("vpc-id"),
 				Values: []*string{&vpc},
 			},
+			{
+				Name:   aws.String("availability-zone"),
+				Values: []*string{&zone},
+			},
 		},
 	})
 	if err != nil {
-		return "", fmt.Errorf("unable to get subnets for vpc %v: %v", vpc, err)
+		return "", fmt.Errorf("unable to get subnets for vpc/zone %v/%v: %v", vpc, zone, err)
 	}
 	for _, id := range subIds.Subnets {
 		if id.SubnetId != nil {

--- a/mantle/platform/machine/aws/machine.go
+++ b/mantle/platform/machine/aws/machine.go
@@ -106,7 +106,7 @@ func (am *machine) saveConsole(origConsole string) error {
 	// returned output will be non-empty but won't necessarily include
 	// the most recent log messages. So we loop until the post-termination
 	// logs are different from the pre-termination logs.
-	err := util.WaitUntilReady(5*time.Minute, 5*time.Second, func() (bool, error) {
+	err := util.WaitUntilReady(10*time.Minute, 10*time.Second, func() (bool, error) {
 		var err error
 		am.console, err = am.cluster.flight.api.GetConsoleOutput(am.ID())
 		if err != nil {
@@ -114,14 +114,14 @@ func (am *machine) saveConsole(origConsole string) error {
 		}
 
 		if am.console == origConsole {
-			plog.Debugf("waiting for console for %v", am.ID())
+			plog.Debugf("waiting for post-terminate console for %v", am.ID())
 			return false, nil
 		}
 
 		return true, nil
 	})
 	if err != nil {
-		err = fmt.Errorf("retrieving console output of %v: %v", am.ID(), err)
+		err = fmt.Errorf("retrieving post-terminate console output of %v: %v", am.ID(), err)
 		if origConsole != "" {
 			plog.Warning(err)
 		} else {


### PR DESCRIPTION
```
commit 7d1623a8d36d3084e3dd5a0eef3112ae1aed8808
Author: Colin Walters <walters@verbum.org>
Date:   Wed Jun 3 16:47:48 2020 +0000

    kola: Bump default instance type to m5.large
    
    m4 is old and shouldn't be the default; this came up as
    part of https://github.com/coreos/fedora-coreos-tracker/issues/507

commit af4b81290a8ed57cfcecad1d5b6c80e8c1ef598c
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Fri Jun 19 14:11:46 2020 -0400

    mantle: platform: don't start instances in "us-east-1c"
    
    That region doesn't support the m5.large hardware type which
    we want to use now.
```
