### PR TITLE
mantle/platform: switch aarch64 to pci bus for virtio devices

### DIFF
--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -409,10 +409,8 @@ func (builder *QemuBuilder) AddFd(fd *os.File) string {
 func virtio(device, args string) string {
 	var suffix string
 	switch system.RpmArch() {
-	case "x86_64", "ppc64le":
+	case "x86_64", "ppc64le", "aarch64":
 		suffix = "pci"
-	case "aarch64":
-		suffix = "device"
 	case "s390x":
 		suffix = "ccw"
 	default:


### PR DESCRIPTION
This should little bit better reflect real HW and avoids situations
when udev can't assign predictable names to NICs. Fixes kola qemu
test ext.config.misc-ro detecting eth* names.