### PR TITLE
kola: fix upgrade tests handling cosa build

### DIFF
--- a/mantle/cmd/kola/kola.go
+++ b/mantle/cmd/kola/kola.go
@@ -476,15 +476,18 @@ func runArtifactIgnitionVersion(cmd *cobra.Command, args []string) error {
 }
 
 func preRunUpgrade(cmd *cobra.Command, args []string) error {
-	// unlike `kola run`, we *require* the --build arg -- XXX: figure out
-	// how to get this working using cobra's MarkFlagRequired()
-	if kola.Options.CosaBuildId == "" {
-		errors.New("Error: missing required argument --build")
-	}
-
+	// note we pass `false` here for useCosa because we want to customize the
+	// *starting* image for upgrade tests
 	err := syncOptionsImpl(false)
 	if err != nil {
 		return err
+	}
+
+	// Unlike `kola run`, we *require* a cosa build. We check this after
+	// syncOptionsImpl so that it may be auto-filled in based on either an
+	// explicit `--build` or $PWD or `--workdir`.
+	if kola.Options.CosaBuildId == "" {
+		return errors.New("Error: missing required argument --build")
 	}
 
 	if findParentImage {


### PR DESCRIPTION
The comment says that `--build` is required, but what we really mean is
that a cosa build is required. Whether that build is auto-discovered or
given explicitly via `--build` doesn't matter. Move the check for a cosa
build down to after `syncOptionsImpl()` to reflect this.

This also fixes a missing `return` which Jing originally had in #1826.

Co-authored-by: Jing Zhang <jingzhan@redhat.com>
Closes: #1827