### PR TITLE
Entrypoint: CI mode for buildConfig-less runs

### DIFF
--- a/entrypoint/Makefile
+++ b/entrypoint/Makefile
@@ -17,7 +17,7 @@ build: test
 .PHONY: fmt
 fmt:
 	gofmt -d -e -l $(shell find . -iname "*.go"  -not -path "./vendor/*")
-	golangci-lint run -v  ./...
+	golangci-lint run -v --timeout 5m ./...
 
 .PHONY: test
 test: fmt

--- a/entrypoint/cmd/build.go
+++ b/entrypoint/cmd/build.go
@@ -63,7 +63,7 @@ func runOCP(c *cobra.Command, args []string) {
 
 	b, err := ocp.NewBuilder(ctx)
 	if err != nil {
-		log.Fatal("Failed to find the OCP build environment.")
+		log.Fatal("Failed to find the build environment.")
 	}
 
 	if err := b.Exec(ctx); err != nil {

--- a/entrypoint/cmd/ci.go
+++ b/entrypoint/cmd/ci.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"github.com/coreos/entrypoint/ocp"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var (
+	cmdCI = &cobra.Command{
+		Use:   "ci",
+		Short: "Execute COSA commands as part of a CI pipeline",
+		Run:   runCI,
+	}
+
+	// cosaOverrideImage uses a different image
+	cosaOverrideImage string
+
+	// serviceAccount is the service acount to use for pod creation
+	// and reading of the secrets.
+	serviceAccount string
+)
+
+func init() {
+	cmdRoot.AddCommand(cmdCI)
+	cmdRoot.PersistentFlags().StringVarP(&cosaOverrideImage, "image", "i", "", "use an alternative image")
+	cmdRoot.PersistentFlags().StringVarP(&serviceAccount, "serviceaccount", "a", "", "service account to use")
+}
+
+// runCI is the Jenkins/CI interface into entrypoint. It "mocks"
+// the OpenShift buildconfig API with just-enough information to be
+// useful.
+func runCI(c *cobra.Command, args []string) {
+	defer cancel()
+	m, err := ocp.NewCIBuilder(ctx, cosaOverrideImage, serviceAccount, specFile)
+	if err != nil {
+		log.Fatalf("failed to define CI builder: %v", err)
+	}
+
+	log.Info("Starting entrypoint in CI Mode")
+	if err := m.Exec(ctx); err != nil {
+		log.Fatalf("failed to execute CI builder: %v", err)
+	}
+}

--- a/entrypoint/cmd/entry.go
+++ b/entrypoint/cmd/entry.go
@@ -11,7 +11,7 @@ import (
 	"os/exec"
 	"path/filepath"
 
-	rhjobspec "github.com/coreos/entrypoint/spec"
+	jobspec "github.com/coreos/entrypoint/spec"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -25,9 +25,8 @@ var (
 	// cosaContainerDir and is set via `-ldflags` at build time.
 	cosaDir string
 
-	// spec is an RHCOS spec. It is anticipated that this will be
-	// changed in the future.
-	spec     rhjobspec.JobSpec
+	// spec is a job spec.
+	spec     jobspec.JobSpec
 	specFile string
 
 	// entryEnvars are set for command execution
@@ -135,7 +134,7 @@ func preRun(c *cobra.Command, args []string) {
 		return
 	}
 
-	ns, err := rhjobspec.JobSpecFromFile(specFile)
+	ns, err := jobspec.JobSpecFromFile(specFile)
 	if err != nil {
 		log.WithFields(log.Fields{"input file": specFile, "error": err}).Fatal(
 			"Failed reading file")

--- a/entrypoint/ocp/bc.go
+++ b/entrypoint/ocp/bc.go
@@ -96,12 +96,19 @@ func newBC() (*buildConfig, error) {
 			apiBuild.Annotations[buildapiv1.BuildConfigAnnotation],
 			apiBuild.Annotations[buildapiv1.BuildNumberAnnotation],
 		)
-		hIP, err := getPodIP(v.HostPod)
-		if err != nil {
-			log.Errorf("Failed to determine buildconfig's pod")
+
+		_, ok := apiBuild.Annotations[ciRunnerTag]
+		if ok {
+			v.HostIP = apiBuild.Annotations[fmt.Sprintf(ciAnnotation, "IP")]
+		} else {
+			log.Info("Querying for pod ID")
+			hIP, err := getPodIP(v.HostPod)
+			if err != nil {
+				log.Errorf("Failed to determine buildconfig's pod")
+			}
+			v.HostIP = hIP
 		}
 
-		v.HostIP = hIP
 		log.WithFields(log.Fields{
 			"buildconfig/name":   apiBuild.Annotations[buildapiv1.BuildConfigAnnotation],
 			"buildconfig/number": apiBuild.Annotations[buildapiv1.BuildNumberAnnotation],

--- a/entrypoint/ocp/ci.go
+++ b/entrypoint/ocp/ci.go
@@ -1,0 +1,211 @@
+package ocp
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/coreos/entrypoint/spec"
+	buildapiv1 "github.com/openshift/api/build/v1"
+	log "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+)
+
+/*
+	A CIBuilder is a ci interface for running entrypoint as part
+	of a legacy CI system (i.e. Jenkins) while benefiting from the BuildConfig
+	niceties.
+
+	While it does not require running as a BuildConfig, it does require that the
+	running pod exposes a service account with:
+	- secret access
+	- the ability to create pods
+*/
+
+type ci struct {
+	jobSpecFile string
+	bc          *buildConfig
+	ciBuild     string
+}
+
+// CIBuilder is the manual/unbounded Build interface.
+// A CIBuilder uses a build.openshift.io/v1 Build interface
+// to use the exact same code path between the two.
+type CIBuilder interface {
+	Exec(ctx context.Context) error
+}
+
+var (
+	// cli is a Builder (and a poor one at that too...)
+	// While a CIBuilder is a Builder, we treat it seperately.
+	_ = CIBuilder(&ci{})
+)
+
+const (
+	ciLabel      = "ci-entry.coreos-assembler.coreos.com"
+	ciAnnotation = ciLabel + "%s"
+	ciRunnerTag  = "cosa-ci-runner"
+)
+
+func (c *ci) Exec(ctx context.Context) error {
+	log.Info("Executing unbounded builder")
+	return c.bc.Exec(ctx)
+}
+
+// NewCIBuilder returns a CIBuilder ready for execution.
+func NewCIBuilder(ctx context.Context, image, serviceAccount, jsF string) (CIBuilder, error) {
+	// Require a Kubernetes Service Account Client
+	if err := k8sAPIClient(); err != nil {
+		return nil, fmt.Errorf("failed create a kubernetes client: %w", err)
+	}
+
+	// Directly inject the jobspec
+	js, err := spec.JobSpecFromFile(jsF)
+	if err != nil {
+		return nil, err
+	}
+	if js.Recipe.GitURL == "" {
+		return nil, errors.New("JobSpec does inclue a Git Recipe")
+	}
+	os.Setenv("SOURCE_REF", js.Recipe.GitRef)
+	os.Setenv("SOURCE_URI", js.Recipe.GitURL)
+
+	log.WithFields(log.Fields{
+		"override image": image,
+		"source ref":     js.Recipe.GitRef,
+		"source uri":     js.Recipe.GitURL,
+	}).Info("jobspec defined source")
+
+	// Get the ci API
+	ciBuild, err := ciAPIBuild(&js, image, serviceAccount)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create a ci API build object")
+	}
+	os.Setenv("BUILD", ciBuild)
+
+	// Create the buildConfig object
+	bc, err := newBC()
+	if err != nil {
+		return nil, err
+	}
+	bc.JobSpec = js
+	bc.JobSpecFile = jsF
+
+	c := &ci{
+		jobSpecFile: jsF,
+		bc:          bc,
+		ciBuild:     ciBuild,
+	}
+	return c, nil
+}
+
+func ciAPIBuild(js *spec.JobSpec, image, serviceAccount string) (string, error) {
+	// Dig deep and query find out what Kubernetes thinks this pod
+	// Discover where this running
+	hostname, ok := os.LookupEnv("HOSTNAME")
+	if !ok {
+		return "", errors.New("Unable to find hostname")
+	}
+
+	myIP, err := getPodIP(hostname)
+	if err != nil {
+		return "", fmt.Errorf("failed to query my hostname: %w", err)
+	}
+
+	// Discover where this running
+	myPod, err := apiClient.Pods(projectNamespace).Get(hostname, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	// find the running pod this is running on.
+	var myContainer *v1.Container = nil
+	for _, k := range myPod.Spec.Containers {
+		lk := strings.ToLower(k.Image)
+		for _, x := range []string{"cosa", "coreos-assembler"} {
+			if strings.Contains(lk, x) {
+				myContainer = &k
+				break
+			}
+		}
+	}
+
+	// allow both the service account and the image to be overriden
+	if serviceAccount == "" {
+		serviceAccount = myPod.Spec.ServiceAccountName
+	}
+	if image == "" {
+		image = myContainer.Image
+	}
+	if serviceAccount == "" || image == "" {
+		return "", errors.New("serviceAccount and image must be defined by running pod or via overrides")
+	}
+
+	l := log.WithFields(log.Fields{
+		"ip":             myIP,
+		"image":          image,
+		"serviceAccount": serviceAccount,
+		"host":           myContainer.Name,
+	})
+	l.Info("identified pod")
+
+	// Create just _enough_ of the OpenShift BuildConfig spec
+	// Create a "ci" build.openshift.io/v1 specification.
+	ciBuildNumber := time.Now().Format("20060102150405")
+	a := buildapiv1.Build{}
+
+	// Create annotations
+	a.Annotations = map[string]string{
+		// ciRunnerTag is tested for to determine if this is
+		// a buildconfig or a faked one
+		ciRunnerTag:                     "true",
+		fmt.Sprintf(ciAnnotation, "IP"): myIP,
+		// Required Labels
+		buildapiv1.BuildConfigAnnotation: "ci-cosa-bc",
+		buildapiv1.BuildNumberAnnotation: ciBuildNumber,
+	}
+
+	// Create basic labels
+	a.Labels = map[string]string{
+		ciLabel: ciBuildNumber,
+	}
+
+	// Populate the Spec
+	a.Spec = buildapiv1.BuildSpec{}
+	a.Spec.ServiceAccount = myPod.Spec.ServiceAccountName
+	a.Spec.Strategy = buildapiv1.BuildStrategy{}
+	a.Spec.Strategy.CustomStrategy = new(buildapiv1.CustomBuildStrategy)
+	a.Spec.Strategy.CustomStrategy.From = corev1.ObjectReference{
+		Name: image,
+	}
+	a.Spec.Source = buildapiv1.BuildSource{
+		ContextDir: cosaSrvDir,
+		Git: &buildapiv1.GitBuildSource{
+			Ref: js.Recipe.GitRef,
+			URI: js.Recipe.GitURL,
+		},
+	}
+
+	// Render the ci buildapiv1 object to a JSON object.
+	// JSON is the messaginging interface for Kubernetes.
+	aW := bytes.NewBuffer([]byte{})
+	s := json.NewYAMLSerializer(json.DefaultMetaFactory, buildScheme, buildScheme)
+	if err := s.Encode(&a, aW); err != nil {
+		return "", err
+	}
+	d, err := ioutil.ReadAll(aW)
+	if err != nil {
+		return "", err
+	}
+
+	return string(d), nil
+
+}

--- a/entrypoint/ocp/k8s.go
+++ b/entrypoint/ocp/k8s.go
@@ -21,6 +21,9 @@ var (
 	// apiClient is v1 Client Interface for interacting Kubernetes
 	apiClient corev1.CoreV1Interface
 
+	// apiClientSet is a generic Kubernetes Client Set
+	apiClientSet *kubernetes.Clientset
+
 	// projectNamespace is the current namespace
 	projectNamespace string
 
@@ -50,7 +53,7 @@ func k8sAPIClient() error {
 		return err
 	}
 	apiClient = nc.CoreV1()
-	//appClient = nc.AppsV1()
+	apiClientSet = nc
 
 	pname, err := ioutil.ReadFile(clusterNamespaceFile)
 	if err != nil {

--- a/entrypoint/ocp/ocp.go
+++ b/entrypoint/ocp/ocp.go
@@ -12,8 +12,8 @@ import (
 
 var (
 	// These are used to parse the OpenShift API
-	//buildScheme       = runtime.NewScheme()
-	buildCodecFactory = serializer.NewCodecFactory(runtime.NewScheme())
+	buildScheme       = runtime.NewScheme()
+	buildCodecFactory = serializer.NewCodecFactory(buildScheme)
 	buildJSONCodec    runtime.Codec
 
 	// API Client for OCP builds.


### PR DESCRIPTION
Requiring COSA to run as a buildConfig is not always feasible, since it requires
running as a fully-capable build pod. This change allows any COSA pod to become
a build pod. 

For example:
        entry --jobspec jobspec.yaml ci

The pod running entry, must be launched with a service account that can
create pods (i.e. the Jenkins SA). OpenShift deployed Jenkins instances
are capable.

The results of run will be put in /srv. It's envisioned that Jenkins
Pipelines and Prow could use this interface, while developers and ART
pipelines can use the BuildConfig interface. One major difference with
this interface is that cannot use the binary source interface yet.

To ensure parity, the CI mode mock's the OpenShift Build v1 API.
