### PR TITLE
cosalib/messaging: add broadcast_fedmsg function

### DIFF
--- a/src/cosalib/fedora_messaging_request.py
+++ b/src/cosalib/fedora_messaging_request.py
@@ -109,7 +109,7 @@ def get_request_finished_topic(request_type, environment):
 
 
 def send_message(config, topic, body):
-    print(f"Sending {topic} for build {body['build_id']}")
+    print(f"Sending {topic} with body {body}")
     # This is a bit hacky; we fork to publish the message here so that we can
     # load the publishing fedora-messaging config. The TL;DR is: we need auth
     # to publish, but we need to use the public endpoint for consuming so we

--- a/src/cosalib/fedora_messaging_request.py
+++ b/src/cosalib/fedora_messaging_request.py
@@ -44,6 +44,9 @@ def send_request_and_wait_for_response(request_type,
                                        environment='prod',
                                        request_timeout=DEFAULT_REQUEST_TIMEOUT_SEC,
                                        body={}):
+    assert environment in ['prod', 'stg']
+    assert request_type in ['ostree-sign', 'artifacts-sign', 'ostree-import']
+
     # Generate a unique id for this request
     request_id = str(uuid.uuid4())
 

--- a/src/cosalib/fedora_messaging_request.py
+++ b/src/cosalib/fedora_messaging_request.py
@@ -26,12 +26,14 @@ FEDORA_MESSAGING_PUBLIC_CONF = {
     'prod': '/etc/fedora-messaging/fedora.toml',
     'stg': '/etc/fedora-messaging/fedora.stg.toml',
 }
+
+FEDORA_MESSAGING_COREOS_TOPIC_PREFIX = {
+    'prod': 'org.fedoraproject.prod.coreos',
+    'stg': 'org.fedoraproject.stg.coreos',
+}
+
 # https://apps.fedoraproject.org/datagrepper/raw?topic=org.fedoraproject.prod.coreos.build.request.ostree-sign&delta=100000
 # https://apps.fedoraproject.org/datagrepper/raw?topic=org.fedoraproject.prod.coreos.build.request.artifacts-sign&delta=100000
-FEDORA_MESSAGING_TOPIC_PREFIX = {
-    'prod': 'org.fedoraproject.prod.coreos.build.request',
-    'stg': 'org.fedoraproject.stg.coreos.build.request',
-}
 
 # Default to timeout after 60 seconds
 DEFAULT_REQUEST_TIMEOUT_SEC = 60
@@ -64,7 +66,7 @@ def send_request_and_wait_for_response(request_type,
 
 
 def get_request_topic(request_type, environment):
-    return f'{FEDORA_MESSAGING_TOPIC_PREFIX[environment]}.{request_type}'
+    return f'{FEDORA_MESSAGING_COREOS_TOPIC_PREFIX[environment]}.build.request.{request_type}'
 
 
 def get_request_finished_topic(request_type, environment):

--- a/src/cosalib/fedora_messaging_request.py
+++ b/src/cosalib/fedora_messaging_request.py
@@ -77,6 +77,29 @@ def send_request_and_wait_for_response(request_type,
     return wait_for_response(cond, request_timeout)
 
 
+# This is used for informational messages for which don't expect a reply.
+# Supported broadcast types:
+# - build.state.change: sent by build pipeline when build started or finished
+# - stream.release: sent by release pipeline when a new stream release occurred
+# - stream.metadata.update: sent by metadata sync job when stream metadata is updated
+def broadcast_fedmsg(broadcast_type,
+                     config=None,
+                     environment='prod',
+                     body={}):
+    assert environment in ['prod', 'stg']
+    assert broadcast_type in ['build.state.change', 'stream.release',
+                              'stream.metadata.update']
+
+    # Send the message/request
+    send_message(config=config,
+                 topic=get_broadcast_topic(broadcast_type, environment),
+                 body=body)
+
+
+def get_broadcast_topic(broadcast_type, environment):
+    return f'{FEDORA_MESSAGING_COREOS_TOPIC_PREFIX[environment]}.{broadcast_type}'
+
+
 def get_request_topic(request_type, environment):
     return f'{FEDORA_MESSAGING_COREOS_TOPIC_PREFIX[environment]}.build.request.{request_type}'
 

--- a/src/cosalib/fedora_messaging_request.py
+++ b/src/cosalib/fedora_messaging_request.py
@@ -32,6 +32,9 @@ FEDORA_MESSAGING_COREOS_TOPIC_PREFIX = {
     'stg': 'org.fedoraproject.stg.coreos',
 }
 
+# You can look at examples of recent fedmsgs for particular topics via
+# datagrepper, e.g.:
+#
 # https://apps.fedoraproject.org/datagrepper/raw?topic=org.fedoraproject.prod.coreos.build.request.ostree-sign&delta=100000
 # https://apps.fedoraproject.org/datagrepper/raw?topic=org.fedoraproject.prod.coreos.build.request.artifacts-sign&delta=100000
 
@@ -39,6 +42,13 @@ FEDORA_MESSAGING_COREOS_TOPIC_PREFIX = {
 DEFAULT_REQUEST_TIMEOUT_SEC = 60
 
 
+# This is used for requesting other services to perform specific actions. The
+# function does not return until the service replies (or we time out).
+# Supported request types:
+# - ostree-sign: sent by build pipeline to sign OSTree commits
+# - artifacts-sign: sent by build pipeline to sign images
+# - ostree-import: sent by release pipeline to import OSTree commits into the
+#                  canonical Fedora repos
 def send_request_and_wait_for_response(request_type,
                                        config=None,
                                        environment='prod',


### PR DESCRIPTION
This function will be used for sending informational messages (i.e. for
which we don't expect a reply) other services may care about. The new
fedmsgs are, with prefix omitted:

- `build.state.change`: to signal build start and finish
- `stream.release`: to signal stream release
- `stream.metadata.update`: to signal stream metadata change

Ref: https://github.com/coreos/fedora-coreos-tracker/issues/225