### PR TITLE
kola: add additionalDisks support in kola.json

### DIFF
--- a/mantle/cmd/kola/spawn.go
+++ b/mantle/cmd/kola/spawn.go
@@ -169,7 +169,9 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 		}
 		// use qemu-specific interface only if needed
 		if strings.HasPrefix(kolaPlatform, "qemu") && (spawnMachineOptions != "" || !spawnRemove) {
-			var machineOpts platform.MachineOptions
+			machineOpts := platform.QemuMachineOptions{
+				DisablePDeathSig: !spawnRemove,
+			}
 			if spawnMachineOptions != "" {
 				b, err := ioutil.ReadFile(spawnMachineOptions)
 				if err != nil {
@@ -184,7 +186,7 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 
 			switch qc := cluster.(type) {
 			case *unprivqemu.Cluster:
-				mach, err = qc.NewMachineWithOptions(userdata, machineOpts, spawnRemove)
+				mach, err = qc.NewMachineWithQemuOptions(userdata, machineOpts)
 			default:
 				plog.Fatalf("unreachable: qemu cluster %v unknown type", qc)
 			}

--- a/mantle/kola/README-kola-ext.md
+++ b/mantle/kola/README-kola-ext.md
@@ -104,16 +104,21 @@ Here's an example `kola.json`:
 ```json
 {
     "architectures": "!s390x ppc64le",
-    "platforms": "qemu-unpriv"
+    "platforms": "qemu-unpriv",
+    "additionalDisks": [ "5G" ]
 }
 ```
 
-The only supported keys are those two; either or none may be provided as well.
-Each value is a single string, which is a whitespace-separated list.
-The reason to use a single string (instead of a native JSON list)
-is that by providing `!` at the front of the string, the value instead
-declares exclusions (`ExclusiveArchitectures` instead of `Architectures` in
-reference to kola internals.
+The only supported keys are those three; any or none may be provided as
+well.  For `architectures` and `platforms`, each value is a single
+string, which is a whitespace-separated list.  The reason to use a
+single string (instead of a native JSON list) is that by providing `!`
+at the front of the string, the value instead declares exclusions
+(`ExclusiveArchitectures` instead of `Architectures` in reference to
+kola internals.
+
+The `additionalDisks` key has the same semantics as the `--add-disk`
+argument to `qemuexec`. It is currently only supported on `qemu-unpriv`.
 
 More recently, you can also (useful for shell scripts) include the JSON file
 inline per test, like this:

--- a/mantle/kola/README-kola-ext.md
+++ b/mantle/kola/README-kola-ext.md
@@ -121,7 +121,7 @@ inline per test, like this:
 ```sh
 #!/bin/bash
 set -xeuo pipefail
-# kola: { "architectures": "x86_64", "platforms": ["aws", "gcp"] }
+# kola: { "architectures": "x86_64", "platforms": "aws gcp"] }
 test code here
 ```
 

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -508,12 +508,13 @@ func RunUpgradeTests(patterns []string, pltfrm, outputDir string, propagateTestE
 	return runProvidedTests(register.UpgradeTests, patterns, pltfrm, outputDir, propagateTestErrors)
 }
 
-// externalTestMeta is parsed from kola.yaml in external tests
+// externalTestMeta is parsed from kola.json in external tests
 type externalTestMeta struct {
-	Architectures string `json:",architectures,omitempty"`
-	Platforms     string `json:",platforms,omitempty"`
-	Distros       string `json:",distros,omitempty"`
-	Tags          string `json:",tags,omitempty"`
+	Architectures   string   `json:",architectures,omitempty"`
+	Platforms       string   `json:",platforms,omitempty"`
+	Distros         string   `json:",distros,omitempty"`
+	Tags            string   `json:",tags,omitempty"`
+	AdditionalDisks []string `json:",additionalDisks,omitempty"`
 }
 
 // metadataFromTestBinary extracts JSON-in-comment like:
@@ -654,6 +655,8 @@ ExecStart=%s
 		ExternalTest:  executable,
 		DependencyDir: dependencydir,
 		Tags:          []string{"external"},
+
+		AdditionalDisks: targetMeta.AdditionalDisks,
 
 		Run: func(c cluster.TestCluster) {
 			mach := c.Machines()[0]
@@ -888,7 +891,7 @@ func runTest(h *harness.H, t *register.Test, pltfrm string, flight platform.Flig
 			userdata = t.UserDataV3
 		}
 
-		if _, err := platform.NewMachines(c, userdata, t.ClusterSize); err != nil {
+		if _, err := platform.NewMachines(c, userdata, t.ClusterSize, t.AdditionalDisks); err != nil {
 			h.Fatalf("Cluster failed starting machines: %v", err)
 		}
 	}

--- a/mantle/kola/register/register.go
+++ b/mantle/kola/register/register.go
@@ -63,6 +63,10 @@ type Test struct {
 	Flags                []Flag   // special-case options for this test
 	Tags                 []string // list of tags that can be matched against -- defaults to none
 
+	// Sizes of additional empty disks to attach to the node (e.g. ["1G",
+	// "5G"]) -- defaults to none.
+	AdditionalDisks []string
+
 	// ExternalTest is a path to a binary that will be uploaded
 	ExternalTest string
 	// DependencyDir is a path to directory that will be uploaded, normally used by external tests

--- a/mantle/kola/tests/misc/raid.go
+++ b/mantle/kola/tests/misc/raid.go
@@ -21,13 +21,12 @@ import (
 	"github.com/coreos/mantle/kola/register"
 	"github.com/coreos/mantle/platform"
 	"github.com/coreos/mantle/platform/conf"
-	"github.com/coreos/mantle/platform/machine/unprivqemu"
 )
 
 var (
 	raidRootUserData = conf.ContainerLinuxConfig(`storage:
   disks:
-    - device: "/dev/disk/by-id/virtio-secondary"
+    - device: "/dev/disk/by-id/virtio-disk1"
       wipe_table: true
       partitions:
        - label: root1
@@ -108,19 +107,9 @@ func RootOnRaid(c cluster.TestCluster) {
 	var m platform.Machine
 	var err error
 	options := platform.MachineOptions{
-		AdditionalDisks: []platform.Disk{
-			{Size: "520M", DeviceOpts: []string{"serial=secondary"}},
-		},
+		AdditionalDisks: []string{"520M"},
 	}
-	switch pc := c.Cluster.(type) {
-	// These cases have to be separated because when put together to the same case statement
-	// the golang compiler no longer checks that the individual types in the case have the
-	// NewMachineWithOptions function, but rather whether platform.Cluster does which fails
-	case *unprivqemu.Cluster:
-		m, err = pc.NewMachineWithOptions(raidRootUserData, options, true)
-	default:
-		c.Fatal("unknown cluster type")
-	}
+	m, err = c.NewMachineWithOptions(raidRootUserData, options)
 	if err != nil {
 		c.Fatal(err)
 	}

--- a/mantle/kola/tests/rhcos/luks.go
+++ b/mantle/kola/tests/rhcos/luks.go
@@ -80,7 +80,7 @@ func setupTangMachine(c cluster.TestCluster) (string, string) {
 	var thumbprint []byte
 	var tangAddress string
 
-	options := platform.MachineOptions{
+	options := platform.QemuMachineOptions{
 		HostForwardPorts: []platform.HostForwardPort{
 			{Service: "ssh", HostPort: 0, GuestPort: 22},
 			{Service: "tang", HostPort: 0, GuestPort: 80},
@@ -96,9 +96,10 @@ func setupTangMachine(c cluster.TestCluster) (string, string) {
 	switch pc := c.Cluster.(type) {
 	// These cases have to be separated because when put together to the same case statement
 	// the golang compiler no longer checks that the individual types in the case have the
-	// NewMachineWithOptions function, but rather whether platform.Cluster does which fails
+	// NewMachineWithQemuOptions function, but rather whether platform.Cluster
+	// does which fails
 	case *unprivqemu.Cluster:
-		m, err = pc.NewMachineWithOptions(ignition, options, true)
+		m, err = pc.NewMachineWithQemuOptions(ignition, options)
 		for _, hfp := range options.HostForwardPorts {
 			if hfp.Service == "tang" {
 				tangAddress = fmt.Sprintf("10.0.2.2:%d", hfp.HostPort)

--- a/mantle/platform/machine/aws/cluster.go
+++ b/mantle/platform/machine/aws/cluster.go
@@ -15,6 +15,7 @@
 package aws
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 
@@ -75,6 +76,13 @@ func (ac *cluster) NewMachine(userdata *conf.UserData) (platform.Machine, error)
 	ac.AddMach(mach)
 
 	return mach, nil
+}
+
+func (ac *cluster) NewMachineWithOptions(userdata *conf.UserData, options platform.MachineOptions) (platform.Machine, error) {
+	if len(options.AdditionalDisks) > 0 {
+		return nil, errors.New("platform aws does not yet support additional disks")
+	}
+	return ac.NewMachine(userdata)
 }
 
 func (ac *cluster) Destroy() {

--- a/mantle/platform/machine/azure/cluster.go
+++ b/mantle/platform/machine/azure/cluster.go
@@ -15,6 +15,7 @@
 package azure
 
 import (
+	"errors"
 	"fmt"
 	"math/rand"
 	"os"
@@ -81,6 +82,13 @@ func (ac *cluster) NewMachine(userdata *conf.UserData) (platform.Machine, error)
 	ac.AddMach(mach)
 
 	return mach, nil
+}
+
+func (ac *cluster) NewMachineWithOptions(userdata *conf.UserData, options platform.MachineOptions) (platform.Machine, error) {
+	if len(options.AdditionalDisks) > 0 {
+		return nil, errors.New("platform azure does not yet support additional disks")
+	}
+	return ac.NewMachine(userdata)
 }
 
 func (ac *cluster) Destroy() {

--- a/mantle/platform/machine/do/cluster.go
+++ b/mantle/platform/machine/do/cluster.go
@@ -17,6 +17,7 @@ package do
 import (
 	"context"
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -85,6 +86,13 @@ func (dc *cluster) NewMachine(userdata *conf.UserData) (platform.Machine, error)
 	dc.AddMach(mach)
 
 	return mach, nil
+}
+
+func (dc *cluster) NewMachineWithOptions(userdata *conf.UserData, options platform.MachineOptions) (platform.Machine, error) {
+	if len(options.AdditionalDisks) > 0 {
+		return nil, errors.New("platform do does not yet support additional disks")
+	}
+	return dc.NewMachine(userdata)
 }
 
 func (dc *cluster) vmname() string {

--- a/mantle/platform/machine/esx/cluster.go
+++ b/mantle/platform/machine/esx/cluster.go
@@ -15,6 +15,7 @@
 package esx
 
 import (
+	"errors"
 	"fmt"
 	"math/rand"
 	"os"
@@ -88,6 +89,13 @@ ExecStart=/usr/bin/bash -c 'echo "COREOS_ESX_IPV4_PRIVATE_0=$(ip addr show ens19
 	ec.AddMach(mach)
 
 	return mach, nil
+}
+
+func (ec *cluster) NewMachineWithOptions(userdata *platformConf.UserData, options platform.MachineOptions) (platform.Machine, error) {
+	if len(options.AdditionalDisks) > 0 {
+		return nil, errors.New("platform esx does not yet support additional disks")
+	}
+	return ec.NewMachine(userdata)
 }
 
 func (ec *cluster) Destroy() {

--- a/mantle/platform/machine/gcloud/cluster.go
+++ b/mantle/platform/machine/gcloud/cluster.go
@@ -16,6 +16,7 @@
 package gcloud
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 
@@ -88,6 +89,13 @@ func (gc *cluster) NewMachine(userdata *conf.UserData) (platform.Machine, error)
 	gc.AddMach(gm)
 
 	return gm, nil
+}
+
+func (gc *cluster) NewMachineWithOptions(userdata *conf.UserData, options platform.MachineOptions) (platform.Machine, error) {
+	if len(options.AdditionalDisks) > 0 {
+		return nil, errors.New("platform gce does not yet support additional disks")
+	}
+	return gc.NewMachine(userdata)
 }
 
 func (gc *cluster) Destroy() {

--- a/mantle/platform/machine/openstack/cluster.go
+++ b/mantle/platform/machine/openstack/cluster.go
@@ -16,6 +16,7 @@ package openstack
 
 import (
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -77,6 +78,13 @@ func (oc *cluster) NewMachine(userdata *conf.UserData) (platform.Machine, error)
 	oc.AddMach(mach)
 
 	return mach, nil
+}
+
+func (oc *cluster) NewMachineWithOptions(userdata *conf.UserData, options platform.MachineOptions) (platform.Machine, error) {
+	if len(options.AdditionalDisks) > 0 {
+		return nil, errors.New("platform openstack does not yet support additional disks")
+	}
+	return oc.NewMachine(userdata)
 }
 
 func (oc *cluster) vmname() string {

--- a/mantle/platform/machine/packet/cluster.go
+++ b/mantle/platform/machine/packet/cluster.go
@@ -16,6 +16,7 @@ package packet
 
 import (
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -109,6 +110,13 @@ func (pc *cluster) NewMachine(userdata *conf.UserData) (platform.Machine, error)
 	pc.AddMach(mach)
 
 	return mach, nil
+}
+
+func (pc *cluster) NewMachineWithOptions(userdata *conf.UserData, options platform.MachineOptions) (platform.Machine, error) {
+	if len(options.AdditionalDisks) > 0 {
+		return nil, errors.New("platform packet does not yet support additional disks")
+	}
+	return pc.NewMachine(userdata)
 }
 
 func (pc *cluster) vmname() string {

--- a/mantle/platform/platform.go
+++ b/mantle/platform/platform.go
@@ -100,8 +100,11 @@ type Cluster interface {
 	// Name returns a unique name for the Cluster.
 	Name() string
 
-	// NewMachine creates a new Container Linux machine.
+	// NewMachine creates a new CoreOS machine.
 	NewMachine(userdata *conf.UserData) (Machine, error)
+
+	// NewMachineWithOptions creates a new CoreOS machine as defined by the given options.
+	NewMachineWithOptions(userdata *conf.UserData, options MachineOptions) (Machine, error)
 
 	// Machines returns a slice of the active machines in the Cluster.
 	Machines() []Machine
@@ -149,6 +152,10 @@ type Flight interface {
 	// resources.  It should log any failures; since they are not
 	// actionable, it does not return an error.
 	Destroy()
+}
+
+type MachineOptions struct {
+	AdditionalDisks []string
 }
 
 // SystemdDropin is a userdata type agnostic struct representing a systemd dropin

--- a/mantle/platform/platform.go
+++ b/mantle/platform/platform.go
@@ -354,7 +354,7 @@ func CopyDirToMachine(inputdir string, m Machine, destdir string) error {
 
 // NewMachines spawns n instances in cluster c, with
 // each instance passed the same userdata.
-func NewMachines(c Cluster, userdata *conf.UserData, n int) ([]Machine, error) {
+func NewMachines(c Cluster, userdata *conf.UserData, n int, addDisks []string) ([]Machine, error) {
 	var wg sync.WaitGroup
 
 	mchan := make(chan Machine, n)
@@ -364,7 +364,10 @@ func NewMachines(c Cluster, userdata *conf.UserData, n int) ([]Machine, error) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			m, err := c.NewMachine(userdata)
+			options := MachineOptions{
+				AdditionalDisks: addDisks,
+			}
+			m, err := c.NewMachineWithOptions(userdata, options)
 			if err != nil {
 				errchan <- err
 			}

--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -46,9 +46,10 @@ type HostForwardPort struct {
 	GuestPort int
 }
 
-type MachineOptions struct {
-	AdditionalDisks  []Disk
+type QemuMachineOptions struct {
+	MachineOptions
 	HostForwardPorts []HostForwardPort
+	DisablePDeathSig bool
 }
 
 type Disk struct {


### PR DESCRIPTION
Add the ability to specify additional disks in `kola.json` for use by
external tests. This will be useful for testing the new rootfs
reprovisioning work.

For now, this only supports the qemu platform.

Closes: #1565