### PR TITLE
create_disk: Install grub config on aarch64

### DIFF
--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -361,6 +361,7 @@ set prefix=($prefix)
 configfile $prefix/grub2/grub.cfg
 boot
 EOF
+    install_grub_cfg
 }
 
 # copy the grub config and any other files we might need
@@ -382,7 +383,6 @@ x86_64)
         --boot-directory $rootfs/boot \
         $disk
     fi
-    install_grub_cfg
     ;;
 aarch64)
     # Our aarch64 is UEFI only.


### PR DESCRIPTION
Regression from bootupd support.

Closes: https://github.com/coreos/coreos-assembler/issues/1746