### PR TITLE
Reboot force

### DIFF
--- a/mantle/platform/util.go
+++ b/mantle/platform/util.go
@@ -131,7 +131,7 @@ func WaitForMachineReboot(m Machine, j *Journal, timeout time.Duration, oldBootI
 	// run a command we know will hold so we know approximately when the reboot happens
 	c := make(chan error)
 	go func() {
-		out, stderr, err := m.SSH(fmt.Sprintf("if [ $(cat /proc/sys/kernel/random/boot_id) == '%s' ]; then sleep infinity; fi", oldBootId))
+		out, stderr, err := m.SSH(fmt.Sprintf("if [ $(cat /proc/sys/kernel/random/boot_id) == '%s' ]; then echo waiting for reboot | logger && sleep infinity; fi", oldBootId))
 		if err == nil {
 			// we're already in the new boot!
 			c <- nil

--- a/tests/kola-ci-self/tests/kola/autopkgtest-reboot
+++ b/tests/kola-ci-self/tests/kola/autopkgtest-reboot
@@ -1,10 +1,18 @@
 #!/bin/bash
 # Copy of the reboot example from https://salsa.debian.org/ci-team/autopkgtest/raw/master/doc/README.package-tests.rst
+# Then modified to also use the "prepare" API with immediate/forced restart
 set -xeuo pipefail
 case "${AUTOPKGTEST_REBOOT_MARK:-}" in
   "") echo "test beginning"; /tmp/autopkgtest-reboot mark1 ;;
   mark1) echo "test in mark1"; /tmp/autopkgtest-reboot mark2 ;;
-  mark2) echo "test in mark2" ;;
+  mark2)
+    echo "test in mark2"
+    # Test hard forced reboot
+    /tmp/autopkgtest-reboot-prepare mark3
+    /sbin/reboot -ff
+    sleep infinity
+    ;;
+  mark3) echo "test in mark3" ;;
   *) echo "unexpected mark: ${AUTOPKGTEST_REBOOT_MARK}"; exit 1;;
 esac
 echo "ok autopkgtest rebooting"


### PR DESCRIPTION
Builds on top of https://github.com/coreos/coreos-assembler/pull/1572



I want to add testing of forced poweroff (i.e. `reboot -ff`)
into OSTree's test suite so we can reliably verify that
it lives up to what it claims on the tin.

The autopkgtest already has a "prepare" API which is exactly
what we want here.  Implementing this though is somewhat
tricky because we need to synchronously get the mark (i.e. state)
out to the harness.  I added a big comment about this.