### PR TITLE
create_disk: Also xfs_freeze /boot

### DIFF
--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -414,9 +414,11 @@ touch $rootfs/boot/ignition.firstboot
 chattr +i $rootfs
 
 fstrim -a -v
-# Ensure the filesystem journal is flushed
-mount -o remount,ro $rootfs
-xfs_freeze -f $rootfs
+# Ensure the filesystem journals are flushed
+for fs in $rootfs/boot $rootfs; do
+    mount -o remount,ro $fs
+    xfs_freeze -f $fs
+done
 umount -R $rootfs
 
 rmdir $rootfs


### PR DESCRIPTION
Followup to ca97e50c6de870664f576f9427f377749a2ee19e
This doesn't change anything today because `/boot` is ext4
which flushes the journal on unmount.  But I was just reading
this script and noticed that we should be doing the same thing
for `/boot` that we do for root.