### PR TITLE
mantle: kola: Remove NetworkManager from list in fcos.network.listeners

### DIFF
--- a/mantle/kola/tests/misc/network.go
+++ b/mantle/kola/tests/misc/network.go
@@ -126,7 +126,6 @@ NextProcess:
 func NetworkListeners(c cluster.TestCluster) {
 	expectedListeners := []listener{
 		{"tcp", "22", "sshd"},
-		{"udp", "68", "NetworkManager"},
 		{"udp", "323", "chronyd"},
 	}
 	checkList := func() error {


### PR DESCRIPTION
In [1] we started using NM in the initrd and removed dhclient (dhcp-client
rpm). In f741af4 this test was switched to look for NetworkManager listening
on port 68 instead of dhclient. With the switch to F32 NetworkManager no longer
listens on port 68 (not sure why). We can remove NM from the list of listeners.

[1] https://github.com/coreos/fedora-coreos-config/commit/90ce41141f9349432a0621c6f0e00748e20c840f

Notes from my investigation:

31.20200310.2.0
    - last testing release with dhclient (dhcp-client rpm)
    - ami-0baff6eba668fe0ae

```
Netid   State    Recv-Q   Send-Q     Local Address:Port     Peer Address:Port   Process
udp     UNCONN   0        0                0.0.0.0:68            0.0.0.0:*       users:((\"dhclient\",pid=1021,fd=6))
udp     UNCONN   0        0              127.0.0.1:323           0.0.0.0:*       users:((\"chronyd\",pid=974,fd=5))
udp     UNCONN   0        0                  [::1]:323              [::]:*       users:((\"chronyd\",pid=974,fd=6))
tcp     LISTEN   0        128              0.0.0.0:22            0.0.0.0:*       users:((\"sshd\",pid=1007,fd=3))
tcp     LISTEN   0        128                 [::]:22               [::]:*       users:((\"sshd\",pid=1007,fd=4))
```

31.20200323.2.0
    - first testing release without dhclient
    - ami-095701be373072c20

```
Netid  State   Recv-Q  Send-Q         Local Address:Port     Peer Address:Port  Process
udp    UNCONN  0       0          172.31.40.17%eth0:68            0.0.0.0:*      users:((\"NetworkManager\",pid=868,fd=17))
udp    UNCONN  0       0                  127.0.0.1:323           0.0.0.0:*      users:((\"chronyd\",pid=879,fd=5))
udp    UNCONN  0       0                      [::1]:323              [::]:*      users:((\"chronyd\",pid=879,fd=6))
tcp    LISTEN  0       128                  0.0.0.0:22            0.0.0.0:*      users:((\"sshd\",pid=931,fd=5))
tcp    LISTEN  0       128                     [::]:22               [::]:*      users:((\"sshd\",pid=931,fd=7))
```

31.20200517.2.0
    - last testing release on f31
    - ami-0a531c8abe2d4ca27

```
Netid  State   Recv-Q  Send-Q         Local Address:Port     Peer Address:Port  Process
udp    UNCONN  0       0         172.31.43.101%eth0:68            0.0.0.0:*      users:((\"NetworkManager\",pid=898,fd=17))
udp    UNCONN  0       0                  127.0.0.1:323           0.0.0.0:*      users:((\"chronyd\",pid=905,fd=5))
udp    UNCONN  0       0                      [::1]:323              [::]:*      users:((\"chronyd\",pid=905,fd=6))
tcp    LISTEN  0       128                  0.0.0.0:22            0.0.0.0:*      users:((\"sshd\",pid=949,fd=5))
tcp    LISTEN  0       128                     [::]:22               [::]:*      users:((\"sshd\",pid=949,fd=7))
```

32.20200601.2.2
    - one of the first f32 releases
    - ami-015a9f826a7f02705

```
Netid   State    Recv-Q   Send-Q     Local Address:Port     Peer Address:Port   Process
udp     UNCONN   0        0              127.0.0.1:323           0.0.0.0:*       users:((\"chronyd\",pid=926,fd=5))
udp     UNCONN   0        0                  [::1]:323              [::]:*       users:((\"chronyd\",pid=92 6,fd=6))
tcp     LISTEN   0        128              0.0.0.0:22            0.0.0.0:*       users:((\"sshd\",pid=1011,fd=5))
tcp     LISTEN   0        128                 [::]:22               [::]:*       users:((\"sshd\",pid=1011,fd=7))
```

32.20200715.2.2
    - latest testing release
    - ami-03f62c70c7ddc217a

```
Netid   State    Recv-Q   Send-Q     Local Address:Port     Peer Address:Port   Process
udp     UNCONN   0        0              127.0.0.1:323           0.0.0.0:*       users:((\"chronyd\",pid=868,fd=5))
udp     UNCONN   0        0                  [::1]:323              [::]:*       users:((\"chronyd\",pid=868,fd=6))
tcp     LISTEN   0        128              0.0.0.0:22            0.0.0.0:*       users:((\"sshd\",pid=929,fd=5))
tcp     LISTEN   0        128                 [::]:22               [::]:*       users:((\"sshd\",pid=929,fd=7))
```