### PR TITLE
cmdlib: only require kvm for building

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -102,6 +102,12 @@ preflight() {
         fatal "Your umask is unset, please use umask 0022 or so"
     fi
 
+    if ! has_privileges && [ -n "${ISEL}" ]; then
+        fatal "running on EL requires privileged mode"
+    fi
+}
+
+preflight_kvm() {
     # permissions on /dev/kvm vary by (host) distro.  If it's
     # not writable, recreate it.
 
@@ -118,10 +124,6 @@ preflight() {
                 sudo setfacl -m u:"$USER":rw /dev/kvm
             fi
         fi
-    fi
-
-    if ! has_privileges && [ -n "${ISEL}" ]; then
-        fatal "running on EL requires privileged mode"
     fi
 }
 
@@ -143,6 +145,7 @@ pick_yaml_or_else_json() {
 
 prepare_build() {
     preflight
+    preflight_kvm
     if ! [ -d builds ]; then
         fatal "No $(pwd)/builds found; did you run coreos-assembler init?"
     fi

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -101,10 +101,6 @@ preflight() {
     if test "$(umask)" = 0000; then
         fatal "Your umask is unset, please use umask 0022 or so"
     fi
-
-    if ! has_privileges && [ -n "${ISEL}" ]; then
-        fatal "running on EL requires privileged mode"
-    fi
 }
 
 preflight_kvm() {


### PR DESCRIPTION
We should be able to `cosa init` and `cosa buildprep` without requiring
KVM. For example, in the FCOS pipeline, we do this when running kola
against various clouds.