### PR TITLE
mantle: clean up cosa/build

### DIFF
--- a/mantle/cosa/build.go
+++ b/mantle/cosa/build.go
@@ -91,7 +91,7 @@ func (build *Build) FindGCPImage() (string, error) {
 func (build *Build) WriteMeta(path string, validate bool) error {
 	if validate {
 		if err := build.Validate(); len(err) != 0 {
-			errors.New("data is not compliant with schema")
+			return errors.New("data is not compliant with schema")
 		}
 	}
 	out, err := json.MarshalIndent(build, "", "    ")


### PR DESCRIPTION
This cleans up cosa/build.go:
```
cosa/build.go:94:14: Error return value of `errors.New` is not checked (errcheck)
                        errors.New("data is not compliant with schema")
                                  ^
```

Fixes part of https://github.com/coreos/coreos-assembler/issues/1813