### PR TITLE
Remove unused spec2 argument for qemu

### DIFF
--- a/mantle/cmd/kola/devshell.go
+++ b/mantle/cmd/kola/devshell.go
@@ -38,7 +38,6 @@ import (
 	"github.com/coreos/mantle/util"
 	"github.com/pkg/errors"
 
-	"github.com/coreos/mantle/kola"
 	"github.com/coreos/mantle/platform"
 )
 
@@ -117,7 +116,7 @@ func runDevShellSSH(ctx context.Context, builder *platform.QemuBuilder, conf *co
 
 	readyReader := bufio.NewReader(journalPipe)
 
-	builder.SetConfig(conf, kola.IsIgnitionV2())
+	builder.SetConfig(conf)
 
 	serialChan := make(chan string)
 	serialPipe, err := builder.SerialPipe()

--- a/mantle/cmd/kola/qemuexec.go
+++ b/mantle/cmd/kola/qemuexec.go
@@ -263,7 +263,7 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 		if directIgnition {
 			return fmt.Errorf("Cannot use fragments/mounts with direct ignition")
 		}
-		builder.SetConfig(config, kola.IsIgnitionV2())
+		builder.SetConfig(config)
 	} else if directIgnition {
 		builder.ConfigFile = ignition
 	}

--- a/mantle/kola/tests/ignition/qemufailure.go
+++ b/mantle/kola/tests/ignition/qemufailure.go
@@ -55,7 +55,7 @@ func ignitionFailure(c cluster.TestCluster) error {
 
 	builder := platform.NewBuilder()
 	defer builder.Close()
-	builder.SetConfig(failConfig, kola.IsIgnitionV2())
+	builder.SetConfig(failConfig)
 	err = builder.AddBootDisk(&platform.Disk{
 		BackingFile: kola.QEMUOptions.DiskImage,
 	})

--- a/mantle/platform/metal.go
+++ b/mantle/platform/metal.go
@@ -647,7 +647,7 @@ WantedBy=multi-user.target
 		return nil, err
 	}
 
-	qemubuilder.SetConfig(&inst.liveIgnition, inst.IgnitionSpec2)
+	qemubuilder.SetConfig(&inst.liveIgnition)
 	qemubuilder.AddIso(srcisopath, "bootindex=2")
 
 	if offline {

--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -338,9 +338,7 @@ type QemuBuilder struct {
 
 	// ignition is a config object that can be used instead of
 	// ConfigFile.
-	ignition *conf.Conf
-	// ignitionSpec2 says to convert to Ignition spec 2
-	ignitionSpec2    bool
+	ignition         *conf.Conf
 	ignitionSet      bool
 	ignitionRendered bool
 
@@ -383,7 +381,7 @@ func (builder *QemuBuilder) ensureTempdir() error {
 }
 
 // SetConfig injects Ignition; this can be used in place of ConfigFile.
-func (builder *QemuBuilder) SetConfig(config *conf.Conf, convSpec2 bool) {
+func (builder *QemuBuilder) SetConfig(config *conf.Conf) {
 	if builder.ignitionRendered {
 		panic("SetConfig called after config rendered")
 	}
@@ -391,7 +389,6 @@ func (builder *QemuBuilder) SetConfig(config *conf.Conf, convSpec2 bool) {
 		panic("SetConfig called multiple times")
 	}
 	builder.ignition = config
-	builder.ignitionSpec2 = convSpec2
 	builder.ignitionSet = true
 }
 


### PR DESCRIPTION
This led me down the wrong path before in debugging
https://github.com/coreos/coreos-assembler/issues/1851
The variable in qemu is dead code since the rework of
Ignition handling.  The `Conf` type now holds either
instead of being spec3 and only downconverted
at the last moment.