### PR TITLE
prune: Handle no-builds case when cleaning pkgcache

### DIFF
--- a/src/cmd-prune
+++ b/src/cmd-prune
@@ -66,14 +66,20 @@ def nevra_to_cache_branch(pkg):
 
 if args.pkgcache:
     arch = cmdlib.get_basearch()
-    metapath = f"builds/latest/{arch}/commitmeta.json"
-    with open(metapath) as f:
-        meta = json.load(f)
-    build_pkg_nevra = meta['rpmostree.rpmdb.pkglist']
+    builds = []
+    if os.path.isfile('builds/builds.json'):
+        with open('builds/builds.json') as f:
+            builds = json.load(f)['builds']
     build_pkg = []
-    for pkg in build_pkg_nevra:
-        cache_branch = nevra_to_cache_branch(pkg)
-        build_pkg.append(cache_branch)
+    if len(builds) > 0:
+        latest_build = builds[0]
+        metapath = f"builds/latest/{arch}/commitmeta.json"
+        with open(metapath) as f:
+            meta = json.load(f)
+        build_pkg_nevra = meta['rpmostree.rpmdb.pkglist']
+        for pkg in build_pkg_nevra:
+            cache_branch = nevra_to_cache_branch(pkg)
+            build_pkg.append(cache_branch)
 
     # In order to improve efficiency, only prune those refs packages modified over 30 days
     ref_pkg = subprocess.check_output("find cache/pkgcache-repo/refs/heads/rpmostree/pkg/ -mtime +30 -type f", shell=True).decode('utf-8').split("\n")


### PR DESCRIPTION
I don't recall exactly how I hit this, but basically `cosa fetch`
was failing for me because I had no builds, and we were trying
to look at `builds/latest`.

Fix the prune code here to handle the case where there are no
builds.