### PR TITLE
mantle: clean up lang

### DIFF
--- a/mantle/lang/bufpipe/pipe_test.go
+++ b/mantle/lang/bufpipe/pipe_test.go
@@ -264,23 +264,40 @@ func TestPipeWriteClose2(t *testing.T) {
 
 func TestWriteEmpty(t *testing.T) {
 	r, w := Pipe()
+	errs := make(chan error)
 	go func() {
-		w.Write([]byte{})
+		_, err := w.Write([]byte{})
+		errs <- err
 		w.Close()
 	}()
+	err := <-errs
+	if err != nil {
+		t.Fatalf("failed to write empty: %v", err)
+	}
+
 	var b [2]byte
-	io.ReadFull(r, b[0:2])
+	if _, err := io.ReadFull(r, b[0:2]); err.Error() != "EOF" {
+		t.Fatalf("failed to read empty: %v", err)
+	}
 	r.Close()
 }
 
 func TestWriteNil(t *testing.T) {
 	r, w := Pipe()
+	errs := make(chan error)
 	go func() {
-		w.Write(nil)
+		_, err := w.Write(nil)
+		errs <- err
 		w.Close()
 	}()
+	err := <-errs
+	if err != nil {
+		t.Fatalf("failed to write nil: %v", err)
+	}
 	var b [2]byte
-	io.ReadFull(r, b[0:2])
+	if _, err := io.ReadFull(r, b[0:2]); err.Error() != "EOF" {
+		t.Fatalf("failed to read nil: %v", err)
+	}
 	r.Close()
 }
 


### PR DESCRIPTION
This cleans up lang/bufpipe/pipe_test.go:
```
lang/bufpipe/pipe_test.go:268:10: Error return value of `w.Write` is not checked (errcheck)
                w.Write([]byte{})
                       ^
lang/bufpipe/pipe_test.go:272:13: Error return value of `io.ReadFull` is not checked (errcheck)
        io.ReadFull(r, b[0:2])
                   ^
lang/bufpipe/pipe_test.go:279:10: Error return value of `w.Write` is not checked (errcheck)
                w.Write(nil)
                       ^
lang/bufpipe/pipe_test.go:283:13: Error return value of `io.ReadFull` is not checked (errcheck)
        io.ReadFull(r, b[0:2])
```

Fixes part of https://github.com/coreos/coreos-assembler/issues/1813