### PR TITLE
CI: check code before building and lint GoLang

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -1,5 +1,15 @@
 // Documentation: https://github.com/coreos/coreos-ci/blob/master/README-upstream-ci.md
 
+pod(image: 'quay.io/coreos-assembler/coreos-assembler:latest', kvm: false, memory: "1Gi") {
+    checkout scm
+    stage("Linting") {
+        shwrap("""
+            make golint
+            make check
+        """)
+    }
+}
+
 pod(image: 'registry.fedoraproject.org/fedora:32', runAsUser: 0, kvm: true, memory: "10Gi") {
     checkout scm
 
@@ -15,7 +25,6 @@ pod(image: 'registry.fedoraproject.org/fedora:32', runAsUser: 0, kvm: true, memo
 
     stage("Unit Test") {
         shwrap("""
-            make check
             make unittest
         """)
     }

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,9 @@ clean:
 	find . -name "*.py[co]" -type f | xargs rm -f
 	find . -name "__pycache__" -type d | xargs rm -rf
 
+golint:
+	bash -x ci/golinter.sh
+
 mantle:
 	cd mantle && $(MAKE)
 

--- a/ci/golinter.sh
+++ b/ci/golinter.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -xue
+tmpd="$(mktemp -p /tmp -d ci-XXX)"
+trap "rm -rf ${tmpd}" EXIT
+
+curd="$(git rev-parse --show-toplevel)"
+ref="$(git rev-parse HEAD)"
+
+pushd "${tmpd}"
+rsync -a "${curd}/" "${tmpd}/cosa"
+find ${tmpd}
+pushd "${tmpd}/cosa"
+
+git remote add citest https://github.com/coreos/coreos-assembler
+git fetch citest master
+upref="$(git rev-parse citest/master)"
+
+failed=0
+for i in entrypoint mantle;
+do
+    pushd "${tmpd}/cosa/$i"
+    golangci-lint run --timeout=10m --new-from-rev="${upref}" || failed=1
+done
+
+if [[ "${failed:-0}" -ne 0 ]]; then
+    cat <<EOM
+************************************************************
+
+            GOLANG LINTING HAS FAILED
+    golangci-lint tests all new code commits.
+
+You can vet your GoLang changes locally in COSA running:
+
+    golangci-lint run --timeout=3m --new-from-rev=${upref}
+
+Or run this script after committing localy using:
+    make golint
+
+
+***********************************************************
+EOM
+    exit 1;
+fi
+
+exit 0


### PR DESCRIPTION
Rather than checking code _after_ installing the RPMs, this moves the
code check before. This also adds GoLang linting on new code only for
code quality checks.

Signed-off-by: Ben Howard <ben.howard@redhat.com>