### PR TITLE
[4.4] mantle: Add ability to grant snapshot volume permission to users

### DIFF
--- a/mantle/cmd/ore/aws/upload.go
+++ b/mantle/cmd/ore/aws/upload.go
@@ -48,22 +48,23 @@ After a successful run, the final line of output will be a line of JSON describi
 		SilenceUsage: true,
 	}
 
-	uploadSourceObject    string
-	uploadBucket          string
-	uploadImageName       string
-	uploadBoard           string
-	uploadFile            string
-	uploadDiskSizeGiB     uint
-	uploadDiskSizeInspect bool
-	uploadDeleteObject    bool
-	uploadForce           bool
-	uploadSourceSnapshot  string
-	uploadObjectFormat    aws.EC2ImageFormat
-	uploadAMIName         string
-	uploadAMIDescription  string
-	uploadGrantUsers      []string
-	uploadCreatePV        bool
-	uploadTags            []string
+	uploadSourceObject       string
+	uploadBucket             string
+	uploadImageName          string
+	uploadBoard              string
+	uploadFile               string
+	uploadDiskSizeGiB        uint
+	uploadDiskSizeInspect    bool
+	uploadDeleteObject       bool
+	uploadForce              bool
+	uploadSourceSnapshot     string
+	uploadObjectFormat       aws.EC2ImageFormat
+	uploadAMIName            string
+	uploadAMIDescription     string
+	uploadGrantUsers         []string
+	uploadGrantUsersSnapshot []string
+	uploadCreatePV           bool
+	uploadTags               []string
 )
 
 func init() {
@@ -84,6 +85,7 @@ func init() {
 	cmdUpload.Flags().StringVar(&uploadAMIName, "ami-name", "", "name of the AMI to create (default: Container-Linux-$USER-$VERSION)")
 	cmdUpload.Flags().StringVar(&uploadAMIDescription, "ami-description", "", "description of the AMI to create (default: empty)")
 	cmdUpload.Flags().StringSliceVar(&uploadGrantUsers, "grant-user", []string{}, "grant launch permission to this AWS user ID")
+	cmdUpload.Flags().StringSliceVar(&uploadGrantUsersSnapshot, "grant-user-snapshot", []string{}, "grant snapshot volume permission to this AWS user ID")
 	cmdUpload.Flags().BoolVar(&uploadCreatePV, "create-pv", false, "create a PV AMI in addition to the HVM AMI")
 	cmdUpload.Flags().StringSliceVar(&uploadTags, "tags", []string{}, "list of key=value tags to attach to the AMI")
 }
@@ -265,6 +267,15 @@ func runUpload(cmd *cobra.Command, args []string) error {
 		err = API.GrantLaunchPermission(hvmID, uploadGrantUsers)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "unable to grant launch permission: %v\n", err)
+			os.Exit(1)
+		}
+	}
+
+	// grant snapshot volume permission to AWS user ids
+	if len(uploadGrantUsersSnapshot) > 0 {
+		err = API.GrantVolumePermission(sourceSnapshot, uploadGrantUsersSnapshot)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "unable to grant snapshot volume permission: %v\n", err)
 			os.Exit(1)
 		}
 	}

--- a/src/cosalib/aws.py
+++ b/src/cosalib/aws.py
@@ -114,6 +114,8 @@ def aws_run_ore(build, args):
     ])
     for user in args.grant_user:
         ore_args.extend(['--grant-user', user])
+    for user in args.grant_user_snapshot:
+        ore_args.extend(['--grant-user-snapshot', user])
 
     print("+ {}".format(subprocess.list2cmdline(ore_args)))
     ore_data = json.loads(subprocess.check_output(ore_args))
@@ -140,5 +142,7 @@ def aws_cli(parser):
     parser.add_argument("--bucket", help="S3 Bucket")
     parser.add_argument("--name-suffix", help="Suffix for name")
     parser.add_argument("--grant-user", help="Grant user launch permission",
+                        nargs="*", default=[])
+    parser.add_argument("--grant-user-snapshot", help="Grant user snapshot volume permission",
                         nargs="*", default=[])
     return parser


### PR DESCRIPTION
Backport of #1574

The GrantVolumePermission function grants permission to access an EC2
snapshot volume (referenced by its snapshot ID) to a list of AWS users
(referenced by their 12-digit numerical user IDs).

This functionality is being made accessible through a new
`grant-user-snappshot` flag on the `ore aws upload` command.