### PR TITLE
build: Clear out change stamp file

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -288,6 +288,7 @@ else
     # creation.
     commit=$(ostree rev-parse --repo="${tmprepo}" "${ref}")
     image_input_checksum=$( (echo "${commit}" && echo "${image_config_checksum}") | sha256sum_str)
+    echo "commit: ${commit} image: ${image_input_checksum}"
     # Note we may not actually have a previous build in the case of
     # successfully composing an ostree but failing the image on the
     # first build.

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -385,6 +385,7 @@ runcompose() {
         set - "$@" --ex-lockfile="${tmp_overridesdir}/local-overrides.json"
     fi
 
+    rm -f "${changed_stamp}"
     # shellcheck disable=SC2086
     set - ${COSA_RPMOSTREE_GDB:-} rpm-ostree compose tree --repo="${tmprepo}" \
             --cachedir="${workdir}"/cache --touch-if-changed "${changed_stamp}" \


### PR DESCRIPTION
Otherwise once we detected a change, we'll keep thinking there's
a new ostree commit for every subsequent build.

This breaks the idempotency of `cosa build`.