### PR TITLE
mantle: clean up code base

### DIFF
--- a/mantle/lang/maps/sorted_test.go
+++ b/mantle/lang/maps/sorted_test.go
@@ -63,7 +63,7 @@ func TestSortedKeys(t *testing.T) {
 
 	// test is pointless if map iterates in-order by random chance
 	mapKeys := make([]string, 0, len(testMap))
-	for k, _ := range testMap {
+	for k := range testMap {
 		mapKeys = append(mapKeys, k)
 	}
 	if sort.StringsAreSorted(mapKeys) {
@@ -89,7 +89,7 @@ func TestNaturalKeys(t *testing.T) {
 
 	// test is pointless if map iterates in-order by random chance
 	mapKeys := make([]string, 0, len(testMap))
-	for k, _ := range testMap {
+	for k := range testMap {
 		mapKeys = append(mapKeys, k)
 	}
 	if natsort.StringsAreSorted(mapKeys) {


### PR DESCRIPTION
This cleans up lang/maps/sorted_test.go in mantle according to
golangci-lint, which improves the readability. And we can bring in
golanci-lint to check both Mantle and Entrypoint.

Fixes part of https://github.com/coreos/coreos-assembler/issues/1813