### PR TITLE
Drop support for ignition-network-kcmdline

### DIFF
--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -143,18 +143,6 @@ if [ "${image_type}" = dasd ] || [ "${image_type}" = metal4k ]; then
     ignition_platform_id=metal
 fi
 
-# Firstboot kernel arguments.
-firstboot_kargs="$(python3 -c '
-import sys, yaml
-LEGACY_DEFAULT = [ "rd.neednet=1", "ip=dhcp,dhcp6" ]
-args = yaml.safe_load(sys.stdin).get("ignition-network-kcmdline", LEGACY_DEFAULT)
-if not args:
-  # False-y value provided, e.g. empty array.
-  print("", end = "")
-else:
-  print(" ".join(args), end = "")
-' < "$configdir/image.yaml")"
-
 # bootfs
 bootfs_type="$(python3 -c 'import sys, yaml; print(yaml.safe_load(sys.stdin).get("bootfs", "ext4"))' < "$configdir/image.yaml")"
 
@@ -259,7 +247,6 @@ runvm "${target_drive[@]}" -- \
             --buildid "${build}" \
             --imgid "${img}" \
             --grub-script /usr/lib/coreos-assembler/grub.cfg \
-            --firstboot-kargs "\"${firstboot_kargs}\"" \
             --kargs "\"${kargs}\"" \
             --osname "${name}" \
             --ostree-ref "${ref_arg}" \

--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -28,7 +28,6 @@ Options:
     --disk: disk device to use
     --buildid: buildid
     --imgid: imageid
-    --firstboot-kargs: kernel args to be used on firstboot
     --grub-script: grub script to install
     --help: show this helper
     --kargs: kernel CLI args
@@ -52,7 +51,6 @@ rootfs_size="0"
 boot_verity=0
 rootfs_type="xfs"
 x86_bios_partition=1
-firstboot_kargs=""
 extrakargs=""
 
 while [ $# -gt 0 ];
@@ -62,7 +60,6 @@ do
         --disk)                  disk="${1}"; shift;;
         --buildid)               buildid="${1}"; shift;;
         --imgid)                 imgid="${1}"; shift;;
-        --firstboot-kargs)       firstboot_kargs="${1}"; shift;;
         --grub-script)           grub_script="${1}"; shift;;
         --help)                  usage; exit;;
         --kargs)                 extrakargs="${extrakargs} ${1}"; shift;;
@@ -395,7 +392,7 @@ s390x)
 	# stage on s390x, either through zipl->grub2-emu or zipl standalone.
 	# See https://github.com/coreos/ignition-dracut/issues/84
 	# A similar hack is present in https://github.com/coreos/coreos-assembler/blob/master/src/gf-platformid#L55
-	echo "$(grep options $blsfile) ignition.firstboot ${firstboot_kargs}" > $tmpfile
+	echo "$(grep options $blsfile) ignition.firstboot" > $tmpfile
 
 	# ideally we want to invoke zipl with bls and zipl.conf but we might need
 	# to chroot to $rootfs/ to do so. We would also do that when FCOS boot on its own.
@@ -414,7 +411,7 @@ ostree config --repo $rootfs/ostree/repo set sysroot.bootloader "${bootloader_ba
 # https://github.com/ostreedev/ostree/issues/1265
 ostree config --repo $rootfs/ostree/repo set sysroot.readonly true
 
-echo "set ignition_network_kcmdline='${firstboot_kargs}'" > $rootfs/boot/ignition.firstboot
+touch $rootfs/boot/ignition.firstboot
 
 # Finally, add the immutable bit to the physical root; we don't
 # expect people to be creating anything there.  A use case for

--- a/src/gf-platformid
+++ b/src/gf-platformid
@@ -52,9 +52,7 @@ coreos_gf upload "${tmpd}"/bls.conf "${blscfg_path}"
 if [ "$basearch" = "s390x" ] ; then
     # Before we re-run zipl make sure we have the firstboot options
     # A hack similar to https://github.com/coreos/coreos-assembler/blob/master/src/create_disk.sh#L381
-    coreos_gf download /boot/ignition.firstboot "${tmpd}"/ignition.firstboot
-    IGN_NET_KARGS=$(sed 's/^set ignition_network_kcmdline=.\(.*\).$/\1/' "${tmpd}"/ignition.firstboot)
-    sed -i -e 's|^\(options .*\)|\1 ignition.firstboot '"${IGN_NET_KARGS}"'|' "${tmpd}"/bls.conf
+    sed -i -e 's|^\(options .*\)|\1 ignition.firstboot|' "${tmpd}"/bls.conf
     coreos_gf rename "${blscfg_path}" "${blscfg_path}.orig"
     coreos_gf upload "${tmpd}"/bls.conf "${blscfg_path}"
 


### PR DESCRIPTION
We've now reached the end of the conditional networking 🌈 rainbow 🌈.
We can rip out the legacy default network firstboot kargs from cosa.
These now live in the config repo. E.g.:

https://github.com/coreos/fedora-coreos-config/blob/be456c437d4181435022ce47079b587f5bcb0319/overlay.d/05core/usr/lib/dracut/modules.d/15coreos-network/50-afterburn-network-kargs-default.conf

For more details, see:
https://github.com/coreos/coreos-assembler/pull/1373
https://github.com/coreos/fedora-coreos-config/pull/426