### PR TITLE
ci: use `compress --fast`

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -89,7 +89,7 @@ pod(image: 'registry.fedoraproject.org/fedora:32', runAsUser: 0, kvm: true, memo
     }
 
     stage("Compress") {
-            cosa_cmd("compress")
+            cosa_cmd("compress --fast")
     }
 
     stage("Upload Dry Run") {


### PR DESCRIPTION
Now that we build lots of artifacts, this should make CI go faster.