### PR TITLE
Revert "mantle: make kola use ecdsa SSH keys"

### DIFF
--- a/mantle/network/ssh.go
+++ b/mantle/network/ssh.go
@@ -15,9 +15,8 @@
 package network
 
 import (
-	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/rsa"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -31,6 +30,7 @@ import (
 const (
 	defaultPort = 22
 	defaultUser = "core"
+	rsaKeySize  = 2048
 )
 
 // DefaultSSHDir is a process-global path that can be set, and
@@ -57,7 +57,7 @@ type SSHAgent struct {
 // NewSSHAgent constructs a new SSHAgent using dialer to create ssh
 // connections.
 func NewSSHAgent(dialer Dialer) (*SSHAgent, error) {
-	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	key, err := rsa.GenerateKey(rand.Reader, rsaKeySize)
 	if err != nil {
 		return nil, err
 	}

--- a/mantle/platform/conf/conf_test.go
+++ b/mantle/platform/conf/conf_test.go
@@ -52,7 +52,7 @@ func TestConfCopyKey(t *testing.T) {
 
 		str := conf.String()
 
-		if !strings.Contains(str, "ecdsa-sha2-nistp256 ") || !strings.Contains(str, " core@default") {
+		if !strings.Contains(str, "ssh-rsa ") || !strings.Contains(str, " core@default") {
 			t.Errorf("ssh public key not found in config %d: %s", i, str)
 			continue
 		}


### PR DESCRIPTION
This reverts commit 5c036d17c9b0fd561642af8f602a61eff84f403e.

That commit broke `kola` on AWS, because that platform only supports
RSA keys.

Ref: https://github.com/coreos/coreos-assembler/pull/1749#issuecomment-704091353

/cc @dustymabe @jlebon