### PR TITLE
buildextend-installer: add --fast option

### DIFF
--- a/src/cmd-buildextend-installer
+++ b/src/cmd-buildextend-installer
@@ -41,6 +41,8 @@ live_exclude_kargs = set([
 # Parse args and dispatch
 parser = argparse.ArgumentParser()
 parser.add_argument("--build", help="Build ID")
+parser.add_argument("--fast", action='store_true', default=False,
+                    help="Reduce compression for development (FCOS only)")
 parser.add_argument("--force", action='store_true', default=False,
                     help="Overwrite previously generated installer")
 parser.add_argument("--no-pxe", action='store_true', default=False,
@@ -55,7 +57,7 @@ print(f"Targeting build: {args.build}")
 
 with open('src/config/image.yaml') as fh:
     image_yaml = yaml.safe_load(fh)
-squashfs_compression = image_yaml.get('squashfs-compression', 'zstd')
+squashfs_compression = 'lz4' if args.fast else image_yaml.get('squashfs-compression', 'zstd')
 
 # Hacky mode switch, until we can drop support for the installer images
 is_live = os.path.basename(sys.argv[0]).endswith('-live')

--- a/src/cmd-buildextend-installer
+++ b/src/cmd-buildextend-installer
@@ -197,10 +197,12 @@ def generate_iso():
         tmp_osmet4k = os.path.join(tmpinitrd_base, img_metal4k_obj['path'] + '.osmet')
         print(f'Generating osmet file for 512b metal image')
         run_verbose(['/usr/lib/coreos-assembler/osmet-pack',
-                     img_metal, '512', tmp_osmet, img_metal_checksum])
+                     img_metal, '512', tmp_osmet, img_metal_checksum,
+                     'fast' if args.fast else 'normal'])
         print(f'Generating osmet file for 4k metal image')
         run_verbose(['/usr/lib/coreos-assembler/osmet-pack',
-                     img_metal4k, '4096', tmp_osmet4k, img_metal4k_checksum])
+                     img_metal4k, '4096', tmp_osmet4k, img_metal4k_checksum,
+                     'fast' if args.fast else 'normal'])
 
     # Generate root squashfs
     tmp_squashfs = None

--- a/src/osmet-pack
+++ b/src/osmet-pack
@@ -10,6 +10,7 @@ if [ ! -f /etc/cosa-supermin ]; then
     sector_size=$1; shift
     osmet_dest=$1; shift
     checksum=$1; shift
+    speed=$1; shift
     coreinst=${1:-${OSMET_PACK_COREOS_INSTALLER:-}}
 
     workdir=$(pwd)
@@ -22,7 +23,7 @@ if [ ! -f /etc/cosa-supermin ]; then
         fatal "Cannot pack osmet from $img; not an uncompressed image"
     fi
 
-    set -- "${TMPDIR}/osmet.bin" "${checksum}"
+    set -- "${TMPDIR}/osmet.bin" "${checksum}" "${speed}"
     if [ -n "${coreinst:-}" ]; then
         cp "${coreinst}" "${TMPDIR}/coreos-installer"
         set -- "$@" "${TMPDIR}/coreos-installer"
@@ -48,6 +49,7 @@ fi
 
 osmet_dest=$1; shift
 checksum=$1; shift
+speed=$1; shift
 coreinst=${1:-}
 
 set -x
@@ -79,8 +81,14 @@ if [ -z "${coreinst}" ]; then
     coreinst=${deploydir}/usr/bin/coreos-installer
 fi
 
+case "$speed" in
+    fast)      fast=--fast ;;
+    normal)    fast=       ;;
+    *)         exit 1      ;;
+esac
+
 RUST_BACKTRACE=full "${coreinst}" osmet pack /dev/disk/by-id/virtio-osmet \
     --description "${description}" \
     --checksum "${checksum}" \
     ${real_rootdev:+--real-rootdev ${real_rootdev}} \
-    --output "${osmet_dest}"
+    --output "${osmet_dest}" $fast


### PR DESCRIPTION
If `--fast` is specified, do two things:

- Use LZ4 compression for the squashfs, producing a substantially larger image.  This only works on FCOS, as RHCOS doesn't have kernel support.  On my machine this reduces the squashfs build time from 4m10s to 15s.
- Pass `--fast` to `coreos-installer osmet pack` (requires https://github.com/coreos/coreos-installer/pull/307).  On my machine this takes another 58s off the build time.