### PR TITLE
entrypoint: build dep and Makefile improvement

### DIFF
--- a/entrypoint/Makefile
+++ b/entrypoint/Makefile
@@ -12,14 +12,15 @@ pkgs := $(shell go list -mod=vendor ./...)
 .PHONY: build
 build: test
 	@mkdir -p bin
-	find cmd -iname *.go -exec go build  -i -ldflags "${ldflags}" -mod vendor -v -o bin {} \;
+	cd cmd && go build  -i -ldflags "${ldflags}" -mod vendor -v -o ../bin/entry .
 
 .PHONY: fmt
 fmt:
 	gofmt -d -e -l $(shell find . -iname "*.go"  -not -path "./vendor/*")
+	golint ${pkgs}
 
-.PHONY: fmt test
-test:
+.PHONY: test
+test: fmt
 	go test -mod=vendor -i ${pkgs}
 	go test -mod=vendor -cover ${pkgs}
 
@@ -31,3 +32,25 @@ clean:
 .PHONY: install
 install: clean build
 	install -v -D -t $(DESTDIR)$(PREFIX)/bin bin/entry
+
+my_uid = $(shell id -u)
+.PHONY: devtest
+devtest: build
+	mkdir -p srv
+	podman run --rm -i --tty \
+		-a=stdin -a=stdout -a=stderr \
+		--uidmap=$(my_uid):0:1 --uidmap=0:1:1000 --uidmap 1001:1001:64536 \
+		--security-opt label=disable --privileged=true \
+		--device /dev/fuse \
+		--device /dev/kvm \
+		--tmpfs /tmp \
+		--volume=/var/tmp:/var/tmp \
+		--volume=$(shell realpath .)/srv:/srv \
+		--env="BUILD=`jq -cM "." ocp/build.json`" \
+		--env="SOURCE_REPOSITORY=http://github.com/coreos/fedora-coreos-config" \
+		--env="SOURCE_REF=testing-devel" \
+		--env='COSA_CMDS=cosa fetch; cosa build;' \
+		--volume=$(shell realpath .)/bin:/run/bin \
+		--entrypoint='["/usr/bin/dumb-init", "/run/bin/entry"]' \
+		quay.io/coreos-assembler/coreos-assembler:latest \
+		builder

--- a/entrypoint/ocp/build.json
+++ b/entrypoint/ocp/build.json
@@ -1,0 +1,86 @@
+{
+  "kind": "Build",
+  "apiVersion": "build.openshift.io/v1",
+  "metadata": {
+    "name": "r-master-19",
+    "namespace": "example",
+    "selfLink": "/apis/build.openshift.io/v1/namespaces/example/builds/cosa-runner-master-19",
+    "uid": "9fd308ea-0586-11eb-98b7-fa163e4ff028",
+    "resourceVersion": "165628275",
+    "creationTimestamp": "2020-10-03T14:42:13Z",
+    "labels": {
+      "app": "cosa",
+      "buildconfig": "cosa-runner-master",
+      "openshift.io/build-config.name": "cosa-runner-master",
+      "openshift.io/build.start-policy": "Parallel",
+      "template": "cosa-template"
+    },
+    "annotations": {
+      "openshift.io/build-config.name": "cosa-runner-master",
+      "openshift.io/build.number": "19"
+    },
+    "ownerReferences": [
+      {
+        "apiVersion": "build.openshift.io/v1",
+        "kind": "BuildConfig",
+        "name": "cosa-runner-master",
+        "uid": "6e824268-04dd-11eb-98b7-fa163e4ff028",
+        "controller": true
+      }
+    ]
+  },
+  "spec": {
+    "serviceAccount": "jenkins-kvm",
+    "source": {
+      "type": "Git",
+      "git": {
+        "uri": "https://github.com/coreos/fedora-coreos-config",
+        "ref": "testing-devel"
+      }
+    },
+    "strategy": {
+      "type": "Custom",
+      "customStrategy": {
+        "from": {
+          "kind": "DockerImage",
+          "name": "docker-registry.default.svc:5000/example/coreos-assembler@sha256:4a16bf77decab2e65485ec9cb529063961bdf0e574d651b42d9ebaae60354e98"
+        },
+        "pullSecret": {
+          "name": "jenkins-kvm-dockercfg-g77h5"
+        },
+        "env": [
+          {
+            "name": "OCP_CUSTOM_BUILDER",
+            "value": "1"
+          },
+          {
+            "name": "OPENSHIFT_CUSTOM_BUILD_BASE_IMAGE",
+            "value": "docker-registry.default.svc:5000/example/coreos-assembler@sha256:4a16bf77decab2e65485ec9cb529063961bdf0e574d651b42d9ebaae60354e98"
+          },
+          {
+            "name": "COSA_CMDS",
+            "value": "cosa init"
+          }
+        ]
+      }
+    },
+    "output": {},
+    "resources": {},
+    "postCommit": {},
+    "nodeSelector": null,
+    "triggeredBy": [
+      {
+        "message": "Manually triggered"
+      }
+    ]
+  },
+  "status": {
+    "phase": "New",
+    "config": {
+      "kind": "BuildConfig",
+      "namespace": "example",
+      "name": "cosa-runner-master"
+    },
+    "output": {}
+  }
+}

--- a/src/deps.txt
+++ b/src/deps.txt
@@ -83,3 +83,6 @@ fcct
 
 # Support for meta.json file locking
 python3-flufl-lock
+
+# entrypoint uses bsdtar for automatic compression detection
+bsdtar


### PR DESCRIPTION
This turns on golint for entrypoint and adds bsdtar.
bsdtar is needed to support OpenShift binary builds.

Makefile also includes a `devtest` target to mocking an OpenShift
Build environment, which is suitable for testing.

Signed-off-by: Ben Howard <ben.howard@redhat.com>