### PR TITLE
[4.5] Revert #1759 and downgrade grub for ppc64le

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -52,6 +52,11 @@ install_rpms() {
     # https://github.com/coreos/coreos-assembler/issues/1496
     yum -y downgrade cryptsetup-2.2.1-1.fc31
 
+    # https://bugzilla.redhat.com/show_bug.cgi?id=1884854
+    if [ "$arch" == "ppc64le" ]; then
+        yum -y downgrade grub2-tools-2.02-100.fc31
+    fi
+
     # Commented out for now, see above
     #dnf remove -y ${builddeps}
     # can't remove grubby on el7 because libguestfs-tools depends on it

--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -26,7 +26,6 @@ import (
 	"math"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"time"
 
@@ -154,11 +153,6 @@ func newQemuBuilder(isPXE bool) *platform.QemuBuilder {
 }
 
 func runTestIso(cmd *cobra.Command, args []string) error {
-	// SKIP testiso due issues in POWER. Check issue #1757
-	if runtime.GOARCH == "ppc64le" {
-		fmt.Println("The testiso is disabled for ppc64le")
-		return nil
-	}
 	if kola.CosaBuild == nil {
 		return fmt.Errorf("Must provide --cosa-build")
 	}


### PR DESCRIPTION
Looks like the issue with testiso failing wasn't really an issue with the kernel but a grub update which caused the legacy
install to break. Downgrading grub fixed the issue. Tracked by: https://bugzilla.redhat.com/show_bug.cgi?id=1884854