### PR TITLE
kola: Don't special case "one executable in directory"

### DIFF
--- a/mantle/kola/README-kola-ext.md
+++ b/mantle/kola/README-kola-ext.md
@@ -35,8 +35,11 @@ Concretely then, an external test directory can have the following content:
 - one or more executables: Each executable is its own test, run independently
   with the Ignition config and/or dependency data provided.
 
-In the case of a test directory with a single executable, the kola test name will be
-`ext.<projname>.<subdirectory>`.  Otherwise, the test will be named `ext.<projname>.<subdirectory>.<executable>`.
+Normally the test will be named `ext.<projname>.<subdirectory>.<executable>`.
+However there is a special case to make it nicer to test Ignition configs;
+In the case of a test directory with a single executable named `test.sh`,
+the kola test name will be `ext.<projname>.<subdirectory>` (i.e. `test.sh`
+will be omitted).
 
 Currently the test systemd unit runs with full privileges - tests
 are assumed to be (potentially) destructive and a general assumption

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -65,6 +65,10 @@ import (
 const InstalledTestsDir = "/usr/lib/coreos-assembler/tests/kola"
 const InstalledTestMetaPrefix = "# kola:"
 
+// InstalledTestDefaultTest is a special name; see the README-kola-ext.md
+// for more information.
+const InstalledTestDefaultTest = "test.sh"
+
 // This is the same string from https://salsa.debian.org/ci-team/autopkgtest/raw/master/doc/README.package-tests.rst
 // Specifying this in the tags list is required to denote a need for Internet access
 const NeedsInternetTag = "needs-internet"
@@ -776,7 +780,7 @@ func registerTestDir(dir, testprefix string, children []os.FileInfo) error {
 
 	for _, executable := range executables {
 		testname := testprefix
-		if len(executables) > 1 {
+		if len(executables) > 1 || executable != InstalledTestDefaultTest {
 			testname = fmt.Sprintf("%s.%s", testname, filepath.Base(executable))
 		}
 		err := registerExternalTest(testname, executable, dependencydir, ignition, meta)


### PR DESCRIPTION
If the user adds a subdirectory they are doing it for a reason, and
it's confusing to omit the name of the executable.
I forget now why we were even special casing this in the first place.