### PR TITLE
mantle/aws/images: support Ebs blockdev not being first

### DIFF
--- a/mantle/platform/api/aws/images.go
+++ b/mantle/platform/api/aws/images.go
@@ -617,13 +617,14 @@ func (a *API) copyImageIn(sourceRegion, sourceImageID, name, description string,
 		}
 	}
 
-	var snapshotID string
 	image, err := a.describeImage(imageID)
 	if err != nil {
 		return ImageData{}, err
 	}
-	if image.BlockDeviceMappings[0].Ebs.SnapshotId != nil {
-		snapshotID = *image.BlockDeviceMappings[0].Ebs.SnapshotId
+
+	snapshotID, err := getImageSnapshotID(image)
+	if err != nil {
+		return ImageData{}, err
 	}
 
 	if len(snapshotTags) > 0 {


### PR DESCRIPTION
Don't hardcode `[0]` when trying to get the snapshot ID, the ephemeral
device might be first. Use the `getImageSnapshotID()` helper instead
which was made to handle this.