### PR TITLE
create_disk.sh: add comment re. s390x partition table

### DIFF
--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -142,6 +142,10 @@ case "$arch" in
         sgdisk -p "$disk"
         ;;
     s390x)
+        # NB: in the bare metal case when targeting ECKD DASD disks, this
+        # partition table is not what actually gets written to disk in the end:
+        # coreos-installer has code which transforms it into a DASD-compatible
+        # partition table and copies each partition individually bitwise.
         sgdisk -Z $disk \
         -U "${uninitialized_gpt_uuid}" \
         -n ${BOOTPN}:0:+384M -c ${BOOTPN}:boot \


### PR DESCRIPTION
It came up in conversation with @bgilbert and @arithx that the partition
table we have here for s390x is actually transformed by coreos-installer
at install-time.

Let's add a comment to keep that in mind here.