### PR TITLE
mantle: clean up cmd/plume/plume

### DIFF
--- a/mantle/cmd/plume/plume.go
+++ b/mantle/cmd/plume/plume.go
@@ -15,13 +15,9 @@
 package main
 
 import (
-	"io/ioutil"
-	"net/http"
-
 	"github.com/coreos/pkg/capnslog"
 	"github.com/spf13/cobra"
 
-	"github.com/coreos/mantle/auth"
 	"github.com/coreos/mantle/cli"
 )
 
@@ -37,17 +33,6 @@ var (
 
 func init() {
 	root.PersistentFlags().StringVar(&gceJSONKeyFile, "gce-json-key", "", "use a JSON key for authentication")
-}
-
-func getGoogleClient() (*http.Client, error) {
-	if gceJSONKeyFile != "" {
-		if b, err := ioutil.ReadFile(gceJSONKeyFile); err == nil {
-			return auth.GoogleClientFromJSONKey(b)
-		} else {
-			return nil, err
-		}
-	}
-	return auth.GoogleClient()
 }
 
 func main() {


### PR DESCRIPTION
This cleans up cmd/plume/plume.go:
```
cmd/plume/plume.go:42:6: `getGoogleClient` is unused (deadcode)
func getGoogleClient() (*http.Client, error) {
     ^
```

Fixes part of https://github.com/coreos/coreos-assembler/issues/1813