### PR TITLE
kola: update tests to use ss instead of netstat

### DIFF
--- a/mantle/kola/tests/crio/crio.go
+++ b/mantle/kola/tests/crio/crio.go
@@ -306,7 +306,7 @@ func crioNetwork(c cluster.TestCluster) {
 	talker := func(ctx context.Context) error {
 		// Wait until listener is ready before trying anything
 		for {
-			_, err := c.SSH(dest, "sudo netstat -tulpn|grep 9988")
+			_, err := c.SSH(dest, "sudo ss -tulpn|grep 9988")
 			if err == nil {
 				break // socket is ready
 			}

--- a/mantle/kola/tests/podman/podman.go
+++ b/mantle/kola/tests/podman/podman.go
@@ -312,7 +312,7 @@ func podmanNetworkTest(c cluster.TestCluster) {
 	talker := func(ctx context.Context) error {
 		// Wait until listener is ready before trying anything
 		for {
-			_, err := c.SSH(dest, "sudo netstat -tulpn | grep 9988")
+			_, err := c.SSH(dest, "sudo ss -tulpn | grep 9988")
 			if err == nil {
 				break // socket is ready
 			}


### PR DESCRIPTION
Update kola tests to use ss instead of the deprecated netstat,
and adjust tests to expect ss output.

This should fix https://github.com/coreos/fedora-coreos-tracker/issues/552.

The following tests have been updated:

fcos.network.listeners
crio.network
podman.network-multi (currently disabled)