### PR TITLE
fix flake8 and shellcheck failures when moving to f33

### DIFF
--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -70,7 +70,7 @@ squashfs_compression = 'lz4' if args.fast else image_yaml.get('squashfs-compress
 # validating its output.
 osmet_pack_with_cosa_coreinst = image_yaml.get('osmet-pack-with-cosa-coreinst', False)
 
-srcdir_prefix = f"src/config/live/"
+srcdir_prefix = "src/config/live/"
 
 if not os.path.isdir(srcdir_prefix):
     raise Exception(f"missing directory {srcdir_prefix}")
@@ -272,13 +272,13 @@ def generate_iso():
     # Add osmet files
     tmp_osmet = os.path.join(tmpinitrd_rootfs, img_metal_obj['path'] + '.osmet')
     tmp_osmet4k = os.path.join(tmpinitrd_rootfs, img_metal4k_obj['path'] + '.osmet')
-    print(f'Generating osmet file for 512b metal image')
+    print('Generating osmet file for 512b metal image')
     run_verbose(['/usr/lib/coreos-assembler/osmet-pack',
                  img_metal, '512', tmp_osmet, img_metal_checksum,
                  'fast' if args.fast else 'normal',
                  '/usr/bin/coreos-installer' if osmet_pack_with_cosa_coreinst
                  else ''])
-    print(f'Generating osmet file for 4k metal image')
+    print('Generating osmet file for 4k metal image')
     run_verbose(['/usr/lib/coreos-assembler/osmet-pack',
                  img_metal4k, '4096', tmp_osmet4k, img_metal4k_checksum,
                  'fast' if args.fast else 'normal',

--- a/src/cmd-compress
+++ b/src/cmd-compress
@@ -156,4 +156,4 @@ for arch in builds.get_build_arches(build):
     changed.append(compress_one_builddir(builddir))
 
 if not any(changed):
-    print(f"All builds already compressed")
+    print("All builds already compressed")

--- a/src/cmd-list
+++ b/src/cmd-list
@@ -12,7 +12,7 @@ from cosalib.cmdlib import parse_date_string
 def main():
     builds = Builds()
     if len(builds.get_builds()) == 0:
-        print(f"No builds!")
+        print("No builds!")
         return
 
     tags = {}

--- a/src/cmd-sign
+++ b/src/cmd-sign
@@ -135,7 +135,7 @@ def robosign_ostree(args, s3, build, gpgkey):
     validate_response(response)
 
     # download back sig and verify it in a throwaway repo
-    print(f"Verifying OSTree signature")
+    print("Verifying OSTree signature")
     with tempfile.TemporaryDirectory(prefix="cosa-sign", dir="tmp") as d:
         repo = OSTree.Repo.new(Gio.File.new_for_path(d))
         repo.create(OSTree.RepoMode.ARCHIVE)

--- a/src/cosalib/fedora_messaging_request.py
+++ b/src/cosalib/fedora_messaging_request.py
@@ -112,7 +112,7 @@ def start_consumer_thread(cond, request_type, request_id, environment):
                          daemon=True)
     t.start()
     registered.wait()
-    print(f"Successfully started consumer thread")
+    print("Successfully started consumer thread")
 
 
 def watch_finished_messages(cond, registered,

--- a/src/cosalib/qemuvariants.py
+++ b/src/cosalib/qemuvariants.py
@@ -243,7 +243,7 @@ class QemuVariantImage(_Build):
                               f" found: '{img_info.get('format')}'"))
 
         if self.mutate_callback:
-            log.info(f"Processing work image callback")
+            log.info("Processing work image callback")
             self.mutate_callback(work_img)
 
         if self.tar_members:

--- a/src/osmet-pack
+++ b/src/osmet-pack
@@ -87,6 +87,8 @@ case "$speed" in
     *)         exit 1      ;;
 esac
 
+# We don't want double quotes because passing '' is not what we want
+# shellcheck disable=SC2086
 RUST_BACKTRACE=full "${coreinst}" osmet pack /dev/disk/by-id/virtio-osmet \
     --description "${description}" \
     --checksum "${checksum}" \


### PR DESCRIPTION
We're not quite ready to move to Fedora 33 for COSA, but
I did a test run and noticed some build check failures, so we
might as well fix them now.