### PR TITLE
qemu: Make primary disk required, don't TFTP etc.

### DIFF
--- a/mantle/cmd/kola/qemuexec.go
+++ b/mantle/cmd/kola/qemuexec.go
@@ -204,15 +204,16 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 		if kola.QEMUOptions.Native4k {
 			sectorSize = 4096
 		}
-		if err = builder.AddPrimaryDisk(&platform.Disk{
+		err = builder.AddBootDisk(&platform.Disk{
 			BackingFile:   kola.QEMUOptions.DiskImage,
 			Channel:       channel,
 			Size:          kola.QEMUOptions.DiskSize,
 			SectorSize:    sectorSize,
 			MultiPathDisk: kola.QEMUOptions.MultiPathDisk,
 			NbdDisk:       kola.QEMUOptions.NbdDisk,
-		}); err != nil {
-			return errors.Wrapf(err, "adding primary disk")
+		})
+		if err != nil {
+			return err
 		}
 	}
 	if kola.QEMUIsoOptions.IsoPath != "" {

--- a/mantle/go.sum
+++ b/mantle/go.sum
@@ -522,6 +522,7 @@ golang.org/x/tools v0.0.0-20200207183749-b753a1ba74fa/go.mod h1:TB2adYChydJhpapK
 golang.org/x/tools v0.0.0-20200212150539-ea181f53ac56/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200224181240-023911ca70b2/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200227222343-706bc42d1f0d/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools v0.0.0-20200228224639-71482053b885/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200304193943-95d2e580d8eb/go.mod h1:o4KQGtdN14AW+yjsvvwRTJJuXz8XRtIHtEnmAXLyFUw=
 golang.org/x/tools v0.0.0-20200312045724-11d5b4c81c7d/go.mod h1:o4KQGtdN14AW+yjsvvwRTJJuXz8XRtIHtEnmAXLyFUw=
 golang.org/x/tools v0.0.0-20200331025713-a30bf2db82d4 h1:kDtqNkeBrZb8B+atrj50B5XLHpzXXqcCdZPP/ApQ5NY=

--- a/mantle/kola/tests/ignition/qemufailure.go
+++ b/mantle/kola/tests/ignition/qemufailure.go
@@ -55,9 +55,12 @@ func ignitionFailure(c cluster.TestCluster) error {
 	builder := platform.NewBuilder()
 	defer builder.Close()
 	builder.SetConfig(failConfig, kola.IsIgnitionV2())
-	builder.AddPrimaryDisk(&platform.Disk{
+	err = builder.AddBootDisk(&platform.Disk{
 		BackingFile: kola.QEMUOptions.DiskImage,
 	})
+	if err != nil {
+		return err
+	}
 	builder.Memory = 1024
 	inst, err := builder.Exec()
 	if err != nil {

--- a/mantle/platform/machine/unprivqemu/cluster.go
+++ b/mantle/platform/machine/unprivqemu/cluster.go
@@ -136,8 +136,9 @@ func (qc *Cluster) NewMachineWithQemuOptions(userdata *conf.UserData, options pl
 		MultiPathDisk: multiPathDisk,
 	}
 
-	if err = builder.AddPrimaryDisk(&primaryDisk); err != nil {
-		return nil, errors.Wrapf(err, "adding primary disk")
+	err = builder.AddBootDisk(&primaryDisk)
+	if err != nil {
+		return nil, err
 	}
 	for _, disk := range options.AdditionalDisks {
 		if err = builder.AddDisk(&platform.Disk{

--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -288,6 +288,8 @@ type QemuBuilder struct {
 
 	iso         *bootIso
 	primaryDisk *Disk
+	// primaryIsBoot is true if the only boot media should be the primary disk
+	primaryIsBoot bool
 
 	MultiPathDisk bool
 
@@ -822,12 +824,21 @@ func (builder *QemuBuilder) addDiskImpl(disk *Disk, primary bool) error {
 // AddPrimaryDisk sets up the primary disk for the instance.
 func (builder *QemuBuilder) AddPrimaryDisk(disk *Disk) error {
 	if builder.primaryDisk != nil {
-		panic("Multiple primary disks specified")
+		return errors.New("Multiple primary disks specified")
 	}
 	// We do this one lazily in order to break an ordering requirement
 	// for SetConfig() and AddPrimaryDisk() in the case where the
 	// config needs to be injected into the disk.
 	builder.primaryDisk = disk
+	return nil
+}
+
+// AddBootDisk sets the instance to boot only from the target disk
+func (builder *QemuBuilder) AddBootDisk(disk *Disk) error {
+	if err := builder.AddPrimaryDisk(disk); err != nil {
+		return err
+	}
+	builder.primaryIsBoot = true
 	return nil
 }
 
@@ -1151,6 +1162,9 @@ func (builder *QemuBuilder) Exec() (*QemuInstance, error) {
 	if builder.primaryDisk != nil {
 		if err := builder.addDiskImpl(builder.primaryDisk, true); err != nil {
 			return nil, err
+		}
+		if builder.primaryIsBoot {
+			argv = append(argv, "-boot", "order=c,strict=on")
 		}
 	}
 


### PR DESCRIPTION
A few times I've ended up with a non-bootable qcow2, and
the behavior of `cosa run` is that you end up hanging at
`[Link:up, TX:0 TXE:0 RX:0 RXE:0]`
which is the TFTP fallback.

Add an API and use it so that for the cases where we know
we're booting a qcow2, we tell the firmware only to boot
from a hard drive, so we end up hanging at:
`Boot failed: not a bootable disk`
which is at least a much more obvious failure.

(I think with QMP we might be able to detect this and
 error, needs investigation)