### PR TITLE
mantle/kola: increase log lines printed when exttest fails

### DIFF
--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -671,7 +671,7 @@ ExecStart=%s
 
 			err := runExternalTest(c, mach)
 			if err != nil {
-				out, stderr, suberr := mach.SSH(fmt.Sprintf("sudo systemctl status %s", shellquote.Join(KoletExtTestUnit)))
+				out, stderr, suberr := mach.SSH(fmt.Sprintf("sudo systemctl status --lines=40 %s", shellquote.Join(KoletExtTestUnit)))
 				if len(out) > 0 {
 					fmt.Printf("systemctl status %s:\n%s\n", KoletExtTestUnit, string(out))
 				} else {


### PR DESCRIPTION
Move from 10 (default) to 40.