### PR TITLE
[4.4]create_disk: remove immutable bit for s390x

### DIFF
--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -266,7 +266,13 @@ ostree admin deploy "${deploy_ref}" --sysroot $rootfs --os "$os_name" $kargsargs
 
 deploy_root="$rootfs/ostree/deploy/${os_name}/deploy/${ostree_commit}.0"
 test -d "${deploy_root}"
-
+case $(arch) in
+    s390x)
+        # remove immutable bit as ostree in rhcos does not have this fix:
+        # https://github.com/ostreedev/ostree/pull/2179
+        chattr -i ${deploy_root}
+    ;;
+esac
 # This will allow us to track the version that an install
 # originally used; if we later need to understand something
 # like "exactly what mkfs.xfs version was used" we can do


### PR DESCRIPTION
The 4.4 pipeline for s390x was failing kola tests because of an updated ostree in the cosa container. This contained the fix for https://bugzilla.redhat.com/show_bug.cgi?id=1867601
which made the root file systems immutable. But the ostree version of RHCOS does not contain the fix causing rollbacks and upgrades to fail.

Removed the immutability bit to fix it as suggested by @cgwalters.

Co-Authored-By: Colin Walters <walters@verbum.org>
(cherry picked from commit 8964218106488f3d72be45cbe8be0fd4c4502e83)