### PR TITLE
cmd-kola: allow excluding tests for specific branch

### DIFF
--- a/src/cmd-kola
+++ b/src/cmd-kola
@@ -38,22 +38,22 @@ else:
     default_cmd = 'run'
     default_output_dir = "tmp/kola"
 
+# XXX: teach to kola to auto-detect based on prefix; see discussions in
+# https://github.com/coreos/coreos-assembler/pull/85
+kolaargs = ['kola']
+
 # automatically add tests from denylist specified in the src config
-denylist_args = []
-denylist_path = "src/config/kola-denylist.yaml"
-if os.path.isfile(denylist_path):
-    with open(denylist_path) as f:
+try:
+    with open("src/config/kola-denylist.yaml") as f:
         denylist = yaml.safe_load(f)
         for obj in (denylist or []):
             # if there are any arches specified, skip tests only for those arches. if not skip unconditionally.
             if basearch in obj.get('arches', [basearch]):
                 print(f"⚠️  Skipping kola test pattern \"{obj['pattern']}\":")
                 print(f"⚠️  {obj['tracker']}")
-                denylist_args += ['--denylist-test', obj['pattern']]
-
-# XXX: teach to kola to auto-detect based on prefix; see discussions in
-# https://github.com/coreos/coreos-assembler/pull/85
-kolaargs = ['kola']
+                kolaargs.extend(['--denylist-test', obj['pattern']])
+except FileNotFoundError:
+    pass
 
 r = re.compile("-p(=.+)?|--platform(=.+)?")
 platformargs = list(filter(r.match, unknown_args))
@@ -68,8 +68,6 @@ kolaargs.extend(['--output-dir', outputdir])
 subargs = args.subargs or [default_cmd]
 kolaargs.extend(subargs)
 kolaargs.extend(unknown_args)
-
-kolaargs.extend(denylist_args)
 
 if args.basic_qemu_scenarios:
     if arch == "x86_64":

--- a/src/cmd-kola
+++ b/src/cmd-kola
@@ -46,12 +46,18 @@ kolaargs = ['kola']
 try:
     with open("src/config/kola-denylist.yaml") as f:
         denylist = yaml.safe_load(f)
+        # also load the FCOS stream name if applicable in case we need it below
+        with open("src/config/manifest.yaml") as g:
+            manifest = yaml.safe_load(g)
+            stream = manifest.get('add-commit-metadata', {}).get('fedora-coreos.stream')
         for obj in (denylist or []):
-            # if there are any arches specified, skip tests only for those arches. if not skip unconditionally.
-            if basearch in obj.get('arches', [basearch]):
-                print(f"⚠️  Skipping kola test pattern \"{obj['pattern']}\":")
-                print(f"⚠️  {obj['tracker']}")
-                kolaargs.extend(['--denylist-test', obj['pattern']])
+            if basearch not in obj.get('arches', [basearch]):
+                continue
+            if stream is not None and stream not in obj.get('streams', [stream]):
+                continue
+            print(f"⚠️  Skipping kola test pattern \"{obj['pattern']}\":")
+            print(f"⚠️  {obj['tracker']}")
+            kolaargs.extend(['--denylist-test', obj['pattern']])
 except FileNotFoundError:
     pass
 

--- a/src/cmd-kola
+++ b/src/cmd-kola
@@ -41,11 +41,6 @@ else:
 # automatically add tests from denylist specified in the src config
 denylist_args = []
 denylist_path = "src/config/kola-denylist.yaml"
-old_denylist_path = "src/config/kola-blacklist.yaml"
-if os.path.isfile(old_denylist_path):
-    print(f"⛔ Detected an old filename for denylist; please update your filename to `kola-denylist.yaml`")
-    denylist_path = old_denylist_path
-
 if os.path.isfile(denylist_path):
     with open(denylist_path) as f:
         denylist = yaml.safe_load(f)


### PR DESCRIPTION
This seems odd on the surface but meshes well with how config files are
synced between FCOS branches. This will allow us to exclude a test for
a specific stream only.