### PR TITLE
Write out a ref with the build ID

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -345,6 +345,8 @@ echo "New image input checksum: ${image_input_checksum}"
 init_build_meta_json "${commit}" tmp/
 buildid=$(jq -r '.["buildid"]' < tmp/meta.json)
 echo "New build ID: ${buildid}"
+# Also write out a ref with the build ID
+ostree --repo="${tmprepo}" refs --create "${buildid}" "${commit}"
 
 "${dn}"/write-commit-object "${tmprepo}" "${commit}" "$(pwd)"
 

--- a/src/cmd-prune
+++ b/src/cmd-prune
@@ -176,6 +176,7 @@ error_during_pruning = False
 for build in builds_to_delete:
     print(f"Pruning build {build.id}")
     try:
+        subprocess.check_call(['ostree', '--repo=tmp/repo', 'refs', '--delete', build.id])
         rmtree(os.path.join(builds_dir, build.id))
     except Exception as e:
         error_during_pruning = True


### PR DESCRIPTION
I'm not sure why we didn't do this from the start.  The immediate
motivation here is I was trying to diff two builds and the ostree
commit previously was pruned while the cosa build still existed.

Now yes I could import the ostree tarball but this seems clearly
better.

With this we can also drop the `tmpref-` hack we have for RHCOS
and just use the build ID as a ref.