### PR TITLE
mantle: work around for ssh crypto policies change

### DIFF
--- a/mantle/kola/tests/ignition/empty.go
+++ b/mantle/kola/tests/ignition/empty.go
@@ -37,7 +37,7 @@ func init() {
 		Name:             "fcos.ignition.v3.noop",
 		Run:              empty,
 		ClusterSize:      1,
-		ExcludePlatforms: []string{"qemu", "esx", "openstack"},
+		ExcludePlatforms: []string{"qemu", "esx"},
 		Distros:          []string{"fcos"},
 		Flags:            []register.Flag{register.NoSSHKeyInUserData},
 		UserData:         conf.Ignition(`{"ignition":{"version":"3.0.0"}}`),

--- a/mantle/kola/tests/ignition/empty.go
+++ b/mantle/kola/tests/ignition/empty.go
@@ -37,7 +37,7 @@ func init() {
 		Name:             "fcos.ignition.v3.noop",
 		Run:              empty,
 		ClusterSize:      1,
-		ExcludePlatforms: []string{"qemu", "esx"},
+		ExcludePlatforms: []string{"qemu", "esx", "aws"},
 		Distros:          []string{"fcos"},
 		Flags:            []register.Flag{register.NoSSHKeyInUserData},
 		UserData:         conf.Ignition(`{"ignition":{"version":"3.0.0"}}`),

--- a/mantle/network/ssh.go
+++ b/mantle/network/ssh.go
@@ -15,8 +15,9 @@
 package network
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/rand"
-	"crypto/rsa"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -30,7 +31,6 @@ import (
 const (
 	defaultPort = 22
 	defaultUser = "core"
-	rsaKeySize  = 2048
 )
 
 // DefaultSSHDir is a process-global path that can be set, and
@@ -57,7 +57,7 @@ type SSHAgent struct {
 // NewSSHAgent constructs a new SSHAgent using dialer to create ssh
 // connections.
 func NewSSHAgent(dialer Dialer) (*SSHAgent, error) {
-	key, err := rsa.GenerateKey(rand.Reader, rsaKeySize)
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		return nil, err
 	}

--- a/mantle/platform/conf/conf_test.go
+++ b/mantle/platform/conf/conf_test.go
@@ -52,7 +52,7 @@ func TestConfCopyKey(t *testing.T) {
 
 		str := conf.String()
 
-		if !strings.Contains(str, "ssh-rsa ") || !strings.Contains(str, " core@default") {
+		if !strings.Contains(str, "ecdsa-sha2-nistp256 ") || !strings.Contains(str, " core@default") {
 			t.Errorf("ssh public key not found in config %d: %s", i, str)
 			continue
 		}

--- a/mantle/platform/machine/aws/flight.go
+++ b/mantle/platform/machine/aws/flight.go
@@ -59,12 +59,19 @@ func NewFlight(opts *aws.Options) (platform.Flight, error) {
 		api:        api,
 	}
 
-	keys, err := af.Keys()
+	// We have worked around the golang library limitation for
+	// keyexchange algorithm by switching to an ecdsa key in
+	// network/ssh.go. However, AWS requires an rsa key. For now
+	// (until we get an updated golang library) we'll just satisfy
+	// the requirement by using a fake key and disabling the
+	// fcos.ignition.v3.noop test on AWS.
+	// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html#how-to-generate-your-own-key-and-import-it-to-aws
+	key, err := platform.GenerateFakeKey()
 	if err != nil {
 		af.Destroy()
 		return nil, err
 	}
-	if err := api.AddKey(af.Name(), keys[0].String()); err != nil {
+	if err := api.AddKey(af.Name(), key); err != nil {
 		af.Destroy()
 		return nil, err
 	}


### PR DESCRIPTION
In 5c036d1 we swtched to ecdsa keys for the new crypto
policy change. In fdcfbbc we switched it back because
when we create new ssh keys on AWS we'd get an error because
that platform only accepts rsa keys:
https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html#how-to-generate-your-own-key-and-import-it-to-aws

For now let's disable the `fcos.ignition.v3.noop` on AWS and
just use a fake key for that platform to satisfy the requirement.
Eventually we'll switch back to RSA keys once the golang library
has been updated.

See https://github.com/coreos/coreos-assembler/issues/1772
