### PR TITLE
mantle: clean up kola/tests/crio

### DIFF
--- a/mantle/kola/tests/crio/crio.go
+++ b/mantle/kola/tests/crio/crio.go
@@ -361,7 +361,7 @@ func crioNetworksReliably(c cluster.TestCluster) {
 	// Figure out the host IP address on the crio default bridge. This is
 	// required as the default subnet was changed in 1.18 to avoid a conflict
 	// with the default podman bridge.
-	subnet := c.MustSSH(m, fmt.Sprintf("jq --raw-output '.ipam.ranges[0][0].subnet' /usr/etc/cni/net.d/100-crio-bridge.conf"))
+	subnet := c.MustSSH(m, "jq --raw-output '.ipam.ranges[0][0].subnet' /usr/etc/cni/net.d/100-crio-bridge.conf")
 	hostIP := fmt.Sprintf("%s.1", strings.TrimSuffix(string(subnet), ".0/16"))
 
 	// Here we generate 10 pods, each will run a container responsible for


### PR DESCRIPTION
This cleans up kola/tests/crio/crio.go:
```
kola/tests/crio/crio.go:364:25: S1039: unnecessary use of fmt.Sprintf (gosimple)
        subnet := c.MustSSH(m, fmt.Sprintf("jq --raw-output '.ipam.ranges[0][0].subnet' /usr/etc/cni/net.d/100-crio-bridge.conf"))
                               ^
```

Fixes part of https://github.com/coreos/coreos-assembler/issues/1813