### PR TITLE
kola: add minMemory in kola.json (external tests)

### DIFF
--- a/mantle/kola/README-kola-ext.md
+++ b/mantle/kola/README-kola-ext.md
@@ -105,8 +105,9 @@ Here's an example `kola.json`:
 {
     "architectures": "!s390x ppc64le",
     "platforms": "qemu-unpriv",
-    "tags": "sometagname needs-internet othertag"
-    "additionalDisks": [ "5G" ]
+    "tags": "sometagname needs-internet othertag",
+    "additionalDisks": [ "5G" ],
+    "minMemory": 4096
 }
 ```
 
@@ -128,6 +129,11 @@ Currently only the `qemu` platform enforces this restriction.
 
 The `additionalDisks` key has the same semantics as the `--add-disk`
 argument to `qemuexec`. It is currently only supported on `qemu-unpriv`.
+
+The `minMemory` key takes a size in MB and ensures that an instance type
+with at least the specified amount of memory is used. On QEMU, this is
+equivalent to the `--memory` argument to `qemuexec`. This is currently
+only enforced on `qemu-unpriv`.
 
 More recently, you can also (useful for shell scripts) include the JSON file
 inline per test, like this:

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -534,6 +534,7 @@ type externalTestMeta struct {
 	Distros         string   `json:",distros,omitempty"`
 	Tags            string   `json:",tags,omitempty"`
 	AdditionalDisks []string `json:",additionalDisks,omitempty"`
+	MinMemory       int      `json:",minMemory,omitempty"`
 }
 
 // metadataFromTestBinary extracts JSON-in-comment like:
@@ -662,6 +663,7 @@ ExecStart=%s
 		Tags:          []string{"external"},
 
 		AdditionalDisks: targetMeta.AdditionalDisks,
+		MinMemory:       targetMeta.MinMemory,
 
 		Run: func(c cluster.TestCluster) {
 			mach := c.Machines()[0]
@@ -898,6 +900,7 @@ func runTest(h *harness.H, t *register.Test, pltfrm string, flight platform.Flig
 
 		options := platform.MachineOptions{
 			AdditionalDisks: t.AdditionalDisks,
+			MinMemory:       t.MinMemory,
 		}
 		if _, err := platform.NewMachines(c, userdata, t.ClusterSize, options); err != nil {
 			h.Fatalf("Cluster failed starting machines: %v", err)

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -896,7 +896,10 @@ func runTest(h *harness.H, t *register.Test, pltfrm string, flight platform.Flig
 			userdata = t.UserDataV3
 		}
 
-		if _, err := platform.NewMachines(c, userdata, t.ClusterSize, t.AdditionalDisks); err != nil {
+		options := platform.MachineOptions{
+			AdditionalDisks: t.AdditionalDisks,
+		}
+		if _, err := platform.NewMachines(c, userdata, t.ClusterSize, options); err != nil {
 			h.Fatalf("Cluster failed starting machines: %v", err)
 		}
 	}

--- a/mantle/kola/register/register.go
+++ b/mantle/kola/register/register.go
@@ -69,6 +69,9 @@ type Test struct {
 	// "5G"]) -- defaults to none.
 	AdditionalDisks []string
 
+	// Minimum amount of memory required for test.
+	MinMemory int
+
 	// ExternalTest is a path to a binary that will be uploaded
 	ExternalTest string
 	// DependencyDir is a path to directory that will be uploaded, normally used by external tests

--- a/mantle/platform/machine/unprivqemu/cluster.go
+++ b/mantle/platform/machine/unprivqemu/cluster.go
@@ -112,6 +112,8 @@ func (qc *Cluster) NewMachineWithQemuOptions(userdata *conf.UserData, options pl
 			return nil, errors.Wrapf(err, "parsing memory option")
 		}
 		builder.Memory = int(memory)
+	} else if options.MinMemory != 0 {
+		builder.Memory = options.MinMemory
 	}
 
 	channel := "virtio"

--- a/mantle/platform/platform.go
+++ b/mantle/platform/platform.go
@@ -156,6 +156,7 @@ type Flight interface {
 
 type MachineOptions struct {
 	AdditionalDisks []string
+	MinMemory       int
 }
 
 // SystemdDropin is a userdata type agnostic struct representing a systemd dropin

--- a/mantle/platform/platform.go
+++ b/mantle/platform/platform.go
@@ -354,7 +354,7 @@ func CopyDirToMachine(inputdir string, m Machine, destdir string) error {
 
 // NewMachines spawns n instances in cluster c, with
 // each instance passed the same userdata.
-func NewMachines(c Cluster, userdata *conf.UserData, n int, addDisks []string) ([]Machine, error) {
+func NewMachines(c Cluster, userdata *conf.UserData, n int, options MachineOptions) ([]Machine, error) {
 	var wg sync.WaitGroup
 
 	mchan := make(chan Machine, n)
@@ -364,9 +364,6 @@ func NewMachines(c Cluster, userdata *conf.UserData, n int, addDisks []string) (
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			options := MachineOptions{
-				AdditionalDisks: addDisks,
-			}
 			m, err := c.NewMachineWithOptions(userdata, options)
 			if err != nil {
 				errchan <- err


### PR DESCRIPTION
For the root reprovisioning work, we need to be able to temporarily save
the rootfs into RAM. This means we need at least 4G of RAM.

Add a new `minMemory` field which tells the platform to make sure the
machine provisioned has at least that amount of memory. On QEMU, this
directly controls the memory of the machine. On cloud platforms, it
would affect the instance type to use. But for now, we only actually
handle this field on QEMU.