### PR TITLE
mantle: clean up switchkernel

### DIFF
--- a/mantle/cmd/kola/switchkernel.go
+++ b/mantle/cmd/kola/switchkernel.go
@@ -90,7 +90,10 @@ var (
 
 func init() {
 	cmdSwitchKernel.Flags().StringVar(&rtKernelRpmDir, "kernel-rt", "", "Path to kernel rt rpm directory")
-	cmdSwitchKernel.MarkFlagRequired("kernel-rt")
+	err := cmdSwitchKernel.MarkFlagRequired("kernel-rt")
+	if err != nil {
+		panic(err)
+	}
 	root.AddCommand(cmdSwitchKernel)
 }
 
@@ -177,8 +180,8 @@ func switchDefaultToRtKernel(c platform.Cluster, m platform.Machine) error {
 	if err != nil {
 		return errors.Wrapf(err, "failed to run %s", cmd)
 	}
-	fmt.Println(fmt.Sprintf("%s", stderr))
-	fmt.Println(fmt.Sprintf("%s", stdout))
+	fmt.Printf("%s\n", stderr)
+	fmt.Printf("%s\n", stdout)
 
 	// reboot the machine to switch kernel
 	fmt.Println("Rebooting machine...")
@@ -207,8 +210,8 @@ func switchRtKernelToDefault(c platform.Cluster, m platform.Machine) error {
 	if err != nil {
 		return errors.Wrapf(err, "failed to run %s", cmd)
 	}
-	fmt.Println(fmt.Sprintf("%s", stderr))
-	fmt.Println(fmt.Sprintf("%s", stdout))
+	fmt.Printf("%s\n", stderr)
+	fmt.Printf("%s\n", stdout)
 
 	// reboot the machine to switch kernel
 	fmt.Println("Rebooting machine...")


### PR DESCRIPTION
This cleans up cmd/kola/switchkernel.go:
```
cmd/kola/switchkernel.go:93:34: Error return value of `cmdSwitchKernel.MarkFlagRequired` is not checked (errcheck)
        cmdSwitchKernel.MarkFlagRequired("kernel-rt")
                                        ^
cmd/kola/switchkernel.go:180:2: S1038: should use fmt.Printf instead of fmt.Println(fmt.Sprintf(...)) (but don't forget the newline) (gosimple)
        fmt.Println(fmt.Sprintf("%s", stderr))
        ^
cmd/kola/switchkernel.go:181:2: S1038: should use fmt.Printf instead of fmt.Println(fmt.Sprintf(...)) (but don't forget the newline) (gosimple)
        fmt.Println(fmt.Sprintf("%s", stdout))
        ^
cmd/kola/switchkernel.go:210:2: S1038: should use fmt.Printf instead of fmt.Println(fmt.Sprintf(...)) (but don't forget the newline) (gosimple)
        fmt.Println(fmt.Sprintf("%s", stderr))
        ^
cmd/kola/switchkernel.go:211:2: S1038: should use fmt.Printf instead of fmt.Println(fmt.Sprintf(...)) (but don't forget the newline) (gosimple)
        fmt.Println(fmt.Sprintf("%s", stdout))
        ^
```

Fixes part of https://github.com/coreos/coreos-assembler/issues/1813