### PR TITLE
buildextend-installer: refactoring for separate rootfs image

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -63,7 +63,7 @@ pod(image: 'registry.fedoraproject.org/fedora:32', runAsUser: 0, kvm: true, memo
           parallel metal: {
               shwrap("cd /srv && env TMPDIR=\$(pwd)/tmp/ kola testiso -S --output-dir tmp/kola-testiso-metal")
           }, metal4k: {
-              shwrap("cd /srv && env TMPDIR=\$(pwd)/tmp/ kola testiso -S --output-dir tmp/kola-testiso-metal4k --no-pxe")
+              shwrap("cd /srv && env TMPDIR=\$(pwd)/tmp/ kola testiso -S --output-dir tmp/kola-testiso-metal4k --no-pxe --qemu-native-4k")
           }
         } finally {
           shwrap("cd /srv && tar -cf - tmp/kola-testiso-metal/ | xz -c9 > ${env.WORKSPACE}/kola-testiso-metal.tar.xz")

--- a/src/cmd-buildextend-installer
+++ b/src/cmd-buildextend-installer
@@ -57,10 +57,6 @@ with open('src/config/image.yaml') as fh:
     image_yaml = yaml.safe_load(fh)
 squashfs_compression = image_yaml.get('squashfs-compression', 'zstd')
 
-# We make this a knob so that RHCOS can disable it until it supports osmet. See
-# https://github.com/coreos/coreos-installer/issues/224.
-osmet = image_yaml.get('osmet', True)
-
 # Hacky mode switch, until we can drop support for the installer images
 is_live = os.path.basename(sys.argv[0]).endswith('-live')
 if is_live:
@@ -192,7 +188,7 @@ def generate_iso():
     open(stamppath, 'w').close()
 
     # Add osmet files
-    if is_live and osmet:
+    if is_live:
         tmp_osmet = os.path.join(tmpinitrd_base, img_metal_obj['path'] + '.osmet')
         print(f'Generating osmet file for 512b metal image')
         run_verbose(['/usr/lib/coreos-assembler/osmet-pack',

--- a/src/cmd-buildextend-installer
+++ b/src/cmd-buildextend-installer
@@ -108,11 +108,14 @@ if os.path.isdir(tmpdir):
 tmpisoroot = os.path.join(tmpdir, image_type)
 tmpisoimages = os.path.join(tmpisoroot, 'images')
 tmpisoisolinux = os.path.join(tmpisoroot, 'isolinux')
+# contents of initramfs on both PXE and ISO
+tmpinitrd_base = os.path.join(tmpdir, 'initrd-base')
+# additional contents of initramfs on PXE
+tmpinitrd_pxe = os.path.join(tmpdir, 'initrd-pxe')
 
-os.mkdir(tmpdir)
-os.mkdir(tmpisoroot)
-os.mkdir(tmpisoimages)
-os.mkdir(tmpisoisolinux)
+for d in (tmpdir, tmpisoroot, tmpisoimages, tmpisoisolinux, tmpinitrd_base,
+        tmpinitrd_pxe):
+    os.mkdir(d)
 
 # Number of padding bytes at the end of the ISO initramfs for embedding
 # an Ignition config
@@ -178,48 +181,52 @@ def generate_iso():
         # initramfs isn't world readable by default so let's open up perms
         os.chmod(os.path.join(tmpisoimages, file), 0o644)
 
-    initramfs = os.path.join(tmpisoimages, initramfs_img)
-    base_initramfs = os.path.join(tmpdir, initramfs_img)
-    shutil.move(initramfs, base_initramfs)
-    # Append the "stampfile initramfs" to the base which says
-    # whether it's a live or legacy initramfs.
-    with tempfile.TemporaryDirectory(prefix='initramfs', dir=tmpdir) as tmproot:
-        if is_live:
-            stampname = 'etc/coreos-live-initramfs'
-        else:
-            stampname = 'etc/coreos-legacy-installer-initramfs'
-        stamppath = os.path.join(tmproot, stampname)
-        os.makedirs(os.path.dirname(stamppath), exist_ok=True)
-        open(stamppath, 'w').close()
-        extend_initrd(base_initramfs, tmproot)
+    # Generate initramfs stamp file which says whether it's a live or legacy
+    # initramfs.
+    if is_live:
+        stampname = 'etc/coreos-live-initramfs'
+    else:
+        stampname = 'etc/coreos-legacy-installer-initramfs'
+    stamppath = os.path.join(tmpinitrd_base, stampname)
+    os.makedirs(os.path.dirname(stamppath), exist_ok=True)
+    open(stamppath, 'w').close()
 
+    # Add osmet files
     if is_live and osmet:
-        with tempfile.TemporaryDirectory(prefix='initramfs', dir=tmpdir) as tmproot:
-            tmp_osmet = os.path.join(tmproot, img_metal_obj['path'] + '.osmet')
-            print(f'Generating osmet file for 512b metal image')
+        tmp_osmet = os.path.join(tmpinitrd_base, img_metal_obj['path'] + '.osmet')
+        print(f'Generating osmet file for 512b metal image')
+        run_verbose(['/usr/lib/coreos-assembler/osmet-pack',
+                     img_metal, '512', tmp_osmet, img_metal_checksum])
+        if img_metal4k_obj is not None:
+            tmp_osmet4k = os.path.join(tmpinitrd_base, img_metal4k_obj['path'] + '.osmet')
+            print(f'Generating osmet file for 4k metal image')
             run_verbose(['/usr/lib/coreos-assembler/osmet-pack',
-                         img_metal, '512', tmp_osmet, img_metal_checksum])
-            if img_metal4k_obj is not None:
-                tmp_osmet4k = os.path.join(tmproot, img_metal4k_obj['path'] + '.osmet')
-                print(f'Generating osmet file for 4k metal image')
-                run_verbose(['/usr/lib/coreos-assembler/osmet-pack',
-                             img_metal4k, '4096', tmp_osmet4k,
-                             img_metal4k_checksum])
-            extend_initrd(base_initramfs, tmproot)
+                         img_metal4k, '4096', tmp_osmet4k,
+                         img_metal4k_checksum])
 
-    # The base_initramfs from here is shared between the ISO and PXE paths
-    cp_reflink(base_initramfs, initramfs)
-
+    # Generate root squashfs
     tmp_squashfs = None
     if is_live:
         print(f'Compressing squashfs with {squashfs_compression}')
         tmp_squashfs = os.path.join(tmpisoroot, 'root.squashfs')
         run_verbose(['/usr/lib/coreos-assembler/gf-mksquashfs',
                     img_metal, tmp_squashfs, squashfs_compression])
+        if not args.no_pxe:
+            cp_reflink(tmp_squashfs, os.path.join(tmpinitrd_pxe, 'root.squashfs'))
 
-        # Add the padding
-        with open(initramfs, 'ab') as fdst:
-            fdst.write(bytes(initrd_ignition_padding))
+    # Generate initramfses
+    # Add common content
+    iso_initramfs = os.path.join(tmpisoimages, initramfs_img)
+    extend_initrd(iso_initramfs, tmpinitrd_base)
+    if not args.no_pxe:
+        # Clone to PXE image
+        pxe_initramfs = os.path.join(tmpdir, initramfs_img)
+        cp_reflink(iso_initramfs, pxe_initramfs)
+        # Add additional content to PXE image
+        extend_initrd(pxe_initramfs, tmpinitrd_pxe)
+    # Add Ignition padding to ISO image
+    with open(iso_initramfs, 'ab') as fdst:
+        fdst.write(bytes(initrd_ignition_padding))
 
     # Read and filter kernel arguments for substituting into ISO bootloader
     result = run_verbose(['/usr/lib/coreos-assembler/gf-get-kargs',
@@ -316,20 +323,20 @@ def generate_iso():
         kernel_dest = os.path.join(tmpisoimages, 'kernel.img')
         shutil.move(os.path.join(tmpisoimages, kernel_img), kernel_dest)
         kernel_img = 'kernel.img'
-        initramfs_dest = os.path.join(tmpisoimages, 'initrd.img')
-        shutil.move(initramfs, initramfs_dest)
-        initramfs = initramfs_dest
+        iso_initramfs_dest = os.path.join(tmpisoimages, 'initrd.img')
+        shutil.move(iso_initramfs, iso_initramfs_dest)
+        iso_initramfs = iso_initramfs_dest
 
         # combine kernel, initramfs and cmdline using lorax/mk-s390-cdboot tool
         run_verbose(['/usr/bin/mk-s390-cdboot',
                      '-i', kernel_dest,
-                     '-r', initramfs,
+                     '-r', iso_initramfs,
                      '-p', os.path.join(tmpisoimages, 'cdboot.prm'),
                      '-o', os.path.join(tmpisoimages, 'cdboot.img')])
         # generate .addrsize file for LPAR
         with open(os.path.join(tmpisoimages, 'initrd.addrsize'), 'wb') as addrsize:
             addrsize_data = struct.pack(">iiii", 0, int(INITRD_ADDRESS, 16), 0,
-                                        os.stat(initramfs).st_size)
+                                        os.stat(iso_initramfs).st_size)
             addrsize.write(addrsize_data)
 
         # safely remove things we don't need in the final ISO tree
@@ -391,7 +398,7 @@ def generate_iso():
     if basearch == "x86_64":
         run_verbose(['/usr/bin/isohybrid', tmpisofile])
 
-    # We've already padded the initrd with initrd_ignition_padding bytes of
+    # We've already padded the ISO initrd with initrd_ignition_padding bytes of
     # zeroes.  Find the byte offset of that padding within the ISO image and
     # write it into a custom header at the end of the ISO 9660 System Area,
     # which is 32 KB at the start of the image "reserved for system use".
@@ -420,7 +427,7 @@ def generate_iso():
         # Start of the initramfs within the ISO
         offset = int(matches[0].group(1)) * 2048  # assume 2 KB per logical block
         # End of the initramfs within the ISO
-        offset += os.stat(initramfs).st_size
+        offset += os.stat(iso_initramfs).st_size
         # Start of the initramfs padding
         offset -= initrd_ignition_padding
         with open(tmpisofile, 'r+b') as isofh:
@@ -449,13 +456,7 @@ def generate_iso():
         kernel_file = os.path.join(builddir, kernel_name)
         initramfs_file = os.path.join(builddir, initramfs_name)
         shutil.copyfile(os.path.join(tmpisoimages, kernel_img), kernel_file)
-        cp_reflink(base_initramfs, initramfs_file)
-        # Append the rootfs squashfs to the PXE initramfs, so that it can be used
-        # directly for installs.
-        if is_live:
-            with tempfile.TemporaryDirectory(prefix='initramfs', dir=tmpdir) as tmproot:
-                shutil.move(tmp_squashfs, tmproot)
-                extend_initrd(initramfs_file, tmproot)
+        shutil.move(pxe_initramfs, initramfs_file)
         buildmeta['images'].update({
             meta_keys['kernel']: {
                 'path': kernel_name,

--- a/src/cmd-buildextend-installer
+++ b/src/cmd-buildextend-installer
@@ -120,24 +120,24 @@ initrd_ignition_padding = 256 * 1024
 
 
 # https://www.kernel.org/doc/html/latest/admin-guide/initrd.html#compressed-cpio-images
-def mkinitrd_pipe(tmproot, destf, compression=True):
+def mkinitrd_pipe(tmproot, destf):
     findproc = subprocess.Popen(['find', '.', '-mindepth', '1', '-print0'],
                                 cwd=tmproot, stdout=subprocess.PIPE)
     cpioproc = subprocess.Popen(['cpio', '-o', '-H', 'newc', '-R', 'root:root',
             '--quiet', '--reproducible', '--force-local', '--null',
             '-D', tmproot], stdin=findproc.stdout, stdout=subprocess.PIPE)
-    gzipargs = ['gzip']
-    if not compression:
-        gzipargs.append('-1')
+    # Almost everything we're adding is already compressed.  The kernel
+    # requires us to compress again, but don't try very hard.
+    gzipargs = ['gzip', '-1']
     gzipproc = subprocess.Popen(gzipargs, stdin=cpioproc.stdout, stdout=destf)
     assert cpioproc.wait() == 0, f"cpio exited with {cpioproc.returncode}"
     assert findproc.wait() == 0, f"find exited with {findproc.returncode}"
     assert gzipproc.wait() == 0, f"gzip exited with {gzipproc.returncode}"
 
 
-def extend_initrd(initramfs, tmproot, compression=True):
+def extend_initrd(initramfs, tmproot):
     with open(initramfs, 'ab') as fdst:
-        mkinitrd_pipe(tmproot, fdst, compression=compression)
+        mkinitrd_pipe(tmproot, fdst)
 
 
 def cp_reflink(src, dest):
@@ -205,7 +205,7 @@ def generate_iso():
                 run_verbose(['/usr/lib/coreos-assembler/osmet-pack',
                              img_metal4k, '4096', tmp_osmet4k,
                              img_metal4k_checksum])
-            extend_initrd(base_initramfs, tmproot, compression=False)
+            extend_initrd(base_initramfs, tmproot)
 
     # The base_initramfs from here is shared between the ISO and PXE paths
     cp_reflink(base_initramfs, initramfs)
@@ -455,8 +455,7 @@ def generate_iso():
         if is_live:
             with tempfile.TemporaryDirectory(prefix='initramfs', dir=tmpdir) as tmproot:
                 shutil.move(tmp_squashfs, tmproot)
-                # Compression is redundant but the kernel requires it
-                extend_initrd(initramfs_file, tmproot, compression=False)
+                extend_initrd(initramfs_file, tmproot)
         buildmeta['images'].update({
             meta_keys['kernel']: {
                 'path': kernel_name,

--- a/src/cmd-buildextend-installer
+++ b/src/cmd-buildextend-installer
@@ -149,17 +149,19 @@ def generate_iso():
     initramfs_img = 'initramfs.img'
 
     tmpisofile = os.path.join(tmpdir, iso_name)
+
     img_metal_obj = buildmeta['images'].get('metal')
-    if img_metal_obj is None:
-        raise Exception("ISO generation requires `metal` image")
-
-    img_metal = os.path.join(builddir, img_metal_obj['path'])
-    img_metal_checksum = img_metal_obj['sha256']
-
     img_metal4k_obj = buildmeta['images'].get('metal4k')
-    if img_metal4k_obj is not None:
+    if is_live:
+        if img_metal_obj is None or img_metal4k_obj is None:
+            raise Exception("Live image generation requires `metal` and `metal4k` images")
         img_metal4k = os.path.join(builddir, img_metal4k_obj['path'])
         img_metal4k_checksum = img_metal4k_obj['sha256']
+    else:
+        if img_metal_obj is None:
+            raise Exception("ISO image generation requires `metal` image")
+    img_metal = os.path.join(builddir, img_metal_obj['path'])
+    img_metal_checksum = img_metal_obj['sha256']
 
     # Find the directory under `/usr/lib/modules/<kver>` where the
     # kernel/initrd live. It will be the 2nd entity output by
@@ -190,15 +192,13 @@ def generate_iso():
     # Add osmet files
     if is_live:
         tmp_osmet = os.path.join(tmpinitrd_base, img_metal_obj['path'] + '.osmet')
+        tmp_osmet4k = os.path.join(tmpinitrd_base, img_metal4k_obj['path'] + '.osmet')
         print(f'Generating osmet file for 512b metal image')
         run_verbose(['/usr/lib/coreos-assembler/osmet-pack',
                      img_metal, '512', tmp_osmet, img_metal_checksum])
-        if img_metal4k_obj is not None:
-            tmp_osmet4k = os.path.join(tmpinitrd_base, img_metal4k_obj['path'] + '.osmet')
-            print(f'Generating osmet file for 4k metal image')
-            run_verbose(['/usr/lib/coreos-assembler/osmet-pack',
-                         img_metal4k, '4096', tmp_osmet4k,
-                         img_metal4k_checksum])
+        print(f'Generating osmet file for 4k metal image')
+        run_verbose(['/usr/lib/coreos-assembler/osmet-pack',
+                     img_metal4k, '4096', tmp_osmet4k, img_metal4k_checksum])
 
     # Generate root squashfs
     tmp_squashfs = None

--- a/src/cmd-buildextend-installer
+++ b/src/cmd-buildextend-installer
@@ -176,7 +176,7 @@ def generate_iso():
                      '--user-mode', '--subpath', os.path.join(moduledir, file),
                      f"{buildmeta_commit}", tmpisoimages])
         # initramfs isn't world readable by default so let's open up perms
-        os.chmod(os.path.join(tmpisoimages, file), 0o755)
+        os.chmod(os.path.join(tmpisoimages, file), 0o644)
 
     initramfs = os.path.join(tmpisoimages, initramfs_img)
     base_initramfs = os.path.join(tmpdir, initramfs_img)

--- a/src/cmd-buildextend-installer
+++ b/src/cmd-buildextend-installer
@@ -398,12 +398,12 @@ def generate_iso():
     # The System Area usually contains partition tables and the like, and
     # we're assuming that none of our platforms use the last 24 bytes of it.
     #
-    # This allows an external tool, coreos-iso-embed-ignition, to modify
+    # This allows an external tool, `coreos-installer iso embed`, to modify
     # an existing ISO image to embed a user's custom Ignition config.
     # The tool wraps the Ignition config in a cpio.gz and uses our header
     # to write it directly into the ISO image.  The cpio.gz will be read
-    # into the initramfs filesystem at runtime and ignition-dracut will
-    # ensure that the config is moved where Ignition will see it.
+    # into the initramfs filesystem at runtime and the Ignition Dracut module
+    # will ensure that the config is moved where Ignition will see it.
     #
     # Skip on s390x because that platform uses an embedded El Torito image
     # with its own copy of the initramfs.


### PR DESCRIPTION
Split refactoring patches out of https://github.com/coreos/coreos-assembler/pull/1608 and add a couple more cleanups.