### PR TITLE
mantle: fix tempdir leaks and move large tempdirs to /var/tmp

### DIFF
--- a/mantle/cmd/kola/devshell.go
+++ b/mantle/cmd/kola/devshell.go
@@ -98,12 +98,11 @@ func runDevShellSSH(builder *platform.QemuBuilder, conf *v3types.Config) error {
 	if err != nil {
 		return err
 	}
+	defer os.RemoveAll(tmpd)
 	sshPubKeyBuf, sshKeyPath, err := util.CreateSSHAuthorizedKey(tmpd)
 	if err != nil {
 		return err
 	}
-
-	defer os.RemoveAll(tmpd)
 
 	sshPubKey := v3types.SSHAuthorizedKey(strings.TrimSpace(string(sshPubKeyBuf)))
 

--- a/mantle/cmd/kola/kola.go
+++ b/mantle/cmd/kola/kola.go
@@ -74,7 +74,6 @@ will be ignored.
 		Long:         `Run all upgrade kola tests (default) or related groups.`,
 		RunE:         runRunUpgrade,
 		PreRunE:      preRunUpgrade,
-		PostRun:      postRunUpgrade,
 		SilenceUsage: true,
 	}
 
@@ -503,6 +502,7 @@ func preRunUpgrade(cmd *cobra.Command, args []string) error {
 	if findParentImage {
 		err = syncFindParentImageOptions()
 		if err != nil {
+			runUpgradeCleanup()
 			return err
 		}
 	}
@@ -510,7 +510,7 @@ func preRunUpgrade(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func postRunUpgrade(cmd *cobra.Command, args []string) {
+func runUpgradeCleanup() {
 	if qemuImageDir != "" && qemuImageDirIsTemp {
 		os.RemoveAll(qemuImageDir)
 	}
@@ -644,6 +644,8 @@ func getParentFcosBuildBase(stream string) (string, error) {
 }
 
 func runRunUpgrade(cmd *cobra.Command, args []string) error {
+	defer runUpgradeCleanup()
+
 	outputDir, err := kola.SetupOutputDir(outputDir, kolaPlatform)
 	if err != nil {
 		return err

--- a/mantle/cmd/kola/kola.go
+++ b/mantle/cmd/kola/kola.go
@@ -554,7 +554,7 @@ func syncFindParentImageOptions() error {
 	switch kolaPlatform {
 	case "qemu-unpriv":
 		if qemuImageDir == "" {
-			if qemuImageDir, err = ioutil.TempDir("", "kola-run-upgrade"); err != nil {
+			if qemuImageDir, err = ioutil.TempDir("/var/tmp", "kola-run-upgrade"); err != nil {
 				return err
 			}
 			qemuImageDirIsTemp = true

--- a/mantle/cmd/kola/qemuexec.go
+++ b/mantle/cmd/kola/qemuexec.go
@@ -159,6 +159,7 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 		config = newconfig
 	}
 	builder := platform.NewBuilder()
+	defer builder.Close()
 	for _, b := range bindro {
 		src, dest, err := parseBindOpt(b)
 		if err != nil {
@@ -188,7 +189,6 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 		builder.IgnitionNetworkKargs = knetargs
 	}
 	builder.AppendKernelArguments = kargs
-	defer builder.Close()
 	builder.Firmware = kola.QEMUOptions.Firmware
 	if kola.QEMUOptions.DiskImage != "" {
 		channel := "virtio"

--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -408,11 +408,11 @@ func testPXE(inst platform.Install, outdir string) error {
 	if err != nil {
 		return err
 	}
+	defer os.RemoveAll(tmpd)
 	sshPubKeyBuf, _, err := util.CreateSSHAuthorizedKey(tmpd)
 	if err != nil {
 		return err
 	}
-	defer os.RemoveAll(tmpd)
 	sshPubKey := ignv3types.SSHAuthorizedKey(strings.TrimSpace(string(sshPubKeyBuf)))
 	liveConfig := ignv3types.Config{
 		Ignition: ignv3types.Ignition{
@@ -508,11 +508,11 @@ func testLiveIso(inst platform.Install, outdir string, offline bool) error {
 	if err != nil {
 		return err
 	}
+	defer os.RemoveAll(tmpd)
 	sshPubKeyBuf, _, err := util.CreateSSHAuthorizedKey(tmpd)
 	if err != nil {
 		return err
 	}
-	defer os.RemoveAll(tmpd)
 	sshPubKey := ignv3types.SSHAuthorizedKey(strings.TrimSpace(string(sshPubKeyBuf)))
 	liveConfig := ignv3types.Config{
 		Ignition: ignv3types.Ignition{
@@ -582,6 +582,7 @@ func testLiveLogin(outdir string) error {
 	builddir := kola.CosaBuild.Dir
 	isopath := filepath.Join(builddir, kola.CosaBuild.Meta.BuildArtifacts.LiveIso.Path)
 	builder := newBaseQemuBuilder()
+	defer builder.Close()
 	// Drop the bootindex bit (applicable to all arches except s390x and ppc64le); we want it to be the default
 	builder.AddIso(isopath, "")
 

--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -258,12 +258,6 @@ func runTestIso(cmd *cobra.Command, args []string) error {
 		baseInst.Insecure = true
 	}
 
-	tmpd, err := ioutil.TempDir("", "kola-testiso")
-	if err != nil {
-		return err
-	}
-	defer os.RemoveAll(tmpd)
-
 	ranTest := false
 
 	foundLegacy := baseInst.CosaBuild.Meta.BuildArtifacts.Kernel != nil

--- a/mantle/kola/tests/ignition/qemufailure.go
+++ b/mantle/kola/tests/ignition/qemufailure.go
@@ -16,7 +16,6 @@ package ignition
 
 import (
 	"fmt"
-	"os"
 	"time"
 
 	ignv3types "github.com/coreos/ignition/v2/config/v3_0/types"
@@ -94,12 +93,7 @@ func ignitionFailure(c cluster.TestCluster) error {
 	}()
 	select {
 	case <-time.After(2 * time.Minute):
-		if inst != nil {
-			proc := os.Process{
-				Pid: inst.Pid(),
-			}
-			proc.Kill()
-		}
+		inst.Kill()
 		return errors.New("timed out waiting for initramfs error")
 	case err := <-errchan:
 		if err != nil {

--- a/mantle/kola/tests/ignition/qemufailure.go
+++ b/mantle/kola/tests/ignition/qemufailure.go
@@ -68,6 +68,7 @@ func ignitionFailure(c cluster.TestCluster) error {
 		},
 	}
 	builder := platform.NewBuilder()
+	defer builder.Close()
 	builder.SetConfig(failConfig, kola.Options.IgnitionVersion == "v2")
 	builder.AddPrimaryDisk(&platform.Disk{
 		BackingFile: kola.QEMUOptions.DiskImage,

--- a/mantle/platform/machine/qemuiso/cluster.go
+++ b/mantle/platform/machine/qemuiso/cluster.go
@@ -135,7 +135,7 @@ func (qc *Cluster) NewMachineWithQemuOptions(userdata *conf.UserData, options pl
 	if err != nil {
 		return nil, err
 	}
-	qm.inst = *inst
+	qm.inst = inst
 
 	err = util.Retry(6, 5*time.Second, func() error {
 		var err error

--- a/mantle/platform/machine/qemuiso/machine.go
+++ b/mantle/platform/machine/qemuiso/machine.go
@@ -27,7 +27,7 @@ import (
 type machine struct {
 	qc          *Cluster
 	id          string
-	inst        platform.QemuInstance
+	inst        *platform.QemuInstance
 	journal     *platform.Journal
 	consolePath string
 	console     string

--- a/mantle/platform/machine/unprivqemu/cluster.go
+++ b/mantle/platform/machine/unprivqemu/cluster.go
@@ -161,7 +161,7 @@ func (qc *Cluster) NewMachineWithQemuOptions(userdata *conf.UserData, options pl
 	if err != nil {
 		return nil, err
 	}
-	qm.inst = *inst
+	qm.inst = inst
 
 	err = util.Retry(6, 5*time.Second, func() error {
 		var err error

--- a/mantle/platform/machine/unprivqemu/machine.go
+++ b/mantle/platform/machine/unprivqemu/machine.go
@@ -27,7 +27,7 @@ import (
 type machine struct {
 	qc          *Cluster
 	id          string
-	inst        platform.QemuInstance
+	inst        *platform.QemuInstance
 	journal     *platform.Journal
 	consolePath string
 	console     string

--- a/mantle/platform/metal.go
+++ b/mantle/platform/metal.go
@@ -481,10 +481,11 @@ func (inst *Install) runPXE(kern *kernelSetup, legacy bool) (*InstalledMachine, 
 	if err != nil {
 		return nil, err
 	}
+	tempdir := t.tempdir
 	t.tempdir = "" // Transfer ownership
 	return &InstalledMachine{
 		QemuInst: qinst,
-		tempdir:  t.tempdir,
+		tempdir:  tempdir,
 	}, nil
 }
 

--- a/mantle/platform/metal.go
+++ b/mantle/platform/metal.go
@@ -241,7 +241,7 @@ func (inst *Install) setup(kern *kernelSetup) (*installerRun, error) {
 
 	builder := inst.Builder
 
-	tempdir, err := ioutil.TempDir("", "kola-testiso")
+	tempdir, err := ioutil.TempDir("/var/tmp", "mantle-pxe")
 	if err != nil {
 		return nil, err
 	}
@@ -525,7 +525,7 @@ func (inst *Install) InstallViaISOEmbed(kargs []string, liveIgnition, targetIgni
 	inst.ignition = targetIgnition
 	inst.liveIgnition = liveIgnition
 
-	tempdir, err := ioutil.TempDir("", "mantle-metal")
+	tempdir, err := ioutil.TempDir("/var/tmp", "mantle-metal")
 	if err != nil {
 		return nil, err
 	}

--- a/mantle/platform/metal.go
+++ b/mantle/platform/metal.go
@@ -147,6 +147,10 @@ func (inst *Install) PXE(kargs []string, liveIgnition, ignition ignv3types.Confi
 }
 
 func (inst *InstalledMachine) Destroy() error {
+	if inst.QemuInst != nil {
+		inst.QemuInst.Destroy()
+		inst.QemuInst = nil
+	}
 	if inst.tempdir != "" {
 		return os.RemoveAll(inst.tempdir)
 	}

--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -268,7 +268,7 @@ func (builder *QemuBuilder) ensureTempdir() error {
 	if builder.tempdir != "" {
 		return nil
 	}
-	tempdir, err := ioutil.TempDir("", "mantle-qemu")
+	tempdir, err := ioutil.TempDir("/var/tmp", "mantle-qemu")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
If we fill up tmpfs, things stop working.  Based on what I've seen locally, I suspect this is the cause of some of the testiso timeouts in CI.