### PR TITLE
WIP: Introduce meta/resource-version

### DIFF
--- a/mantle/cosa/cosa_v1.go
+++ b/mantle/cosa/cosa_v1.go
@@ -44,6 +44,7 @@ type Build struct {
 	GitDirty                  string                `json:"coreos-assembler.config-dirty,omitempty"`
 	ImageInputChecksum        string                `json:"coreos-assembler.image-input-checksum,omitempty"`
 	InputHasOfTheRpmOstree    string                `json:"rpm-ostree-inputhash"`
+	Meta                      interface{}           `json:"meta,omitempty"`
 	Name                      string                `json:"name"`
 	Oscontainer               *Image                `json:"oscontainer,omitempty"`
 	OstreeCommit              string                `json:"ostree-commit"`
@@ -113,5 +114,9 @@ type Image struct {
 }
 
 type Items interface{}
+
+type Meta struct {
+	ResourceVersion string `json:"resource-version"`
+}
 
 type PackageSetDifferences []Items

--- a/mantle/cosa/schema_doc.go
+++ b/mantle/cosa/schema_doc.go
@@ -152,7 +152,18 @@ var generatedSchemaJSON = `{
          "default":"",
          "minLength": 1
         }
-      }
+      },
+      "meta": {
+        "type": "object",
+        "required": ["resource-version"],
+        "properties": {
+          "resource-version": {
+            "$id": "#/meta/resource-version",
+            "type":"string",
+            "title":"resource-version"
+            }
+          }
+        }
  },
  "$schema":"http://json-schema.org/draft-07/schema#",
  "$id":"http://github.com/coreos/coreos-assembler/blob/master/schema/v1.json",
@@ -175,8 +186,9 @@ var generatedSchemaJSON = `{
      "summary"
  ],
  "optional": [
-   "images",
-   "aliyun",
+  "images",
+  "meta",
+  "aliyun",
    "amis",
    "azure",
    "azurestack",
@@ -485,6 +497,11 @@ var generatedSchemaJSON = `{
         }
       }
     },
+    "meta": {
+      "$id":"#/properties/meta",
+      "type":"meta",
+      "title":"Meta"
+     },
    "name": {
      "$id":"#/properties/name",
      "type":"string",

--- a/src/cosalib/meta.py
+++ b/src/cosalib/meta.py
@@ -75,6 +75,17 @@ class GenericBuildMeta(dict):
         Write out the dict to the meta path.
         """
         self.validate()
+        newver = self.get('meta', {}).get('resource-version', "0")
+        curver = "0"
+        if os.path.exists(self._meta_path):
+            with open(self._meta_path) as f:
+                current = json.load(f)
+                curver = current.get('meta', {}).get('resource-version', "0")
+            if curver != newver:
+                raise Exception(f"resource-version conflict updating {self._meta_path}, expected {newver}, found {curver}")
+        selfmeta = self.get('meta', {})
+        selfmeta['resource-version'] = "{}".format(int(curver) + 1)
+        self['meta'] = selfmeta
         write_json(self._meta_path, dict(self))
 
     def get(self, *args):

--- a/src/schema/v1.json
+++ b/src/schema/v1.json
@@ -147,7 +147,18 @@
          "default":"",
          "minLength": 1
         }
-      }
+      },
+      "meta": {
+        "type": "object",
+        "required": ["resource-version"],
+        "properties": {
+          "resource-version": {
+            "$id": "#/meta/resource-version",
+            "type":"string",
+            "title":"resource-version"
+            }
+          }
+        }
  },
  "$schema":"http://json-schema.org/draft-07/schema#",
  "$id":"http://github.com/coreos/coreos-assembler/blob/master/schema/v1.json",
@@ -183,6 +194,7 @@
    "pkgdiff",
    "parent-pkgdiff",
    "release-payload",
+   "meta",
 
    "coreos-assembler.basearch",
    "coreos-assembler.build-timestamp",
@@ -480,6 +492,11 @@
         }
       }
     },
+    "meta": {
+      "$id":"#/properties/meta",
+      "type":"object",
+      "title":"Meta"
+     },
    "name": {
      "$id":"#/properties/name",
      "type":"string",


### PR DESCRIPTION
Split out of discussions in https://github.com/coreos/coreos-assembler/pull/1657

I tested that running in the same cosa workdir in two separate
shells, `cosa buildextend-aws` and `cosa buildextend-gcp`

fails with:

```
[INFO]: Calculating metadata for fedora-coreos-32.20200805.dev.0-gcp.x86_64.tar.gz
Traceback (most recent call last):
  File "/usr/lib/coreos-assembler/cmd-buildextend-gcp", line 103, in <module>
    build.build_artifacts()
  File "/usr/lib/coreos-assembler/cosalib/build.py", line 382, in build_artifacts
    self._build_artifacts(*args, **kwargs)
  File "/usr/lib/coreos-assembler/cosalib/qemuvariants.py", line 309, in _build_artifacts
    self.meta_write()
  File "/usr/lib/coreos-assembler/cosalib/build.py", line 369, in meta_write
    self.meta.write()
  File "/usr/lib/coreos-assembler/cosalib/meta.py", line 85, in write
    raise Exception(f"resource-version conflict updating {self._meta_path}, expected {newver}, found {curver}")
Exception: resource-version conflict updating /var/srv/walters/builds/fcos/builds/32.20200805.dev.0/x86_64/meta.json, expected 2, found 3
```