### PR TITLE
mantle: default Ignition spec to v3

### DIFF
--- a/mantle/cmd/kola/qemuexec.go
+++ b/mantle/cmd/kola/qemuexec.go
@@ -243,7 +243,7 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 		if directIgnition {
 			return fmt.Errorf("Cannot use fragments/mounts with direct ignition")
 		}
-		builder.SetConfig(*config, kola.Options.IgnitionVersion == "v2")
+		builder.SetConfig(*config, kola.Options.IgnitionVersion == "v3")
 	} else if directIgnition {
 		builder.ConfigFile = ignition
 	}

--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -255,7 +255,7 @@ func runTestIso(cmd *cobra.Command, args []string) error {
 		Native4k:        kola.QEMUOptions.Native4k,
 		PxeAppendRootfs: pxeAppendRootfs,
 
-		IgnitionSpec2: kola.Options.IgnitionVersion == "v2",
+		IgnitionSpec2: kola.Options.IgnitionVersion == "v3",
 	}
 
 	if instInsecure {

--- a/mantle/platform/cluster.go
+++ b/mantle/platform/cluster.go
@@ -198,7 +198,7 @@ func (bc *BaseCluster) RenderUserData(userdata *platformConf.UserData, ignitionV
 		}
 	}
 
-	conf, err := userdata.Render(bc.bf.ctPlatform, bc.IgnitionVersion() == "v2")
+	conf, err := userdata.Render(bc.bf.ctPlatform, bc.IgnitionVersion() == "v3")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Now that RHCOS is slated to use Ignition v2.5.0, the default spec
version should now be v3.