### PR TITLE
kola: don't resolve symlinks for ext test naming

### DIFF
--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -820,14 +820,7 @@ func RegisterExternalTestsWithPrefix(dir, prefix string) error {
 // RegisterExternalTests iterates over a directory, and finds subdirectories
 // that have exactly one executable binary.
 func RegisterExternalTests(dir string) error {
-	// eval symlinks to turn e.g. src/config into fedora-coreos-config
-	// for the test basename.
-	realdir, err := filepath.EvalSymlinks(dir)
-	if err != nil {
-		return err
-	}
-	basename := fmt.Sprintf("ext.%s", filepath.Base(realdir))
-
+	basename := fmt.Sprintf("ext.%s", filepath.Base(dir))
 	return RegisterExternalTestsWithPrefix(dir, basename)
 }
 


### PR DESCRIPTION
Otherwise using patterns in `kola-denylist.yaml` won't always work since
`src/config` might be a repo or might be a symlink.

Let's just standardize on `config` being the name of "the repo which is
at src/config" so that we don't have to think about this when adding
tests to the denylist.