### PR TITLE
Tweak kola execution for Kubernetes

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -504,7 +504,7 @@ EOF
     echo "$@" > "${tmp_builddir}"/cmd.sh
 
     touch "${runvm_console}"
-    kola_args=(kola qemuexec -m 2048 --auto-cpus -U --workdir none)
+    kola_args=(kola qemuexec -m 1024 --auto-cpus -U --workdir none '--qemu-swtpm=false')
     base_qemu_args=(-drive 'if=none,id=root,format=raw,snapshot=on,file='"${vmbuilddir}"'/root,index=1' \
                     -device 'virtio-blk,drive=root'
                     -kernel "${vmbuilddir}/kernel" -initrd "${vmbuilddir}/initrd" \


### PR DESCRIPTION
This changes cmdlib.sh to not present a TPM2 device for runvm calls.
Since we the virtual TPM2 device is not needed for any build stage,
removing it is trivial.

The second change caps the CPU's at one when running on Kubernetes. The
logic is a loose-port from the `virt-install` code [1]. When running
parallel metal builds, hangs were observed. The suspected root cause is
CPU thrashing.

[1] https://github.com/coreos/coreos-assembler/commit/fa3a3582fcb0af0487f20e4c41f6fb41594e6c21

Signed-off-by: Ben Howard <ben.howard@redhat.com>