### PR TITLE
kola: improvements for lack of local build metadata

### DIFF
--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -20,6 +20,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/pkg/errors"
+
 	"github.com/coreos/mantle/auth"
 	"github.com/coreos/mantle/kola"
 	"github.com/coreos/mantle/platform"
@@ -230,12 +232,14 @@ func syncOptionsImpl(useCosa bool) error {
 		if kola.Options.CosaWorkdir != "" && kola.Options.CosaWorkdir != "none" {
 			localbuild, err := sdk.GetLatestLocalBuild(kola.Options.CosaWorkdir)
 			if err != nil {
-				return err
+				if !os.IsNotExist(errors.Cause(err)) {
+					return err
+				}
+			} else {
+				kola.Options.CosaBuildId = localbuild.Meta.BuildID
+				kola.CosaBuild = localbuild
+				foundCosa = true
 			}
-
-			kola.Options.CosaBuildId = localbuild.Meta.BuildID
-			kola.CosaBuild = localbuild
-			foundCosa = true
 		}
 	}
 


### PR DESCRIPTION
I've run into a few times where I have tried to use `cosa run
--qemu-image` without having done a local build first and it errors
out looking for a `meta.json`. This improves how we handle the lack
of local build metadata when a disk image is provided.
