### PR TITLE
buildextend-live: drop --legacy-pxe option

### DIFF
--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -53,8 +53,6 @@ parser.add_argument("--fast", action='store_true', default=False,
                     help="Reduce compression for development (FCOS only)")
 parser.add_argument("--force", action='store_true', default=False,
                     help="Overwrite previously generated installer")
-parser.add_argument("--legacy-pxe", action='store_true', default=False,
-                    help="Generate stub PXE rootfs image")
 args = parser.parse_args()
 
 # Identify the builds and target the latest build if none provided
@@ -298,23 +296,8 @@ def generate_iso():
         if fh.read(4) != b'hsqs':
             raise Exception("root.squashfs not at expected offset in rootfs image")
     pxe_rootfs = os.path.join(tmpdir, rootfs_img)
-    # This is super-messy but it's temporary.
-    if args.legacy_pxe:
-        tmpinitrd_legacy = os.path.join(tmpdir, 'initrd-legacy')
-        os.makedirs(os.path.join(tmpinitrd_legacy, 'etc'))
-        os.rename(
-            os.path.join(tmpinitrd_rootfs, 'etc/coreos-live-rootfs'),
-            os.path.join(tmpinitrd_legacy, 'etc/coreos-live-rootfs')
-        )
-        extend_initrd(pxe_rootfs, tmpinitrd_legacy, compress=False)
-        # coreos-installer download won't accept an artifact sized
-        # less than 1 MiB
-        with open(pxe_rootfs, 'r+b') as fh:
-            if fh.seek(0, 2) < 1024 * 1024:
-                fh.truncate(1024 * 1024)
-    else:
-        # Clone to PXE image
-        cp_reflink(iso_rootfs, pxe_rootfs)
+    # Clone to PXE image
+    cp_reflink(iso_rootfs, pxe_rootfs)
     # Save stream hash of rootfs for verifying out-of-band fetches
     os.makedirs(os.path.join(tmpinitrd_base, 'etc'), exist_ok=True)
     make_stream_hash(pxe_rootfs, os.path.join(tmpinitrd_base, 'etc/coreos-live-want-rootfs'))
@@ -324,9 +307,6 @@ def generate_iso():
     # Clone to PXE image
     pxe_initramfs = os.path.join(tmpdir, initrd_img)
     cp_reflink(iso_initramfs, pxe_initramfs)
-    # Put the rootfs contents in the initramfs in the legacy PXE case
-    if args.legacy_pxe:
-        extend_initrd(pxe_initramfs, tmpinitrd_rootfs)
 
     # Read and filter kernel arguments for substituting into ISO bootloader
     result = run_verbose(['/usr/lib/coreos-assembler/gf-get-kargs',


### PR DESCRIPTION
It's no longer used on any FCOS stream.