### PR TITLE
mantle: kola: Enable fcos.network.listeners test on qemu-unpriv platform

### DIFF
--- a/mantle/kola/tests/misc/network.go
+++ b/mantle/kola/tests/misc/network.go
@@ -37,7 +37,6 @@ func init() {
   units:
     - name: docker.service
       enabled: true`),
-		ExcludePlatforms: []string{"qemu-unpriv"},
 	})
 	// TODO: rewrite test for NetworkManager
 	register.RegisterTest(&register.Test{


### PR DESCRIPTION
This test was disabled in 67b9c0d. I just tested and the test runs
and passes on the qemu-unpriv platform. I don't know of a good reason
to have it disabled so let's try enabling it.