### PR TITLE
Dockerfile.buildroot: use dumb-init

### DIFF
--- a/Dockerfile.buildroot
+++ b/Dockerfile.buildroot
@@ -8,7 +8,7 @@
 # CI system will likely use this as a base image.
 FROM quay.io/coreos-assembler/coreos-assembler:latest
 USER root
-ENTRYPOINT ["/usr/bin/bash"]
+ENTRYPOINT ["/usr/bin/dumb-init", "/usr/bin/bash"]
 WORKDIR /root/containerbuild
 COPY src src
 RUN ./src/install-buildroot.sh && yum clean all && rm src -rf


### PR DESCRIPTION
Anyone using this image as a pet container for building lots of things
really wants this.

Related: https://github.com/coreos/coreos-ci-lib/pull/33