### PR TITLE
entrypoint: add `cosa remote`

### DIFF
--- a/entrypoint/cmd/builder.go
+++ b/entrypoint/cmd/builder.go
@@ -1,0 +1,117 @@
+package main
+
+/*
+	Definition for the "remote" command.
+*/
+
+import (
+	"fmt"
+	"github.com/coreos/entrypoint/remote"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+var (
+	containBuilds bool
+	jobSpec       string
+	buildSteps    string
+	localCosaDir  string
+
+	cmdRemote = &cobra.Command{
+		Use:   "remote",
+		Short: "Run cosa commands remotely",
+		Run:   runRemote,
+	}
+)
+
+func init() {
+	cmdRoot.AddCommand(cmdRemote)
+	cmdRemote.Flags().BoolVarP(&containBuilds, "containBuilds", "c", false, "contain builds or not")
+	cmdRemote.Flags().StringVarP(&jobSpec, "jobSpec", "j", "", "location of the jobSpec")
+	cmdRemote.Flags().StringVarP(&buildSteps, "buildSteps", "b", "", "location of the build.steps")
+	cmdRemote.Flags().StringVarP(&localCosaDir, "localCosaDir", "l", "", "location of the local cosa source")
+
+	if localCosaDir == "" {
+		path, err := os.Getwd()
+		if err != nil {
+			localCosaDir = cosaContainerDir
+		} else {
+			localCosaDir = filepath.Dir(path)
+		}
+	}
+}
+
+func runRemote(c *cobra.Command, args []string) {
+	_, err := os.Stat(localCosaDir)
+	if os.IsNotExist(err) {
+		log.Fatalf("cosaDir: %s does not exist", localCosaDir)
+	}
+
+	dirs := [...]string{"src", "overrides", "builds", "tmp", "cache"}
+	for _, d := range dirs {
+		dir := fmt.Sprintf("%s/%s", localCosaDir, d)
+		_, err := os.Stat(dir)
+		if os.IsNotExist(err) {
+			log.Fatalf("%s does not exist", dir)
+		}
+	}
+
+	var includes []string
+
+	srcDir := fmt.Sprintf("%s/%s", localCosaDir, "src")
+	includes = append(includes, srcDir)
+
+	overridesDir := fmt.Sprintf("%s/%s", localCosaDir, "overrides")
+	includes = append(includes, overridesDir)
+
+	if containBuilds {
+		buildsDir := fmt.Sprintf("%s/%s", localCosaDir, "builds")
+		includes = append(includes, buildsDir)
+	}
+
+	if jobSpec != "" {
+		_, err := os.Stat(jobSpec)
+		if os.IsNotExist(err) {
+			log.Fatalf("%s does not exist!\n", jobSpec)
+		}
+		includes = append(includes, jobSpec)
+	}
+
+	if buildSteps != "" {
+		_, err := os.Stat(buildSteps)
+		if os.IsNotExist(err) {
+			log.Fatalf("%s does not exist!\n", buildSteps)
+		}
+		includes = append(includes, buildSteps)
+	}
+
+	dest := fmt.Sprintf("%s/devel.tar", localCosaDir)
+
+	var emptyDirs []string
+	emptyDirs = append(emptyDirs, "tmp")
+	emptyDirs = append(emptyDirs, "cache")
+	if !containBuilds {
+		emptyDirs = append(emptyDirs, "builds")
+	}
+
+	a := remote.CosaArchive{
+		CreateDirs: emptyDirs,
+		Includes:   includes,
+	}
+	if err := a.CreateArchive(dest); err != nil {
+		log.Fatalf("failed to create the tar ball: %v", err)
+	}
+
+	cmdArg := fmt.Sprintf("--from-archive=%s", dest)
+	ocCmdArgs := []string{"start-build", "bc/cosa-runner-master", cmdArg, "--follow=true"}
+	cmd := exec.Command("oc", ocCmdArgs...)
+	_, err = cmd.CombinedOutput()
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/entrypoint/remote/archive.go
+++ b/entrypoint/remote/archive.go
@@ -1,0 +1,153 @@
+package remote
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	log "github.com/sirupsen/logrus"
+	"io"
+	"os"
+)
+
+type CosaArchive struct {
+	CreateDirs []string
+	Includes   []string
+}
+
+func (a *CosaArchive) CreateArchive(dest string) error {
+	_, err := os.Stat(dest)
+	if os.IsExist(err) {
+		log.Tracef("dest %s already exists", dest)
+		if err := os.Remove(dest); err != nil {
+			return err
+		}
+		log.Tracef("original dest %s deleted\n", dest)
+	}
+	tarFile, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+	defer tarFile.Close()
+
+	gWriter := gzip.NewWriter(tarFile)
+	defer gWriter.Close()
+
+	tarFileWriter := tar.NewWriter(gWriter)
+	defer tarFileWriter.Close()
+
+	for _, path := range a.Includes {
+		file, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+
+		err = writeArchive(file, "", tarFileWriter)
+		if err != nil {
+			return err
+		}
+		log.Debugf("wrote %s to tarball", path)
+	}
+
+	for _, dir := range a.CreateDirs {
+		err := os.Mkdir(dir, 0755)
+		if err != nil {
+			return err
+		}
+		defer os.RemoveAll(dir)
+		file, err := os.Open(dir)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+
+		if err := createDirInArchive(file, file.Name(), tarFileWriter); err != nil {
+			return err
+		}
+		log.Debugf("created %v dir in tarball", dir)
+	}
+
+	log.Infof("created tar ball: %v", dest)
+	return nil
+}
+
+func writeArchive(file *os.File, prefix string, writer *tar.Writer) error {
+	info, err := file.Stat()
+	if err != nil {
+		return err
+	}
+
+	if info.IsDir() {
+		if prefix == "" {
+			prefix = info.Name()
+		} else {
+			prefix = prefix + "/" + info.Name()
+		}
+
+		readdir, err := file.Readdir(-1)
+		if err != nil {
+			return err
+		}
+
+		hdr, err := tar.FileInfoHeader(info, "")
+		if err != nil {
+			return err
+		}
+		hdr.Name = prefix
+
+		if err = writer.WriteHeader(hdr); err != nil {
+			return err
+		}
+
+		for _, fi := range readdir {
+			f, err := os.Open(file.Name() + "/" + fi.Name())
+			if err != nil {
+				return err
+			}
+			err = writeArchive(f, prefix, writer)
+			if err != nil {
+				return err
+			}
+		}
+	} else {
+		header, err := tar.FileInfoHeader(info, "")
+		if err != nil {
+			return err
+		}
+
+		header.Name = prefix + "/" + header.Name
+		if err != nil {
+			return err
+		}
+
+		err = writer.WriteHeader(header)
+		if err != nil {
+			return err
+		}
+
+		_, err = io.Copy(writer, file)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func createDirInArchive(file *os.File, prefix string, writer *tar.Writer) error {
+	info, err := file.Stat()
+	if err != nil {
+		return err
+	}
+
+	hdr, err := tar.FileInfoHeader(info, "")
+	if err != nil {
+		return err
+	}
+	hdr.Name = prefix
+
+	if err = writer.WriteHeader(hdr); err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
This creates tar ball with directories in cosa, and runs oc command to
start bc/cosa-runner-master.

By having COSA as a buildConfig, we can now have a cosa remote command that:
- creates a devel.tar of src, overrides, and local COSA hacks with a JobSpec and build.steps
- call oc start-build bc/cosa-priv --from-archive=devel.tar --follow=true

Details: https://github.com/coreos/coreos-assembler/blob/master/entrypoint/README.md#cosa-remote