### PR TITLE
buildextend-live: add karg embed area offsets to header

### DIFF
--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -337,11 +337,12 @@ def generate_iso():
             newbuf = buf.replace('@@KERNEL-ARGS@@', kargs)
             # if we injected kargs, also check for an embed area
             if buf != newbuf:
+                karg_area_start = re.search(r'@@KERNEL-ARGS@@', buf)
                 buf = newbuf
-                karg_area = re.search(r'(#+) COREOS_KARG_EMBED_AREA\n', buf)
-                if karg_area is not None:
-                    length = len(karg_area[1])
-                    files_with_karg_embed_areas[filename] = karg_area.start()
+                karg_area_end = re.search(r'(#+) COREOS_KARG_EMBED_AREA\n', buf)
+                if karg_area_end is not None:
+                    length = karg_area_end.start() + len(karg_area_end[1]) - karg_area_start.start()
+                    files_with_karg_embed_areas[filename] = karg_area_start.start()
                     if karg_embed_area_length == 0:
                         karg_embed_area_length = length
                     elif length != karg_embed_area_length:

--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -514,6 +514,20 @@ def generate_iso():
     # (in the 64 bytes before the 24 bytes for the initrd info). This is then
     # picked up by `coreos-installer iso embed-kargs`.
     if basearch != "s390x":
+        # size of System Area section at start of ISO9660 images
+        ISO_SYSTEM_AREA_SIZE = 32768
+
+        # number of karg files we allow for in the format
+        MAX_KARG_FILES = 6
+        assert len(files_with_karg_embed_areas) <= MAX_KARG_FILES
+
+        # these can really never change without ratcheting on the
+        # coreos-installer side first
+        INITRDFMT = '<8s2Q'
+        assert struct.calcsize(INITRDFMT) == 24
+        KARGSFMT = f"<8s{MAX_KARG_FILES+1}Q"  # +1 for area length
+        assert struct.calcsize(KARGSFMT) == 64
+
         # Start of the Ignition padding within the ISO
         offset = file_offset_in_iso(isoinfo, ignition_img)
         with open(tmpisofile, 'r+b') as isofh:
@@ -523,22 +537,16 @@ def generate_iso():
                 raise Exception(f'ISO image {initrd_ignition_padding} bytes at {offset} are not zero')
 
             # Write header at the end of the System Area
+            isofh.seek(ISO_SYSTEM_AREA_SIZE - (struct.calcsize(INITRDFMT) +
+                                               struct.calcsize(KARGSFMT)))
+            offsets = [0] * MAX_KARG_FILES
 
-            # Right now we only have 2 karg files, but let's be generous and
-            # make space for 6. If we go beyond that in the future, we can
-            # ratchet it in.
-            assert len(files_with_karg_embed_areas) <= 6
-            kargsfmt = "<8s7Q"
-            initrdfmt = '<8s2Q'
-            isofh.seek(32768 - (struct.calcsize(initrdfmt) +
-                                struct.calcsize(kargsfmt)))
-            offsets = [0] * 6
             for i, fn in enumerate(files_with_karg_embed_areas):
                 offset_in_file = files_with_karg_embed_areas[fn]
                 offsets[i] = file_offset_in_iso(isoinfo, fn) + offset_in_file
-            isofh.write(struct.pack(kargsfmt, b'corekarg', karg_embed_area_length, *offsets))
+            isofh.write(struct.pack(KARGSFMT, b'corekarg', karg_embed_area_length, *offsets))
             # Magic number + offset + length
-            isofh.write(struct.pack(initrdfmt, b'coreiso+', offset, initrd_ignition_padding))
+            isofh.write(struct.pack(INITRDFMT, b'coreiso+', offset, initrd_ignition_padding))
             print(f'Embedded {initrd_ignition_padding} bytes Ignition config space at {offset}')
 
     buildmeta['images'].update({

--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -317,6 +317,8 @@ def generate_iso():
     kargs = ' '.join(kargs_array)
     print(f'Substituting ISO kernel arguments: {kargs}')
 
+    files_with_karg_embed_areas = {}
+    karg_embed_area_length = 0
     # Grab all the contents from the live dir from the configs
     for srcdir, _, filenames in os.walk(srcdir_prefix):
         dir_suffix = srcdir.replace(srcdir_prefix, '', 1)
@@ -332,7 +334,18 @@ def generate_iso():
             # Assumes all files are text
             with open(srcfile) as fh:
                 buf = fh.read()
-            buf = buf.replace('@@KERNEL-ARGS@@', kargs)
+            newbuf = buf.replace('@@KERNEL-ARGS@@', kargs)
+            # if we injected kargs, also check for an embed area
+            if buf != newbuf:
+                buf = newbuf
+                karg_area = re.search(r'(#+) COREOS_KARG_EMBED_AREA\n', buf)
+                if karg_area is not None:
+                    length = len(karg_area[1])
+                    files_with_karg_embed_areas[filename] = karg_area.start()
+                    if karg_embed_area_length == 0:
+                        karg_embed_area_length = length
+                    elif length != karg_embed_area_length:
+                        raise Exception(f"Karg embed areas of varying length {list(files_with_karg_embed_areas)}")
             with open(dstfile, 'w') as fh:
                 fh.write(buf)
             shutil.copystat(srcfile, dstfile)
@@ -495,6 +508,11 @@ def generate_iso():
     #
     # Skip on s390x because that platform uses an embedded El Torito image
     # with its own copy of the initramfs.
+    #
+    # Recently, we also play a similar trick for injecting kernel arguments: we
+    # store the location of "karg embed areas" at the end of the System Area
+    # (in the 64 bytes before the 24 bytes for the initrd info). This is then
+    # picked up by `coreos-installer iso embed-kargs`.
     if basearch != "s390x":
         # Start of the Ignition padding within the ISO
         offset = file_offset_in_iso(isoinfo, ignition_img)
@@ -503,9 +521,22 @@ def generate_iso():
             isofh.seek(offset)
             if isofh.read(initrd_ignition_padding) != bytes(initrd_ignition_padding):
                 raise Exception(f'ISO image {initrd_ignition_padding} bytes at {offset} are not zero')
+
             # Write header at the end of the System Area
+
+            # Right now we only have 2 karg files, but let's be generous and
+            # make space for 6. If we go beyond that in the future, we can
+            # ratchet it in.
+            assert len(files_with_karg_embed_areas) <= 6
+            kargsfmt = "<8s7Q"
             initrdfmt = '<8s2Q'
-            isofh.seek(32768 - struct.calcsize(initrdfmt))
+            isofh.seek(32768 - (struct.calcsize(initrdfmt) +
+                                struct.calcsize(kargsfmt)))
+            offsets = [0] * 6
+            for i, fn in enumerate(files_with_karg_embed_areas):
+                offset_in_file = files_with_karg_embed_areas[fn]
+                offsets[i] = file_offset_in_iso(isoinfo, fn) + offset_in_file
+            isofh.write(struct.pack(kargsfmt, b'corekarg', karg_embed_area_length, *offsets))
             # Magic number + offset + length
             isofh.write(struct.pack(initrdfmt, b'coreiso+', offset, initrd_ignition_padding))
             print(f'Embedded {initrd_ignition_padding} bytes Ignition config space at {offset}')

--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -318,6 +318,7 @@ def generate_iso():
     print(f'Substituting ISO kernel arguments: {kargs}')
 
     files_with_karg_embed_areas = {}
+    cmdline = ''
     karg_embed_area_length = 0
     # Grab all the contents from the live dir from the configs
     for srcdir, _, filenames in os.walk(srcdir_prefix):
@@ -341,6 +342,12 @@ def generate_iso():
                 buf = newbuf
                 karg_area_end = re.search(r'(#+) COREOS_KARG_EMBED_AREA\n', buf)
                 if karg_area_end is not None:
+                    file_kargs = buf[karg_area_start.start():karg_area_end.start()]
+                    if len(cmdline) == 0:
+                        cmdline = file_kargs
+                    elif cmdline != file_kargs:
+                        raise Exception(f'Default cmdline is different: "{cmdline}" != "{file_kargs}"')
+
                     length = karg_area_end.start() + len(karg_area_end[1]) - karg_area_start.start()
                     files_with_karg_embed_areas[filename] = karg_area_start.start()
                     if karg_embed_area_length == 0:
@@ -351,6 +358,9 @@ def generate_iso():
                 fh.write(buf)
             shutil.copystat(srcfile, dstfile)
             print(f'{srcfile} -> {dstfile}')
+
+    with open(os.path.join(tmpisoroot, '.cmdline'), 'w') as fh:
+        fh.write(cmdline)
 
     # These sections are based on lorax templates
     # see https://github.com/weldr/lorax/tree/master/share/templates.d/99-generic
@@ -526,8 +536,8 @@ def generate_iso():
         # coreos-installer side first
         INITRDFMT = '<8s2Q'
         assert struct.calcsize(INITRDFMT) == 24
-        KARGSFMT = f"<8s{MAX_KARG_FILES+1}Q"  # +1 for area length
-        assert struct.calcsize(KARGSFMT) == 64
+        KARGSFMT = f"<8s{MAX_KARG_FILES+1+1}Q"  # +1 for area length and +1 for offset to default read-only '.cmdline'
+        assert struct.calcsize(KARGSFMT) == 72
 
         # Start of the Ignition padding within the ISO
         offset = file_offset_in_iso(isoinfo, ignition_img)
@@ -540,11 +550,14 @@ def generate_iso():
             # Write header at the end of the System Area
             isofh.seek(ISO_SYSTEM_AREA_SIZE - (struct.calcsize(INITRDFMT) +
                                                struct.calcsize(KARGSFMT)))
-            offsets = [0] * MAX_KARG_FILES
+
+            offsets = [0] * (MAX_KARG_FILES + 1)  # +1 for offset to default
+            # This is ours default read-only '.cmdline' file, which is used for `coreos-installer iso kargs reset ISO`
+            offsets[0] = file_offset_in_iso(isoinfo, '.cmdline')
 
             for i, fn in enumerate(files_with_karg_embed_areas):
                 offset_in_file = files_with_karg_embed_areas[fn]
-                offsets[i] = file_offset_in_iso(isoinfo, fn) + offset_in_file
+                offsets[i + 1] = file_offset_in_iso(isoinfo, fn) + offset_in_file
             isofh.write(struct.pack(KARGSFMT, b'corekarg', karg_embed_area_length, *offsets))
             # Magic number + offset + length
             isofh.write(struct.pack(INITRDFMT, b'coreiso+', offset, initrd_ignition_padding))


### PR DESCRIPTION
Collect ISO files which include karg embed areas, then inject their
offsets into the System Area right behind the initramfs header. This
information will be used by `coreos-installer iso embed-kargs`.