### PR TITLE
schema update: add new field for 'payload-releases'

### DIFF
--- a/mantle/cosa/cosa_v1.go
+++ b/mantle/cosa/cosa_v1.go
@@ -22,49 +22,51 @@ type Artifact struct {
 }
 
 type Build struct {
-	AlibabaAliyunUploads      []AliyunImage           `json:"aliyun,omitempty"`
-	Amis                      []Amis                  `json:"amis,omitempty"`
-	Architecture              string                  `json:"coreos-assembler.basearch,omitempty"`
-	Azure                     *Cloudartifact          `json:"azure,omitempty"`
-	BuildArtifacts            *BuildArtifacts         `json:"images,omitempty"`
-	BuildID                   string                  `json:"buildid"`
-	BuildRef                  string                  `json:"ref,omitempty"`
-	BuildSummary              string                  `json:"summary"`
-	BuildTimeStamp            string                  `json:"coreos-assembler.build-timestamp,omitempty"`
-	BuildURL                  string                  `json:"build-url,omitempty"`
-	ConfigGitRev              string                  `json:"coreos-assembler.config-gitrev,omitempty"`
-	ContainerConfigGit        *Git                    `json:"coreos-assembler.container-config-git,omitempty"`
-	CoreOsSource              string                  `json:"coreos-assembler.code-source,omitempty"`
-	CosaContainerImageGit     *Git                    `json:"coreos-assembler.container-image-git,omitempty"`
-	CosaImageChecksum         string                  `json:"coreos-assembler.image-config-checksum,omitempty"`
-	CosaImageVersion          int                     `json:"coreos-assembler.image-genver,omitempty"`
-	FedoraCoreOsParentCommit  string                  `json:"fedora-coreos.parent-commit,omitempty"`
-	FedoraCoreOsParentVersion string                  `json:"fedora-coreos.parent-version,omitempty"`
-	Gcp                       *Gcp                    `json:"gcp,omitempty"`
-	GitDirty                  string                  `json:"coreos-assembler.config-dirty,omitempty"`
-	ImageInputChecksum        string                  `json:"coreos-assembler.image-input-checksum,omitempty"`
-	InputHasOfTheRpmOstree    string                  `json:"rpm-ostree-inputhash"`
-	Name                      string                  `json:"name"`
-	Oscontainer               *Image                  `json:"oscontainer,omitempty"`
-	OstreeCommit              string                  `json:"ostree-commit"`
-	OstreeContentBytesWritten int                     `json:"ostree-content-bytes-written"`
-	OstreeContentChecksum     string                  `json:"ostree-content-checksum"`
-	OstreeNCacheHits          int                     `json:"ostree-n-cache-hits"`
-	OstreeNContentTotal       int                     `json:"ostree-n-content-total"`
-	OstreeNContentWritten     int                     `json:"ostree-n-content-written"`
-	OstreeNMetadataTotal      int                     `json:"ostree-n-metadata-total"`
-	OstreeNMetadataWritten    int                     `json:"ostree-n-metadata-written"`
-	OstreeTimestamp           string                  `json:"ostree-timestamp"`
-	OstreeVersion             string                  `json:"ostree-version"`
-	OverridesActive           bool                    `json:"coreos-assembler.overrides-active,omitempty"`
-	PkgdiffAgainstParent      []PackageSetDifferences `json:"parent-pkgdiff,omitempty"`
-	PkgdiffBetweenBuilds      []PackageSetDifferences `json:"pkgdiff,omitempty"`
+	AlibabaAliyunUploads      []AliyunImage         `json:"aliyun,omitempty"`
+	Amis                      []Amis                `json:"amis,omitempty"`
+	Architecture              string                `json:"coreos-assembler.basearch,omitempty"`
+	Azure                     *Cloudartifact        `json:"azure,omitempty"`
+	BuildArtifacts            *BuildArtifacts       `json:"images,omitempty"`
+	BuildID                   string                `json:"buildid"`
+	BuildRef                  string                `json:"ref,omitempty"`
+	BuildSummary              string                `json:"summary"`
+	BuildTimeStamp            string                `json:"coreos-assembler.build-timestamp,omitempty"`
+	BuildURL                  string                `json:"build-url,omitempty"`
+	ConfigGitRev              string                `json:"coreos-assembler.config-gitrev,omitempty"`
+	ContainerConfigGit        *Git                  `json:"coreos-assembler.container-config-git,omitempty"`
+	CoreOsSource              string                `json:"coreos-assembler.code-source,omitempty"`
+	CosaContainerImageGit     *Git                  `json:"coreos-assembler.container-image-git,omitempty"`
+	CosaImageChecksum         string                `json:"coreos-assembler.image-config-checksum,omitempty"`
+	CosaImageVersion          int                   `json:"coreos-assembler.image-genver,omitempty"`
+	FedoraCoreOsParentCommit  string                `json:"fedora-coreos.parent-commit,omitempty"`
+	FedoraCoreOsParentVersion string                `json:"fedora-coreos.parent-version,omitempty"`
+	Gcp                       *Gcp                  `json:"gcp,omitempty"`
+	GitDirty                  string                `json:"coreos-assembler.config-dirty,omitempty"`
+	ImageInputChecksum        string                `json:"coreos-assembler.image-input-checksum,omitempty"`
+	InputHasOfTheRpmOstree    string                `json:"rpm-ostree-inputhash"`
+	Name                      string                `json:"name"`
+	Oscontainer               *Image                `json:"oscontainer,omitempty"`
+	OstreeCommit              string                `json:"ostree-commit"`
+	OstreeContentBytesWritten int                   `json:"ostree-content-bytes-written"`
+	OstreeContentChecksum     string                `json:"ostree-content-checksum"`
+	OstreeNCacheHits          int                   `json:"ostree-n-cache-hits"`
+	OstreeNContentTotal       int                   `json:"ostree-n-content-total"`
+	OstreeNContentWritten     int                   `json:"ostree-n-content-written"`
+	OstreeNMetadataTotal      int                   `json:"ostree-n-metadata-total"`
+	OstreeNMetadataWritten    int                   `json:"ostree-n-metadata-written"`
+	OstreeTimestamp           string                `json:"ostree-timestamp"`
+	OstreeVersion             string                `json:"ostree-version"`
+	OverridesActive           bool                  `json:"coreos-assembler.overrides-active,omitempty"`
+	PkgdiffAgainstParent      PackageSetDifferences `json:"parent-pkgdiff,omitempty"`
+	PkgdiffBetweenBuilds      PackageSetDifferences `json:"pkgdiff,omitempty"`
+	ReleasePayload            *Image                `json:"release-payload,omitempty"`
 }
 
 type BuildArtifacts struct {
 	Aliyun        *Artifact `json:"aliyun,omitempty"`
 	Aws           *Artifact `json:"aws,omitempty"`
 	Azure         *Artifact `json:"azure,omitempty"`
+	AzureStack    *Artifact `json:"azurestack,omitempty"`
 	Dasd          *Artifact `json:"dasd,omitempty"`
 	DigitalOcean  *Artifact `json:"digitalocean,omitempty"`
 	Exoscale      *Artifact `json:"exoscale,omitempty"`
@@ -104,8 +106,9 @@ type Git struct {
 }
 
 type Image struct {
-	Digest string `json:"digest"`
-	Image  string `json:"image"`
+	Comment string `json:"comment,omitempty"`
+	Digest  string `json:"digest"`
+	Image   string `json:"image"`
 }
 
 type Items interface{}

--- a/mantle/cosa/schema_doc.go
+++ b/mantle/cosa/schema_doc.go
@@ -50,11 +50,19 @@ var generatedSchemaJSON = `{
              "digest",
              "image"
          ],
+         "optional": [
+             "comment"
+         ],
          "properties": {
            "digest": {
              "$id": "#/image/digest",
              "type":"string",
              "title":"Digest"
+            },
+           "comment": {
+             "$id": "#/image/comment",
+             "type":"string",
+             "title":"Comment"
             },
            "image": {
              "$id": "#/image/image",
@@ -134,7 +142,17 @@ var generatedSchemaJSON = `{
              "minLength": 1
             }
           }
-     }
+     },
+     "pkg-items": {
+       "type":"array",
+       "title":"Package Set differences",
+       "items": {
+         "$id":"#/pkgdiff/items/item",
+         "title":"Items",
+         "default":"",
+         "minLength": 1
+        }
+      }
  },
  "$schema":"http://json-schema.org/draft-07/schema#",
  "$id":"http://github.com/coreos/coreos-assembler/blob/master/schema/v1.json",
@@ -161,6 +179,7 @@ var generatedSchemaJSON = `{
    "aliyun",
    "amis",
    "azure",
+   "azurestack",
    "build-url",
    "digitalocean",
    "gcp",
@@ -168,6 +187,7 @@ var generatedSchemaJSON = `{
    "oscontainer",
    "pkgdiff",
    "parent-pkgdiff",
+   "release-payload",
 
    "coreos-assembler.basearch",
    "coreos-assembler.build-timestamp",
@@ -311,6 +331,7 @@ var generatedSchemaJSON = `{
        "aliyun",
        "aws",
        "azure",
+       "azurestack",
        "dasd",
        "digitalocean",
        "exoscale",
@@ -437,6 +458,12 @@ var generatedSchemaJSON = `{
          "title":"Azure",
          "$ref": "#/definitions/artifact"
         },
+       "azurestack": {
+         "$id":"#/properties/images/properties/azurestack",
+         "type":"object",
+         "title":"AzureStack",
+         "$ref": "#/definitions/artifact"
+       },
        "digitalocean": {
          "$id":"#/properties/images/properties/digitalocean",
          "type":"object",
@@ -538,25 +565,13 @@ var generatedSchemaJSON = `{
      "$id":"#/properties/pkgdiff",
      "type":"array",
      "title":"pkgdiff between builds",
-     "items": {
-       "$id":"#/properties/pkgdiff/items",
-       "type":"array",
-       "title":"Package Set differences",
-       "items": {
-         "$id":"#/properties/pkgdiff/items/items",
-         "title":"Items",
-         "default":"",
-         "minLength": 1
-        }
-      }
+     "$ref": "#/definitions/pkg-items"
     },
    "parent-pkgdiff": {
      "$id":"#/properties/parent-pkgdiff",
      "type":"array",
      "title":"pkgdiff against parent",
-     "items": {
-       "$ref":"#/properties/pkgdiff/items"
-      }
+     "$ref": "#/definitions/pkg-items"
     },
    "rpm-ostree-inputhash": {
      "$id":"#/properties/rpm-ostree-inputhash",
@@ -677,6 +692,12 @@ var generatedSchemaJSON = `{
          "title":"Image Family"
         }
       }
+    },
+    "release-payload": {
+      "$id":"#/properties/release-payload",
+      "type":"object",
+      "title":"ReleasePayload",
+      "$ref": "#/definitions/image"
     }
   }
 }

--- a/src/schema/v1.json
+++ b/src/schema/v1.json
@@ -45,11 +45,19 @@
              "digest",
              "image"
          ],
+         "optional": [
+             "comment"
+         ],
          "properties": {
            "digest": {
              "$id": "#/image/digest",
              "type":"string",
              "title":"Digest"
+            },
+           "comment": {
+             "$id": "#/image/comment",
+             "type":"string",
+             "title":"Comment"
             },
            "image": {
              "$id": "#/image/image",
@@ -164,6 +172,7 @@
    "oscontainer",
    "pkgdiff",
    "parent-pkgdiff",
+   "release-payload",
 
    "coreos-assembler.basearch",
    "coreos-assembler.build-timestamp",
@@ -680,6 +689,12 @@
          "title":"Image Family"
         }
       }
+    },
+    "release-payload": {
+      "$id":"#/properties/release-payload",
+      "type":"object",
+      "title":"Release Payload",
+      "$ref": "#/definitions/image"
     }
   }
 }

--- a/src/schema/v1.json
+++ b/src/schema/v1.json
@@ -137,7 +137,17 @@
              "minLength": 1
             }
           }
-     }
+     },
+     "pkg-items": {
+       "type":"array",
+       "title":"Package Set differences",
+       "items": {
+         "$id":"#/pkgdiff/items/item",
+         "title":"Items",
+         "default":"",
+         "minLength": 1
+        }
+      }
  },
  "$schema":"http://json-schema.org/draft-07/schema#",
  "$id":"http://github.com/coreos/coreos-assembler/blob/master/schema/v1.json",
@@ -550,25 +560,13 @@
      "$id":"#/properties/pkgdiff",
      "type":"array",
      "title":"pkgdiff between builds",
-     "items": {
-       "$id":"#/properties/pkgdiff/items",
-       "type":"array",
-       "title":"Package Set differences",
-       "items": {
-         "$id":"#/properties/pkgdiff/items/items",
-         "title":"Items",
-         "default":"",
-         "minLength": 1
-        }
-      }
+     "$ref": "#/definitions/pkg-items"
     },
    "parent-pkgdiff": {
      "$id":"#/properties/parent-pkgdiff",
      "type":"array",
      "title":"pkgdiff against parent",
-     "items": {
-       "$ref":"#/properties/pkgdiff/items"
-      }
+     "$ref": "#/definitions/pkg-items"
     },
    "rpm-ostree-inputhash": {
      "$id":"#/properties/rpm-ostree-inputhash",
@@ -693,7 +691,7 @@
     "release-payload": {
       "$id":"#/properties/release-payload",
       "type":"object",
-      "title":"Release Payload",
+      "title":"ReleasePayload",
       "$ref": "#/definitions/image"
     }
   }


### PR DESCRIPTION
This adds a new optional schema element for 'payload-release' for use with OCP/OKD releases. On the RHCOS side, the targeted intention is to add the location of the OCP testing payload for the machine-os-content.

It also:
- fixes a bug in the schema definition of the pkgdiffs
- updates the mantle cosa structs (includes the AzureStack recent changes)