### PR TITLE
mantle: clean up auth

### DIFF
--- a/mantle/auth/google.go
+++ b/mantle/auth/google.go
@@ -16,6 +16,7 @@
 package auth
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -68,7 +69,7 @@ func readCache(cachePath string) (*oauth2.Token, error) {
 
 	// make sure token is refreshable
 	if tok != nil && !tok.Valid() {
-		ts := conf.TokenSource(oauth2.NoContext, tok)
+		ts := conf.TokenSource(context.TODO(), tok)
 		tok, err = ts.Token()
 		if err != nil || !tok.Valid() {
 			fmt.Printf("Could not refresh cached token: %v\n", err)
@@ -98,7 +99,7 @@ func getToken() (*oauth2.Token, error) {
 		if _, err := fmt.Scan(&code); err != nil {
 			return nil, err
 		}
-		tok, err = conf.Exchange(oauth2.NoContext, code)
+		tok, err = conf.Exchange(context.TODO(), code)
 		if err != nil {
 			return nil, err
 		}
@@ -120,7 +121,7 @@ func GoogleClient() (*http.Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	return conf.Client(oauth2.NoContext, tok), nil
+	return conf.Client(context.TODO(), tok), nil
 }
 
 // GoogleTokenSource provides an outh2.TokenSource authorized in the
@@ -130,7 +131,7 @@ func GoogleTokenSource() (oauth2.TokenSource, error) {
 	if err != nil {
 		return nil, err
 	}
-	return conf.TokenSource(oauth2.NoContext, tok), nil
+	return conf.TokenSource(context.TODO(), tok), nil
 }
 
 // GoogleServiceClient fetchs a token from Google Compute Engine's
@@ -162,7 +163,7 @@ func GoogleClientFromJSONKey(jsonKey []byte, scope ...string) (*http.Client, err
 		return nil, err
 	}
 
-	return jwtConf.Client(oauth2.NoContext), nil
+	return jwtConf.Client(context.TODO()), nil
 
 }
 
@@ -178,5 +179,5 @@ func GoogleTokenSourceFromJSONKey(jsonKey []byte, scope ...string) (oauth2.Token
 		return nil, err
 	}
 
-	return jwtConf.TokenSource(oauth2.NoContext), nil
+	return jwtConf.TokenSource(context.TODO()), nil
 }


### PR DESCRIPTION
This cleans up auth/google.go.

Fixes part of https://github.com/coreos/coreos-assembler/issues/1813:
```
auth/google.go:71:26: SA1019: oauth2.NoContext is deprecated: Use context.Background() or context.TODO() instead.  (staticcheck)
                ts := conf.TokenSource(oauth2.NoContext, tok)
                                       ^
auth/google.go:101:28: SA1019: oauth2.NoContext is deprecated: Use context.Background() or context.TODO() instead.  (staticcheck)
                tok, err = conf.Exchange(oauth2.NoContext, code)
                                         ^
auth/google.go:123:21: SA1019: oauth2.NoContext is deprecated: Use context.Background() or context.TODO() instead.  (staticcheck)
        return conf.Client(oauth2.NoContext, tok), nil
                           ^
auth/google.go:133:26: SA1019: oauth2.NoContext is deprecated: Use context.Background() or context.TODO() instead.  (staticcheck)
        return conf.TokenSource(oauth2.NoContext, tok), nil
                                ^
auth/google.go:165:24: SA1019: oauth2.NoContext is deprecated: Use context.Background() or context.TODO() instead.  (staticcheck)
        return jwtConf.Client(oauth2.NoContext), nil
                              ^
auth/google.go:181:29: SA1019: oauth2.NoContext is deprecated: Use context.Background() or context.TODO() instead.  (staticcheck)
        return jwtConf.TokenSource(oauth2.NoContext), nil
                                   ^
```

