### PR TITLE
meta: Use timestamp on meta.json to detect read-modify-write conflicts

### DIFF
--- a/tests/test_cosalib_meta.py
+++ b/tests/test_cosalib_meta.py
@@ -76,6 +76,7 @@ def test_set(tmpdir):
     m.set('test', 'changed')
     m.write()
     assert m.get('test') == 'changed'
+    m.read()
     m.set(['a', 'b'], 'z')
     m.write()
     assert m.get(['a', 'b']) == 'z'


### PR DESCRIPTION
This is a much simpler version of
https://github.com/coreos/coreos-assembler/pull/1663
that will also reliably work even for code that's not using `GenericBuildMeta`.