### PR TITLE
platform/api/gcloud: Bump requested disk size to 16GB

### DIFF
--- a/mantle/platform/api/gcloud/compute.go
+++ b/mantle/platform/api/gcloud/compute.go
@@ -76,7 +76,7 @@ func (a *API) mkinstance(userdata, name string, keys []*agent.Key) *compute.Inst
 					DiskName:    name,
 					SourceImage: a.options.Image,
 					DiskType:    "/zones/" + a.options.Zone + "/diskTypes/" + a.options.DiskType,
-					DiskSizeGb:  12,
+					DiskSizeGb:  16,
 				},
 			},
 		},


### PR DESCRIPTION
Addresses https://github.com/coreos/coreos-assembler/issues/1587, where
request for new GCE instances fails due to the requested disk size being
smaller than the RHCOS disk size of 16GB.