### PR TITLE
mantle: clean up kola/tests/ignition/qemufailure

### DIFF
--- a/mantle/kola/tests/ignition/qemufailure.go
+++ b/mantle/kola/tests/ignition/qemufailure.go
@@ -89,7 +89,9 @@ func ignitionFailure(c cluster.TestCluster) error {
 
 	select {
 	case <-ctx.Done():
-		inst.Kill()
+		if err := inst.Kill(); err != nil {
+			return errors.Wrapf(err, "failed to kill the vm instance")
+		}
 		return errors.Wrapf(ctx.Err(), "timed out waiting for initramfs error")
 	case err := <-errchan:
 		if err != nil {


### PR DESCRIPTION
This cleans up kola/tests/ignition/qemufailure.go:
```
kola/tests/ignition/qemufailure.go:92:12: Error return value of `inst.Kill` is not checked (errcheck)
                inst.Kill()
                         ^
```

Fixes part of https://github.com/coreos/coreos-assembler/issues/1813