### PR TITLE
Use build ref or commit, drop "ref_is_tmp" hack

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -161,7 +161,7 @@ if [ -n "${previous_commit}" ]; then
     fi
 
     # and point the ref to it if there isn't one already (in which case it might be newer, but e.g. creating disk failed)
-    if ! ostree rev-parse --repo="${tmprepo}" "${ref}" &>/dev/null; then
+    if test -n "${ref}" && ! ostree rev-parse --repo="${tmprepo}" "${ref}" &>/dev/null; then
         ostree refs --repo="${tmprepo}" --create "${ref}" "${previous_commit}"
     fi
 
@@ -373,10 +373,9 @@ if [ "${commit}" == "${previous_commit}" ] && \
     fi
 else
     ostree init --repo=repo --mode=archive
-    ostree pull-local --repo=repo "${tmprepo}" "${ref}"
-    if [ -n "${ref_is_temp}" ]; then
-        ostree refs --repo=repo --delete "${ref}"
-    fi
+    # Pass the ref if it's set
+    # shellcheck disable=SC2086
+    ostree pull-local --repo=repo "${tmprepo}" "${buildid}" ${ref}
     # Don't compress; archive repos are already compressed individually and we'd
     # gain ~20M at best. We could probably have better gains if we compress the
     # whole repo in bare/bare-user mode, but that's a different story...
@@ -445,7 +444,7 @@ fi
 cat "${composejson}" "${overridesjson}" tmp/meta.json tmp/buildmeta.json tmp/diff.json tmp/parent-diff.json tmp/images.json tmp/cosa-image.json "${commitmeta_input_json}" | jq -s add > meta.json
 
 # Filter out `ref` if it's temporary
-if [ -n "${ref_is_temp}" ]; then
+if [ -z "${ref}" ]; then
     jq 'del(.ref)' < meta.json > meta.json.new
     /usr/lib/coreos-assembler/finalize-artifact meta.json{.new,}
 fi

--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -108,19 +108,17 @@ fi
 # by prepare_build since the config might've changed since then
 name=$(meta_key name)
 ref=$(meta_key ref)
-ref_is_temp=""
 if [ "${ref}" = "None" ]; then
-    ref="tmpref-${name}"
-    ref_is_temp=1
+    ref=""
 fi
 commit=$(meta_key ostree-commit)
 
 ostree_repo=${tmprepo}
-rev_parsed=$(ostree rev-parse --repo="${ostree_repo}" "${ref}" 2>/dev/null || :)
+rev_parsed=$(ostree rev-parse --repo="${ostree_repo}" "${build}" 2>/dev/null || :)
 if [ "${rev_parsed}" != "${commit}" ]; then
     # Probably an older commit or tmp/ was wiped. Let's extract it to a separate
     # temporary repo (not to be confused with ${tmprepo}...) so we can feed it
-    # as a ref (if not temp) to Anaconda.
+    # as a ref (if not temp) to create_disk.
     echo "Cache for build ${build} is gone"
     echo "Importing commit ${commit} into temporary OSTree repo"
     mkdir -p tmp/repo
@@ -130,11 +128,6 @@ if [ "${rev_parsed}" != "${commit}" ]; then
     fi
     tar -C tmp/repo -xf "${builddir}/${commit_tar_name}"
     ostree_repo=$PWD/tmp/repo
-    if [ -n "${ref_is_temp}" ]; then
-        # this gets promptly "dereferenced" back in run_virtinstall, but it
-        # keeps the code below simple so it can work in both temp/not temp cases
-        ostree refs --repo="${ostree_repo}" "${commit}" --create "${ref}"
-    fi # otherwise, the repo already has a ref, so no need to create
 fi
 
 image_format=raw
@@ -171,7 +164,7 @@ fi
 echo "Estimating disk size..."
 # The additional 35% here is obviously a hack, but we can't easily completely fill the filesystem,
 # and doing so has apparently negative performance implications.
-/usr/lib/coreos-assembler/estimate-commit-disk-size ${BLKSIZE:+--blksize ${BLKSIZE}} --repo "$ostree_repo" "$ref" --add-percent 35 > "$PWD/tmp/ostree-size.json"
+/usr/lib/coreos-assembler/estimate-commit-disk-size ${BLKSIZE:+--blksize ${BLKSIZE}} --repo "$ostree_repo" "$commit" --add-percent 35 > "$PWD/tmp/ostree-size.json"
 rootfs_size="$(jq '."estimate-mb".final' "$PWD/tmp/ostree-size.json")"
 # extra size is the non-ostree partitions, see create_disk.sh
 image_size="$(( rootfs_size + 513 ))M"
@@ -237,11 +230,6 @@ kargs="$kargs $tty ignition.platform.id=$ignition_platform_id"
 ostree_remote="$(python3 -c 'import sys, yaml; print(yaml.safe_load(sys.stdin).get("ostree-remote", "NONE"))' < "$configdir/image.yaml")"
 
 qemu-img create -f ${image_format} "${path}.tmp" "${image_size}"
-# We support deploying a commit directly instead of a ref
-ref_arg=${ref}
-if [ -n "${ref_is_temp}" ]; then
-    ref_arg=${commit}
-fi
 
 extra_target_device_opts=""
 # we need 4096 block size for ECKD DASD and (obviously) metal4k
@@ -258,7 +246,8 @@ runvm "${target_drive[@]}" -- \
             --grub-script /usr/lib/coreos-assembler/grub.cfg \
             --kargs "\"${kargs}\"" \
             --osname "${name}" \
-            --ostree-ref "${ref_arg}" \
+            --ostree-commit "${commit}" \
+            --ostree-ref "${ref:-NONE}" \
             --ostree-remote "${ostree_remote}" \
             --ostree-repo "${ostree_repo}" \
             --rootfs-size "${rootfs_size}" \

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -209,12 +209,7 @@ prepare_build() {
     # Also grab rojig summary for image upload descriptions
     name=$(jq -r '.rojig.name' < "${manifest_tmp_json}")
     summary=$(jq -r '.rojig.summary' < "${manifest_tmp_json}")
-    ref=$(jq -r '.ref' < "${manifest_tmp_json}")
-    ref_is_temp=""
-    if [ "${ref}" = "null" ]; then
-        ref="tmpref-${name}"
-        ref_is_temp=1
-    fi
+    ref=$(jq -r '.ref//""' < "${manifest_tmp_json}")
     export name ref summary
     # And validate fields coreos-assembler requires, but not rpm-ostree
     required_fields=("automatic-version-prefix")
@@ -293,7 +288,7 @@ prepare_compose_overlays() {
         exit 1
     fi
 
-    if [ -d "${overridesdir}" ] || [ -n "${ref_is_temp}" ] || [ -d "${ovld}" ]; then
+    if [ -d "${overridesdir}" ] || [ -d "${ovld}" ]; then
         mkdir -p "${tmp_overridesdir}"
         cat > "${override_manifest}" <<EOF
 include: ${manifest}
@@ -304,10 +299,6 @@ EOF
         cp "${workdir}"/src/config/*.repo "${tmp_overridesdir}"/
         manifest=${override_manifest}
     fi
-    if [ -n "${ref_is_temp}" ]; then
-        echo 'ref: "'"${ref}"'"' >> "${override_manifest}"
-    fi
-
 
     if [ -d "${ovld}" ]; then
         for n in "${ovld}"/*; do

--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -63,7 +63,8 @@ do
         --help)                  usage; exit;;
         --kargs)                 extrakargs="${extrakargs} ${1}"; shift;;
         --osname)                os_name="${1}"; shift;;
-        --ostree-ref)            ref="${1}"; shift;;
+        --ostree-commit)         commit="${1}"; shift;;
+        --ostree-ref)            ref="${1}"; if test "${ref}" = NONE; then ref=""; fi; shift;;
         --ostree-remote)         remote_name="${1}"; shift;;
         --ostree-repo)           ostree="${1}"; shift;;
         --rootfs-size)           rootfs_size="${1}"; shift;;
@@ -87,7 +88,7 @@ disk=$(realpath /dev/disk/by-id/virtio-target)
 buildid="${buildid:?--buildid must be defined}"
 imgid="${imgid:?--imgid must be defined}"
 ostree="${ostree:?--ostree-repo must be defined}"
-ref="${ref:?--ostree-ref must be defined}"
+commit="${commit:?--ostree-commit must be defined}"
 remote_name="${remote_name:?--ostree-remote must be defined}"
 grub_script="${grub_script:?--grub-script must be defined}"
 os_name="${os_name:?--os_name must be defined}"
@@ -257,18 +258,18 @@ fi
 
 # Now that we have the basic disk layout, initialize the basic
 # OSTree layout, load in the ostree commit and deploy it.
-ostree_commit=$(ostree --repo="${ostree}" rev-parse "${ref}")
 ostree admin init-fs --modern $rootfs
 if [ "${rootfs_type}" = "ext4verity" ]; then
     ostree config --repo=$rootfs/ostree/repo set ex-fsverity.required 'true'
 fi
-remote_arg=
 deploy_ref="${ref}"
 if [ "${remote_name}" != NONE ]; then
-    remote_arg="--remote=${remote_name}"
     deploy_ref="${remote_name}:${ref}"
+    time ostree pull-local --repo $rootfs/ostree/repo --remote="${remote_name}" "$ostree" "$ref"
+else
+    deploy_ref=$commit
+    time ostree pull-local --repo $rootfs/ostree/repo "$ostree" "$commit"
 fi
-time ostree pull-local "$ostree" "$ref" --repo $rootfs/ostree/repo $remote_arg
 ostree admin os-init "$os_name" --sysroot $rootfs
 # Note that $ignition_firstboot is interpreted by grub at boot time,
 # *not* the shell here.  Hence the backslash escape.
@@ -280,7 +281,7 @@ do
 done
 ostree admin deploy "${deploy_ref}" --sysroot $rootfs --os "$os_name" $kargsargs
 
-deploy_root="$rootfs/ostree/deploy/${os_name}/deploy/${ostree_commit}.0"
+deploy_root="$rootfs/ostree/deploy/${os_name}/deploy/${commit}.0"
 test -d "${deploy_root}"
 
 # This will allow us to track the version that an install
@@ -302,7 +303,7 @@ cat > $rootfs/.coreos-aleph-version.json << EOF
 {
 	"build": "${buildid}",
 	"ref": "${ref}",
-	"ostree-commit": "${ostree_commit}",
+	"ostree-commit": "${commit}",
 	"imgid": "${imgid}"
 }
 EOF


### PR DESCRIPTION
This is a general cleanup followup to the previous PR
to add a "buildid" as a ref always.
In most cases actually where we were using the ref we can
just use the commit.

But switch a few things to use the buildid, and drop the
`ref_is_tmp` hack.