### PR TITLE
mantle & kola: Full ignition spec 3.1.0 support

### DIFF
--- a/mantle/cmd/kola/kola.go
+++ b/mantle/cmd/kola/kola.go
@@ -26,8 +26,6 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	ignconverter "github.com/coreos/ign-converter/translate/v30tov22"
-	ignv3 "github.com/coreos/ignition/v2/config/v3_0"
 	"github.com/coreos/pkg/capnslog"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -37,6 +35,7 @@ import (
 	"github.com/coreos/mantle/fcos"
 	"github.com/coreos/mantle/kola"
 	"github.com/coreos/mantle/kola/register"
+	"github.com/coreos/mantle/platform/conf"
 	"github.com/coreos/mantle/sdk"
 	"github.com/coreos/mantle/system"
 	"github.com/coreos/mantle/util"
@@ -463,24 +462,12 @@ func runIgnitionConvert2(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	ignc3, _, err := ignv3.Parse(buf)
+	config, err := conf.Ignition(string(buf)).Render("", true)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "could not convert the given config to spec 2")
 	}
-	ignc2, err := ignconverter.Translate(ignc3)
-	if err != nil {
-		return err
-	}
-	obuf, err := json.Marshal(ignc2)
-	if err != nil {
-		return err
-	}
-	_, err = os.Stdout.Write(obuf)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	_, err = os.Stdout.Write([]byte(config.String()))
+	return err
 }
 
 func runArtifactIgnitionVersion(cmd *cobra.Command, args []string) error {

--- a/mantle/cmd/kola/qemuexec.go
+++ b/mantle/cmd/kola/qemuexec.go
@@ -134,6 +134,9 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	if directIgnition && ignition == "" {
+		return fmt.Errorf("Cannot use ignition-direct without a path to an Ignition config")
+	}
 	if !directIgnition {
 		if ignition == "" {
 			config, err = conf.Ignition("").Render("", kola.IsIgnitionV2())

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -223,6 +223,12 @@ func NewFlight(pltfrm string) (flight platform.Flight, err error) {
 	return
 }
 
+// IsIgnitionV2 returns true if Ignition spec 2 support was asked on the command
+// line.
+func IsIgnitionV2() bool {
+	return Options.IgnitionVersion == "v2"
+}
+
 // matchesPatterns returns true if `s` matches one of the patterns in `patterns`.
 func matchesPatterns(s string, patterns []string) (bool, error) {
 	for _, pattern := range patterns {
@@ -629,7 +635,7 @@ func runExternalTest(c cluster.TestCluster, mach platform.Machine) error {
 }
 
 func registerExternalTest(testname, executable, dependencydir, ignition string, baseMeta externalTestMeta) error {
-	config, err := conf.Ignition(ignition).Render("", Options.IgnitionVersion == "v2")
+	config, err := conf.Ignition(ignition).Render("", IsIgnitionV2())
 	if err != nil {
 		return errors.Wrapf(err, "Parsing config.ign")
 	}
@@ -902,7 +908,7 @@ func runTest(h *harness.H, t *register.Test, pltfrm string, flight platform.Flig
 
 	if t.ClusterSize > 0 {
 		var userdata *conf.UserData
-		if Options.IgnitionVersion == "v2" && t.UserData != nil {
+		if IsIgnitionV2() && t.UserData != nil {
 			userdata = t.UserData
 		} else {
 			userdata = t.UserDataV3

--- a/mantle/platform/conf/conf.go
+++ b/mantle/platform/conf/conf.go
@@ -1118,8 +1118,8 @@ func getAutologinUnit(name, args string) string {
 
 // AddAutoLogin adds an Ignition config for automatic login on consoles
 func (c *Conf) AddAutoLogin() {
-	c.AddSystemdUnit("getty@.service", getAutologinUnit("getty@.service", "--noclear"), Enable)
-	c.AddSystemdUnit("serial-getty@.service", getAutologinUnit("serial-getty@.service", "--keep-baud 115200,38400,9600"), Enable)
+	c.AddSystemdUnitDropin("getty@.service", "10-autologin.conf", getAutologinUnit("getty@.service", "--noclear"))
+	c.AddSystemdUnitDropin("serial-getty@.service", "10-autologin.conf", getAutologinUnit("serial-getty@.service", "--keep-baud 115200,38400,9600"))
 }
 
 func getAutologinFragment(name, args string) v3types.Unit {

--- a/mantle/platform/conf/conf.go
+++ b/mantle/platform/conf/conf.go
@@ -918,7 +918,7 @@ func (c *Conf) AddSystemdUnitDropin(service, name, contents string) {
 	}
 }
 
-func (c *Conf) AddAuthorizedKeysV2(username string, keys []string) {
+func (c *Conf) addAuthorizedKeysV2(username string, keys []string) {
 	for i := range c.ignitionV2.Passwd.Users {
 		user := &c.ignitionV2.Passwd.Users[i]
 		if user.Name == username {
@@ -932,7 +932,7 @@ func (c *Conf) AddAuthorizedKeysV2(username string, keys []string) {
 	})
 }
 
-func (c *Conf) AddAuthorizedKeysV21(username string, keys []string) {
+func (c *Conf) addAuthorizedKeysV21(username string, keys []string) {
 	var keyObjs []v21types.SSHAuthorizedKey
 	for _, key := range keys {
 		keyObjs = append(keyObjs, v21types.SSHAuthorizedKey(key))
@@ -950,7 +950,7 @@ func (c *Conf) AddAuthorizedKeysV21(username string, keys []string) {
 	})
 }
 
-func (c *Conf) AddAuthorizedKeysV22(username string, keys []string) {
+func (c *Conf) addAuthorizedKeysV22(username string, keys []string) {
 	var keyObjs []v22types.SSHAuthorizedKey
 	for _, key := range keys {
 		keyObjs = append(keyObjs, v22types.SSHAuthorizedKey(key))
@@ -968,7 +968,7 @@ func (c *Conf) AddAuthorizedKeysV22(username string, keys []string) {
 	})
 }
 
-func (c *Conf) AddAuthorizedKeysV23(username string, keys []string) {
+func (c *Conf) addAuthorizedKeysV23(username string, keys []string) {
 	var keyObjs []v23types.SSHAuthorizedKey
 	for _, key := range keys {
 		keyObjs = append(keyObjs, v23types.SSHAuthorizedKey(key))
@@ -986,7 +986,7 @@ func (c *Conf) AddAuthorizedKeysV23(username string, keys []string) {
 	})
 }
 
-func (c *Conf) AddAuthorizedKeysV24(username string, keys []string) {
+func (c *Conf) addAuthorizedKeysV24(username string, keys []string) {
 	var keyObjs []v24types.SSHAuthorizedKey
 	for _, key := range keys {
 		keyObjs = append(keyObjs, v24types.SSHAuthorizedKey(key))
@@ -1004,7 +1004,7 @@ func (c *Conf) AddAuthorizedKeysV24(username string, keys []string) {
 	})
 }
 
-func (c *Conf) AddAuthorizedKeysV3(username string, keys []string) {
+func (c *Conf) addAuthorizedKeysV3(username string, keys []string) {
 	var keyObjs []v3types.SSHAuthorizedKey
 	for _, key := range keys {
 		keyObjs = append(keyObjs, v3types.SSHAuthorizedKey(key))
@@ -1025,7 +1025,7 @@ func (c *Conf) AddAuthorizedKeysV3(username string, keys []string) {
 	c.MergeV3(newConfig)
 }
 
-func (c *Conf) AddAuthorizedKeysV31(username string, keys []string) {
+func (c *Conf) addAuthorizedKeysV31(username string, keys []string) {
 	var keyObjs []v31types.SSHAuthorizedKey
 	for _, key := range keys {
 		keyObjs = append(keyObjs, v31types.SSHAuthorizedKey(key))
@@ -1046,7 +1046,7 @@ func (c *Conf) AddAuthorizedKeysV31(username string, keys []string) {
 	c.MergeV31(newConfig)
 }
 
-func (c *Conf) AddAuthorizedKeysV32exp(username string, keys []string) {
+func (c *Conf) addAuthorizedKeysV32exp(username string, keys []string) {
 	var keyObjs []v32exptypes.SSHAuthorizedKey
 	for _, key := range keys {
 		keyObjs = append(keyObjs, v32exptypes.SSHAuthorizedKey(key))
@@ -1071,21 +1071,21 @@ func (c *Conf) AddAuthorizedKeysV32exp(username string, keys []string) {
 // authorized_keys file for the given user.
 func (c *Conf) AddAuthorizedKeys(user string, keys []string) {
 	if c.ignitionV2 != nil {
-		c.AddAuthorizedKeysV2(user, keys)
+		c.addAuthorizedKeysV2(user, keys)
 	} else if c.ignitionV21 != nil {
-		c.AddAuthorizedKeysV21(user, keys)
+		c.addAuthorizedKeysV21(user, keys)
 	} else if c.ignitionV22 != nil {
-		c.AddAuthorizedKeysV22(user, keys)
+		c.addAuthorizedKeysV22(user, keys)
 	} else if c.ignitionV23 != nil {
-		c.AddAuthorizedKeysV23(user, keys)
+		c.addAuthorizedKeysV23(user, keys)
 	} else if c.ignitionV24 != nil {
-		c.AddAuthorizedKeysV24(user, keys)
+		c.addAuthorizedKeysV24(user, keys)
 	} else if c.ignitionV3 != nil {
-		c.AddAuthorizedKeysV3(user, keys)
+		c.addAuthorizedKeysV3(user, keys)
 	} else if c.ignitionV31 != nil {
-		c.AddAuthorizedKeysV31(user, keys)
+		c.addAuthorizedKeysV31(user, keys)
 	} else if c.ignitionV32exp != nil {
-		c.AddAuthorizedKeysV32exp(user, keys)
+		c.addAuthorizedKeysV32exp(user, keys)
 	}
 }
 

--- a/mantle/platform/conf/conf.go
+++ b/mantle/platform/conf/conf.go
@@ -1099,6 +1099,139 @@ func (c *Conf) CopyKeys(keys []*agent.Key) {
 	c.AddAuthorizedKeys("core", keyStrs)
 }
 
+func (c *Conf) addConfigSourceV2(source string) {
+	url, err := url.Parse(source)
+	if err != nil {
+		panic(err)
+	}
+	c.ignitionV2.Ignition.Config.Append = append(c.ignitionV2.Ignition.Config.Append, v2types.ConfigReference{
+		Source: v2types.Url(*url),
+		Verification: v2types.Verification{
+			Hash: nil,
+		},
+	})
+}
+
+func (c *Conf) addConfigSourceV21(source string) {
+	c.ignitionV21.Ignition.Config.Append = append(c.ignitionV21.Ignition.Config.Append, v21types.ConfigReference{
+		Source: source,
+		Verification: v21types.Verification{
+			Hash: nil,
+		},
+	})
+}
+
+func (c *Conf) addConfigSourceV22(source string) {
+	c.ignitionV22.Ignition.Config.Append = append(c.ignitionV22.Ignition.Config.Append, v22types.ConfigReference{
+		Source: source,
+		Verification: v22types.Verification{
+			Hash: nil,
+		},
+	})
+}
+
+func (c *Conf) addConfigSourceV23(source string) {
+	c.ignitionV23.Ignition.Config.Append = append(c.ignitionV23.Ignition.Config.Append, v23types.ConfigReference{
+		Source: source,
+		Verification: v23types.Verification{
+			Hash: nil,
+		},
+	})
+}
+
+func (c *Conf) addConfigSourceV24(source string) {
+	var headers []v24types.HTTPHeader
+	c.ignitionV24.Ignition.Config.Append = append(c.ignitionV24.Ignition.Config.Append, v24types.ConfigReference{
+		HTTPHeaders: headers,
+		Source:      source,
+		Verification: v24types.Verification{
+			Hash: nil,
+		},
+	})
+}
+
+func (c *Conf) addConfigSourceV3(source string) {
+	newConfig := v3types.Config{
+		Ignition: v3types.Ignition{
+			Version: "3.0.0",
+			Config: v3types.IgnitionConfig{
+				Merge: []v3types.ConfigReference{
+					v3types.ConfigReference{
+						Source: &source,
+					},
+				},
+			},
+		},
+	}
+	c.MergeV3(newConfig)
+}
+
+func (c *Conf) addConfigSourceV31(source string) {
+	var resources []v31types.Resource
+	var headers []v31types.HTTPHeader
+	resources = append(resources, v31types.Resource{
+		Compression: nil,
+		HTTPHeaders: headers,
+		Source:      &source,
+		Verification: v31types.Verification{
+			Hash: nil,
+		},
+	})
+	newConfig := v31types.Config{
+		Ignition: v31types.Ignition{
+			Version: "3.1.0",
+			Config: v31types.IgnitionConfig{
+				Merge: resources,
+			},
+		},
+	}
+	c.MergeV31(newConfig)
+}
+
+func (c *Conf) addConfigSourceV32exp(source string) {
+	var resources []v32exptypes.Resource
+	var headers []v32exptypes.HTTPHeader
+	resources = append(resources, v32exptypes.Resource{
+		Compression: nil,
+		HTTPHeaders: headers,
+		Source:      &source,
+		Verification: v32exptypes.Verification{
+			Hash: nil,
+		},
+	})
+	newConfig := v32exptypes.Config{
+		Ignition: v32exptypes.Ignition{
+			Version: "3.2.0-experimental",
+			Config: v32exptypes.IgnitionConfig{
+				Merge: resources,
+			},
+		},
+	}
+	c.MergeV32exp(newConfig)
+}
+
+// AddConfigSource adds an Ignition config to append (v2) or merge (v3) the
+// config available at the `source` URL with the current config.
+func (c *Conf) AddConfigSource(source string) {
+	if c.ignitionV2 != nil {
+		c.addConfigSourceV2(source)
+	} else if c.ignitionV21 != nil {
+		c.addConfigSourceV21(source)
+	} else if c.ignitionV22 != nil {
+		c.addConfigSourceV22(source)
+	} else if c.ignitionV23 != nil {
+		c.addConfigSourceV23(source)
+	} else if c.ignitionV24 != nil {
+		c.addConfigSourceV24(source)
+	} else if c.ignitionV3 != nil {
+		c.addConfigSourceV3(source)
+	} else if c.ignitionV31 != nil {
+		c.addConfigSourceV31(source)
+	} else if c.ignitionV32exp != nil {
+		c.addConfigSourceV32exp(source)
+	}
+}
+
 // IsIgnition returns true if the config is for Ignition.
 // Returns false in the case of empty configs
 func (c *Conf) IsIgnition() bool {

--- a/mantle/platform/conf/conf.go
+++ b/mantle/platform/conf/conf.go
@@ -92,12 +92,16 @@ type Conf struct {
 	ignitionV32exp *v32exptypes.Config
 }
 
+// Empty creates a completely empty configuration. Any configuration addition
+// applied to an empty config triggers a panic.
 func Empty() *UserData {
 	return &UserData{
 		kind: kindEmpty,
 	}
 }
 
+// ContainerLinuxConfig creates a Container Linux Config Userdata struct from
+// the provided string.
 func ContainerLinuxConfig(data string) *UserData {
 	return &UserData{
 		kind: kindContainerLinuxConfig,
@@ -596,6 +600,8 @@ func (c *Conf) AddFile(path, filesystem, contents string, mode int) {
 		c.addFileV23(path, filesystem, contents, mode)
 	} else if c.ignitionV24 != nil {
 		c.addFileV24(path, filesystem, contents, mode)
+	} else {
+		panic("Could not find a supported Ignition config version")
 	}
 }
 
@@ -725,6 +731,8 @@ func (c *Conf) AddSystemdUnit(name, contents string, state systemdUnitState) {
 		c.addSystemdUnitV31(name, contents, enable, mask)
 	} else if c.ignitionV32exp != nil {
 		c.addSystemdUnitV32exp(name, contents, enable, mask)
+	} else {
+		panic("Could not find a supported Ignition config version")
 	}
 }
 
@@ -921,6 +929,8 @@ func (c *Conf) AddSystemdUnitDropin(service, name, contents string) {
 		c.addSystemdDropinV31(service, name, contents)
 	} else if c.ignitionV32exp != nil {
 		c.addSystemdDropinV32exp(service, name, contents)
+	} else {
+		panic("Could not find a supported Ignition config version")
 	}
 }
 
@@ -1092,6 +1102,8 @@ func (c *Conf) AddAuthorizedKeys(user string, keys []string) {
 		c.addAuthorizedKeysV31(user, keys)
 	} else if c.ignitionV32exp != nil {
 		c.addAuthorizedKeysV32exp(user, keys)
+	} else {
+		panic("Could not find a supported Ignition config version")
 	}
 }
 
@@ -1235,6 +1247,8 @@ func (c *Conf) AddConfigSource(source string) {
 		c.addConfigSourceV31(source)
 	} else if c.ignitionV32exp != nil {
 		c.addConfigSourceV32exp(source)
+	} else {
+		panic("Could not find a supported Ignition config version")
 	}
 }
 

--- a/mantle/platform/conf/conf.go
+++ b/mantle/platform/conf/conf.go
@@ -105,7 +105,13 @@ func ContainerLinuxConfig(data string) *UserData {
 	}
 }
 
+// Ignition returns an Ignition UserData struct from the provided string. If the
+// given string is empty, it will create a default empty config using the latest
+// stable supported Ignition spec.
 func Ignition(data string) *UserData {
+	if data == "" {
+		data = `{"ignition": {"version": "3.1.0"}}`
+	}
 	return &UserData{
 		kind: kindIgnition,
 		data: data,


### PR DESCRIPTION
Second part of Ignition spec 3.1.0 support for mantle & kola.

This makes most Ignition config handling independent of the config spec version.

Fixes: https://github.com/coreos/coreos-assembler/issues/1430