### PR TITLE
mantle: clean up kola/tests/rpmostree/deployments

### DIFF
--- a/mantle/kola/tests/rpmostree/deployments.go
+++ b/mantle/kola/tests/rpmostree/deployments.go
@@ -299,7 +299,7 @@ func rpmOstreeInstallUninstall(c cluster.TestCluster) {
 
 		// check the metadata to make sure everything went well
 		if len(postUninstallStatus.Deployments) != 2 {
-			c.Fatal("Expected %d deployments, got %d", 2, len(postUninstallStatus.Deployments))
+			c.Fatalf("Expected %d deployments, got %d", 2, len(postUninstallStatus.Deployments))
 		}
 
 		if postUninstallStatus.Deployments[0].Checksum != originalCsum {


### PR DESCRIPTION
This cleans up kola/tests/rpmostree/deployments.go:
```
kola/tests/rpmostree/deployments.go:302:4: printf: Fatal call has possible formatting directive %d (govet)
                        c.Fatal("Expected %d deployments, got %d", 2, len(postUninstallStatus.Deployments))
                        ^
```

Fixes part of https://github.com/coreos/coreos-assembler/issues/1813