### PR TITLE
mantle: clean up kola/tests/ostree/unlock

### DIFF
--- a/mantle/kola/tests/ostree/unlock.go
+++ b/mantle/kola/tests/ostree/unlock.go
@@ -254,7 +254,7 @@ func ostreeHotfixTest(c cluster.TestCluster) {
 		}
 
 		if rollbackStatus.Deployments[0].Unlocked != "none" {
-			c.Fatalf(`Rollback did not remove hotfix mode; got: $q`, rollbackStatus.Deployments[0].Unlocked)
+			c.Fatalf(`Rollback did not remove hotfix mode; got: %q`, rollbackStatus.Deployments[0].Unlocked)
 		}
 
 		_, secCmdErr := c.SSH(m, ("command -v " + rpmName))


### PR DESCRIPTION
This cleans up kola/tests/ostree/unlock.go:
```
kola/tests/ostree/unlock.go:257:12: printf: Fatalf call has arguments but no formatting directives (govet)
                        c.Fatalf(`Rollback did not remove hotfix mode; got: $q`, rollbackStatus.Deployments[0].Unlocked)
```

Fixes part of https://github.com/coreos/coreos-assembler/issues/1813