### PR TITLE
platform/qemu: wire waiting methods via a context tree

### DIFF
--- a/mantle/cmd/kola/devshell.go
+++ b/mantle/cmd/kola/devshell.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -88,7 +89,7 @@ func displaySerialMsg(serialMsg string) {
 	fmt.Printf("\033[2K\r%s", stripControlCharacters(s))
 }
 
-func runDevShellSSH(builder *platform.QemuBuilder, conf *conf.Conf) error {
+func runDevShellSSH(ctx context.Context, builder *platform.QemuBuilder, conf *conf.Conf) error {
 	if !terminal.IsTerminal(0) {
 		return fmt.Errorf("stdin is not a tty")
 	}
@@ -152,7 +153,7 @@ func runDevShellSSH(builder *platform.QemuBuilder, conf *conf.Conf) error {
 	errchan := make(chan error)
 	readychan := make(chan struct{})
 	go func() {
-		buf, err := inst.WaitIgnitionError()
+		buf, err := inst.WaitIgnitionError(ctx)
 		if err != nil {
 			errchan <- err
 		} else {

--- a/mantle/cmd/kola/qemuexec.go
+++ b/mantle/cmd/kola/qemuexec.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
@@ -107,6 +108,9 @@ func parseBindOpt(s string) (string, string, error) {
 func runQemuExec(cmd *cobra.Command, args []string) error {
 	var err error
 	var config *conf.Conf
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	if devshellConsole {
 		devshell = true
@@ -242,7 +246,7 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 	builder.Append(args...)
 
 	if devshell && !devshellConsole {
-		return runDevShellSSH(builder, config)
+		return runDevShellSSH(ctx, builder, config)
 	}
 	if config != nil {
 		if directIgnition {
@@ -260,7 +264,7 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 	defer inst.Destroy()
 
 	if propagateInitramfsFailure {
-		err := inst.WaitAll()
+		err := inst.WaitAll(ctx)
 		if err != nil {
 			return err
 		}

--- a/mantle/platform/machine/qemuiso/machine.go
+++ b/mantle/platform/machine/qemuiso/machine.go
@@ -15,6 +15,7 @@
 package qemuiso
 
 import (
+	"context"
 	"errors"
 	"io/ioutil"
 	"time"
@@ -63,7 +64,8 @@ func (m *machine) SSH(cmd string) ([]byte, []byte, error) {
 }
 
 func (m *machine) IgnitionError() error {
-	buf, err := m.inst.WaitIgnitionError()
+	ctx := context.Background()
+	buf, err := m.inst.WaitIgnitionError(ctx)
 	if err != nil {
 		return err
 	}

--- a/mantle/platform/machine/unprivqemu/machine.go
+++ b/mantle/platform/machine/unprivqemu/machine.go
@@ -15,6 +15,7 @@
 package unprivqemu
 
 import (
+	"context"
 	"errors"
 	"io/ioutil"
 	"time"
@@ -63,7 +64,8 @@ func (m *machine) SSH(cmd string) ([]byte, []byte, error) {
 }
 
 func (m *machine) IgnitionError() error {
-	buf, err := m.inst.WaitIgnitionError()
+	ctx := context.Background()
+	buf, err := m.inst.WaitIgnitionError(ctx)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This introduces a tree of context values in the QEMU driver,
in order to link waiting methods together and to make them
cancellable in a uniform way.