### PR TITLE
cmdlib: Ensure overlay files have read-only executables

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -256,7 +256,7 @@ commit_overlay() {
     echo -n "Committing ${name}: ${path} ... "
     ostree commit --repo="${tmprepo}" --tree=dir="${respath}" -b "${name}" \
         --owner-uid 0 --owner-gid 0 --no-xattrs --no-bindings --parent=none \
-        --timestamp "${git_timestamp}"
+        --mode-ro-executables --timestamp "${git_timestamp}"
 }
 
 # Implement support for automatic local overrides:


### PR DESCRIPTION
Storing overlay files in git is very convenient, but
introduces possible umask issues; for example see
https://github.com/coreos/fedora-coreos-config/pull/543

This sidesteps the problem for executables by removing
the write bit entirely.

(The problem remains for non-executables; that's
 trickier)