### PR TITLE
cmd-fetch: better ignore cosa overrides by default

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -256,6 +256,7 @@ extra_compose_args+=("$parent_arg")
 composejson="$(readlink -f "${workdir}"/tmp/compose.json)"
 # Put this under tmprepo so it gets automatically chown'ed if needed
 lockfile_out=${tmprepo}/tmp/manifest-lock.generated.${basearch}.json
+# shellcheck disable=SC2119
 prepare_compose_overlays
 # See https://github.com/coreos/coreos-assembler/pull/1379 - we want the local
 # dev case to explicitly fetch updates when they want them, plus CI pipelines

--- a/src/cmd-fetch
+++ b/src/cmd-fetch
@@ -28,7 +28,7 @@ EOF
 
 UPDATE_LOCKFILE=
 OUTPUT_LOCKFILE=
-WITH_COSA_OVERRIDES=
+IGNORE_COSA_OVERRIDES_ARG=--ignore-cosa-overrides
 DRY_RUN=
 STRICT=
 rc=0
@@ -53,7 +53,7 @@ while true; do
             OUTPUT_LOCKFILE=$1
             ;;
         --with-cosa-overrides)
-            WITH_COSA_OVERRIDES=1
+            IGNORE_COSA_OVERRIDES_ARG=
             ;;
         --dry-run)
             DRY_RUN=1
@@ -107,11 +107,9 @@ if [ -n "${STRICT}" ]; then
 fi
 
 # By default, we ignore cosa overrides since they're temporary. With
-# WITH_COSA_OVERRIDES, we don't ignore them (and thus don't need to fetch any
+# --with-cosa-overrides, we don't ignore them (and thus don't need to fetch any
 # overridden packages).
-if [ -n "${WITH_COSA_OVERRIDES}" ]; then
-    prepare_compose_overlays
-fi
+prepare_compose_overlays ${IGNORE_COSA_OVERRIDES_ARG}
 
 # shellcheck disable=SC2086
 runcompose --download-only ${args}

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -266,6 +266,15 @@ commit_overlay() {
 # as overrides/{rootfs} to OSTree commits, and also handles
 # overrides/rpm.
 prepare_compose_overlays() {
+    local with_cosa_overrides=1
+    while [ $# -gt 0 ]; do
+        flag="${1}"; shift;
+        case "${flag}" in
+            --ignore-cosa-overrides) with_cosa_overrides=;;
+             *) echo "${flag} is not understood."; exit 1;;
+         esac;
+    done
+
     local overridesdir=${workdir}/overrides
     local tmp_overridesdir=${TMPDIR}/override
     local override_manifest="${tmp_overridesdir}"/coreos-assembler-override-manifest.yaml
@@ -319,7 +328,7 @@ EOF
     fi
 
     local_overrides_lockfile="${tmp_overridesdir}/local-overrides.json"
-    if [[ -n $(ls "${overridesdir}/rpm/"*.rpm 2> /dev/null) ]]; then
+    if [ -n "${with_cosa_overrides}" ] && [[ -n $(ls "${overridesdir}/rpm/"*.rpm 2> /dev/null) ]]; then
         (cd "${overridesdir}"/rpm && rm -rf .repodata && createrepo_c .)
         # synthesize an override lockfile to force rpm-ostree to pick up our
         # override RPMS -- we try to be nice here and allow multiple versions of


### PR DESCRIPTION
Even without `--with-cosa-overrides`, `cosa fetch` would still pick up
the stale lockfile at `tmp/override/local-overrides.json` leftover from
a previous run.

Let's just always run `prepare_compose_overlays` which already takes
care of deleting the lockfile if no cosa overrides are present. We just
need to wire `--with-cosa-overrides` through for the `cosa fetch`
semantics we want.