### PR TITLE
mantle: clean up network/journal

### DIFF
--- a/mantle/network/journal/format.go
+++ b/mantle/network/journal/format.go
@@ -57,7 +57,9 @@ func (s *shortWriter) WriteEntry(entry Entry) error {
 	}
 
 	if s.isReboot(entry) {
-		io.WriteString(s.w, "-- Reboot --\n")
+		if _, err := io.WriteString(s.w, "-- Reboot --\n"); err != nil {
+			return err
+		}
 	}
 
 	var buf bytes.Buffer


### PR DESCRIPTION
This cleans up network/journal/format.go:
```
network/journal/format.go:60:17: Error return value of `io.WriteString` is not checked (errcheck)
                io.WriteString(s.w, "-- Reboot --\n")
```

Fixes part of https://github.com/coreos/coreos-assembler/issues/1813