### PR TITLE
Dockerfile: tickle Quay for rebuild

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /root/containerbuild
 # Only need a few of our scripts for the first few steps
 COPY ./src/print-dependencies.sh ./src/deps*.txt ./src/vmdeps*.txt ./src/build-deps.txt /root/containerbuild/src/
 COPY ./build.sh /root/containerbuild/
-RUN ./build.sh configure_yum_repos # nocache 20200610
+RUN ./build.sh configure_yum_repos # nocache 20200619
 RUN ./build.sh install_rpms
 
 # Ok copy in the rest of them for the next few steps


### PR DESCRIPTION
Added the new rpm-ostree to f32-coreos-continuous to unblock
https://github.com/coreos/fedora-coreos-tracker/issues/540.