### PR TITLE
mantle: clean up kola/tests/misc

### DIFF
--- a/mantle/kola/tests/misc/network.go
+++ b/mantle/kola/tests/misc/network.go
@@ -147,7 +147,9 @@ func NetworkListeners(c cluster.TestCluster) {
 func NetworkInitramfsSecondBoot(c cluster.TestCluster) {
 	m := c.Machines()[0]
 
-	m.Reboot()
+	if err := m.Reboot(); err != nil {
+		c.Errorf("failed to reboot the machine: %v", err)
+	}
 
 	// get journal lines from the current boot
 	output := c.MustSSH(m, "journalctl -b 0 -o cat -u initrd-switch-root.target -u systemd-networkd.service")


### PR DESCRIPTION
This cleans up kola/tests/misc/network.go:
```
kola/tests/misc/network.go:150:10: Error return value of `m.Reboot` is not checked (errcheck)
        m.Reboot()
```

Fixes part of https://github.com/coreos/coreos-assembler/issues/1813