### PR TITLE
mantle: make kola use ecdsa SSH keys

### DIFF
--- a/mantle/network/ssh.go
+++ b/mantle/network/ssh.go
@@ -15,8 +15,9 @@
 package network
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/rand"
-	"crypto/rsa"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -30,7 +31,6 @@ import (
 const (
 	defaultPort = 22
 	defaultUser = "core"
-	rsaKeySize  = 2048
 )
 
 // DefaultSSHDir is a process-global path that can be set, and
@@ -57,7 +57,7 @@ type SSHAgent struct {
 // NewSSHAgent constructs a new SSHAgent using dialer to create ssh
 // connections.
 func NewSSHAgent(dialer Dialer) (*SSHAgent, error) {
-	key, err := rsa.GenerateKey(rand.Reader, rsaKeySize)
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		return nil, err
 	}

--- a/mantle/platform/conf/conf_test.go
+++ b/mantle/platform/conf/conf_test.go
@@ -52,7 +52,7 @@ func TestConfCopyKey(t *testing.T) {
 
 		str := conf.String()
 
-		if !strings.Contains(str, "ssh-rsa ") || !strings.Contains(str, " core@default") {
+		if !strings.Contains(str, "ecdsa-sha2-nistp256 ") || !strings.Contains(str, " core@default") {
 			t.Errorf("ssh public key not found in config %d: %s", i, str)
 			continue
 		}


### PR DESCRIPTION
Upstream SSH has been claiming [1] for a few releases now that:

```
It is now possible to perform chosen-prefix attacks against the
SHA-1 algorithm for less than USD$50K. For this reason, we will be
disabling the "ssh-rsa" public key signature algorithm by default in a
near-future release.
```

In Fedora we switched recently [2] to disallow ssh-rsa so we need to
switch our tools to a different type of key.

[1] https://www.openssh.com/txt/release-8.3
[2] https://gitlab.com/redhat-crypto/fedora-crypto-policies/-/commit/b298a9e107b7e9699b36879eca031d1900ded1c4