### PR TITLE
oscontainer: Skip cosa commit if not present

### DIFF
--- a/src/oscontainer.py
+++ b/src/oscontainer.py
@@ -205,8 +205,10 @@ def oscontainer_build(containers_storage, tmpdir, src, ref, image_name_and_tag,
         with open(metapath) as f:
             meta = json.load(f)
         rhcos_commit = meta['coreos-assembler.container-config-git']['commit']
-        cosa_commit = meta['coreos-assembler.container-image-git']['commit']
-        config += ['-l', f"com.coreos.coreos-assembler-commit={cosa_commit}"]
+        imagegit = meta.get('coreos-assembler.container-image-git')
+        if imagegit is not None:
+            cosa_commit = imagegit['commit']
+            config += ['-l', f"com.coreos.coreos-assembler-commit={cosa_commit}"]
         config += ['-l', f"com.coreos.redhat-coreos-commit={rhcos_commit}"]
 
         if display_name is not None:


### PR DESCRIPTION
I regularly develop on coreos-assembler outside of a container,
this key needs to be optional.

Regression from 237b6d7e1a23fc98e89aa708b0dd7ba8f5c178f6

See also e.g. ded997b8634b0026899306d86d7ce688d0934bee