### PR TITLE
kola/harness.go: Warn about non-executable files with shebang

### DIFF
--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -761,6 +761,16 @@ func registerTestDir(dir, testprefix string, children []os.FileInfo) error {
 			if err := registerTestDir(subdir, subprefix, subchildren); err != nil {
 				return err
 			}
+		} else if isreg && (c.Mode().Perm()&0001) == 0 {
+			file, err := os.Open(filepath.Join(dir, c.Name()))
+			if err != nil {
+				return errors.Wrapf(err, "opening %s", c.Name())
+			}
+			scanner := bufio.NewScanner(file)
+			scanner.Scan()
+			if strings.HasPrefix(scanner.Text(), "#!") {
+				plog.Warningf("Found non-executable file with shebang: %s\n", c.Name())
+			}
 		}
 	}
 


### PR DESCRIPTION
Update `registerTestDir()` to warn about discovering non-executable files with a shebang in externally defined test directories, since those files are probably meant to be executable tests. 