### PR TITLE
More draining of create_disk args into JSON passing

### DIFF
--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -152,11 +152,11 @@ yaml2json() {
 # by the shell script in create_disk.sh.
 yaml2json "$configdir/image.yaml" image-config.json
 yaml2json "/usr/lib/coreos-assembler/image-default.yaml" image-default.json
-cat image-default.json image-config.json | jq -s add > image.json
+# Combine with the defaults
+cat image-default.json image-config.json | jq -s add > image-configured.json
 
-# bootfs
-bootfs_type="$(python3 -c 'import sys, yaml; print(yaml.safe_load(sys.stdin).get("bootfs", "ext4"))' < "$configdir/image.yaml")"
-rootfs_type=$(jq -re .rootfs < image.json)
+# We do some extra handling of the rootfs here; it feeds into size estimation.
+rootfs_type=$(jq -re .rootfs < image-configured.json)
 
 # fs-verity requires block size = page size. We need to take that into account
 # in the disk size estimation due to higher fragmentation on larger blocks.
@@ -195,31 +195,6 @@ if [ "${image_type}" == metal4k ]; then
 fi
 
 set -x
-# Extract the target kernel config, which may inform how we build disks.
-kconfig="${tmp_builddir:-tmp}/target-kernel.config"
-target_moduledir=$(ostree --repo="${ostree_repo}" ls "${commit}" /usr/lib/modules | grep -o '/usr/lib/modules/.*')
-ostree --repo="${ostree_repo}" cat "${commit}" "${target_moduledir}/config" > "${kconfig}"
-# Part of: https://github.com/ostreedev/ostree/pull/1959
-# We need to support kernels that don't have this enabled yet, including RHEL8
-# and current Fedora 31.
-# https://bugzilla.redhat.com/show_bug.cgi?id=1765933
-# For a while this was enabled by default, but we backed it out due to the use
-# case of running coreos-installer from old systems (e.g. Debian stable), or
-# ones without CONFIG_FS_VERITY.
-case "${bootfs_type}" in
-  ext4verity)
-        if grep -Eq '^CONFIG_FS_VERITY=y' "${kconfig}"; then
-            disk_args+=("--boot-verity")
-        else
-            echo 'error: Missing CONFIG_FS_VERITY from target kernel config' 1>&2
-            exit 1
-        fi
-        ;;
-  ext4) ;;
-  *) echo "Unsupported bootfs: ${bootfs_type}" 1>&2; exit 1;;
-esac
-rm -f "${kconfig}"
-
 kargs="$(python3 -c 'import sys, yaml; args = yaml.safe_load(sys.stdin).get("extra-kargs", []); print(" ".join(args))' < "$configdir/image.yaml")"
 tty="console=tty0 console=${DEFAULT_TERMINAL},115200n8"
 # On each s390x hypervisor, a tty would be automatically detected by the kernel
@@ -231,8 +206,6 @@ case "$basearch" in
 esac
 kargs="$kargs $tty ignition.platform.id=$ignition_platform_id"
 
-ostree_remote="$(python3 -c 'import sys, yaml; print(yaml.safe_load(sys.stdin).get("ostree-remote", "NONE"))' < "$configdir/image.yaml")"
-
 qemu-img create -f ${image_format} "${path}.tmp" "${image_size}"
 
 extra_target_device_opts=""
@@ -243,19 +216,23 @@ fi
 target_drive=("-drive" "if=none,id=target,format=${image_format},file=${path}.tmp,cache=unsafe" \
               "-device" "virtio-blk,serial=target,drive=target${extra_target_device_opts}")
 
+# Generate the JSON describing the disk we want to build
+cat >image-dynamic.json << EOF
+{
+    "rootfs-size": "${rootfs_size}",
+    "osname": "${name}",
+    "buildid": "${build}",
+    "imgid": "${img}",
+    "ostree-commit": "${commit}",
+    "ostree-ref": "${ref}",
+    "ostree-repo": "${ostree_repo}"
+}
+EOF
+cat image-configured.json image-dynamic.json | jq -s add > image.json
 runvm "${target_drive[@]}" -- \
         /usr/lib/coreos-assembler/create_disk.sh \
             --config "$(pwd)"/image.json \
-            --buildid "${build}" \
-            --imgid "${img}" \
-            --grub-script /usr/lib/coreos-assembler/grub.cfg \
             --kargs "\"${kargs}\"" \
-            --osname "${name}" \
-            --ostree-commit "${commit}" \
-            --ostree-ref "${ref:-NONE}" \
-            --ostree-remote "${ostree_remote}" \
-            --ostree-repo "${ostree_repo}" \
-            --rootfs-size "${rootfs_size}" \
             "${disk_args[@]}"
 /usr/lib/coreos-assembler/finalize-artifact "${path}.tmp" "${path}"
 

--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -26,17 +26,8 @@ Fedora CoreOS style disk image from an OS Tree.
 
 Options:
     --disk: disk device to use
-    --buildid: buildid
-    --imgid: imageid
-    --grub-script: grub script to install
     --help: show this helper
     --kargs: kernel CLI args
-    --osname: the OS name to use, e.g. fedora
-    --ostree-ref: the OSTRee reference to install
-    --ostree-remote: the ostree remote
-    --ostree-repo: location of the ostree repo
-    --rootfs-size: Create the root filesystem with specified size
-    --boot-verity: Provide this to enable ext4 fs-verity for /boot
     --no-x86-bios-bootloader: don't install BIOS bootloader on x86_64
 
 You probably don't want to run this script by hand. This script is
@@ -46,8 +37,6 @@ EOC
 
 config=
 disk=
-rootfs_size="0"
-boot_verity=0
 x86_bios_bootloader=1
 extrakargs=""
 
@@ -57,18 +46,8 @@ do
     case "${flag}" in
         --config)                config="${1}"; shift;;
         --disk)                  disk="${1}"; shift;;
-        --buildid)               buildid="${1}"; shift;;
-        --imgid)                 imgid="${1}"; shift;;
-        --grub-script)           grub_script="${1}"; shift;;
         --help)                  usage; exit;;
         --kargs)                 extrakargs="${extrakargs} ${1}"; shift;;
-        --osname)                os_name="${1}"; shift;;
-        --ostree-commit)         commit="${1}"; shift;;
-        --ostree-ref)            ref="${1}"; if test "${ref}" = NONE; then ref=""; fi; shift;;
-        --ostree-remote)         remote_name="${1}"; shift;;
-        --ostree-repo)           ostree="${1}"; shift;;
-        --rootfs-size)           rootfs_size="${1}"; shift;;
-        --boot-verity)           boot_verity=1;;
         --no-x86-bios-bootloader) x86_bios_bootloader=0;;
          *) echo "${flag} is not understood."; usage; exit 10;;
      esac;
@@ -85,17 +64,19 @@ arch="$(uname -m)"
 disk=$(realpath /dev/disk/by-id/virtio-target)
 
 config="${config:?--config must be defined}"
-buildid="${buildid:?--buildid must be defined}"
-imgid="${imgid:?--imgid must be defined}"
-ostree="${ostree:?--ostree-repo must be defined}"
-commit="${commit:?--ostree-commit must be defined}"
-remote_name="${remote_name:?--ostree-remote must be defined}"
-grub_script="${grub_script:?--grub-script must be defined}"
-os_name="${os_name:?--os_name must be defined}"
 
+# Parse the passed config JSON and extract a mandatory value
 getconfig() {
     k=$1
-    jq -re .$k < ${config}
+    jq -re .'"'$k'"' < ${config}
+}
+# Return a configuration value, or default if not set
+getconfig_def() {
+    k=$1
+    shift
+    default=$1
+    shift
+    jq -re .'"'$k'"'//'"'${default}'"' < ${config}
 }
 
 # First parse the old luks_rootfs flag (a custom "stringified bool")
@@ -108,6 +89,18 @@ case "${rootfs_type}" in
     xfs|ext4verity|luks|btrfs) ;;
     *) echo "Invalid rootfs type: ${rootfs_type}" 1>&2; exit 1;;
 esac
+
+bootfs=$(getconfig "bootfs")
+grub_script=$(getconfig "grub-script")
+ostree=$(getconfig "ostree-repo")
+commit=$(getconfig "ostree-commit")
+ref=$(getconfig "ostree-ref")
+# We support not setting a remote name (used by RHCOS)
+remote_name=$(getconfig_def "ostree-remote" "")
+os_name=$(getconfig "osname")
+rootfs_size=$(getconfig "rootfs-size")
+buildid=$(getconfig "buildid")
+imgid=$(getconfig "imgid")
 
 set -x
 
@@ -207,11 +200,15 @@ if [ "${rootfs_type}" = "luks" ]; then
 fi
 
 bootargs=
-if [ "${boot_verity}" = 1 ]; then
-    # Need blocks to match host page size; TODO
-    # really mkfs.ext4 should know this.
-    bootargs="-b $(getconf PAGE_SIZE) -O verity"
-fi
+case "${bootfs}" in
+    ext4verity)
+        # Need blocks to match host page size; TODO
+        # really mkfs.ext4 should know this.
+        bootargs="-b $(getconf PAGE_SIZE) -O verity"
+        ;;
+    ext4) ;;
+    *) echo "Unhandled bootfs: ${bootfs}" 1>&2; exit 1 ;;
+esac
 mkfs.ext4 ${bootargs} "${disk}${BOOTPN}" -L boot -U "${bootfs_uuid}"
 if [ ${EFIPN:+x} ]; then
        mkfs.fat "${disk}${EFIPN}" -n EFI-SYSTEM
@@ -269,8 +266,8 @@ ostree admin init-fs --modern $rootfs
 if [ "${rootfs_type}" = "ext4verity" ]; then
     ostree config --repo=$rootfs/ostree/repo set ex-fsverity.required 'true'
 fi
-deploy_ref="${ref}"
-if [ "${remote_name}" != NONE ]; then
+deploy_ref=
+if test -n "${remote_name}"; then
     deploy_ref="${remote_name}:${ref}"
     time ostree pull-local --repo $rootfs/ostree/repo --remote="${remote_name}" "$ostree" "$ref"
 else

--- a/src/image-default.yaml
+++ b/src/image-default.yaml
@@ -1,2 +1,4 @@
 # This file contains defaults for image.yaml that is used by create_disk.sh
+bootfs: "ext4"
 rootfs: "xfs"
+grub-script: "/usr/lib/coreos-assembler/grub.cfg"


### PR DESCRIPTION
Followup to https://github.com/coreos/coreos-assembler/pull/1787/commits/b769f56560b099396f84a9ce694ae3586ddcfe41
All of the parsing and re-parsing of the image YAML into an argument
list for `create_disk.sh` was messy.  Particularly things like
having the defaults hardcoded in the middle of code and using `NONE`
for the empty value, etc.

Add almost everything into JSON that we pass in so we don't need
to "stringify" everything.

The main thing I didn't touch here was kargs but that should also
be better with this because we can cleanly pass an array.