### PR TITLE
cmdlib: stop copying resolv.conf

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -472,10 +472,6 @@ runvm() {
     # include COSA in the image
     find /usr/lib/coreos-assembler/ -type f > "${vmpreparedir}/hostfiles"
 
-    # resolv.conf may be symlink.
-    mkdir -p "${vmpreparedir}/etc"
-    cp -Lv /etc/resolv.conf "${vmpreparedir}/etc/resolv.conf"
-
     # the reason we do a heredoc here is so that the var substition takes
     # place immediately instead of having to proxy them through to the VM
     cat > "${vmpreparedir}/init" <<EOF


### PR DESCRIPTION
This is breaking `supermin --build` for me because it doesn't know what
to do with `etc/resolv.conf` in the prepare dir.

But anyway in user-mode networking, Slirp already takes care of DNS
forwarding in the supermin VM to the host's DNS provider so we shouldn't
need to copy `resolv.conf` at all.