### PR TITLE
mantle: kola: stop ignoring user provided --platform option

### DIFF
--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -160,10 +160,12 @@ func syncOptionsImpl(useCosa bool) error {
 	}
 
 	// TODO: Could also auto-synchronize if e.g. --aws-ami is passed
-	if kolaPlatform == "" && kola.QEMUIsoOptions.IsoPath != "" {
-		kolaPlatform = "qemu-iso"
-	} else {
-		kolaPlatform = "qemu-unpriv"
+	if kolaPlatform == "" {
+		if kola.QEMUIsoOptions.IsoPath != "" {
+			kolaPlatform = "qemu-iso"
+		} else {
+			kolaPlatform = "qemu-unpriv"
+		}
 	}
 
 	// There used to be a "privileged" qemu path, it is no longer supported.


### PR DESCRIPTION
This fixes a regression from 51d94a3 where the kolaPlatform would
get set to `qemu-unpriv` even if the user had passed --platform gce
or any other valid value. I noticed that the GCE and AWS tests started
failing with a weird error like:

```
--- FAIL: podman.network-single (0.01s)
        harness.go:900: Cluster failed starting machines: lstat
        /home/jenkins/workspace/fedora-coreos/fedora-coreos-fedora-coreos-pipeline-kola-aws/builds/32.20200725.20.0/x86_64/fedora-coreos-32.20200725.20.0-qemu.x86_64.qcow2.xz:
        no such file or directory
```

It's because they were inappropriately trying to execute qemu tests. The
error message we got is because the qemu artifact didn't exist in the local
test environment because we don't sync them down (they're not necessary).