### PR TITLE
kola: tweaks around handling of external tests

### DIFF
--- a/mantle/cmd/kola/kola.go
+++ b/mantle/cmd/kola/kola.go
@@ -167,6 +167,13 @@ func registerExternals() error {
 		return err
 	}
 	for _, d := range runExternals {
+		if d == "." {
+			if cwd, err := os.Getwd(); err != nil {
+				return err
+			} else {
+				d = cwd
+			}
+		}
 		err := kola.RegisterExternalTests(d)
 		if err != nil {
 			return err

--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -182,6 +182,12 @@ func syncOptionsImpl(useCosa bool) error {
 		return err
 	}
 
+	// if no external dirs were given, automatically add the working directory;
+	// does nothing if ./tests/kola/ doesn't exist
+	if len(runExternals) == 0 {
+		runExternals = []string{"."}
+	}
+
 	foundCosa := false
 	if kola.Options.CosaBuildId != "" {
 		// specified --build? fetch that build. in this path we *require* a


### PR DESCRIPTION
```
commit eca576068f79b8df16715f5651a0310b33b8cbe8
Date:   Mon Jul 13 16:24:49 2020 -0400

    kola: resolve directory when using `-E .`

    Otherwise the generated tests will have funny names like `ext...foobar`.

commit 0ab5a4a45898d2d34bceedba754d5dfde715e17f
Date:   Mon Jul 13 16:24:50 2020 -0400

    kola: add ext tests in current dir if no -E given

    E.g. when hacking on Ignition tests, I want to be able to just do
    `kola run --workdir /srv/fcos ext.ignition.foobar` from the Ignition git
    repo.
```

Found these useful when hacking on #1589 for tests for https://github.com/coreos/fedora-coreos-config/pull/503.