### PR TITLE
kola: clean up unused plog

### DIFF
--- a/mantle/kola/tests/rhcos/upgrade.go
+++ b/mantle/kola/tests/rhcos/upgrade.go
@@ -17,16 +17,12 @@ package rhcos
 import (
 	"path/filepath"
 
-	"github.com/coreos/pkg/capnslog"
-
 	"github.com/coreos/mantle/kola"
 	"github.com/coreos/mantle/kola/cluster"
 	"github.com/coreos/mantle/kola/register"
 	"github.com/coreos/mantle/kola/tests/util"
 	"github.com/coreos/mantle/platform/conf"
 )
-
-var plog = capnslog.NewPackageLogger("github.com/coreos/mantle", "kola/tests/upgrade")
 
 func init() {
 	register.RegisterUpgradeTest(&register.Test{


### PR DESCRIPTION
This cleans up unused plog in kola/tests/rhcos/upgrade.go.

Fixes part of https://github.com/coreos/coreos-assembler/issues/1813