### PR TITLE
[rhcos-4.3] ci: use Fedora 31 image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,8 @@ python:
 env:
     - SCVERSION="stable"
 
-before_install:
-    - docker pull quay.io/coreos-assembler/coreos-assembler:latest
-    - docker build -t coreos-assembler-test -f Dockerfile.dev .
-
 script:
-    - docker run -ti --rm --entrypoint "/usr/bin/sudo" coreos-assembler-test:latest su -c "cd /root/containerbuild/; make check"
-    - docker run -ti --rm --entrypoint "/usr/bin/sudo" coreos-assembler-test:latest su -c "cd /root/containerbuild/; make unittest"
+    - docker build -t coreos-assembler-test -f Dockerfile .
 
 notifications:
   email: false


### PR DESCRIPTION
Using coreos-assembler:master to save time in ci execution was
causing some package dependency issues since python2 support was
dropped in Fedora 32.  CI will have to take a little longer now.