### PR TITLE
mantle: clean up cmd/ore/gcloud/upload

### DIFF
--- a/mantle/cmd/ore/gcloud/upload.go
+++ b/mantle/cmd/ore/gcloud/upload.go
@@ -15,6 +15,7 @@
 package gcloud
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/url"
@@ -50,11 +51,17 @@ var (
 
 func init() {
 	cmdUpload.Flags().StringVar(&uploadBucket, "bucket", "", "gs://bucket/prefix/")
-	cmdUpload.MarkFlagRequired("bucket")
+	if err := cmdUpload.MarkFlagRequired("bucket"); err != nil {
+		panic(err)
+	}
 	cmdUpload.Flags().StringVar(&uploadImageName, "name", "", "name for uploaded image")
-	cmdUpload.MarkFlagRequired("name")
+	if err := cmdUpload.MarkFlagRequired("name"); err != nil {
+		panic(err)
+	}
 	cmdUpload.Flags().StringVar(&uploadFile, "file", "", "path to image .tar.gz file to upload")
-	cmdUpload.MarkFlagRequired("file")
+	if err := cmdUpload.MarkFlagRequired("file"); err != nil {
+		panic(err)
+	}
 	cmdUpload.Flags().BoolVar(&uploadForce, "force", false, "overwrite existing GS and GCE images without prompt")
 	cmdUpload.Flags().StringVar(&uploadWriteUrl, "write-url", "", "output the uploaded URL to the named file")
 	cmdUpload.Flags().StringVar(&uploadImageFamily, "family", "", "GCP image family to attach image to")
@@ -97,7 +104,8 @@ func runUpload(cmd *cobra.Command, args []string) {
 	// Sanitize the image name for GCE
 	imageNameGCE := gceSanitize(uploadImageName)
 
-	storageAPI, err := storage.New(api.Client())
+	ctx := context.Background()
+	storageAPI, err := storage.NewService(ctx)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Storage client failed: %v\n", err)
 		os.Exit(1)


### PR DESCRIPTION
This cleans up cmd/ore/gcloud/upload.go:
```
    cmd/ore/gcloud/upload.go:53:28: Error return value of `cmdUpload.MarkFlagRequired` is not checked (errcheck)
            cmdUpload.MarkFlagRequired("bucket")
                                       ^
    cmd/ore/gcloud/upload.go:55:28: Error return value of `cmdUpload.MarkFlagRequired` is not checked (errcheck)
             cmdUpload.MarkFlagRequired("name")
                                       ^
     cmd/ore/gcloud/upload.go:57:28: Error return value of `cmdUpload.MarkFlagRequired` is not checked (errcheck)
             cmdUpload.MarkFlagRequired("file")
                                       ^
     cmd/ore/gcloud/upload.go:100:21: SA1019: storage.New is deprecated: please use NewService instead. To provide a         custom HTTP client, use option.WithHTTPClient. If you are using google.golang.org/api/googleapis/transport.API        Key, use option.WithAPIKey with NewService instead.  (staticcheck)
             storageAPI, err := storage.New(api.Client())
                                ^
```

Since the errors were not checked before, I assume they are not critical or not likely to happen, so I just added them in the log to pass golangci-lint.

Fixes part of https://github.com/coreos/coreos-assembler/issues/1813