### PR TITLE
kola: Handle quotes in autopkgtest reboot mark

### DIFF
--- a/mantle/cmd/kolet/kolet.go
+++ b/mantle/cmd/kolet/kolet.go
@@ -95,14 +95,14 @@ const (
 	autopkgTestRebootPath   = "/tmp/autopkgtest-reboot"
 	autopkgtestRebootScript = `#!/bin/bash
 set -xeuo pipefail
-~core/kolet reboot-request $1
+~core/kolet reboot-request "$1"
 reboot
 `
 	autopkgTestRebootPreparePath = "/tmp/autopkgtest-reboot-prepare"
 
 	autopkgtestRebootPrepareScript = `#!/bin/bash
 set -euo pipefail
-exec ~core/kolet reboot-request $1
+exec ~core/kolet reboot-request "$1"
 `
 
 	// File used to communicate between the script and the kolet runner internally

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -567,8 +567,12 @@ func runExternalTest(c cluster.TestCluster, mach platform.Machine) error {
 		}
 		plog.Debug("Starting kolet run-test-unit")
 		if previousRebootState != "" {
-			plog.Debugf("Setting AUTOPKGTEST_REBOOT_MARK=%s", previousRebootState)
-			c.MustSSHf(mach, "echo AUTOPKGTEST_REBOOT_MARK=%s | sudo tee /run/kola-runext-env", previousRebootState)
+			// quote around the value for systemd
+			contents := fmt.Sprintf("AUTOPKGTEST_REBOOT_MARK='%s'", previousRebootState)
+			plog.Debugf("Setting %s", contents)
+			if err := platform.InstallFile(strings.NewReader(contents), mach, "/run/kola-runext-env"); err != nil {
+				return err
+			}
 			previousRebootState = ""
 		}
 		stdout, stderr, err = mach.SSH(fmt.Sprintf("sudo ./kolet run-test-unit %s", shellquote.Join(KoletExtTestUnit)))

--- a/tests/kola-ci-self/tests/kola/autopkgtest-reboot
+++ b/tests/kola-ci-self/tests/kola/autopkgtest-reboot
@@ -4,8 +4,8 @@
 set -xeuo pipefail
 case "${AUTOPKGTEST_REBOOT_MARK:-}" in
   "") echo "test beginning"; /tmp/autopkgtest-reboot mark1 ;;
-  mark1) echo "test in mark1"; /tmp/autopkgtest-reboot mark2 ;;
-  mark2)
+  mark1) echo "test in mark1"; /tmp/autopkgtest-reboot 'mark2 "internal quotes"' ;;
+  'mark2 "internal quotes"')
     echo "test in mark2"
     # Test hard forced reboot
     /tmp/autopkgtest-reboot-prepare mark3


### PR DESCRIPTION
I was working again on OSTree's destructive tests and I tried
switching to serializing JSON via Rust's serde into
the `AUTOPKGTEST_REBOOT_MARK` field so I could more easily
pass data between reboots.

Well, that turned out to be a mess; of course we had multiple
levels of quoting bugs in multiple places.  I initially tried just shell quoting
it - it took me a little while to realize that we *also* need
to quote it for systemd to parse from the environment file.

Rather than dealing with quoting in ssh I ended up just base64
encoding because hey, it works.