### PR TITLE
cmdlib: ignore SRPMs when finding override packages

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -321,7 +321,7 @@ EOF
         local_overrides_lockfile="${tmp_overridesdir}/local-overrides.json"
         dnf repoquery  --repofrompath=tmp,"file://${overridesdir}/rpm" \
             --disablerepo '*' --enablerepo tmp --refresh --latest-limit 1 \
-            --qf '%{NAME}\t%{EVR}\t%{ARCH}' --quiet | python3 -c '
+            --exclude '*.src' --qf '%{NAME}\t%{EVR}\t%{ARCH}' --quiet | python3 -c '
 import sys, json
 lockfile = {"packages": {}}
 for line in sys.stdin:


### PR DESCRIPTION
Be nice to users who add SRPMs in the `overrides/rpm` repo (since some
tools will download them too), and just ignore them.

Closes: #1577