### PR TITLE
mantle: clean up cli

### DIFF
--- a/mantle/cli/cli.go
+++ b/mantle/cli/cli.go
@@ -70,14 +70,6 @@ func Execute(main *cobra.Command) {
 	os.Exit(0)
 }
 
-func setRepoLogLevel(repo string, l capnslog.LogLevel) {
-	r, err := capnslog.GetRepoLogger(repo)
-	if err != nil {
-		return // don't care if it isn't linked in
-	}
-	r.SetRepoLogLevel(l)
-}
-
 func startLogging(cmd *cobra.Command) {
 	switch {
 	case logDebug:


### PR DESCRIPTION
This cleans up cli/cli.go, drop deadcode.

Fixes part of https://github.com/coreos/coreos-assembler/issues/1813:
```
cli/cli.go:73:6: `setRepoLogLevel` is unused (deadcode)
func setRepoLogLevel(repo string, l capnslog.LogLevel) {
     ^
```