### PR TITLE
mantle: Avoid two empty string `""` in most Ignition calls

### DIFF
--- a/mantle/cmd/kola/kola.go
+++ b/mantle/cmd/kola/kola.go
@@ -462,7 +462,7 @@ func runIgnitionConvert2(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	config, err := conf.Ignition(string(buf)).Render("", true)
+	config, err := conf.Ignition(string(buf)).Render(true)
 	if err != nil {
 		return errors.Wrapf(err, "could not convert the given config to spec 2")
 	}

--- a/mantle/cmd/kola/qemuexec.go
+++ b/mantle/cmd/kola/qemuexec.go
@@ -139,7 +139,7 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 	}
 	if !directIgnition {
 		if ignition == "" {
-			config, err = conf.Ignition("").Render("", kola.IsIgnitionV2())
+			config, err = conf.EmptyIgnition().Render(kola.IsIgnitionV2())
 			if err != nil {
 				return errors.Wrapf(err, "creating empty config")
 			}
@@ -148,7 +148,7 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 			if err != nil {
 				return err
 			}
-			config, err = conf.Ignition(string(buf)).Render("", kola.IsIgnitionV2())
+			config, err = conf.Ignition(string(buf)).Render(kola.IsIgnitionV2())
 			if err != nil {
 				return errors.Wrapf(err, "parsing %s", ignition)
 			}

--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -193,7 +193,7 @@ func newQemuBuilder(isPXE bool, outdir string) (*platform.QemuBuilder, *conf.Con
 	if !builder.InheritConsole {
 		builder.ConsoleToFile(filepath.Join(outdir, "console.txt"))
 	}
-	config, err := conf.Ignition("").Render("", kola.IsIgnitionV2())
+	config, err := conf.EmptyIgnition().Render(kola.IsIgnitionV2())
 	if err != nil {
 		return nil, nil, err
 	}

--- a/mantle/cmd/ore/do/create-image.go
+++ b/mantle/cmd/ore/do/create-image.go
@@ -195,7 +195,7 @@ systemd:
         WantedBy=multi-user.target
 `, imageURL)
 
-	conf, err := conf.ContainerLinuxConfig(clc).Render(ctplatform.DO, false)
+	conf, err := conf.ContainerLinuxConfig(clc).RenderForCtPlatform(false, ctplatform.DO)
 	if err != nil {
 		return "", fmt.Errorf("Couldn't render userdata: %v", err)
 	}

--- a/mantle/cmd/ore/packet/create-device.go
+++ b/mantle/cmd/ore/packet/create-device.go
@@ -63,7 +63,7 @@ func runCreateDevice(cmd *cobra.Command, args []string) error {
 		}
 		userdata = conf.Unknown(string(data))
 	}
-	conf, err := userdata.Render(ctplatform.Packet, false)
+	conf, err := userdata.RenderForCtPlatform(false, ctplatform.Packet)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Couldn't parse userdata file %v: %v\n", userDataPath, err)
 		os.Exit(1)

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -639,7 +639,7 @@ func runExternalTest(c cluster.TestCluster, mach platform.Machine) error {
 }
 
 func registerExternalTest(testname, executable, dependencydir, ignition string, baseMeta externalTestMeta) error {
-	config, err := conf.Ignition(ignition).Render("", IsIgnitionV2())
+	config, err := conf.Ignition(ignition).Render(IsIgnitionV2())
 	if err != nil {
 		return errors.Wrapf(err, "Parsing config.ign")
 	}

--- a/mantle/kola/tests/ignition/qemufailure.go
+++ b/mantle/kola/tests/ignition/qemufailure.go
@@ -46,7 +46,7 @@ func runIgnitionFailure(c cluster.TestCluster) {
 func ignitionFailure(c cluster.TestCluster) error {
 	// We can't create files in / due to the immutable bit OSTree creates, so
 	// this is a convenient way to test Ignition failure.
-	failConfig, err := conf.Ignition("").Render("", kola.IsIgnitionV2())
+	failConfig, err := conf.EmptyIgnition().Render(kola.IsIgnitionV2())
 	if err != nil {
 		return errors.Wrapf(err, "creating empty config")
 	}

--- a/mantle/platform/cluster.go
+++ b/mantle/platform/cluster.go
@@ -198,7 +198,7 @@ func (bc *BaseCluster) RenderUserData(userdata *platformConf.UserData, ignitionV
 		}
 	}
 
-	conf, err := userdata.Render(bc.bf.ctPlatform, bc.IgnitionVersion() == "v2")
+	conf, err := userdata.RenderForCtPlatform(bc.IgnitionVersion() == "v2", bc.bf.ctPlatform)
 	if err != nil {
 		return nil, err
 	}

--- a/mantle/platform/conf/conf.go
+++ b/mantle/platform/conf/conf.go
@@ -109,6 +109,12 @@ func ContainerLinuxConfig(data string) *UserData {
 	}
 }
 
+// EmptyIgnition returns an a default empty config using the latest
+// stable supported Ignition spec.
+func EmptyIgnition() *UserData {
+	return Ignition("")
+}
+
 // Ignition returns an Ignition UserData struct from the provided string. If the
 // given string is empty, it will create a default empty config using the latest
 // stable supported Ignition spec.
@@ -171,7 +177,13 @@ func (u *UserData) IsIgnitionCompatible() bool {
 
 // Render parses userdata and returns a new Conf. It returns an error if the
 // userdata can't be parsed.
-func (u *UserData) Render(ctPlatform string, ignv2 bool) (*Conf, error) {
+func (u *UserData) Render(ignv2 bool) (*Conf, error) {
+	return u.RenderForCtPlatform(ignv2, "")
+}
+
+// RenderForCtPlatform parses userdata and returns a new Conf. It returns an error if the
+// userdata can't be parsed.
+func (u *UserData) RenderForCtPlatform(ignv2 bool, ctPlatform string) (*Conf, error) {
 	c := &Conf{}
 
 	renderIgnition := func() error {

--- a/mantle/platform/conf/conf_test.go
+++ b/mantle/platform/conf/conf_test.go
@@ -42,7 +42,7 @@ func TestConfCopyKey(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		conf, err := tt.Render("", false)
+		conf, err := tt.Render(false)
 		if err != nil {
 			t.Errorf("failed to parse config %d: %v", i, err)
 			continue

--- a/mantle/platform/metal.go
+++ b/mantle/platform/metal.go
@@ -592,7 +592,7 @@ func (inst *Install) InstallViaISOEmbed(kargs []string, liveIgnition, targetIgni
 
 		// TODO also use https://github.com/coreos/coreos-installer/issues/118#issuecomment-585572952
 		// when it arrives
-		targetConfig, err := conf.Ignition("").Render("", inst.IgnitionSpec2)
+		targetConfig, err := conf.EmptyIgnition().Render(inst.IgnitionSpec2)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Seeing the two `""` in most of our calls like
`conf.Ignition("").Render("", kola.IsIgnitionV2())`
felt confusing - I had to go look up what those strings meant.

For the `Render()` case the main reason we're still carrying
some CL code is because some of the tests we'd eventually
like to port still refer to it.  But we're not actually
using it, so split off a separate API for the unusual case.

And make an `EmptyIgnition()` API instead of providing the empty
string.