### PR TITLE
Add initial azurestack platform

### DIFF
--- a/mantle/platforms.md
+++ b/mantle/platforms.md
@@ -78,6 +78,10 @@ create images from the image file.
  - `kola` works entirely on ARM based authentication, `ore` has methods for both ASM or ARM credentials.
  - `GC` in Azure searches for Resource Groups with a prefix of `kola-cluster` in the name.
 
+## Azure Stack
+
+Like Azure, but not.
+
 ## DigitalOcean
 
  - The DO platform wraps [godo](https://github.com/digitalocean/godo).

--- a/src/cmd-artifact-disk
+++ b/src/cmd-artifact-disk
@@ -52,7 +52,7 @@ def artifact_cli():
     # Support for legacy cmd-buildextend-* targets
     symlink = None
     for k in targets:
-        if f"cmd-buildextend-{k}" in sys.argv[0]:
+        if sys.argv[0].endswith(f"cmd-buildextend-{k}"):
             symlink = k
             log.info(f"CLI is a symlink for cmd-buildextends-{k}")
             break

--- a/src/cmd-buildextend-azurestack
+++ b/src/cmd-buildextend-azurestack
@@ -1,0 +1,1 @@
+cmd-artifact-disk

--- a/src/cosalib/qemuvariants.py
+++ b/src/cosalib/qemuvariants.py
@@ -62,6 +62,14 @@ VARIANTS = {
             '-o': 'force_size,subformat=fixed'
         },
     },
+    "azurestack": {
+        "image_format": "vpc",
+        "image_suffix": "vhd",
+        "platform": "azurestack",
+        "convert_options": {
+            '-o': 'force_size,subformat=fixed'
+        },
+    },
     "digitalocean": {
         "image_format": "qcow2",
         "image_suffix": "qcow2.gz",

--- a/src/schema/v1.json
+++ b/src/schema/v1.json
@@ -156,6 +156,7 @@
    "aliyun",
    "amis",
    "azure",
+   "azurestack",
    "build-url",
    "digitalocean",
    "gcp",
@@ -306,6 +307,7 @@
        "aliyun",
        "aws",
        "azure",
+       "azurestack",
        "dasd",
        "digitalocean",
        "exoscale",
@@ -432,6 +434,12 @@
          "title":"Azure",
          "$ref": "#/definitions/artifact"
         },
+       "azurestack": {
+         "$id":"#/properties/images/properties/azurestack",
+         "type":"object",
+         "title":"AzureStack",
+         "$ref": "#/definitions/artifact"
+       },
        "digitalocean": {
          "$id":"#/properties/images/properties/digitalocean",
          "type":"object",


### PR DESCRIPTION
- Use the same disk format as Azure
- Change the platform id
- Be more like OpenStack in just generating a disk image, not
  wrapping ore, because users need to upload this on premise

Also fix a bug in the CLI wrapper which was erroneously matching
`azure` first.