### PR TITLE
ci: archive rpmdb listing for easier debugging

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -8,7 +8,9 @@ pod(image: 'registry.fedoraproject.org/fedora:32', runAsUser: 0, kvm: true, memo
             dnf install -y git
             git submodule update --init
             ./build.sh
+            rpm -qa | sort > rpmdb.txt
         """)
+        archiveArtifacts artifacts: 'rpmdb.txt'
     }
 
     stage("Unit Test") {


### PR DESCRIPTION
Then we can diff the rpmdb from two CI runs to help debug issues. That's
more or less what I did to investigate #1723, but this should make it
trivial.