### PR TITLE
build: Downgrade cryptsetup to 2.2.1-1.fc31

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -57,6 +57,9 @@ install_rpms() {
     archdeps=$(grep -v '^#' "${srcdir}/deps-$(arch)".txt)
     echo "${builddeps}" "${deps}" "${archdeps}" | xargs yum -y install
 
+    # https://github.com/coreos/coreos-assembler/issues/1496
+    yum -y downgrade cryptsetup-2.2.1-1.fc31
+
     # Commented out for now, see above
     #dnf remove -y ${builddeps}
     # can't remove grubby on el7 because libguestfs-tools depends on it


### PR DESCRIPTION
The cryptsetup upstream maintainers seem to be telling
us to stop doing what we're doing.  Which, hopefully
we will soon!  But for now let's downgrade.

I thought about hardcoding the header, but I worry that
there might e.g. be differences across architectures.

This is a modified cherry-pick that adjusts the original
commit for F31.

Closes: https://github.com/coreos/coreos-assembler/issues/1496
(cherry picked from commit f7827504da13590d8c444cf6c980baed647e7aa5)