### PR TITLE
kola: Avoid "sleep infinity" unit

### DIFF
--- a/ci/run-kola-self-tests
+++ b/ci/run-kola-self-tests
@@ -3,7 +3,7 @@ set -euo pipefail
 dn=$(cd $(dirname $0) && pwd)
 toplevel=$(cd ${dn} && git rev-parse --show-toplevel)
 set -x
-kola run --output-dir tmp/kolaself -E ${toplevel}/tests/kola-ci-self 'ext.kola-ci-self*'
+kola run --output-dir tmp/kolaself -E ${toplevel}/tests/kola-ci-self 'ext.kola-ci-self*' "$@"
 log=$(find tmp/kolaself -type f -name kola-runext-autopkgtest-reboot.txt)
 test -n "${log}"
 if ! grep -qF -e 'ok autopkgtest rebooting' < "${log}"; then

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -190,10 +190,8 @@ type KoletResult struct {
 	Reboot string
 }
 
-// KoletRebootUnit is a systemd unit that sleeps until the harness acknowledges
-// a reboot request by stopping it.
-const KoletRebootWaitUnit = "kolet-reboot-wait.service"
 const KoletExtTestUnit = "kola-runext.service"
+const KoletRebootAckFifo = "/run/kolet-reboot-ack"
 
 // NativeRunner is a closure passed to all kola test functions and used
 // to run native go functions directly on kola machines. It is necessary
@@ -551,6 +549,9 @@ func metadataFromTestBinary(executable string) (*externalTestMeta, error) {
 	return meta, nil
 }
 
+// runExternalTest is an implmenetation of the "external" test framework.
+// See README-kola-ext.md as well as the comments in kolet.go for reboot
+// handling.
 func runExternalTest(c cluster.TestCluster, mach platform.Machine) error {
 	var previousRebootState string
 	var stdout []byte
@@ -566,7 +567,6 @@ func runExternalTest(c cluster.TestCluster, mach platform.Machine) error {
 			c.MustSSHf(mach, "echo AUTOPKGTEST_REBOOT_MARK=%s | sudo tee /run/kola-runext-env", previousRebootState)
 			previousRebootState = ""
 		}
-		// We ignore stderr here, it will end up in the journal
 		stdout, stderr, err = mach.SSH(fmt.Sprintf("sudo ./kolet run-test-unit %s", shellquote.Join(KoletExtTestUnit)))
 		if err != nil {
 			return errors.Wrapf(err, "kolet run-test-unit failed: %s", stderr)
@@ -578,28 +578,27 @@ func runExternalTest(c cluster.TestCluster, mach platform.Machine) error {
 				return errors.Wrapf(err, "parsing kolet json %s", string(stdout))
 			}
 		}
-		if koletRes.Reboot != "" {
-			previousRebootState = koletRes.Reboot
-			plog.Debugf("Reboot request with mark='%s'", previousRebootState)
-			// Stop sshd to ensure we don't race trying to log back in during shutdown
-			_, _, err = mach.SSH(fmt.Sprintf("sudo /bin/sh -c 'systemctl stop sshd && systemctl stop %s'", KoletRebootWaitUnit))
-			if err != nil {
-				return errors.Wrapf(err, "failed to stop %s", KoletRebootWaitUnit)
-			}
-			plog.Debug("Waiting for reboot")
-			suberr := mach.WaitForReboot(120*time.Second, bootID)
-			if suberr == nil {
-				plog.Debug("Reboot complete")
-				err = nil
-				continue
-			} else {
-				return errors.Wrapf(suberr, "Waiting for reboot")
-			}
-		}
-		// Otherwise, we're done
-		if err == nil {
+		// If no  reboot is requested, we're done
+		if koletRes.Reboot == "" {
 			return nil
 		}
+
+		// A reboot is requested
+		previousRebootState = koletRes.Reboot
+		plog.Debugf("Reboot request with mark='%s'", previousRebootState)
+		// This signals to the subject that we have saved the mark, and the subject
+		// can proceed with rebooting.  We stop sshd to ensure that the wait below
+		// doesn't log in while ssh is shutting down.
+		_, _, err = mach.SSH(fmt.Sprintf("sudo /bin/sh -c 'systemctl stop sshd && echo > %s'", KoletRebootAckFifo))
+		if err != nil {
+			return errors.Wrapf(err, "failed to acknowledge reboot")
+		}
+		plog.Debug("Waiting for reboot")
+		err = mach.WaitForReboot(120*time.Second, bootID)
+		if err != nil {
+			return errors.Wrapf(err, "Waiting for reboot")
+		}
+		plog.Debug("Reboot complete")
 	}
 }
 


### PR DESCRIPTION
Followup to review comments in
#1575

And also for some reason I didn't fully debug, the reboot
acknowlegement was failing on RHCOS, so let's switch to
using FIFOs for IPC instead of doing "IPC via systemd DBus unit files".