### PR TITLE
qemu: Automatically inject serial console karg into ISO

### DIFF
--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -917,8 +917,17 @@ func (builder *QemuBuilder) setupIso() error {
 		if err := instCmd.Run(); err != nil {
 			return errors.Wrapf(err, "running coreos-installer iso embed")
 		}
-		builder.iso.path = isoEmbeddedPath
 		builder.configInjected = true
+
+		consoleArg := fmt.Sprintf("console=%s", consoleKernelArgument[system.RpmArch()])
+		instCmdKargs := exec.Command("coreos-installer", "iso", "embed-kargs", "--kargs", consoleArg, isoEmbeddedPath)
+		instCmdKargs.Stderr = os.Stderr
+		if err := instCmdKargs.Run(); err != nil {
+			// Don't make this a hard error yet; we may be operating on an old
+			// live ISO or with an old coreos-installer.
+			plog.Warningf("running coreos-installer iso embed-kargs: %v", err)
+		}
+		builder.iso.path = isoEmbeddedPath
 	}
 
 	// Arches s390x and ppc64le don't support UEFI and use the cdrom option to boot the ISO.


### PR DESCRIPTION
Now that we support injecting kernel arguments in the ISO, let's make
use of it by default when booting a live ISO to inject the appropriate
serial console karg. This is more convenient for manual testing (because
one no longer has to interrupt the boot process to type it in), but also
has the major advantage of ISO tests now being able to capture console
output.

In the future, we can also hook up the `--kargs` option to this.