### PR TITLE
kola/spawn: enable internet access

### DIFF
--- a/mantle/cmd/kola/spawn.go
+++ b/mantle/cmd/kola/spawn.go
@@ -141,6 +141,7 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 	cluster, err := flight.NewCluster(&platform.RuntimeConfig{
 		OutputDir:        outputDir,
 		AllowFailedUnits: true,
+		InternetAccess:   true,
 	})
 	if err != nil {
 		return errors.Wrapf(err, "Cluster failed")


### PR DESCRIPTION
Regression from #1514. `kola spawn` is for users, so just always enable
Internet access there. In the future we could have `--no-net` control
this knob too if the need arises.

This is needed by the rpm-ostree CI which uses `kola` to bring up nodes.