### PR TITLE
cosalib/meta: implement meta.json merging

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -46,11 +46,15 @@ pod(image: 'registry.fedoraproject.org/fedora:32', runAsUser: 0, kvm: true, memo
             }
           },
           buildextend: {
-              cosa_cmd("buildextend-metal")
-              cosa_cmd("buildextend-metal4k")
-              cosa_cmd("buildextend-live --fast")
-              cosa_cmd("buildextend-openstack")
-              cosa_cmd("buildextend-vmware")
+              parallel metal: {
+                 cosa_cmd("buildextend-metal")
+                 cosa_cmd("buildextend-metal4k")
+              }
+              parallel artifacts: {
+                  cosa_cmd("buildextend-live --fast")
+                  cosa_cmd("buildextend-openstack")
+                  cosa_cmd("buildextend-vmware")
+              }
               cosa_cmd("compress")
               // quick schema validation"
               cosa_cmd("meta --get name")

--- a/src/cmd-build
+++ b/src/cmd-build
@@ -251,7 +251,7 @@ fi
 extra_compose_args+=("$parent_arg")
 
 # These need to be absolute paths right now for rpm-ostree
-composejson=${PWD}/tmp/compose.json
+composejson="$(readlink -f "${workdir}"/tmp/compose.json)"
 # Put this under tmprepo so it gets automatically chown'ed if needed
 lockfile_out=${tmprepo}/tmp/manifest-lock.generated.${basearch}.json
 prepare_compose_overlays

--- a/src/cmd-build
+++ b/src/cmd-build
@@ -8,7 +8,7 @@ dn=$(dirname "$0")
 print_help() {
     cat 1>&2 <<'EOF'
 Usage: coreos-assembler build --help
-       coreos-assembler build [--force] [--force-image] [--skip-prune] [--strict] [--tag TAG] [--version VERSION] [TARGET...]
+       coreos-assembler build [--delay-meta-merge] [--force] [--force-image] [--skip-prune] [--strict] [--tag TAG] [--version VERSION] [TARGET...]
 
   Build OSTree and image base artifacts from previously fetched packages.
   Accepted TARGET arguments:
@@ -24,6 +24,7 @@ EOF
 }
 
 # Parse options
+DELAY_META_MERGE=false
 FORCE=
 FORCE_IMAGE=
 SKIP_PRUNE=0
@@ -33,7 +34,7 @@ PARENT_BUILD=
 TAG=
 STRICT=
 rc=0
-options=$(getopt --options hft: --longoptions tag:,help,force,version:,parent:,parent-build:,force-nocache,force-image,skip-prune,strict -- "$@") || rc=$?
+options=$(getopt --options hft: --longoptions tag:,help,force,version:,parent:,parent-build:,delay-meta-merge,force-nocache,force-image,skip-prune,strict -- "$@") || rc=$?
 [ $rc -eq 0 ] || {
     print_help
     exit 1
@@ -47,6 +48,9 @@ while true; do
             ;;
         -f | --force | --force-nocache)
             FORCE="--force-nocache"
+            ;;
+        --delay-meta-merge)
+            DELAY_META_MERGE=true
             ;;
         --force-image)
             FORCE_IMAGE=1
@@ -395,7 +399,9 @@ cat > tmp/buildmeta.json <<EOF
  "coreos-assembler.image-config-checksum": "${image_config_checksum}",
  "coreos-assembler.image-input-checksum": "${image_input_checksum}",
  "coreos-assembler.code-source": "${src_location}",
- "coreos-assembler.container-config-git": $(jq -M '.git' ${PWD}/coreos-assembler-config-git.json)
+ "coreos-assembler.container-config-git": $(jq -M '.git' ${PWD}/coreos-assembler-config-git.json),
+ "coreos-assembler.meta-stamp": $(python -c 'import time; print(time.time_ns())'),
+ "coreos-assembler.delayed-meta-merge": ${DELAY_META_MERGE}
 }
 EOF
 

--- a/src/cmd-buildextend-installer
+++ b/src/cmd-buildextend-installer
@@ -5,7 +5,6 @@
 
 import argparse
 import hashlib
-import json
 import os
 import re
 import shutil
@@ -14,13 +13,15 @@ import subprocess
 import sys
 import tarfile
 import tempfile
+import time
 import yaml
 import glob
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from cosalib.builds import Builds
-from cosalib.cmdlib import run_verbose, write_json, sha256sum_file
+from cosalib.cmdlib import run_verbose, sha256sum_file
 from cosalib.cmdlib import import_ostree_commit, get_basearch
+from cosalib.meta import GenericBuildMeta
 
 
 def ostree_extract_efi(repo, commit, destdir):
@@ -59,7 +60,6 @@ print(f"Targeting build: {args.build}")
 with open('src/config/image.yaml') as fh:
     image_yaml = yaml.safe_load(fh)
 squashfs_compression = 'lz4' if args.fast else image_yaml.get('squashfs-compression', 'zstd')
-
 # Hacky mode switch, until we can drop support for the installer images
 is_live = os.path.basename(sys.argv[0]).endswith('-live')
 if is_live:
@@ -77,8 +77,15 @@ if not os.path.isdir(srcdir_prefix):
 workdir = os.path.abspath(os.getcwd())
 builddir = builds.get_build_dir(args.build)
 buildmeta_path = os.path.join(builddir, 'meta.json')
-with open(buildmeta_path) as f:
-    buildmeta = json.load(f)
+buildmeta = GenericBuildMeta(workdir=workdir)
+
+# used to lock
+build_semaphore = os.path.join(
+    buildmeta.build_dir, f".{image_type}.building")
+if os.path.exists(build_semaphore):
+    raise Exception(
+        f"{build_semaphore} exists: another process is building {image_type}")
+
 
 # Grab the commit hash for this build
 buildmeta_commit = buildmeta['ostree-commit']
@@ -212,8 +219,8 @@ def generate_iso():
 
     tmpisofile = os.path.join(tmpdir, iso_name)
 
-    img_metal_obj = buildmeta['images'].get('metal')
-    img_metal4k_obj = buildmeta['images'].get('metal4k')
+    img_metal_obj = buildmeta.get_artifact_meta("metal", unmerged=True)["images"].get("metal")
+    img_metal4k_obj = buildmeta.get_artifact_meta("metal4k", unmerged=True)["images"].get("metal4k")
     if is_live:
         if img_metal_obj is None or img_metal4k_obj is None:
             raise Exception("Live image generation requires `metal` and `metal4k` images")
@@ -575,7 +582,7 @@ def generate_iso():
             }
         })
 
-    write_json(buildmeta_path, buildmeta)
+    buildmeta.write(artifact_name=image_type)
     print(f"Updated: {buildmeta_path}")
 
 
@@ -585,5 +592,12 @@ if 'ostree' in buildmeta['images']:
 commit_tar = os.path.join(builddir, commit_tar_name)
 import_ostree_commit(repo, buildmeta_commit, commit_tar)
 
-# Do it!
-generate_iso()
+# lock and build
+with open(build_semaphore, 'w') as f:
+    f.write(f"{time.time_ns()}")
+
+try:
+    generate_iso()
+finally:
+    if os.path.exists(build_semaphore):
+        os.unlink(build_semaphore)

--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -73,7 +73,7 @@ if [[ "$basearch" != "s390x" && $image_type == dasd ]]; then
 fi
 
 export LIBGUESTFS_BACKEND=direct
-
+export IMAGE_TYPE="${image_type}"
 prepare_build
 
 if [ -z "${build}" ]; then
@@ -88,9 +88,17 @@ if [ ! -d "${builddir}" ]; then
     fatal "Build dir ${builddir} does not exist."
 fi
 
+# add building sempahore
+build_semaphore="${builddir}/.${image_type}.building"
+if [ -e "${build_semaphore}" ]; then
+    fatal "${build_semaphore} found: another process is building ${image_type}"
+fi
+touch "${build_semaphore}"
+trap 'rm -rvf ${build_semaphore}' EXIT
+
 # check if the image already exists in the meta.json
-meta_img=$(jq -r ".[\"images\"][\"${image_type}\"]" < "${builddir}/meta.json")
-if [ "${meta_img}" != "null" ]; then
+meta_img=$(meta_key "images.${image_type}.path")
+if [ "${meta_img}" != "None" ]; then
     echo "${image_type} image already exists:"
     echo "$meta_img"
     exit 0
@@ -98,14 +106,14 @@ fi
 
 # reread these values from the build itself rather than rely on the ones loaded
 # by prepare_build since the config might've changed since then
-name=$(json_key name)
-ref=$(json_key ref)
+name=$(meta_key name)
+ref=$(meta_key ref)
 ref_is_temp=""
-if [ "${ref}" = "null" ]; then
+if [ "${ref}" = "None" ]; then
     ref="tmpref-${name}"
     ref_is_temp=1
 fi
-commit=$(json_key ostree-commit)
+commit=$(meta_key ostree-commit)
 
 ostree_repo=${tmprepo}
 rev_parsed=$(ostree rev-parse --repo="${ostree_repo}" "${ref}" 2>/dev/null || :)
@@ -270,20 +278,23 @@ runvm "${target_drive[@]}" -- \
             --rootfs "${rootfs_type}" \
             "${disk_args[@]}"
 /usr/lib/coreos-assembler/finalize-artifact "${path}.tmp" "${path}"
-echo "{}" > tmp/vm-iso-checksum.json
 
+sha256=$(sha256sum_str < "${img}")
 # there's probably a jq one-liner for this...
 python3 -c "
 import sys, json
 j = json.load(sys.stdin)
 j['images']['${image_type}'] = {
     'path': '${img}',
-    'sha256': '$(sha256sum_str < "${img}")',
+    'sha256': '${sha256}',
     'size': $(stat -c '%s' "${img}")
 }
 json.dump(j, sys.stdout, indent=4)
-" < "${builddir}/meta.json" | cat - tmp/vm-iso-checksum.json | jq -s add > meta.json.new
+" < "${builddir}/meta.json" | jq -s add > "meta.json.new"
 
 # and now the crucial bits
-/usr/lib/coreos-assembler/finalize-artifact meta.json.new "${builddir}/meta.json"
+cosa meta --workdir "${workdir}" --build "${build}" --artifact "${image_type}" --artifact-json "$(readlink -f meta.json.new)"
 /usr/lib/coreos-assembler/finalize-artifact "${img}" "${builddir}/${img}"
+
+# clean up the tmpild
+rm -rf "${tmp_builddir}"

--- a/src/cmd-meta
+++ b/src/cmd-meta
@@ -4,16 +4,23 @@ cmd-meta is a helper for interacting with a builds meta.json
 """
 
 import argparse
+import glob
 import os
 import sys
 
 COSA_PATH = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, COSA_PATH)
-from cosalib.meta import GenericBuildMeta as Meta
+from cosalib.meta import (
+    GenericMeta,
+    GenericBuildMeta,
+    COSA_DELAYED_MERGE,
+    COSA_VER_STAMP
+)
 
 
 def new_cli():
     parser = argparse.ArgumentParser()
+    parser.add_argument('--artifact', help="when merging name of the artifact")
     parser.add_argument('--workdir', default=os.getcwd())
     parser.add_argument('--build', default='latest')
     parser.add_argument('--skip-validation',
@@ -22,9 +29,25 @@ def new_cli():
     parser.add_argument('--schema', help='location of meta.json schema',
                         default=os.environ.get("COSA_META_SCHEMA",
                                                f'{COSA_PATH}/schema/v1.json'))
+    parser.add_argument('--true', dest='bool', default=None,
+                        help='set a field', action='store_true')
+    parser.add_argument('--false', dest='bool', default=None,
+                        help='set a field', action='store_false')
+    parser.add_argument('--no-clean', action="store_true",
+                        help="when finalizing leave artifacts meta.*.json")
     sub_parser = parser.add_mutually_exclusive_group(required=True)
     sub_parser.add_argument('--get', help='get a field', action='append')
+    sub_parser.add_argument('--get-value',
+                            help='get value only', action='append')
+    sub_parser.add_argument('--set-int', help='set a field', action='append')
     sub_parser.add_argument('--set', help='set a field', action='append')
+    sub_parser.add_argument('--set-bool', help='set a field', action='store')
+    sub_parser.add_argument('--artifact-json', action='append',
+                            help=('merge in artifact meta.json into meta.json'
+                                  ' according to merge rules'))
+    sub_parser.add_argument('--finalize', action='store_true',
+                            help='commit artifact json into the main meta.json'
+                            )
     sub_parser.add_argument(
         '--dump', help='dumps the entire structure', action='store_true')
     sub_parser.add_argument(
@@ -36,30 +59,63 @@ def new_cli():
     schema = args.schema
     if args.skip_validation:
         schema = None
-    meta = Meta(args.workdir, args.build, schema=schema)
+    meta = GenericBuildMeta(args.workdir, args.build, schema=schema)
+    old_ts = meta.get(COSA_VER_STAMP)
 
-    # support the coreos-assembler.* keys
     def pather(val):
         path = val.split('.')
         if val.startswith("coreos-assembler."):
             new_path = [f"{path[0]}.{path[1]}"]
             new_path.extend(path[2:])
-            return new_path
+            return ".".join(new_path)
         return path
 
     # Get keys
-    if args.get is not None:
-        dotpath = args.get[0]
+    if args.get is not None or args.get_value is not None:
+        dotpath = args.get[0] if args.get else args.get_value[0]
         keypath = pather(dotpath)
         loc = meta.get(keypath)
-        print(f'{dotpath}: {loc}')
+        if args.get_value:
+            print(f'{loc}')
+        else:
+            print(f'{dotpath}: {loc}')
     # Set keys
     elif args.set is not None:
         for item in args.set:
             k, v = item.split('=')
             keypath = pather(k)
             meta.set(keypath, v)
-        meta.write(merge_func=None)
+            meta.validate()
+            meta.write(merge_func=None)
+    # Set boolean values
+    elif args.set_bool is not None:
+        keypath = pather(args.set_bool)
+        meta.set(keypath, bool(args.bool))
+        meta.validate()
+        print(meta.write(merge_func=None))
+    # Merge meta.json into the existing meta.json
+    elif args.artifact_json is not None:
+        for item in args.artifact_json:
+            item_data = GenericMeta(path=item, schema=schema)
+            meta.update(item_data.dict())
+            out = meta.write(artifact_name=args.artifact)
+            print(f"{out} wrote with version stamp {meta.get(COSA_VER_STAMP)}")
+    # Finalize the meta.json
+    elif args.finalize:
+        if not meta.get(COSA_DELAYED_MERGE):
+            print(f"{COSA_DELAYED_MERGE} is not set, skipping merge")
+            sys.exit(0)
+        print("Finalizing meta.<ARTIFACT>.json into meta.json")
+        print(f"[stamp {old_ts}] starting on {meta.path}")
+        for candidate in glob.glob(f'{meta.build_dir}/meta.*.json'):
+            item_data = GenericMeta(path=candidate, schema=schema)
+            print(f"[ stamp {item_data.get(COSA_VER_STAMP)}] on {candidate}")
+            meta.clear()
+            meta.update(item_data.dict())
+            meta.write(final=True)
+            if not args.no_clean:
+                os.unlink(candidate)
+        print(f"[ stamp {meta.get(COSA_VER_STAMP)}] applied to {meta.path}")
     elif args.dump is True:
         print(meta)
     elif args.image_path is not None:

--- a/src/cmd-meta
+++ b/src/cmd-meta
@@ -59,11 +59,12 @@ def new_cli():
             k, v = item.split('=')
             keypath = pather(k)
             meta.set(keypath, v)
-        meta.write()
+        meta.write(merge_func=None)
     elif args.dump is True:
         print(meta)
     elif args.image_path is not None:
-        print(os.path.join(os.path.dirname(meta.path), meta.get('images')[args.image_path]['path']))
+        print(os.path.join(os.path.dirname(meta.path),
+              meta.get('images')[args.image_path]['path']))
 
 
 if __name__ == '__main__':

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -225,9 +225,10 @@ prepare_build() {
     export fastbuilddir
 
     # Allocate temporary space for this build
-    tmp_builddir=${workdir}/tmp/build
+    export tmp_builddir="${workdir}/tmp/build${IMAGE_TYPE:+.$IMAGE_TYPE}"
     rm "${tmp_builddir}" -rf
     mkdir "${tmp_builddir}"
+
     # And everything after this assumes it's in the temp builddir
     # In case `cd` fails:  https://github.com/koalaman/shellcheck/wiki/SC2164
     cd "${tmp_builddir}" || exit
@@ -235,7 +236,7 @@ prepare_build() {
     # contains artifacts we definitely don't want to outlive it, unlike
     # other things in ${workdir}/tmp. But we don't export it since e.g. if it's
     # over an NFS mount (like a PVC in OCP), some apps might error out.
-    mkdir tmp && TMPDIR=$(pwd)/tmp
+    mkdir -p tmp && export TMPDIR="${workdir}/tmp"
 
     # Needs to be absolute for rpm-ostree today
     changed_stamp=${TMPDIR}/treecompose.changed
@@ -279,7 +280,7 @@ prepare_compose_overlays() {
     fi
 
     if [ -d "${overridesdir}" ] || [ -n "${ref_is_temp}" ] || [ -d "${ovld}" ]; then
-        mkdir "${tmp_overridesdir}"
+        mkdir -p "${tmp_overridesdir}"
         cat > "${override_manifest}" <<EOF
 include: ${manifest}
 EOF
@@ -396,6 +397,10 @@ json_key() {
     jq -r ".[\"$1\"]" < "${builddir}/meta.json"
 }
 
+meta_key() {
+    cosa meta --workdir="${workdir}" --build="${build:-latest}" --get-value "${@}"
+}
+
 # runvm generates and runs a minimal VM which we use to "bootstrap" our build
 # process.  It mounts the workdir via 9p.  If you need to add new packages into
 # the vm, update `vmdeps.txt`.
@@ -416,10 +421,13 @@ runvm() {
                 ;;
         esac
     done
-    local vmpreparedir=${workdir}/tmp/supermin.prepare
-    local vmbuilddir=${workdir}/tmp/supermin.build
 
-    rm -rf "${vmpreparedir}" "${vmbuilddir}"
+    # shellcheck disable=SC2155
+    local vmpreparedir="${tmp_builddir}/supermin.prepare"
+    local vmbuilddir="${tmp_builddir}/supermin.build"
+    local runvm_console="${tmp_builddir}/runvm-console.txt"
+    local rc_file="${tmp_builddir}/rc"
+
     mkdir -p "${vmpreparedir}" "${vmbuilddir}"
 
     local rpms
@@ -429,6 +437,7 @@ runvm() {
     [ -n "${ISEL}" ]     && filter='^#EL7 '
     rpms=$(sed "s/${filter}//" "${DIR}"/vmdeps.txt | grep -v '^#')
     archrpms=$(sed "s/${filter}//" "${DIR}"/vmdeps-"$(arch)".txt | grep -v '^#')
+
     # shellcheck disable=SC2086
     supermin --prepare --use-installed -o "${vmpreparedir}" $rpms $archrpms
 
@@ -452,11 +461,11 @@ rc=0
 # tee to the virtio port so its output is also part of the supermin output in
 # case e.g. a key msg happens in dmesg when the command does a specific operation
 if [ -z "${RUNVM_SHELL:-}" ]; then
-  bash ${TMPDIR}/cmd.sh |& tee /dev/virtio-ports/cosa-cmdout || rc=\$?
+  bash ${tmp_builddir}/cmd.sh |& tee /dev/virtio-ports/cosa-cmdout || rc=\$?
 else
   bash; poweroff -f -f; sleep infinity
 fi
-echo \$rc > ${workdir}/tmp/rc
+echo \$rc > ${rc_file}
 if [ -n "\${cachedev}" ]; then
     /sbin/fstrim -v ${workdir}/cache
 fi
@@ -466,17 +475,14 @@ EOF
     (cd "${vmpreparedir}" && tar -czf init.tar.gz --remove-files init)
     # put the supermin output in a separate file since it's noisy
     if ! supermin --build "${vmpreparedir}" --size 5G -f ext2 -o "${vmbuilddir}" \
-            &> "${workdir}/tmp/supermin.out"; then
-        cat "${workdir}/tmp/supermin.out"
+            &> "${tmp_builddir}/supermin.out"; then
+        cat "${tmp_builddir}/supermin.out"
         fatal "Failed to run: supermin --build"
     fi
-    rm "${workdir}/tmp/supermin.out"
+    rm "${tmp_builddir}/supermin.out"
 
-    echo "$@" > "${TMPDIR}"/cmd.sh
-
-    local runvm_console
-    runvm_console="${workdir}/tmp/runvm-console.txt"
-    rm -f "${workdir}/tmp/rc" "${runvm_console}"
+    # this is the command run in the supermin container
+    echo "$@" > "${tmp_builddir}"/cmd.sh
 
     touch "${runvm_console}"
     kola_args=(kola qemuexec -m 2048 --auto-cpus -U --workdir none)
@@ -513,12 +519,11 @@ EOF
         exec "${kola_args[@]}" -- "${base_qemu_args[@]}" -serial stdio "${qemu_args[@]}"
     fi
 
-    if [ ! -f "${workdir}"/tmp/rc ]; then
+    if [ ! -f "${rc_file}" ]; then
         cat "${runvm_console}"
         fatal "Couldn't find rc file; failure inside supermin init?"
     fi
-    rc="$(cat "${workdir}"/tmp/rc)"
-    rm -f "${workdir}/tmp/rc"
+    rc="$(cat "${rc_file}")"
     return "${rc}"
 }
 

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -422,6 +422,10 @@ runvm() {
         esac
     done
 
+    # tmp_builddir is set in prepare_build, but some stages may not
+    # know that it exists.
+    export tmp_builddir="${tmp_builddir:-${workdir}/tmp/build${IMAGE_TYPE:+.$IMAGE_TYPE}}"
+
     # shellcheck disable=SC2155
     local vmpreparedir="${tmp_builddir}/supermin.prepare"
     local vmbuilddir="${tmp_builddir}/supermin.build"

--- a/src/cosalib/build.py
+++ b/src/cosalib/build.py
@@ -362,11 +362,11 @@ class _Build:
         """
         self.meta.update(update_dict)
 
-    def meta_write(self):
+    def meta_write(self, artifact_name=None):
         """
         Writes out the meta.json file based on the internal structure.
         """
-        self.meta.write()
+        self.meta.write(artifact_name=artifact_name)
 
     def build_artifacts(self, *args, **kwargs):
         """

--- a/src/cosalib/meta.py
+++ b/src/cosalib/meta.py
@@ -199,7 +199,7 @@ class GenericMeta(dict):
         dn = os.path.dirname(self.path)
         alt_path = os.path.join(dn, f"meta.{artifact}.json")
         if (os.path.exists(alt_path) and unmerged is True and
-            self.get(COSA_DELAYED_MERGE) is True):
+           self.get(COSA_DELAYED_MERGE) is True):
             data = load_json(alt_path)
 
         return {

--- a/src/cosalib/qemuvariants.py
+++ b/src/cosalib/qemuvariants.py
@@ -179,9 +179,10 @@ class QemuVariantImage(_Build):
         """
         Return the path of the Qemu QCOW2 image from the meta-data
         """
+        qemu_meta = self.meta.get_artifact_meta("qemu", unmerged=True)
         qimage = os.path.join(
             self.build_dir,
-            self.meta.get('images', {}).get('qemu', {}).get('path', None)
+            qemu_meta.get('images', {}).get('qemu', {}).get('path', None)
         )
         if not qimage:
             raise ImageError("qemu image has not be built yet")

--- a/src/cosalib/qemuvariants.py
+++ b/src/cosalib/qemuvariants.py
@@ -306,4 +306,4 @@ class QemuVariantImage(_Build):
         img_meta = self.get_artifact_meta()
         self._found_files[self.image_name] = img_meta
         imgs[self.platform] = img_meta
-        self.meta_write()
+        self.meta_write(artifact_name=self.platform_image_name)

--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -231,7 +231,9 @@ else
     mkfs.xfs "${root_dev}" -L root -m reflink=1 -m uuid="${rootfs_uuid}"
 fi
 
-rootfs=$PWD/tmp/rootfs
+# since we normally run in supermin container and we need
+# support parallel runs, use /tmp
+rootfs=/tmp/rootfs
 
 # mount the partitions
 rm -rf ${rootfs}

--- a/tests/test_cosalib_cmdlib.py
+++ b/tests/test_cosalib_cmdlib.py
@@ -151,3 +151,39 @@ def test_image_info(tmpdir):
         '-o', 'force_size,subformat=fixed',
         f"{tmpdir}/test.vpc", "10M"])
     assert cmdlib.image_info(f"{tmpdir}/test.vpc").get('format') == "vpc"
+
+
+def test_merge_dicts(tmpdir):
+    x = {
+        1: "Nope",
+        2: ["a", "b", "c"],
+        3: {"3a": True}
+    }
+
+    y = {4: True}
+
+    z = {1: "yup",
+         3: {
+             "3a": False,
+             "3b": "found"
+            }
+    }
+
+    # merge y into x
+    m = cmdlib.merge_dicts(x, y)
+    for i in range(1, 4):
+        assert i in m
+    assert y[4] is True
+
+    # merge z into x
+    m = cmdlib.merge_dicts(x, z)
+    assert m[1] == "Nope"
+    assert x[2] == m[2]
+    assert m[3]["3a"] is True
+    assert m[3]["3b"] == "found"
+
+   # merge x into z
+    m = cmdlib.merge_dicts(z, x)
+    assert m[1] == "yup"
+    assert x[2] == m[2]
+    assert m[3] == z[3]


### PR DESCRIPTION
Instead of blindly overwriting meta.json, this adds support for merging
the on-disk version with the in-memory version.

`write_json` has been given a `merge_func` callback. This enables the lock to be held in one spot. `write_json` calls the `merge_func` with the on-disk version with the version being merged, preserving the lock. The version with the higher stamp is the base version for the merge. 

Partially Implements: cosa-20200805
https://github.com/coreos/enhancements/pull/2