### PR TITLE
Add an image-default.yaml, pass JSON to create_disk.sh

### DIFF
--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -151,15 +151,19 @@ if [ "${image_type}" = dasd ] || [ "${image_type}" = metal4k ]; then
     ignition_platform_id=metal
 fi
 
+yaml2json() {
+    python3 -c 'import sys, json, yaml; json.dump(yaml.safe_load(sys.stdin), sys.stdout)' < "$1" > "$2"
+}
+
+# Convert the image.yaml to JSON so that it can be more easily parsed
+# by the shell script in create_disk.sh.
+yaml2json "$configdir/image.yaml" image-config.json
+yaml2json "/usr/lib/coreos-assembler/image-default.yaml" image-default.json
+cat image-default.json image-config.json | jq -s add > image.json
+
 # bootfs
 bootfs_type="$(python3 -c 'import sys, yaml; print(yaml.safe_load(sys.stdin).get("bootfs", "ext4"))' < "$configdir/image.yaml")"
-
-# First parse the old luks_rootfs flag (a custom "stringified bool")
-rootfs_type="$(python3 -c 'import sys, yaml; lf=yaml.safe_load(sys.stdin).get("luks_rootfs", ""); print("luks" if lf.lower() in ("yes", "true") else "")' < "$configdir/image.yaml")"
-if [ -z "${rootfs_type}" ]; then
-    # Now the newer rootfs flag
-    rootfs_type="$(python3 -c 'import sys, yaml; print(yaml.safe_load(sys.stdin).get("rootfs", "xfs"))' < "$configdir/image.yaml")"
-fi
+rootfs_type=$(jq -re .rootfs < image.json)
 
 # fs-verity requires block size = page size. We need to take that into account
 # in the disk size estimation due to higher fragmentation on larger blocks.
@@ -253,6 +257,7 @@ target_drive=("-drive" "if=none,id=target,format=${image_format},file=${path}.tm
 
 runvm "${target_drive[@]}" -- \
         /usr/lib/coreos-assembler/create_disk.sh \
+            --config "$(pwd)"/image.json \
             --buildid "${build}" \
             --imgid "${img}" \
             --grub-script /usr/lib/coreos-assembler/grub.cfg \
@@ -262,7 +267,6 @@ runvm "${target_drive[@]}" -- \
             --ostree-remote "${ostree_remote}" \
             --ostree-repo "${ostree_repo}" \
             --rootfs-size "${rootfs_size}" \
-            --rootfs "${rootfs_type}" \
             "${disk_args[@]}"
 /usr/lib/coreos-assembler/finalize-artifact "${path}.tmp" "${path}"
 

--- a/src/image-default.yaml
+++ b/src/image-default.yaml
@@ -1,0 +1,2 @@
+# This file contains defaults for image.yaml that is used by create_disk.sh
+rootfs: "xfs"


### PR DESCRIPTION
The way we parse an `image.yaml` and then convert it
into arguments for `create_disk.sh` is unwieldy.

Instead, convert `image.yaml` into JSON, inheriting default values
from a separate `image-default.yaml` we ship.  Then pass
that JSON to `create_disk.sh`.

This only converts the `rootfs` argument, but if people
are OK with this I can go ahead and convert everything
else - getting us to where the only argument to `create_disk.sh`
is a JSON file that's already been pre-validated.