### PR TITLE
[4.3] Remove "configure_yum_repos" function

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ WORKDIR /root/containerbuild
 # Only need a few of our scripts for the first few steps
 COPY ./src/cmdlib.sh /root/containerbuild/src/
 COPY ./build.sh ./deps*.txt ./vmdeps*.txt ./build-deps.txt /root/containerbuild/
-RUN ./build.sh configure_yum_repos # nocache 20200110
 RUN ./build.sh install_rpms
 
 # Ok copy in the rest of them for the next few steps

--- a/build.sh
+++ b/build.sh
@@ -13,7 +13,6 @@ if [ $# -gt 1 ]; then
   echo Usage: "build.sh [CMD]"
   echo "Supported commands:"
   echo "    configure_user"
-  echo "    configure_yum_repos"
   echo "    install_rpms"
   echo "    make_and_makeinstall"
   exit 1
@@ -21,16 +20,6 @@ fi
 
 set -x
 srcdir=$(pwd)
-
-configure_yum_repos() {
-    local version_id
-    version_id=$(. /etc/os-release && echo ${VERSION_ID})
-    # Add continuous tag for latest build tools and mark as required so we
-    # can depend on those latest tools being available in all container
-    # builds.
-    echo -e "[f${version_id}-coreos-continuous]\nenabled=1\nmetadata_expire=1m\nbaseurl=https://kojipkgs.fedoraproject.org/repos-dist/f${version_id}-coreos-continuous/latest/\$basearch/\ngpgcheck=0\nskip_if_unavailable=False\n" > /etc/yum.repos.d/coreos.repo
-
-}
 
 install_rpms() {
     # First, a general update; this is best practice.  We also hit an issue recently
@@ -134,7 +123,6 @@ if [ $# -ne 0 ]; then
   ${1}
 else
   # Otherwise, just run all the steps
-  configure_yum_repos
   install_rpms
   write_archive_info
   make_and_makeinstall


### PR DESCRIPTION
The packages should all exist within the stable repos so we shouldn't
need the fast-track packages from the continuous repos.

This is a manual backport of 32966347b19aa82de00f932664d2b2f6f234a9c9
since no other repos are setup for rhcos-4.3 we can remove the function
entirely.