### PR TITLE
buildextend-installer: pad legacy PXE rootfs to 1 MiB

### DIFF
--- a/src/cmd-buildextend-installer
+++ b/src/cmd-buildextend-installer
@@ -317,6 +317,11 @@ def generate_iso():
                 os.path.join(tmpinitrd_legacy, 'etc/coreos-live-rootfs')
             )
             extend_initrd(pxe_rootfs, tmpinitrd_legacy, compress=False)
+            # coreos-installer download won't accept an artifact sized
+            # less than 1 MiB
+            with open(pxe_rootfs, 'r+b') as fh:
+                if fh.seek(0, 2) < 1024 * 1024:
+                    fh.truncate(1024 * 1024)
         else:
             # Clone to PXE image
             cp_reflink(iso_rootfs, pxe_rootfs)

--- a/src/cmd-buildextend-installer
+++ b/src/cmd-buildextend-installer
@@ -316,7 +316,7 @@ def generate_iso():
                 os.path.join(tmpinitrd_rootfs, 'etc/coreos-live-rootfs'),
                 os.path.join(tmpinitrd_legacy, 'etc/coreos-live-rootfs')
             )
-            extend_initrd(pxe_rootfs, tmpinitrd_legacy)
+            extend_initrd(pxe_rootfs, tmpinitrd_legacy, compress=False)
         else:
             # Clone to PXE image
             cp_reflink(iso_rootfs, pxe_rootfs)


### PR DESCRIPTION
`coreos-installer download` refuses to download any artifact smaller than 1 MiB.  To avoid breaking deployed versions of coreos-installer, pad the legacy PXE rootfs to 1 MiB.  The kernel is fine with padding, bsdtar is fine with it, and the artifact will only exist for two months anyway.

Also stop compressing the legacy rootfs.  The compression is technically a bug, though it turns out not to matter.