### PR TITLE
cosalib: lock meta.json before reading and writing

### DIFF
--- a/src/cosalib/build.py
+++ b/src/cosalib/build.py
@@ -279,9 +279,12 @@ class _Build:
         """
 
         file_path = self.__file(name)
+        require_exclusive = False
+        if self.build_dir in file_path:
+            require_exclusive = True
         log.debug("Reading in %s", file_path)
         try:
-            return load_json(file_path)
+            return load_json(file_path, require_exclusive=require_exclusive)
         except FileNotFoundError:
             e = self._exceptions.get(name)
             if e:

--- a/src/cosalib/meta.py
+++ b/src/cosalib/meta.py
@@ -56,7 +56,6 @@ class GenericBuildMeta(dict):
         expected.
         """
         if not self._validator:
-            print("no validator")
             return
         self._validator.validate(dict(self))
 

--- a/src/deps.txt
+++ b/src/deps.txt
@@ -80,3 +80,6 @@ coreos-installer
 
 # For the ability to easily pass in an fcc to kola
 fcct
+
+# Support for meta.json file locking
+python3-flufl-lock


### PR DESCRIPTION
This imposes a 15s lock on meta.json. The lock is NFS safe.

Implements: cosa-20200804
https://github.com/coreos/enhancements/pull/2