### PR TITLE
mantle: clean up kola/tests/ignition/security

### DIFF
--- a/mantle/kola/tests/ignition/security.go
+++ b/mantle/kola/tests/ignition/security.go
@@ -156,8 +156,9 @@ func ServeTLS(customFile []byte) error {
 	}
 
 	caserver := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write(customFile)
+		_, _ = w.Write(customFile)
 	}))
+
 	l, err := net.Listen("tcp", ":443")
 	if err != nil {
 		return err


### PR DESCRIPTION
This cleans up kola/tests/ignition/security.go:
```
kola/tests/ignition/security.go:159:10: Error return value of `w.Write` is not checked (errcheck)
                w.Write(customFile)
```

Fixes part of https://github.com/coreos/coreos-assembler/issues/1813