### PR TITLE
 create_disk: Use bootupd to install uefi if configured

### DIFF
--- a/src/vmdeps-aarch64.txt
+++ b/src/vmdeps-aarch64.txt
@@ -1,5 +1,6 @@
 # For grub install when creating images and pxe install
 grub2 grub2-tools-extra
+bootupd
 
 # For creating bootable UEFI media on aarch64
 shim-aa64 grub2-efi-aa64

--- a/src/vmdeps-x86_64.txt
+++ b/src/vmdeps-x86_64.txt
@@ -1,5 +1,6 @@
 # For grub install when creating images without anaconda
 grub2
+bootupd
 
 # For creating bootable UEFI media on x86_64
 shim-x64 grub2-efi-x64


### PR DESCRIPTION

See https://github.com/coreos/bootupd
and coreos/fedora-coreos-tracker#510

Basically in order to handle *updates*, bootupd also
takes care of installation.  For example this also generates a JSON
file with the versions.

In order to sanely "ratchet" this change, only use bootupd if
we find the ostree deployment is using it.