### PR TITLE
build: Switch to python3

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -402,7 +402,7 @@ cat > tmp/buildmeta.json <<EOF
  "coreos-assembler.image-input-checksum": "${image_input_checksum}",
  "coreos-assembler.code-source": "${src_location}",
  "coreos-assembler.container-config-git": $(jq -M '.git' ${PWD}/coreos-assembler-config-git.json),
- "coreos-assembler.meta-stamp": $(python -c 'import time; print(time.time_ns())'),
+ "coreos-assembler.meta-stamp": $(python3 -c 'import time; print(time.time_ns())'),
  "coreos-assembler.delayed-meta-merge": ${DELAY_META_MERGE}
 }
 EOF


### PR DESCRIPTION
I made a f33 toolbox container and this fell over because
it didn't include python 2.  This was the only thing that
needed changing at least to `cosa build`.