### PR TITLE
mantle: clean up cmd/ore/do

### DIFF
--- a/mantle/cmd/ore/do/create-image.go
+++ b/mantle/cmd/ore/do/create-image.go
@@ -108,14 +108,24 @@ func createSnapshot() error {
 	if err != nil {
 		return err
 	}
-	defer API.DeleteKey(ctx, keyID)
+	defer func() {
+		err := API.DeleteKey(ctx, keyID)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%v\n", err)
+		}
+	}()
 
 	droplet, err := API.CreateDroplet(ctx, imageName+"-install", keyID, userdata)
 	if err != nil {
 		return fmt.Errorf("couldn't create droplet: %v", err)
 	}
 	dropletID := droplet.ID
-	defer API.DeleteDroplet(ctx, dropletID)
+	defer func() {
+		err := API.DeleteDroplet(ctx, dropletID)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%v\n", err)
+		}
+	}()
 
 	// the droplet will power itself off when install completes
 	err = util.WaitUntilReady(10*time.Minute, 15*time.Second, func() (bool, error) {


### PR DESCRIPTION
This cleans up cmd/ore/do/create-image.go:
```
cmd/ore/do/create-image.go:111:21: Error return value of `API.DeleteKey` is not checked (errcheck)
        defer API.DeleteKey(ctx, keyID)
                           ^
cmd/ore/do/create-image.go:118:25: Error return value of `API.DeleteDroplet` is not checked (errcheck)
        defer API.DeleteDroplet(ctx, dropletID)
                               ^
```

Fixes part of https://github.com/coreos/coreos-assembler/issues/1813