### PR TITLE
Make success/failure even more obvious

### DIFF
--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -94,7 +94,7 @@ if [ -e "${build_semaphore}" ]; then
     fatal "${build_semaphore} found: another process is building ${image_type}"
 fi
 touch "${build_semaphore}"
-trap 'rm -rvf ${build_semaphore}' EXIT
+trap 'rm -rf ${build_semaphore}' EXIT
 
 # check if the image already exists in the meta.json
 meta_img=$(meta_key "images.${image_type}.path")
@@ -297,5 +297,8 @@ json.dump(j, sys.stdout, indent=4)
 cosa meta --workdir "${workdir}" --build "${build}" --artifact "${image_type}" --artifact-json "$(readlink -f meta.json.new)"
 /usr/lib/coreos-assembler/finalize-artifact "${img}" "${builddir}/${img}"
 
+# Quiet for the rest of this so the last thing we see is a success message
+set +x
 # clean up the tmpild
 rm -rf "${tmp_builddir}"
+echo "Successfully generated: ${img}"

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -22,7 +22,12 @@ info() {
 }
 
 fatal() {
-    echo "fatal: $*" 1>&2; exit 1
+    if test -t 1; then
+        echo "$(tput setaf 1)fatal:$(tput sgr0) $*" 1>&2
+    else
+        echo "fatal: $*" 1>&2
+    fi
+    exit 1
 }
 
 # Get target base architecture


### PR DESCRIPTION
Followup to previous PR; change things so that on a successful
image build the last thing we see is e.g.:
`Successfully generated: fedora-coreos-32.20200903.dev.0-7-qemu.x86_64.qcow2`

And if we're on a tty, color the `fatal:` text red.