### PR TITLE
mantle: clean up gcloud create-image

### DIFF
--- a/mantle/cmd/ore/gcloud/create-image.go
+++ b/mantle/cmd/ore/gcloud/create-image.go
@@ -15,6 +15,7 @@
 package gcloud
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"os"
@@ -92,7 +93,8 @@ func runCreateImage(cmd *cobra.Command, args []string) {
 		createImageBoard, createImageVersion, createImageName), "/")
 	imageNameGCE := gceSanitize(createImageFamily + "-" + createImageVersion)
 
-	storageAPI, err := storage.New(api.Client())
+	ctx := context.Background()
+	storageAPI, err := storage.NewService(ctx)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Storage client failed: %v\n", err)
 		os.Exit(1)


### PR DESCRIPTION
This cleans up cmd/ore/gcloud/create-image.go:
```
cmd/ore/gcloud/create-image.go:95:21: SA1019: storage.New is deprecated: please use NewService instead. To provide a custom HTTP client, use option.WithHTTPClient. If you are using google.golang.org/api/googleapis/transport.APIKey, use option.WithAPIKey with NewService instead.  (staticcheck)
        storageAPI, err := storage.New(api.Client())
                           ^
```

Fixes part of https://github.com/coreos/coreos-assembler/issues/1813