### PR TITLE
Move to Fedora 33

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -1,6 +1,6 @@
 // Documentation: https://github.com/coreos/coreos-ci/blob/master/README-upstream-ci.md
 
-pod(image: 'registry.fedoraproject.org/fedora:32', runAsUser: 0, kvm: true, memory: "10Gi") {
+pod(image: 'registry.fedoraproject.org/fedora:33', runAsUser: 0, kvm: true, memory: "10Gi") {
     checkout scm
 
     stage("Build") {

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:32
+FROM registry.fedoraproject.org/fedora:33
 WORKDIR /root/containerbuild
 
 # We split into multiple steps here so that local dev workflows which involve

--- a/build.sh
+++ b/build.sh
@@ -50,9 +50,6 @@ install_rpms() {
     # Process our base dependencies + build dependencies and install
     (echo "${builddeps}" && "${srcdir}"/src/print-dependencies.sh) | xargs yum -y install
 
-    # https://github.com/coreos/coreos-assembler/issues/1496
-    yum -y downgrade cryptsetup-2.3.0-1.fc32
-
     # Commented out for now, see above
     #dnf remove -y ${builddeps}
     # can't remove grubby on el7 because libguestfs-tools depends on it


### PR DESCRIPTION
It's in testing now, and the blocker that was preventing us from moving
is gone (see https://github.com/coreos/coreos-assembler/issues/1496).