### PR TITLE
build: Make sure error message is last if we fail buildextend

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -112,7 +112,9 @@ done
 build_followup_targets() {
     cd "${workdir}"
     for target in "${!targets[@]}"; do
-        "/usr/lib/coreos-assembler/cmd-buildextend-${target}"
+        if ! "/usr/lib/coreos-assembler/cmd-buildextend-${target}"; then
+            fatal "failed buildextend-${target}"
+        fi
     done
 }
 


### PR DESCRIPTION
Currently we print the "cleanup rm -rf" messages as the last
thing, meaning that one has to read back a few lines to
see that there's an error message.

That's still the case, but now it's more obvious that one should
look for it.  I'd spent a minute being confused why my changes
weren't appearing before figuring out that the build had failed.

(My shell prompt does display the prior command's exit status in
 red if it failed but I need to make that more prominent too)