### PR TITLE
mantle: platform: update iso embed call

### DIFF
--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -1042,7 +1042,7 @@ func (builder *QemuBuilder) setupIso() error {
 		if err != nil {
 			return err
 		}
-		instCmd := exec.Command("coreos-installer", "iso", "embed", isoEmbeddedPath)
+		instCmd := exec.Command("coreos-installer", "iso", "ignition", "embed", isoEmbeddedPath)
 		instCmd.Stdin = configf
 		instCmd.Stderr = os.Stderr
 		if err := instCmd.Run(); err != nil {


### PR DESCRIPTION
To get rid of the deprecation warning:

```
+ kola testiso -S --scenarios pxe-install,pxe-offline-install,iso-install,iso-offline-install --output-dir tmp/kola-testiso-metal
Testing scenarios: [pxe-install pxe-offline-install iso-install iso-offline-install]
Successfully tested scenario pxe-install for 32.20201005.dev.0 on bios (metal)
Successfully tested scenario pxe-offline-install for 32.20201005.dev.0 on bios (metal)
`iso embed` is deprecated; use `iso ignition embed`.  Continuing.
```

We need to update to `coreos-installer iso ignition embed`.