### PR TITLE
mantle: clean up qemuexec

### DIFF
--- a/mantle/cmd/kola/qemuexec.go
+++ b/mantle/cmd/kola/qemuexec.go
@@ -92,7 +92,6 @@ func renderFragments(fragments []string, c *conf.Conf) error {
 		switch fragtype {
 		case "autologin":
 			c.AddAutoLogin()
-			break
 		default:
 			return fmt.Errorf("Unknown fragment: %s", fragtype)
 		}
@@ -228,7 +227,10 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 		}
 	}
 	if kola.QEMUIsoOptions.IsoPath != "" {
-		builder.AddIso(kola.QEMUIsoOptions.IsoPath, "")
+		err := builder.AddIso(kola.QEMUIsoOptions.IsoPath, "")
+		if err != nil {
+			return err
+		}
 	}
 	builder.Hostname = hostname
 	if memory != 0 {


### PR DESCRIPTION
This cleans up cmd/kola/qemuexec.go:
```
cmd/kola/qemuexec.go:95:4: S1023: redundant break statement (gosimple)
                        break
                        ^
cmd/kola/qemuexec.go:231:17: Error return value of `builder.AddIso` is not checked (errcheck)
                builder.AddIso(kola.QEMUIsoOptions.IsoPath, "")
                              ^
```

Fixes part of https://github.com/coreos/coreos-assembler/issues/1813