### PR TITLE
[4.5] mantle: Add ability to grant snapshot volume permission to users

### DIFF
--- a/mantle/cmd/ore/aws/upload.go
+++ b/mantle/cmd/ore/aws/upload.go
@@ -47,21 +47,22 @@ After a successful run, the final line of output will be a line of JSON describi
 		SilenceUsage: true,
 	}
 
-	uploadSourceObject    string
-	uploadBucket          string
-	uploadImageName       string
-	uploadBoard           string
-	uploadFile            string
-	uploadDiskSizeGiB     uint
-	uploadDiskSizeInspect bool
-	uploadDeleteObject    bool
-	uploadForce           bool
-	uploadSourceSnapshot  string
-	uploadObjectFormat    aws.EC2ImageFormat
-	uploadAMIName         string
-	uploadAMIDescription  string
-	uploadGrantUsers      []string
-	uploadTags            []string
+	uploadSourceObject       string
+	uploadBucket             string
+	uploadImageName          string
+	uploadBoard              string
+	uploadFile               string
+	uploadDiskSizeGiB        uint
+	uploadDiskSizeInspect    bool
+	uploadDeleteObject       bool
+	uploadForce              bool
+	uploadSourceSnapshot     string
+	uploadObjectFormat       aws.EC2ImageFormat
+	uploadAMIName            string
+	uploadAMIDescription     string
+	uploadGrantUsers         []string
+	uploadGrantUsersSnapshot []string
+	uploadTags               []string
 )
 
 func init() {
@@ -80,6 +81,7 @@ func init() {
 	cmdUpload.Flags().StringVar(&uploadAMIName, "ami-name", "", "name of the AMI to create")
 	cmdUpload.Flags().StringVar(&uploadAMIDescription, "ami-description", "", "description of the AMI to create (default: empty)")
 	cmdUpload.Flags().StringSliceVar(&uploadGrantUsers, "grant-user", []string{}, "grant launch permission to this AWS user ID")
+	cmdUpload.Flags().StringSliceVar(&uploadGrantUsersSnapshot, "grant-user-snapshot", []string{}, "grant snapshot volume permission to this AWS user ID")
 	cmdUpload.Flags().StringSliceVar(&uploadTags, "tags", []string{}, "list of key=value tags to attach to the AMI")
 }
 
@@ -245,6 +247,15 @@ func runUpload(cmd *cobra.Command, args []string) error {
 		err = API.GrantLaunchPermission(amiID, uploadGrantUsers)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "unable to grant launch permission: %v\n", err)
+			os.Exit(1)
+		}
+	}
+
+	// grant snapshot volume permission to AWS user ids
+	if len(uploadGrantUsersSnapshot) > 0 {
+		err = API.GrantVolumePermission(sourceSnapshot, uploadGrantUsersSnapshot)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "unable to grant snapshot volume permission: %v\n", err)
 			os.Exit(1)
 		}
 	}

--- a/mantle/platform/api/aws/images.go
+++ b/mantle/platform/api/aws/images.go
@@ -460,6 +460,26 @@ func (a *API) createImage(params *ec2.RegisterImageInput) (string, error) {
 	return imageID, nil
 }
 
+// GrantVolumePermission grants permission to access an EC2 snapshot volume (referenced by its snapshot ID)
+// to a list of AWS users (referenced by their 12-digit numerical user IDs).
+func (a *API) GrantVolumePermission(snapshotID string, userIDs []string) error {
+	arg := &ec2.ModifySnapshotAttributeInput{
+		Attribute:              aws.String("createVolumePermission"),
+		SnapshotId:             aws.String(snapshotID),
+		CreateVolumePermission: &ec2.CreateVolumePermissionModifications{},
+	}
+	for _, userID := range userIDs {
+		arg.CreateVolumePermission.Add = append(arg.CreateVolumePermission.Add, &ec2.CreateVolumePermission{
+			UserId: aws.String(userID),
+		})
+	}
+	_, err := a.ec2.ModifySnapshotAttribute(arg)
+	if err != nil {
+		return fmt.Errorf("couldn't grant snapshot volume permission: %v", err)
+	}
+	return nil
+}
+
 func (a *API) GrantLaunchPermission(imageID string, userIDs []string) error {
 	arg := &ec2.ModifyImageAttributeInput{
 		Attribute:        aws.String("launchPermission"),

--- a/src/cosalib/aws.py
+++ b/src/cosalib/aws.py
@@ -125,6 +125,8 @@ def aws_run_ore(build, args):
     ])
     for user in args.grant_user:
         ore_args.extend(['--grant-user', user])
+    for user in args.grant_user_snapshot:
+        ore_args.extend(['--grant-user-snapshot', user])
 
     print("+ {}".format(subprocess.list2cmdline(ore_args)))
     ore_data = json.loads(subprocess.check_output(ore_args))
@@ -151,5 +153,7 @@ def aws_cli(parser):
     parser.add_argument("--bucket", help="S3 Bucket")
     parser.add_argument("--name-suffix", help="Suffix for name")
     parser.add_argument("--grant-user", help="Grant user launch permission",
+                        nargs="*", default=[])
+    parser.add_argument("--grant-user-snapshot", help="Grant user snapshot volume permission",
                         nargs="*", default=[])
     return parser


### PR DESCRIPTION
Backport of https://github.com/coreos/coreos-assembler/pull/1574

The GrantVolumePermission function grants permission to access an EC2
snapshot volume (referenced by its snapshot ID) to a list of AWS users
(referenced by their 12-digit numerical user IDs).

This functionality is being made accessible through a new
`grant-user-snappshot` flag on the `ore aws upload` command.