### PR TITLE
create_disk: move /boot to partition 3; move BIOS-BOOT to 1 and always create it

### DIFF
--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -198,7 +198,7 @@ case "${image_type}" in
 esac
 
 if [ "${image_type}" == metal4k ]; then
-    disk_args+=("--no-x86-bios-partition")
+    disk_args+=("--no-x86-bios-bootloader")
 fi
 
 set -x

--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -122,26 +122,26 @@ if [ "${rootfs_size}" != "0" ]; then
 fi
 case "$arch" in
     x86_64)
+        EFIPN=2
         set -- -Z $disk \
         -U "${uninitialized_gpt_uuid}" \
         -n ${BOOTPN}:0:+384M -c ${BOOTPN}:boot \
-        -n 2:0:+127M -c 2:EFI-SYSTEM -t 2:C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+        -n ${EFIPN}:0:+127M -c ${EFIPN}:EFI-SYSTEM -t ${EFIPN}:C12A7328-F81F-11D2-BA4B-00A0C93EC93B
         if [ "${x86_bios_partition}" = 1 ]; then
             set -- "$@" -n 3:0:+1M   -c 3:BIOS-BOOT  -t 3:21686148-6449-6E6F-744E-656564454649
         fi
         set -- "$@" -n ${ROOTPN}:0:${rootfs_size}     -c ${ROOTPN}:root       -t ${ROOTPN}:0FC63DAF-8483-4772-8E79-3D69D8477DE4
         sgdisk "$@"
         sgdisk -p "$disk"
-        EFIPN=2
         ;;
     aarch64)
+        EFIPN=2
         sgdisk -Z $disk \
         -U "${uninitialized_gpt_uuid}" \
         -n ${BOOTPN}:0:+384M -c ${BOOTPN}:boot \
-        -n 2:0:+127M -c 2:EFI-SYSTEM -t 2:C12A7328-F81F-11D2-BA4B-00A0C93EC93B \
+        -n ${EFIPN}:0:+127M -c ${EFIPN}:EFI-SYSTEM -t ${EFIPN}:C12A7328-F81F-11D2-BA4B-00A0C93EC93B \
         -n ${ROOTPN}:0:${rootfs_size}     -c ${ROOTPN}:root       -t ${ROOTPN}:0FC63DAF-8483-4772-8E79-3D69D8477DE4
         sgdisk -p "$disk"
-        EFIPN=2
         ;;
     s390x)
         sgdisk -Z $disk \

--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -128,9 +128,9 @@ case "$arch" in
         -n ${BOOTPN}:0:+384M -c ${BOOTPN}:boot \
         -n ${EFIPN}:0:+127M -c ${EFIPN}:EFI-SYSTEM -t ${EFIPN}:C12A7328-F81F-11D2-BA4B-00A0C93EC93B
         if [ "${x86_bios_partition}" = 1 ]; then
-            set -- "$@" -n 3:0:+1M   -c 3:BIOS-BOOT  -t 3:21686148-6449-6E6F-744E-656564454649
+            set -- "$@" -n 3:0:+1M -c 3:BIOS-BOOT -t 3:21686148-6449-6E6F-744E-656564454649
         fi
-        set -- "$@" -n ${ROOTPN}:0:${rootfs_size}     -c ${ROOTPN}:root       -t ${ROOTPN}:0FC63DAF-8483-4772-8E79-3D69D8477DE4
+        set -- "$@" -n ${ROOTPN}:0:${rootfs_size} -c ${ROOTPN}:root -t ${ROOTPN}:0FC63DAF-8483-4772-8E79-3D69D8477DE4
         sgdisk "$@"
         sgdisk -p "$disk"
         ;;
@@ -140,25 +140,25 @@ case "$arch" in
         -U "${uninitialized_gpt_uuid}" \
         -n ${BOOTPN}:0:+384M -c ${BOOTPN}:boot \
         -n ${EFIPN}:0:+127M -c ${EFIPN}:EFI-SYSTEM -t ${EFIPN}:C12A7328-F81F-11D2-BA4B-00A0C93EC93B \
-        -n ${ROOTPN}:0:${rootfs_size}     -c ${ROOTPN}:root       -t ${ROOTPN}:0FC63DAF-8483-4772-8E79-3D69D8477DE4
+        -n ${ROOTPN}:0:${rootfs_size} -c ${ROOTPN}:root -t ${ROOTPN}:0FC63DAF-8483-4772-8E79-3D69D8477DE4
         sgdisk -p "$disk"
         ;;
     s390x)
         sgdisk -Z $disk \
         -U "${uninitialized_gpt_uuid}" \
         -n ${BOOTPN}:0:+384M -c ${BOOTPN}:boot \
-        -n ${ROOTPN}:0:${rootfs_size}     -c ${ROOTPN}:root       -t ${ROOTPN}:0FC63DAF-8483-4772-8E79-3D69D8477DE4
+        -n ${ROOTPN}:0:${rootfs_size} -c ${ROOTPN}:root -t ${ROOTPN}:0FC63DAF-8483-4772-8E79-3D69D8477DE4
         sgdisk -p "$disk"
         ;;
     ppc64le)
-        BOOTPN=2
         PREPPN=1
+        BOOTPN=2
         # ppc64le doesn't use special uuid for root partition
         sgdisk -Z $disk \
         -U "${uninitialized_gpt_uuid}" \
-        -n ${PREPPN}:0:+4M   -c ${PREPPN}:PowerPC-PReP-boot -t ${PREPPN}:9E1A2D38-C612-4316-AA26-8B49521E5A8B \
+        -n ${PREPPN}:0:+4M -c ${PREPPN}:PowerPC-PReP-boot -t ${PREPPN}:9E1A2D38-C612-4316-AA26-8B49521E5A8B \
         -n ${BOOTPN}:0:+384M -c ${BOOTPN}:boot \
-        -n ${ROOTPN}:0:${rootfs_size}     -c ${ROOTPN}:root              -t ${ROOTPN}:0FC63DAF-8483-4772-8E79-3D69D8477DE4
+        -n ${ROOTPN}:0:${rootfs_size} -c ${ROOTPN}:root -t ${ROOTPN}:0FC63DAF-8483-4772-8E79-3D69D8477DE4
         sgdisk -p "$disk"
         ;;
 esac
@@ -218,8 +218,8 @@ fi
 mkfs.ext4 ${bootargs} "${disk}${BOOTPN}" -L boot -U "${bootfs_uuid}"
 if [ ${EFIPN:+x} ]; then
        mkfs.fat "${disk}${EFIPN}" -n EFI-SYSTEM
-       # partition $BIOPN has no FS, its for bios grub
-       # partition $PREPPN has no FS, its for PowerPC PReP Boot
+       # BIOS boot partition has no FS; it's for BIOS GRUB
+       # partition $PREPPN has no FS; it's for PowerPC PReP Boot
 fi
 case "${rootfs_type}" in
     ext4verity)

--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -262,8 +262,8 @@ chcon $(matchpathcon -n /boot) $rootfs/boot
 # FAT doesn't support SELinux labeling, it uses "genfscon", so we
 # don't need to give it a label manually.
 if [ ${EFIPN:+x} ]; then
-       mkdir $rootfs/boot/efi
-       mount "${disk}${EFIPN}" $rootfs/boot/efi
+    mkdir $rootfs/boot/efi
+    mount "${disk}${EFIPN}" $rootfs/boot/efi
 fi
 
 # Now that we have the basic disk layout, initialize the basic
@@ -357,9 +357,9 @@ x86_64)
         # And BIOS grub in addition.  See also
         # https://github.com/coreos/fedora-coreos-tracker/issues/32
         grub2-install \
-        --target i386-pc \
-        --boot-directory $rootfs/boot \
-        $disk
+            --target i386-pc \
+            --boot-directory $rootfs/boot \
+            $disk
     fi
     ;;
 aarch64)
@@ -373,31 +373,31 @@ ppc64le)
     ;;
 s390x)
     bootloader_backend=zipl
-	# current zipl expects 'title' to be first line, and no blank lines in BLS file
-	# see https://github.com/ibm-s390-tools/s390-tools/issues/64
-	blsfile=$(find $rootfs/boot/loader/entries/*.conf)
-	tmpfile=$(mktemp)
-	for f in title version linux initrd options; do
-		echo $(grep $f $blsfile) >> $tmpfile
-	done
-	cat $tmpfile > $blsfile
-	# we force firstboot in building base image on s390x, ignition-dracut hook will remove
-	# this and update zipl for second boot
-	# this is only a temporary solution until we are able to do firstboot check at bootloader
-	# stage on s390x, either through zipl->grub2-emu or zipl standalone.
-	# See https://github.com/coreos/ignition-dracut/issues/84
-	# A similar hack is present in https://github.com/coreos/coreos-assembler/blob/master/src/gf-platformid#L55
-	echo "$(grep options $blsfile) ignition.firstboot" > $tmpfile
+    # current zipl expects 'title' to be first line, and no blank lines in BLS file
+    # see https://github.com/ibm-s390-tools/s390-tools/issues/64
+    blsfile=$(find $rootfs/boot/loader/entries/*.conf)
+    tmpfile=$(mktemp)
+    for f in title version linux initrd options; do
+        echo $(grep $f $blsfile) >> $tmpfile
+    done
+    cat $tmpfile > $blsfile
+    # we force firstboot in building base image on s390x, ignition-dracut hook will remove
+    # this and update zipl for second boot
+    # this is only a temporary solution until we are able to do firstboot check at bootloader
+    # stage on s390x, either through zipl->grub2-emu or zipl standalone.
+    # See https://github.com/coreos/ignition-dracut/issues/84
+    # A similar hack is present in https://github.com/coreos/coreos-assembler/blob/master/src/gf-platformid#L55
+    echo "$(grep options $blsfile) ignition.firstboot" > $tmpfile
 
-	# ideally we want to invoke zipl with bls and zipl.conf but we might need
-	# to chroot to $rootfs/ to do so. We would also do that when FCOS boot on its own.
-	# without chroot we can use --target option in zipl but it requires kernel + initramfs
-	# pair instead
-	zipl --verbose \
-		--target $rootfs/boot \
-		--image $rootfs/boot/"$(grep linux $blsfile | cut -d' ' -f2)" \
-		--ramdisk $rootfs/boot/"$(grep initrd $blsfile | cut -d' ' -f2)" \
-		--parmfile $tmpfile
+    # ideally we want to invoke zipl with bls and zipl.conf but we might need
+    # to chroot to $rootfs/ to do so. We would also do that when FCOS boot on its own.
+    # without chroot we can use --target option in zipl but it requires kernel + initramfs
+    # pair instead
+    zipl --verbose \
+        --target $rootfs/boot \
+        --image $rootfs/boot/"$(grep linux $blsfile | cut -d' ' -f2)" \
+        --ramdisk $rootfs/boot/"$(grep initrd $blsfile | cut -d' ' -f2)" \
+        --parmfile $tmpfile
     ;;
 esac
 

--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -113,8 +113,8 @@ set -x
 # Partition and create fs's. The 0...4...a...1 uuid is a sentinal used by coreos-gpt-setup
 # in ignition-dracut. It signals that the disk needs to have it's uuid randomized and the
 # backup header moved to the end of the disk.
-# Pin /boot and / to the partition number 1 and 4 respectivelly
-BOOTPN=1
+# Pin /boot and / to the partition number 3 and 4 respectively
+BOOTPN=3
 ROOTPN=4
 # Make the size relative
 if [ "${rootfs_size}" != "0" ]; then
@@ -124,13 +124,13 @@ case "$arch" in
     x86_64)
         EFIPN=2
         set -- -Z $disk \
-        -U "${uninitialized_gpt_uuid}" \
-        -n ${BOOTPN}:0:+384M -c ${BOOTPN}:boot \
-        -n ${EFIPN}:0:+127M -c ${EFIPN}:EFI-SYSTEM -t ${EFIPN}:C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+        -U "${uninitialized_gpt_uuid}"
         if [ "${x86_bios_partition}" = 1 ]; then
-            set -- "$@" -n 3:0:+1M -c 3:BIOS-BOOT -t 3:21686148-6449-6E6F-744E-656564454649
+            set -- "$@" -n 1:0:+1M -c 1:BIOS-BOOT -t 1:21686148-6449-6E6F-744E-656564454649
         fi
-        set -- "$@" -n ${ROOTPN}:0:${rootfs_size} -c ${ROOTPN}:root -t ${ROOTPN}:0FC63DAF-8483-4772-8E79-3D69D8477DE4
+        set -- "$@" -n ${EFIPN}:0:+127M -c ${EFIPN}:EFI-SYSTEM -t ${EFIPN}:C12A7328-F81F-11D2-BA4B-00A0C93EC93B \
+        -n ${BOOTPN}:0:+384M -c ${BOOTPN}:boot \
+        -n ${ROOTPN}:0:${rootfs_size} -c ${ROOTPN}:root -t ${ROOTPN}:0FC63DAF-8483-4772-8E79-3D69D8477DE4
         sgdisk "$@"
         sgdisk -p "$disk"
         ;;
@@ -138,8 +138,8 @@ case "$arch" in
         EFIPN=2
         sgdisk -Z $disk \
         -U "${uninitialized_gpt_uuid}" \
-        -n ${BOOTPN}:0:+384M -c ${BOOTPN}:boot \
         -n ${EFIPN}:0:+127M -c ${EFIPN}:EFI-SYSTEM -t ${EFIPN}:C12A7328-F81F-11D2-BA4B-00A0C93EC93B \
+        -n ${BOOTPN}:0:+384M -c ${BOOTPN}:boot \
         -n ${ROOTPN}:0:${rootfs_size} -c ${ROOTPN}:root -t ${ROOTPN}:0FC63DAF-8483-4772-8E79-3D69D8477DE4
         sgdisk -p "$disk"
         ;;
@@ -152,7 +152,6 @@ case "$arch" in
         ;;
     ppc64le)
         PREPPN=1
-        BOOTPN=2
         # ppc64le doesn't use special uuid for root partition
         sgdisk -Z $disk \
         -U "${uninitialized_gpt_uuid}" \


### PR DESCRIPTION
The offset of the BIOS boot partition gets encoded into the boot sector, and that offset is currently 512 MiB, which is awkward if we're going to support rearranging boot-related partitions.  Move the BIOS boot partition to partition 1 at the beginning of the disk, and move `/boot` to partition 3 on all platforms (including `ppc64le`, where it was overridden to partition 2).

In addition, create an unused BIOS boot partition on 4Kn disks.  This reduces the number of distinct partition layouts we need to support.

For https://github.com/coreos/fedora-coreos-config/pull/718, but shouldn't be required by it.  Closes https://github.com/coreos/fedora-coreos-tracker/issues/669.