### PR TITLE
mantle: openstack: fix passing of openstack config file path

### DIFF
--- a/mantle/go.mod
+++ b/mantle/go.mod
@@ -47,6 +47,7 @@ require (
 	golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f
 	golang.org/x/text v0.3.3
 	google.golang.org/api v0.34.0
+	gopkg.in/yaml.v2 v2.3.0
 )
 
 replace google.golang.org/cloud => cloud.google.com/go v0.0.0-20190220171618-cbb15e60dc6d

--- a/mantle/platform/api/openstack/api.go
+++ b/mantle/platform/api/openstack/api.go
@@ -85,7 +85,9 @@ type API struct {
 
 // LoadCloudsYAML defines how to load a clouds.yaml file.
 // By default, this calls the local LoadCloudsYAML function.
+// See https://github.com/gophercloud/utils/blob/master/openstack/clientconfig/requests.go
 func (opts Options) LoadCloudsYAML() (map[string]clientconfig.Cloud, error) {
+	// If provided a path to a config file then we load it here.
 	if opts.ConfigPath != "" {
 		var clouds clientconfig.Clouds
 		if content, err := ioutil.ReadFile(opts.ConfigPath); err != nil {
@@ -95,6 +97,9 @@ func (opts Options) LoadCloudsYAML() (map[string]clientconfig.Cloud, error) {
 		}
 		return clouds.Clouds, nil
 	}
+
+	// If not provided a path to a config, fall back to
+	// LoadCloudsYAML() from the clientconfig library.
 	return clientconfig.LoadCloudsYAML()
 }
 

--- a/mantle/platform/api/openstack/api.go
+++ b/mantle/platform/api/openstack/api.go
@@ -49,7 +49,7 @@ var (
 type Options struct {
 	*platform.Options
 
-	// Config file. Defaults to $HOME/.config/openstack.json.
+	// Config file. The path to a clouds.yaml file.
 	ConfigPath string
 	// Profile name
 	Profile string
@@ -81,6 +81,18 @@ type API struct {
 }
 
 func New(opts *Options) (*API, error) {
+	// The clientconfig library tries to find a clouds.yaml in:
+	//     1. OS_CLIENT_CONFIG_FILE
+	//     2. Current directory.
+	//     3. unix-specific user_config_dir (~/.config/openstack/clouds.yaml)
+	//     4. unix-specific site_config_dir (/etc/openstack/clouds.yaml)
+	// See https://github.com/gophercloud/utils/blob/8677e053dcf1f05d0fa0a616094aace04690eb94/openstack/clientconfig/utils.go#L93-L112
+	//
+	// If the user provided a path to a config file set the
+	// $OS_CLIENT_CONFIG_FILE env var to it.
+	if opts.ConfigPath != "" {
+		os.Setenv("OS_CLIENT_CONFIG_FILE", opts.ConfigPath)
+	}
 
 	if opts.Profile == "" {
 		opts.Profile = "openstack"


### PR DESCRIPTION
This is a followup to b5eb5d6. We need to set $OS_CLIENT_CONFIG_FILE
to the value given by the user, which is the path to the clouds.yaml
on their local system.