### PR TITLE
Use build ref or commit, drop "ref_is_tmp" hack

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -268,6 +268,9 @@ if [ ! -f "${workdir}"/builds/builds.json ] && [ ! -f "${fetch_stamp}" ] ; then
 fi
 # --cache-only is here since `fetch` is a separate verb
 # shellcheck disable=SC2086
+if test -n "${previous_commit}"; then
+    extra_compose_args+=(--previous-commit "${previous_commit}")
+fi
 RUNVM_NONET=1 runcompose --cache-only ${FORCE} --add-metadata-from-json "${commitmeta_input_json}" \
            --write-composejson-to "${composejson}" \
            --ex-write-lockfile-to "${lockfile_out}".tmp \
@@ -283,10 +286,7 @@ if [ -f "${changed_stamp}" ] && [ -f "${composejson}" ]; then
     # Save this in case the image build fails
     cp-reflink "${composejson}" "${workdir}"/tmp/compose-"${commit}".json
 else
-    # Pick up from tmprepo; that's what rpm-ostree is comparing against. It may
-    # be the same as previous_commit, or newer if a previous build failed image
-    # creation.
-    commit=$(ostree rev-parse --repo="${tmprepo}" "${ref}")
+    commit="${previous_commit}"
     image_input_checksum=$( (echo "${commit}" && echo "${image_config_checksum}") | sha256sum_str)
     echo "commit: ${commit} image: ${image_input_checksum}"
     # Note we may not actually have a previous build in the case of

--- a/src/cmd-build
+++ b/src/cmd-build
@@ -161,7 +161,7 @@ if [ -n "${previous_commit}" ]; then
     fi
 
     # and point the ref to it if there isn't one already (in which case it might be newer, but e.g. creating disk failed)
-    if ! ostree rev-parse --repo="${tmprepo}" "${ref}" &>/dev/null; then
+    if test -n "${ref}" && ! ostree rev-parse --repo="${tmprepo}" "${ref}" &>/dev/null; then
         ostree refs --repo="${tmprepo}" --create "${ref}" "${previous_commit}"
     fi
 
@@ -373,10 +373,9 @@ if [ "${commit}" == "${previous_commit}" ] && \
     fi
 else
     ostree init --repo=repo --mode=archive
-    ostree pull-local --repo=repo "${tmprepo}" "${ref}"
-    if [ -n "${ref_is_temp}" ]; then
-        ostree refs --repo=repo --delete "${ref}"
-    fi
+    # Pass the ref if it's set
+    # shellcheck disable=SC2086
+    ostree pull-local --repo=repo "${tmprepo}" "${buildid}" ${ref}
     # Don't compress; archive repos are already compressed individually and we'd
     # gain ~20M at best. We could probably have better gains if we compress the
     # whole repo in bare/bare-user mode, but that's a different story...
@@ -443,12 +442,6 @@ fi
 # Merge all the JSON; note that we want ${composejson} first
 # since we may be overriding data from a previous build.
 cat "${composejson}" "${overridesjson}" tmp/meta.json tmp/buildmeta.json tmp/diff.json tmp/parent-diff.json tmp/images.json tmp/cosa-image.json "${commitmeta_input_json}" | jq -s add > meta.json
-
-# Filter out `ref` if it's temporary
-if [ -n "${ref_is_temp}" ]; then
-    jq 'del(.ref)' < meta.json > meta.json.new
-    /usr/lib/coreos-assembler/finalize-artifact meta.json{.new,}
-fi
 
 # Move lockfile into build dir
 mv "${lockfile_out}" .

--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -108,19 +108,17 @@ fi
 # by prepare_build since the config might've changed since then
 name=$(meta_key name)
 ref=$(meta_key ref)
-ref_is_temp=""
 if [ "${ref}" = "None" ]; then
-    ref="tmpref-${name}"
-    ref_is_temp=1
+    ref=""
 fi
 commit=$(meta_key ostree-commit)
 
 ostree_repo=${tmprepo}
-rev_parsed=$(ostree rev-parse --repo="${ostree_repo}" "${ref}" 2>/dev/null || :)
+rev_parsed=$(ostree rev-parse --repo="${ostree_repo}" "${build}" 2>/dev/null || :)
 if [ "${rev_parsed}" != "${commit}" ]; then
     # Probably an older commit or tmp/ was wiped. Let's extract it to a separate
     # temporary repo (not to be confused with ${tmprepo}...) so we can feed it
-    # as a ref (if not temp) to Anaconda.
+    # as a ref (if not temp) to create_disk.
     echo "Cache for build ${build} is gone"
     echo "Importing commit ${commit} into temporary OSTree repo"
     mkdir -p tmp/repo
@@ -130,11 +128,6 @@ if [ "${rev_parsed}" != "${commit}" ]; then
     fi
     tar -C tmp/repo -xf "${builddir}/${commit_tar_name}"
     ostree_repo=$PWD/tmp/repo
-    if [ -n "${ref_is_temp}" ]; then
-        # this gets promptly "dereferenced" back in run_virtinstall, but it
-        # keeps the code below simple so it can work in both temp/not temp cases
-        ostree refs --repo="${ostree_repo}" "${commit}" --create "${ref}"
-    fi # otherwise, the repo already has a ref, so no need to create
 fi
 
 image_format=raw
@@ -175,7 +168,7 @@ fi
 echo "Estimating disk size..."
 # The additional 35% here is obviously a hack, but we can't easily completely fill the filesystem,
 # and doing so has apparently negative performance implications.
-/usr/lib/coreos-assembler/estimate-commit-disk-size ${BLKSIZE:+--blksize ${BLKSIZE}} --repo "$ostree_repo" "$ref" --add-percent 35 > "$PWD/tmp/ostree-size.json"
+/usr/lib/coreos-assembler/estimate-commit-disk-size ${BLKSIZE:+--blksize ${BLKSIZE}} --repo "$ostree_repo" "$commit" --add-percent 35 > "$PWD/tmp/ostree-size.json"
 rootfs_size="$(jq '."estimate-mb".final' "$PWD/tmp/ostree-size.json")"
 # extra size is the non-ostree partitions, see create_disk.sh
 image_size="$(( rootfs_size + 513 ))M"
@@ -241,11 +234,6 @@ kargs="$kargs $tty ignition.platform.id=$ignition_platform_id"
 ostree_remote="$(python3 -c 'import sys, yaml; print(yaml.safe_load(sys.stdin).get("ostree-remote", "NONE"))' < "$configdir/image.yaml")"
 
 qemu-img create -f ${image_format} "${path}.tmp" "${image_size}"
-# We support deploying a commit directly instead of a ref
-ref_arg=${ref}
-if [ -n "${ref_is_temp}" ]; then
-    ref_arg=${commit}
-fi
 
 extra_target_device_opts=""
 # we need 4096 block size for ECKD DASD and (obviously) metal4k
@@ -263,7 +251,8 @@ runvm "${target_drive[@]}" -- \
             --grub-script /usr/lib/coreos-assembler/grub.cfg \
             --kargs "\"${kargs}\"" \
             --osname "${name}" \
-            --ostree-ref "${ref_arg}" \
+            --ostree-commit "${commit}" \
+            --ostree-ref "${ref:-NONE}" \
             --ostree-remote "${ostree_remote}" \
             --ostree-repo "${ostree_repo}" \
             --rootfs-size "${rootfs_size}" \

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -208,12 +208,7 @@ prepare_build() {
     # Also grab rojig summary for image upload descriptions
     name=$(jq -r '.rojig.name' < "${manifest_tmp_json}")
     summary=$(jq -r '.rojig.summary' < "${manifest_tmp_json}")
-    ref=$(jq -r '.ref' < "${manifest_tmp_json}")
-    ref_is_temp=""
-    if [ "${ref}" = "null" ]; then
-        ref="tmpref-${name}"
-        ref_is_temp=1
-    fi
+    ref=$(jq -r '.ref//""' < "${manifest_tmp_json}")
     export name ref summary
     # And validate fields coreos-assembler requires, but not rpm-ostree
     required_fields=("automatic-version-prefix")
@@ -292,7 +287,7 @@ prepare_compose_overlays() {
         exit 1
     fi
 
-    if [ -d "${overridesdir}" ] || [ -n "${ref_is_temp}" ] || [ -d "${ovld}" ]; then
+    if [ -d "${overridesdir}" ] || [ -d "${ovld}" ]; then
         mkdir -p "${tmp_overridesdir}"
         cat > "${override_manifest}" <<EOF
 include: ${manifest}
@@ -303,10 +298,6 @@ EOF
         cp "${workdir}"/src/config/*.repo "${tmp_overridesdir}"/
         manifest=${override_manifest}
     fi
-    if [ -n "${ref_is_temp}" ]; then
-        echo 'ref: "'"${ref}"'"' >> "${override_manifest}"
-    fi
-
 
     if [ -d "${ovld}" ]; then
         for n in "${ovld}"/*; do


### PR DESCRIPTION

This is a general cleanup followup to the previous PR
to add a "buildid" as a ref always.
In most cases actually where we were using the ref we can
just use the commit.

But switch a few things to use the buildid, and drop the
`ref_is_tmp` hack.