### PR TITLE
kola: check for systemd ordering cycles in console

### DIFF
--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -175,6 +175,10 @@ var (
 			desc:  "core dump",
 			match: regexp.MustCompile("[Cc]ore dump"),
 		},
+		{
+			desc:  "systemd ordering cycle",
+			match: regexp.MustCompile("Ordering cycle found"),
+		},
 	}
 )
 


### PR DESCRIPTION
This would've caught
https://github.com/coreos/fedora-coreos-tracker/issues/660.