### PR TITLE
mantle: clean up kola/cluster

### DIFF
--- a/mantle/kola/cluster/cluster.go
+++ b/mantle/kola/cluster/cluster.go
@@ -157,7 +157,9 @@ func (t *TestCluster) MustSSH(m platform.Machine, cmd string) []byte {
 	if err != nil {
 		if t.SSHOnTestFailure() {
 			plog.Errorf("dropping to shell: %q failed: output %s, status %v", cmd, out, err)
-			platform.Manhole(m)
+			if err := platform.Manhole(m); err != nil {
+				plog.Error(err)
+			}
 		}
 		t.Fatalf("%q failed: output %s, status %v", cmd, out, err)
 	}


### PR DESCRIPTION
This cleans up kola/cluster/cluster.go:
```
kola/cluster/cluster.go:160:20: Error return value of `platform.Manhole` is not checked (errcheck)
                        platform.Manhole(m)
                                        ^
```

Fixes part of https://github.com/coreos/coreos-assembler/issues/1813