### PR TITLE
gangplank: don't test at build time

### DIFF
--- a/gangplank/Makefile
+++ b/gangplank/Makefile
@@ -11,7 +11,7 @@ ARCH:=$(shell uname -m)
 
 pkgs := $(shell go list -mod=vendor ./...)
 .PHONY: build
-build: test
+build:
 	cd cmd && go build  -i -ldflags "${ldflags}" -mod vendor -v -o ../bin/gangplank .
 
 .PHONY: fmt


### PR DESCRIPTION
This is covered by `make check` already, and it makes iterating on
!gangplank slower because every `make` wants to rerun the tests. (And
for some reason right now those tests are failing when building on f33).