### PR TITLE
cmd/compress: do not compress Vultr images

### DIFF
--- a/src/cmd-compress
+++ b/src/cmd-compress
@@ -46,7 +46,8 @@ else:
 print(f"Targeting build: {build}")
 
 # Don't compress certain images
-imgs_to_skip = ["ostree", "iso", "rojig", "live-iso", "vmware", "initramfs", "live-initramfs", "kernel", "live-kernel"]
+imgs_to_skip = ["initramfs", "iso", "kernel", "live-initramfs",
+                "live-iso", "live-kernel", "ostree", "rojig", "vmware", "vultr"]
 
 
 def get_cpu_param(param):


### PR DESCRIPTION
This skips the compression step for Vultr images, as the cloud import
API expects a raw disk image and does not accept compressed content.

Ref: https://github.com/coreos/fedora-coreos-docs/pull/71#issuecomment-658101914