### PR TITLE
mantle: gcp: add ability to make gcp images public

### DIFF
--- a/mantle/cmd/ore/gcloud/upload.go
+++ b/mantle/cmd/ore/gcloud/upload.go
@@ -44,6 +44,7 @@ var (
 	uploadImageFamily      string
 	uploadImageDescription string
 	uploadCreateImage      bool
+	uploadPublic           bool
 	uploadImageLicenses    []string
 )
 
@@ -59,6 +60,7 @@ func init() {
 	cmdUpload.Flags().StringVar(&uploadImageFamily, "family", "", "GCP image family to attach image to")
 	cmdUpload.Flags().StringVar(&uploadImageDescription, "description", "", "The description that should be attached to the image")
 	cmdUpload.Flags().BoolVar(&uploadCreateImage, "create-image", true, "Create an image in GCP after uploading")
+	cmdUpload.Flags().BoolVar(&uploadPublic, "public", false, "Set public ACLs on image")
 	cmdUpload.Flags().StringSliceVar(
 		&uploadImageLicenses, "license", []string{},
 		"License to attach to image. Can be specified multiple times.")
@@ -175,6 +177,16 @@ func runUpload(cmd *cobra.Command, args []string) {
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Creating GCE image failed: %v\n", err)
 			os.Exit(1)
+		}
+
+		// If requested, set the image ACL to public
+		if uploadPublic {
+			fmt.Printf("Setting image to have public access: %v\n", imageNameGCE)
+			err = api.SetImagePublic(imageNameGCE)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Marking GCE image with public ACLs failed: %v\n", err)
+				os.Exit(1)
+			}
 		}
 	}
 

--- a/src/cosalib/gcp.py
+++ b/src/cosalib/gcp.py
@@ -65,6 +65,8 @@ def gcp_run_ore(build, args):
     ]
     if args.description:
         ore_upload_cmd.extend(['--description', args.description])
+    if args.public:
+        ore_upload_cmd.extend(['--public'])
     if not args.create_image:
         ore_upload_cmd.extend(['--create-image=false'])
     if args.license:
@@ -153,4 +155,8 @@ def gcp_cli(parser):
                         action="store_true",
                         default=False,
                         help="If the image should be marked as deprecated")
+    parser.add_argument("--public",
+                        action="store_true",
+                        default=False,
+                        help="If the image should be given public ACLs")
     return parser


### PR DESCRIPTION
This adds support for marking images with public ACLs when they are
created. Doing this isn't necessary for projects that have been marked
as public on the GCP backend by GCP engineers (like the `fedora-coreos-cloud`
project), but is for other projects to share images publicly.

Fixes https://github.com/coreos/coreos-assembler/issues/1561