### PR TITLE
cosalib/meta.py: reload meta.json after write

### DIFF
--- a/src/cosalib/meta.py
+++ b/src/cosalib/meta.py
@@ -79,6 +79,7 @@ class GenericBuildMeta(dict):
         if ts != self._initial_timestamp:
             raise Exception(f"Detected read-modify-write conflict, expected timestamp={self._initial_timestamp} found {ts}")
         write_json(self._meta_path, dict(self))
+        self.read()
 
     def get(self, *args):
         """


### PR DESCRIPTION
With c283ed580de12324b0e1135a0748d17ef66a73d8, writes meta.json are
guarded based on the time-stamp to prevent read-write-modify condtions.
It's likely safe to revert since production and developer pipelines do
no run in parallel or distributed mode, however this is a quick fix.

The WIP code on merging the meta.json does a reload from disk after
writing. To unblock production builds, adding the read after a write is
a quick fix.