### PR TITLE
mantle: clean up kola/tests/ignition/resource

### DIFF
--- a/mantle/kola/tests/ignition/resource.go
+++ b/mantle/kola/tests/ignition/resource.go
@@ -381,7 +381,7 @@ func Serve() error {
 	go func() {
 		http.HandleFunc("/http", func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Add("Content-Type", "text/plain")
-			w.Write([]byte("kola-http"))
+			_, _ = w.Write([]byte("kola-http"))
 		})
 		err := http.ListenAndServe(":80", nil)
 		fmt.Println(err)
@@ -391,7 +391,7 @@ func Serve() error {
 		readHandler := func(filename string, r io.ReaderFrom) error {
 			switch filename {
 			case "/tftp":
-				r.ReadFrom(bytes.NewBufferString("kola-tftp"))
+				_, _ = r.ReadFrom(bytes.NewBufferString("kola-tftp"))
 			default:
 				return fmt.Errorf("404 not found")
 			}


### PR DESCRIPTION
This cleans up kola/tests/ignition/resource.go:
```
kola/tests/ignition/resource.go:384:11: Error return value of `w.Write` is not checked (errcheck)
                        w.Write([]byte("kola-http"))
                               ^
kola/tests/ignition/resource.go:394:15: Error return value of `r.ReadFrom` is not checked (errcheck)
                                r.ReadFrom(bytes.NewBufferString("kola-tftp"))
```

Fixes part of https://github.com/coreos/coreos-assembler/issues/1813

Since the errors were not dealt with before, just make tiny changes to pass golang-ci lint.