### PR TITLE
Revert "Use build ref or commit, drop "ref_is_tmp" hack"

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -161,7 +161,7 @@ if [ -n "${previous_commit}" ]; then
     fi
 
     # and point the ref to it if there isn't one already (in which case it might be newer, but e.g. creating disk failed)
-    if test -n "${ref}" && ! ostree rev-parse --repo="${tmprepo}" "${ref}" &>/dev/null; then
+    if ! ostree rev-parse --repo="${tmprepo}" "${ref}" &>/dev/null; then
         ostree refs --repo="${tmprepo}" --create "${ref}" "${previous_commit}"
     fi
 
@@ -373,9 +373,10 @@ if [ "${commit}" == "${previous_commit}" ] && \
     fi
 else
     ostree init --repo=repo --mode=archive
-    # Pass the ref if it's set
-    # shellcheck disable=SC2086
-    ostree pull-local --repo=repo "${tmprepo}" "${buildid}" ${ref}
+    ostree pull-local --repo=repo "${tmprepo}" "${ref}"
+    if [ -n "${ref_is_temp}" ]; then
+        ostree refs --repo=repo --delete "${ref}"
+    fi
     # Don't compress; archive repos are already compressed individually and we'd
     # gain ~20M at best. We could probably have better gains if we compress the
     # whole repo in bare/bare-user mode, but that's a different story...
@@ -444,7 +445,7 @@ fi
 cat "${composejson}" "${overridesjson}" tmp/meta.json tmp/buildmeta.json tmp/diff.json tmp/parent-diff.json tmp/images.json tmp/cosa-image.json "${commitmeta_input_json}" | jq -s add > meta.json
 
 # Filter out `ref` if it's temporary
-if [ -z "${ref}" ]; then
+if [ -n "${ref_is_temp}" ]; then
     jq 'del(.ref)' < meta.json > meta.json.new
     /usr/lib/coreos-assembler/finalize-artifact meta.json{.new,}
 fi

--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -108,17 +108,19 @@ fi
 # by prepare_build since the config might've changed since then
 name=$(meta_key name)
 ref=$(meta_key ref)
+ref_is_temp=""
 if [ "${ref}" = "None" ]; then
-    ref=""
+    ref="tmpref-${name}"
+    ref_is_temp=1
 fi
 commit=$(meta_key ostree-commit)
 
 ostree_repo=${tmprepo}
-rev_parsed=$(ostree rev-parse --repo="${ostree_repo}" "${build}" 2>/dev/null || :)
+rev_parsed=$(ostree rev-parse --repo="${ostree_repo}" "${ref}" 2>/dev/null || :)
 if [ "${rev_parsed}" != "${commit}" ]; then
     # Probably an older commit or tmp/ was wiped. Let's extract it to a separate
     # temporary repo (not to be confused with ${tmprepo}...) so we can feed it
-    # as a ref (if not temp) to create_disk.
+    # as a ref (if not temp) to Anaconda.
     echo "Cache for build ${build} is gone"
     echo "Importing commit ${commit} into temporary OSTree repo"
     mkdir -p tmp/repo
@@ -128,6 +130,11 @@ if [ "${rev_parsed}" != "${commit}" ]; then
     fi
     tar -C tmp/repo -xf "${builddir}/${commit_tar_name}"
     ostree_repo=$PWD/tmp/repo
+    if [ -n "${ref_is_temp}" ]; then
+        # this gets promptly "dereferenced" back in run_virtinstall, but it
+        # keeps the code below simple so it can work in both temp/not temp cases
+        ostree refs --repo="${ostree_repo}" "${commit}" --create "${ref}"
+    fi # otherwise, the repo already has a ref, so no need to create
 fi
 
 image_format=raw
@@ -164,7 +171,7 @@ fi
 echo "Estimating disk size..."
 # The additional 35% here is obviously a hack, but we can't easily completely fill the filesystem,
 # and doing so has apparently negative performance implications.
-/usr/lib/coreos-assembler/estimate-commit-disk-size ${BLKSIZE:+--blksize ${BLKSIZE}} --repo "$ostree_repo" "$commit" --add-percent 35 > "$PWD/tmp/ostree-size.json"
+/usr/lib/coreos-assembler/estimate-commit-disk-size ${BLKSIZE:+--blksize ${BLKSIZE}} --repo "$ostree_repo" "$ref" --add-percent 35 > "$PWD/tmp/ostree-size.json"
 rootfs_size="$(jq '."estimate-mb".final' "$PWD/tmp/ostree-size.json")"
 # extra size is the non-ostree partitions, see create_disk.sh
 image_size="$(( rootfs_size + 513 ))M"
@@ -230,6 +237,11 @@ kargs="$kargs $tty ignition.platform.id=$ignition_platform_id"
 ostree_remote="$(python3 -c 'import sys, yaml; print(yaml.safe_load(sys.stdin).get("ostree-remote", "NONE"))' < "$configdir/image.yaml")"
 
 qemu-img create -f ${image_format} "${path}.tmp" "${image_size}"
+# We support deploying a commit directly instead of a ref
+ref_arg=${ref}
+if [ -n "${ref_is_temp}" ]; then
+    ref_arg=${commit}
+fi
 
 extra_target_device_opts=""
 # we need 4096 block size for ECKD DASD and (obviously) metal4k
@@ -246,8 +258,7 @@ runvm "${target_drive[@]}" -- \
             --grub-script /usr/lib/coreos-assembler/grub.cfg \
             --kargs "\"${kargs}\"" \
             --osname "${name}" \
-            --ostree-commit "${commit}" \
-            --ostree-ref "${ref:-NONE}" \
+            --ostree-ref "${ref_arg}" \
             --ostree-remote "${ostree_remote}" \
             --ostree-repo "${ostree_repo}" \
             --rootfs-size "${rootfs_size}" \

--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -63,8 +63,7 @@ do
         --help)                  usage; exit;;
         --kargs)                 extrakargs="${extrakargs} ${1}"; shift;;
         --osname)                os_name="${1}"; shift;;
-        --ostree-commit)         commit="${1}"; shift;;
-        --ostree-ref)            ref="${1}"; if test "${ref}" = NONE; then ref=""; fi; shift;;
+        --ostree-ref)            ref="${1}"; shift;;
         --ostree-remote)         remote_name="${1}"; shift;;
         --ostree-repo)           ostree="${1}"; shift;;
         --rootfs-size)           rootfs_size="${1}"; shift;;
@@ -88,7 +87,7 @@ disk=$(realpath /dev/disk/by-id/virtio-target)
 buildid="${buildid:?--buildid must be defined}"
 imgid="${imgid:?--imgid must be defined}"
 ostree="${ostree:?--ostree-repo must be defined}"
-commit="${commit:?--ostree-commit must be defined}"
+ref="${ref:?--ostree-ref must be defined}"
 remote_name="${remote_name:?--ostree-remote must be defined}"
 grub_script="${grub_script:?--grub-script must be defined}"
 os_name="${os_name:?--os_name must be defined}"
@@ -258,18 +257,18 @@ fi
 
 # Now that we have the basic disk layout, initialize the basic
 # OSTree layout, load in the ostree commit and deploy it.
+ostree_commit=$(ostree --repo="${ostree}" rev-parse "${ref}")
 ostree admin init-fs --modern $rootfs
 if [ "${rootfs_type}" = "ext4verity" ]; then
     ostree config --repo=$rootfs/ostree/repo set ex-fsverity.required 'true'
 fi
+remote_arg=
 deploy_ref="${ref}"
 if [ "${remote_name}" != NONE ]; then
+    remote_arg="--remote=${remote_name}"
     deploy_ref="${remote_name}:${ref}"
-    time ostree pull-local --repo $rootfs/ostree/repo --remote="${remote_name}" "$ostree" "$ref"
-else
-    deploy_ref=$commit
-    time ostree pull-local --repo $rootfs/ostree/repo "$ostree" "$commit"
 fi
+time ostree pull-local "$ostree" "$ref" --repo $rootfs/ostree/repo $remote_arg
 ostree admin os-init "$os_name" --sysroot $rootfs
 # Note that $ignition_firstboot is interpreted by grub at boot time,
 # *not* the shell here.  Hence the backslash escape.
@@ -281,7 +280,7 @@ do
 done
 ostree admin deploy "${deploy_ref}" --sysroot $rootfs --os "$os_name" $kargsargs
 
-deploy_root="$rootfs/ostree/deploy/${os_name}/deploy/${commit}.0"
+deploy_root="$rootfs/ostree/deploy/${os_name}/deploy/${ostree_commit}.0"
 test -d "${deploy_root}"
 
 # This will allow us to track the version that an install
@@ -303,7 +302,7 @@ cat > $rootfs/.coreos-aleph-version.json << EOF
 {
 	"build": "${buildid}",
 	"ref": "${ref}",
-	"ostree-commit": "${commit}",
+	"ostree-commit": "${ostree_commit}",
 	"imgid": "${imgid}"
 }
 EOF


### PR DESCRIPTION
This reverts commit e734a6e696dac0f9014dc6ed5da9caaba46a496e.
It breaks change detection for RHCOS, needs rpm-ostree API.