### PR TITLE
[4.5] Skip testiso for POWER

### DIFF
--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -26,6 +26,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -153,6 +154,11 @@ func newQemuBuilder(isPXE bool) *platform.QemuBuilder {
 }
 
 func runTestIso(cmd *cobra.Command, args []string) error {
+	// SKIP testiso due issues in POWER. Check issue #1757
+	if runtime.GOARCH == "ppc64le" {
+		fmt.Println("The testiso is disabled for ppc64le")
+		return nil
+	}
 	if kola.CosaBuild == nil {
 		return fmt.Errorf("Must provide --cosa-build")
 	}


### PR DESCRIPTION
The new Kernel change is causing testiso to fail.
We need to skip this test until we have a final
solution.
Check https://github.com/coreos/coreos-assembler/issues/1757

Signed-off-by: Renata Ravanelli <rravanel@redhat.com>