### PR TITLE
guestfish: fix mounting of '/boot/efi'

### DIFF
--- a/src/gf-fsck
+++ b/src/gf-fsck
@@ -19,9 +19,13 @@ boot=$(coreos_gf findfs-label boot)
 coreos_gf debug sh "fsck.ext4 -f -n ${boot}"
 
 # ESP, if it exists
-if [ "$(coreos_gf part-get-gpt-type /dev/sda 1)" = "${EFI_SYSTEM_PARTITION_GUID}" ]; then
-    coreos_gf debug sh "fsck.vfat -f -n /dev/sda1"
-fi
+partitions="$(coreos_gf list-partitions)"
+for pt in $partitions; do
+    label="$(coreos_gf vfs-label "${pt}")"
+    if [ "$label" == "EFI-SYSTEM" ]; then
+        coreos_gf debug sh "fsck.vfat -f -n ${pt}"
+    fi
+done
 
 # And fsck the main rootfs
 rootfstype=$(coreos_gf vfs-type /dev/sda4)


### PR DESCRIPTION
EFI partition is no longer 1(but 2), so we have to find it and mount accordingly:
```
fedora-coreos-33.20201120.dev.0-metal.x86_64.raw1    BIOS boot
fedora-coreos-33.20201120.dev.0-metal.x86_64.raw2    EFI System
```
    
On the other hand, on s390x(because images do not contain EFI and 1st partition now is /dev/sda3) it fails now with:
```
++ guestfish --remote -- part-get-gpt-type /dev/sda 1
libguestfs: error: part_get_gpt_type: /dev/sda: sgdisk output did not contain 'Partition GUID code'
+ '[' '' = C12A7328-F81F-11D2-BA4B-00A0C93EC93B ']'
 ```