### PR TITLE
kola: Support config.fcc for external tests

### DIFF
--- a/docs/kola/external-tests.md
+++ b/docs/kola/external-tests.md
@@ -39,6 +39,7 @@ system and run as a systemd unit, along with an optional Ignition config named
 Concretely then, an external test directory can have the following content:
 
 - `config.ign` (optional): Ignition config provided
+- `config.fcc` (optional): See https://github.com/coreos/fcct
 - `kola.json` (optional): JSON file described below
 - `data` (optional): Directory (or symlink to dir): Will be uploaded and
   available as `${KOLA_EXT_DATA}`

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -748,6 +749,12 @@ func registerTestDir(dir, testprefix string, children []os.FileInfo) error {
 				return errors.Wrapf(err, "reading %s", c.Name())
 			}
 			ignition = string(v)
+		} else if isreg && c.Name() == "config.fcc" {
+			b, err := exec.Command("fcct", fpath).Output()
+			if err != nil {
+				return errors.Wrapf(err, "failed to fcct %s", fpath)
+			}
+			ignition = string(b)
 		} else if isreg && c.Name() == "kola.json" {
 			f, err := os.Open(fpath)
 			if err != nil {


### PR DESCRIPTION
Increases the ergonomics of writing external tests.