### PR TITLE
Dockerfile: blow out cache to force full Quay rebuild

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /root/containerbuild
 # Only need a few of our scripts for the first few steps
 COPY ./src/print-dependencies.sh ./src/deps*.txt ./src/vmdeps*.txt ./src/build-deps.txt /root/containerbuild/src/
 COPY ./build.sh /root/containerbuild/
-RUN ./build.sh configure_yum_repos # nocache 20200619
+RUN ./build.sh configure_yum_repos # nocache 20201026
 RUN ./build.sh install_rpms
 
 # Ok copy in the rest of them for the next few steps


### PR DESCRIPTION
There's a binding between the bootupd version in cosa vs the one in the
tree, and we think this is causing an issue in CI. Let's make sure cosa
pulls in the latest bootupd.

Ref: https://github.com/coreos/fedora-coreos-config/pull/711