### PR TITLE
src/build-deps.txt: add golint as a build dep

### DIFF
--- a/src/build-deps.txt
+++ b/src/build-deps.txt
@@ -1,2 +1,3 @@
 # Used by mantle
-golang 
+golang
+golang-x-lint


### PR DESCRIPTION
Adding an extra build dependency. My plant is to use `golint` for `entry` as an extra code-quality check.