### PR TITLE
[fcos-stable] buildextend-installer: pad PXE rootfs to 1 MiB

### DIFF
--- a/src/cmd-buildextend-installer
+++ b/src/cmd-buildextend-installer
@@ -275,6 +275,11 @@ def generate_iso():
         if is_live:
             pxe_rootfs = os.path.join(tmpdir, 'rootfs.img')
             extend_initrd(pxe_rootfs, tmpinitrd_pxe_rootfs)
+            # coreos-installer download won't accept an artifact sized
+            # less than 1 MiB
+            with open(pxe_rootfs, 'r+b') as fh:
+                if fh.seek(0, 2) < 1024 * 1024:
+                    fh.truncate(1024 * 1024)
             # Save stream hash of rootfs for verifying out-of-band fetches
             os.makedirs(os.path.join(tmpinitrd_pxe, 'etc'), exist_ok=True)
             make_stream_hash(pxe_rootfs, os.path.join(tmpinitrd_pxe, 'etc/coreos-live-want-rootfs'))


### PR DESCRIPTION
`coreos-installer download` refuses to download any artifact smaller than 1 MiB.  To avoid breaking deployed versions of coreos-installer, pad the legacy PXE rootfs to 1 MiB.  The kernel is fine with padding, gunzip is fine with it, and the artifact will only exist for two months anyway.