### PR TITLE
entrypoint: avoid triggering `build` at `install` time

### DIFF
--- a/entrypoint/Makefile
+++ b/entrypoint/Makefile
@@ -30,7 +30,7 @@ clean:
 	@rm -rf bin
 
 .PHONY: install
-install: clean build
+install: bin/entry
 	install -v -D -t $(DESTDIR)$(PREFIX)/bin bin/entry
 
 my_uid = $(shell id -u)


### PR DESCRIPTION
I do `make && sudo make install` and golang wants to rebuild the
binaries as root, which fails because the Go environment isn't set up
there.

There are ways to deal around this (using eg. Colin's `makesudoinstall`:
https://github.com/cgwalters/homegit/blob/735331bb748c71c5b2fac36a10c891381e38e0ae/dotfiles/bashrc#L21),
though it's good to clean up the `install` target to have it actually
key off of the binary. This matches the mantle Makefile.