### PR TITLE
schema: update for meta.json merging

### DIFF
--- a/mantle/cosa/cosa_v1.go
+++ b/mantle/cosa/cosa_v1.go
@@ -36,6 +36,7 @@ type Build struct {
 	ContainerConfigGit        *Git                  `json:"coreos-assembler.container-config-git,omitempty"`
 	CoreOsSource              string                `json:"coreos-assembler.code-source,omitempty"`
 	CosaContainerImageGit     *Git                  `json:"coreos-assembler.container-image-git,omitempty"`
+	CosaDelayedMetaMerge      bool                  `json:"coreos-assembler.delayed-meta-merge,omitempty"`
 	CosaImageChecksum         string                `json:"coreos-assembler.image-config-checksum,omitempty"`
 	CosaImageVersion          int                   `json:"coreos-assembler.image-genver,omitempty"`
 	FedoraCoreOsParentCommit  string                `json:"fedora-coreos.parent-commit,omitempty"`
@@ -44,6 +45,7 @@ type Build struct {
 	GitDirty                  string                `json:"coreos-assembler.config-dirty,omitempty"`
 	ImageInputChecksum        string                `json:"coreos-assembler.image-input-checksum,omitempty"`
 	InputHasOfTheRpmOstree    string                `json:"rpm-ostree-inputhash"`
+	MetaStamp                 float64               `json:"coreos-assembler.meta-stamp,omitempty"`
 	Name                      string                `json:"name"`
 	Oscontainer               *Image                `json:"oscontainer,omitempty"`
 	OstreeCommit              string                `json:"ostree-commit"`

--- a/mantle/cosa/schema_doc.go
+++ b/mantle/cosa/schema_doc.go
@@ -196,9 +196,11 @@ var generatedSchemaJSON = `{
    "coreos-assembler.config-gitrev",
    "coreos-assembler.container-config-git",
    "coreos-assembler.container-image-git",
+   "coreos-assembler.delayed-meta-merge",
    "coreos-assembler.image-config-checksum",
    "coreos-assembler.image-genver",
    "coreos-assembler.image-input-checksum",
+   "coreos-assembler.meta-stamp",
    "coreos-assembler.overrides-active",
    "fedora-coreos.parent-commit",
    "fedora-coreos.parent-version",
@@ -273,6 +275,19 @@ var generatedSchemaJSON = `{
      "type":"object",
      "title":"COSA Container Image Git",
      "$ref": "#/definitions/git"
+    },
+   "coreos-assembler.delayed-meta-merge": {
+     "$id":"#/properties/coreos-assembler.delayed-meta-merge",
+     "type":"boolean",
+     "title":"COSA Delayed Meta Merge",
+     "default": "False"
+    },
+   "coreos-assembler.meta-stamp": {
+     "$id":"#/properties/coreos-assembler.meta-stamp",
+     "type":"number",
+     "title":"Meta Stamp",
+     "default":"",
+     "minLength": 16
     },
     "fedora-coreos.parent-version": {
      "$id":"#/properties/fedora-coreos.parent-version",

--- a/src/schema/v1.json
+++ b/src/schema/v1.json
@@ -191,9 +191,11 @@
    "coreos-assembler.config-gitrev",
    "coreos-assembler.container-config-git",
    "coreos-assembler.container-image-git",
+   "coreos-assembler.delayed-meta-merge",
    "coreos-assembler.image-config-checksum",
    "coreos-assembler.image-genver",
    "coreos-assembler.image-input-checksum",
+   "coreos-assembler.meta-stamp",
    "coreos-assembler.overrides-active",
    "fedora-coreos.parent-commit",
    "fedora-coreos.parent-version",
@@ -268,6 +270,19 @@
      "type":"object",
      "title":"COSA Container Image Git",
      "$ref": "#/definitions/git"
+    },
+   "coreos-assembler.delayed-meta-merge": {
+     "$id":"#/properties/coreos-assembler.delayed-meta-merge",
+     "type":"boolean",
+     "title":"COSA Delayed Meta Merge",
+     "default": "False"
+    },
+   "coreos-assembler.meta-stamp": {
+     "$id":"#/properties/coreos-assembler.meta-stamp",
+     "type":"number",
+     "title":"Meta Stamp",
+     "default":"",
+     "minLength": 16
     },
     "fedora-coreos.parent-version": {
      "$id":"#/properties/fedora-coreos.parent-version",


### PR DESCRIPTION
Added two new keys to the schema:
- coreos-assembler.meta-stamp: to version meta.json
- coroes-assembler.delayed-meta-merge: boolean for determining when
        and if meta.json should be written to artifacted paths.

Break out from 
https://github.com/coreos/coreos-assembler/pull/1675

Partially Implements: cosa-20200805
https://github.com/coreos/enhancements#2