### PR TITLE
mantle: clean up cmd/ore/aws

### DIFF
--- a/mantle/cmd/ore/aws/upload.go
+++ b/mantle/cmd/ore/aws/upload.go
@@ -182,7 +182,11 @@ func runUpload(cmd *cobra.Command, args []string) error {
 	s3ObjectPath := strings.TrimPrefix(s3URL.Path, "/")
 
 	if uploadForce {
-		API.RemoveImage(uploadAMIName, s3BucketName, s3ObjectPath)
+		err := API.RemoveImage(uploadAMIName, s3BucketName, s3ObjectPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%v\n", err)
+			os.Exit(1)
+		}
 	}
 
 	// if no snapshot was specified, check for an existing one or a


### PR DESCRIPTION
This cleans up cmd/ore/aws/upload.go:
```
cmd/ore/aws/upload.go:185:18: Error return value of `API.RemoveImage` is not checked (errcheck)
                API.RemoveImage(uploadAMIName, s3BucketName, s3ObjectPath)
```

Fixes part of https://github.com/coreos/coreos-assembler/issues/1813