### PR TITLE
drop tty for aarch64 and specify firmware in kola ignition failure test

### DIFF
--- a/mantle/kola/tests/ignition/qemufailure.go
+++ b/mantle/kola/tests/ignition/qemufailure.go
@@ -63,6 +63,7 @@ func ignitionFailure(c cluster.TestCluster) error {
 		return err
 	}
 	builder.Memory = 1024
+	builder.Firmware = kola.QEMUOptions.Firmware
 	inst, err := builder.Exec()
 	if err != nil {
 		return err

--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -240,9 +240,10 @@ tty="console=tty0 console=${DEFAULT_TERMINAL},115200n8"
 # On each s390x hypervisor, a tty would be automatically detected by the kernel
 # and systemd, there is no need to specify one. However, we keep DEFAULT_TERMINAL
 # as ttysclp0, which is helpful for building/testing with KVM+virtio (cmd-run).
-if [ "$basearch" == "s390x" ]; then
-    tty=
-fi
+# For aarch64, ttyAMA0 is used as the default console
+case "$basearch" in
+    "aarch64"|"s390x") tty= ;;
+esac
 kargs="$kargs $tty ignition.platform.id=$ignition_platform_id"
 
 ostree_remote="$(python3 -c 'import sys, yaml; print(yaml.safe_load(sys.stdin).get("ostree-remote", "NONE"))' < "$configdir/image.yaml")"


### PR DESCRIPTION
For aarch64, drop the tty as the default console is ttyAMA0. specifying the tty causes devshell console
to get stuck in the initramfs phase when there is a failure. Also specify firmware in the ignition failure
kola test as aarch64 is uefi.