### PR TITLE
mantle: clean up kola/tests/misc/files

### DIFF
--- a/mantle/kola/tests/misc/files.go
+++ b/mantle/kola/tests/misc/files.go
@@ -42,7 +42,7 @@ func Filesystem(c cluster.TestCluster) {
 
 func sugidFiles(c cluster.TestCluster, validfiles []string, mode string) {
 	m := c.Machines()[0]
-	badfiles := make([]string, 0, 0)
+	badfiles := make([]string, 0)
 
 	output := c.MustSSH(m, fmt.Sprintf("sudo find / -ignore_readdir_race -path /sys -prune -o -path /proc -prune -o -path /sysroot/ostree -prune -o -type f -perm -%v -print", mode))
 
@@ -59,7 +59,7 @@ func sugidFiles(c cluster.TestCluster, validfiles []string, mode string) {
 				valid = true
 			}
 		}
-		if valid != true {
+		if !valid {
 			badfiles = append(badfiles, file)
 		}
 	}


### PR DESCRIPTION
This cleans up kola/tests/misc/files.go:
```
kola/tests/misc/files.go:45:29: S1019: should use make([]string, 0) instead (gosimple)
        badfiles := make([]string, 0, 0)
                                   ^
kola/tests/misc/files.go:62:6: S1002: should omit comparison to bool constant, can be simplified to `!valid` (gosimple)
                if valid != true {
                   ^
```

Fixes part of https://github.com/coreos/coreos-assembler/issues/1813