### PR TITLE
[4.4] Skip testiso for POWER

### DIFF
--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 
 	"github.com/coreos/mantle/util"
 	"github.com/pkg/errors"
@@ -76,6 +77,11 @@ func init() {
 }
 
 func runTestIso(cmd *cobra.Command, args []string) error {
+	// SKIP testio due issues in POWER. Check issue #1757
+	if runtime.GOARCH == "ppc64le" {
+		fmt.Println("The testiso is disabled for ppc64le")
+		return nil
+	}
 	if kola.CosaBuild == nil {
 		return fmt.Errorf("Must provide --cosa-build")
 	}


### PR DESCRIPTION
The new Kernel change is causing testiso to fail.
We need to skip this test until we have a final
solution.
Check #1757

Signed-off-by: Renata Ravanelli <rravanel@redhat.com>