### PR TITLE
mantle: clean up kola/tests/upgrade/basic

### DIFF
--- a/mantle/kola/tests/upgrade/basic.go
+++ b/mantle/kola/tests/upgrade/basic.go
@@ -274,7 +274,7 @@ func undoZincatiDisablement(c cluster.TestCluster, m platform.Machine) {
 func (g *Graph) sync(c cluster.TestCluster, m platform.Machine) {
 	b, err := json.Marshal(g)
 	if err != nil {
-		c.Fatalf("failed to marshal graph: %v")
+		c.Fatalf("failed to marshal graph: %v", err)
 	}
 
 	if err := platform.InstallFile(bytes.NewReader(b), m, "graph.json"); err != nil {


### PR DESCRIPTION
This cleans up kola/tests/upgrade/basic.go:
```
kola/tests/upgrade/basic.go:277:3: printf: Fatalf format %v reads arg #1, but call has 0 args (govet)
                c.Fatalf("failed to marshal graph: %v")
                ^
```

Fixes part of https://github.com/coreos/coreos-assembler/issues/1813