### PR TITLE
kola: Validate growpart

### DIFF
--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -377,9 +377,14 @@ func filterTests(tests map[string]*register.Test, patterns []string, pltfrm stri
 			continue
 		}
 
-		// Check native tests for arch specific exclusion
+		// Check native tests for arch-specific and distro-specfic exclusion
 		for k, NativeFuncWrap := range t.NativeFuncs {
-			_, excluded := isAllowed(system.RpmArch(), nil, NativeFuncWrap.ExcludeArchitectures)
+			_, excluded := isAllowed(Options.Distribution, nil, NativeFuncWrap.Exclusions)
+			if excluded {
+				delete(t.NativeFuncs, k)
+				continue
+			}
+			_, excluded = isAllowed(system.RpmArch(), nil, NativeFuncWrap.Exclusions)
 			if excluded {
 				delete(t.NativeFuncs, k)
 			}

--- a/mantle/kola/register/register.go
+++ b/mantle/kola/register/register.go
@@ -32,15 +32,17 @@ const (
 	RequiresInternetAccess             // run the test only if the platform supports Internet access
 )
 
-// Wrapper for the NativeFunc which includes an optional string of arches to exclude for each native test
+// NativeFuncWrap is a wrapper for the NativeFunc which includes an optional string of arches and/or distributions to
+// exclude for each native test.
 type NativeFuncWrap struct {
-	NativeFunc           func() error
-	ExcludeArchitectures []string
+	NativeFunc func() error
+	Exclusions []string
 }
 
-// Simple constructor for returning NativeFuncWrap structure
-func CreateNativeFuncWrap(f func() error, excludearches ...string) NativeFuncWrap {
-	return NativeFuncWrap{f, excludearches}
+// CreateNativeFuncWrap is a simple constructor for returning NativeFuncWrap structure.
+// exclusions can be architectures and/or distributions.
+func CreateNativeFuncWrap(f func() error, exclusions ...string) NativeFuncWrap {
+	return NativeFuncWrap{f, exclusions}
 }
 
 // Test provides the main test abstraction for kola. The run function is


### PR DESCRIPTION
Support excluding distributions in native tests run by kolet. 
Add native function tests to basic to verify that `rhcos-growpart.service` and `ignition-ostree-growfs.service` have run successfully.
Check that the root filesystem is at least 15 GB in RHCOS and 7 GB in FCOS.