### PR TITLE
kola: build kolet statically

### DIFF
--- a/mantle/build
+++ b/mantle/build
@@ -55,12 +55,24 @@ EOM
 }
 
 host_build() {
-	echo "Building $1"
+	local cmd=$1; shift
+	echo "Building $cmd"
 	go build -i \
 		-ldflags "${ldflags}" \
 		-mod vendor \
-		-o "bin/$1" \
-		"${REPO_PATH}/cmd/$1"
+		-o "bin/$cmd" \
+		"$@" "${REPO_PATH}/cmd/$cmd"
+}
+
+host_static_build() {
+	local cmd=$1; shift
+	echo "Building $cmd (static)"
+	go build \
+		-ldflags "${ldflags} -extldflags=-static" \
+		-mod vendor \
+		-o "bin/$cmd" \
+		-tags osusergo,netgo \
+		"${REPO_PATH}/cmd/$cmd"
 }
 
 # Unused now, but kept in case we want it in the future
@@ -76,10 +88,14 @@ cross_build() {
 }
 
 for arg in "$@"; do
-    if [ "${arg}" = "schema" ]; then
-        schema_generate
-    else
-	    cmd=$(basename "${arg}")
-	    host_build "${cmd}"
-    fi
+	if [ "${arg}" = "schema" ]; then
+		schema_generate
+	else
+		cmd=$(basename "${arg}")
+		if [ "${cmd}" = "kolet" ]; then
+			host_static_build kolet
+		else
+			host_build "${cmd}"
+		fi
+	fi
 done


### PR DESCRIPTION
Right now, we're building kolet in the cosa buildroot and then copying
it into the target system. This worked for a while by pure chance,
because it's really easy to hit a library mismatch between the cosa and
target environments. And now we do hit this case when using f33 to build
RHCOS due to symbol versioning in glibc.

The proper way to fix this would be for cosa to build kolet in a
buildroot that matches the target OS. This is resolvable, though it
would significantly affect the developer experience because devs would
now have to also download and maintain the target buildroot.

Target-specific buildroots are still something valuable to have (because
for dev and CI you do want a matching buildroot when hacking on host
components) but purely for cosa given that kolet is the only compiled
code it needs to run directly on the host, it's a very costly approach.

This patch instead addresses this simply by building kolet statically.
This has its own set of trade-offs (see discussions in
#1896), though should
work fine for the time being.

(In a previous version, this patch copied the libraries into the node
and used rpath to have kolet pick them up. Another approach I considered
was running kolet in a container, though (1) we would need to implement
some image caching to make it less expensive and (2) it would mean
having our test harness rely on the container runtime itself which seems
circular.)

And of course, we can eventually move to using buildroots in the future
once we flesh out the UX better there and the benefits outweigh the
costs.

This allows moving cosa to f33 without breaking RHCOS.

Partially addresses: #1863

