### PR TITLE
mantle: clean up cosa/schema

### DIFF
--- a/mantle/cosa/schema.go
+++ b/mantle/cosa/schema.go
@@ -67,6 +67,10 @@ func (build *Build) Validate() []error {
 		schema.NewStringLoader(string(data)),
 	)
 
+	if err != nil {
+		return append(e, err)
+	}
+
 	if result.Valid() {
 		return nil
 	}


### PR DESCRIPTION
This cleans up cosa/schema.go:
```
cosa/schema.go:65:10: ineffectual assignment to `err` (ineffassign)
        result, err := schema.Validate(
                ^
```

Fixes part of https://github.com/coreos/coreos-assembler/issues/1813