### PR TITLE
mantle: clean up kola/tests/rpmostree/status

### DIFF
--- a/mantle/kola/tests/rpmostree/status.go
+++ b/mantle/kola/tests/rpmostree/status.go
@@ -86,7 +86,7 @@ func rpmOstreeStatus(c cluster.TestCluster) {
 	// let's validate that the version from the JSON matches the normal output
 	var rpmOstreeVersion string
 	rpmOstreeStatusOut := c.MustSSH(m, "rpm-ostree status")
-	reVersion, err := regexp.Compile(rpmOstreeVersionRegex)
+	reVersion, _ := regexp.Compile(rpmOstreeVersionRegex)
 	statusArray := strings.Split(string(rpmOstreeStatusOut), "\n")
 	for _, line := range statusArray {
 		versionMatch := reVersion.FindStringSubmatch(strings.Trim(line, " "))


### PR DESCRIPTION
This cleans up kola/tests/rpmostree/status.go:
```
kola/tests/rpmostree/status.go:89:13: ineffectual assignment to `err` (ineffassign)
        reVersion, err := regexp.Compile(rpmOstreeVersionRegex)
```

Fixes part of https://github.com/coreos/coreos-assembler/issues/1813