### PR TITLE
testiso: Remove special casing of memory for s390x

### DIFF
--- a/mantle/platform/metal.go
+++ b/mantle/platform/metal.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"math"
 	"net"
 	"net/http"
 	"os"
@@ -75,11 +74,6 @@ func NewMetalQemuBuilderDefault() *QemuBuilder {
 	// https://github.com/coreos/fedora-coreos-tracker/issues/388
 	// https://github.com/coreos/fedora-coreos-docs/pull/46
 	builder.Memory = 4096
-	if system.RpmArch() == "s390x" {
-		// After some trial and error looks like we need at least 10G on s390x
-		// Recorded an issue to investigate this: https://github.com/coreos/coreos-assembler/issues/1489
-		builder.Memory = int(math.Max(float64(builder.Memory), 10240))
-	}
 	return builder
 }
 


### PR DESCRIPTION
with the removal of the legacy installer, this is no longer needed as the new installer works well with the default 4G.