### PR TITLE
deps.txt: add python3-flufl

### DIFF
--- a/src/deps.txt
+++ b/src/deps.txt
@@ -80,3 +80,6 @@ coreos-installer
 
 # For the ability to easily pass in an fcc to kola
 fcct
+
+# Support for meta.json file locking
+python3-flufl-lock


### PR DESCRIPTION
Adding python3-flufl as a dependency for potential NFS-safe file locking.

flufl.lock is not used right but is being proposed as a means to do file
locking for meta.json merging. Should flufl.lock not be used, this
commit should be reverted at a later time.

This dependency only adds 59K to the COSA container and will make CI
happy for the huge PR's coming later.
