### PR TITLE
kola: use filepath.Base() for `test.sh` special-case

### DIFF
--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -786,7 +786,7 @@ func registerTestDir(dir, testprefix string, children []os.FileInfo) error {
 
 	for _, executable := range executables {
 		testname := testprefix
-		if len(executables) > 1 || executable != InstalledTestDefaultTest {
+		if len(executables) > 1 || filepath.Base(executable) != InstalledTestDefaultTest {
 			testname = fmt.Sprintf("%s.%s", testname, filepath.Base(executable))
 		}
 		err := registerExternalTest(testname, executable, dependencydir, ignition, meta)


### PR DESCRIPTION
Follow-up to #1684.