### PR TITLE
kola/ext: bump minimum of memory to 8G on 64k page arches, ppc64le for now

### DIFF
--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -665,6 +665,12 @@ ExecStart=%s
 `, KoletExtTestUnit, kolaExtBinDataEnv, kolaExtBinDataDir, remotepath)
 	config.AddSystemdUnit(KoletExtTestUnit, unit, conf.NoState)
 
+	// Architectures using 64k pages use slightly more memory, ask for more than requested
+	// to make sure that we don't run out of it. Currently only ppc64le uses 64k pages.
+	if system.RpmArch() == "ppc64le" && targetMeta.MinMemory < 8192 {
+		targetMeta.MinMemory = 8192
+	}
+
 	t := &register.Test{
 		Name:          testname,
 		ClusterSize:   1, // Hardcoded for now


### PR DESCRIPTION
Re-provisioning tests fail on ppc64le due to lack of the memory, bumping it
beyond 6G makes them succeed. Most probably caused by slightly higher overhead
of the 64k pages in combination with slightly bigger size of COS on ppc64le.
