### PR TITLE
mantle: clean up kola/tests/ostree/basic

### DIFF
--- a/mantle/kola/tests/ostree/basic.go
+++ b/mantle/kola/tests/ostree/basic.go
@@ -214,7 +214,7 @@ func ostreeRemoteTest(c cluster.TestCluster) {
 		osRemoteListSplit := strings.Split(string(osRemoteListOut), "\n")
 		// should have original remote + newly added remote
 		if len(osRemoteListSplit) != initialRemotesNum+1 {
-			c.Fatalf(`Did not find expected amount of ostree remotes: %q. Expected %d`, string(osRemoteListOut), osRemoteListSplit)
+			c.Fatalf(`Did not find expected amount of ostree remotes: %q. Got %d. Expected %d`, string(osRemoteListOut), len(osRemoteListSplit), initialRemotesNum+1)
 		}
 
 		var remoteFound bool = false


### PR DESCRIPTION
This cleans up kola/tests/ostree/basic.go:
```
kola/tests/ostree/basic.go:217:4: printf: Fatalf format %d has arg osRemoteListSplit of wrong type []string (govet)
                        c.Fatalf(`Did not find expected amount of ostree remotes: %q. Expected %d`, string(osRemoteListOut), osRemoteListSplit)
                        ^
```

Fixes part of https://github.com/coreos/coreos-assembler/issues/1813