### PR TITLE
entrypoint: Extend timeout for the golangci-lint

### DIFF
--- a/entrypoint/Makefile
+++ b/entrypoint/Makefile
@@ -17,7 +17,7 @@ build: test
 .PHONY: fmt
 fmt:
 	gofmt -d -e -l $(shell find . -iname "*.go"  -not -path "./vendor/*")
-	golangci-lint run -v  ./...
+	golangci-lint run -v --timeout 5m ./...
 
 .PHONY: test
 test: fmt


### PR DESCRIPTION
golangci-lint will occasionally timeout in lower performant environments, especially those that are IO constrained.
Run usually takes around 90s, so let's bump it to 5m, arbitrary number >90s, to make sure we don't timeout.
For the record default timeout is 1m.