### PR TITLE
kola/rhcos/luks: pull tang container from quay.io

### DIFF
--- a/mantle/kola/tests/rhcos/luks.go
+++ b/mantle/kola/tests/rhcos/luks.go
@@ -116,9 +116,9 @@ func setupTangMachine(c cluster.TestCluster) (string, string) {
 
 	// TODO: move container image to centralized namespace
 	// container source: https://github.com/mike-nguyen/tang-docker-container/
-	containerID, _, err := m.SSH("sudo podman run -d -p 80:80 docker.io/mnguyenrh/tangd")
+	containerID, errMsg, err := m.SSH("sudo podman run -d -p 80:80 quay.io/mike_nguyen/tang")
 	if err != nil {
-		c.Fatalf("Unable to start Tang container: %v", err)
+		c.Fatalf("Unable to start Tang container: %v\n%s", err, string(errMsg))
 	}
 
 	// Wait a little bit for the container to start


### PR DESCRIPTION
There have been intermittent failures in the Tang/SSS tests starting
the Tang container.  The error message is a bit cryptic saying the
Process exited with status 125.  This commit will print out stderr
to facilitate debugging.  The error is suspected to be caused by an
issue pulling from docker.io.  Lets switch to quay.io to see if that
alieviates the failures, if not stderr should give more clues on
the failures.