### PR TITLE
mantle: clean up network/mockssh/mockssh

### DIFF
--- a/mantle/network/mockssh/mockssh.go
+++ b/mantle/network/mockssh/mockssh.go
@@ -158,7 +158,7 @@ func (m *mockServer) handleServerConn(conn net.Conn) {
 
 func (m *mockServer) handleServerChannel(newChannel ssh.NewChannel) {
 	if newChannel.ChannelType() != "session" {
-		newChannel.Reject(ssh.UnknownChannelType, "unknown channel type")
+		_ = newChannel.Reject(ssh.UnknownChannelType, "unknown channel type")
 		return
 	}
 
@@ -178,30 +178,30 @@ func (m *mockServer) handleServerChannel(newChannel ssh.NewChannel) {
 	// shell and pty requests are not implemented.
 	for req := range requests {
 		if session == nil {
-			req.Reply(false, nil)
+			_ = req.Reply(false, nil)
 		}
 		switch req.Type {
 		case "exec":
 			v := struct{ Value string }{}
 			if err := ssh.Unmarshal(req.Payload, &v); err != nil {
-				req.Reply(false, nil)
+				_ = req.Reply(false, nil)
 			} else {
 				session.Exec = v.Value
-				req.Reply(true, nil)
+				_ = req.Reply(true, nil)
 				go m.handler(session)
 			}
 			session = nil
 		case "env":
 			kv := struct{ Key, Value string }{}
 			if err := ssh.Unmarshal(req.Payload, &kv); err != nil {
-				req.Reply(false, nil)
+				_ = req.Reply(false, nil)
 			} else {
 				env := fmt.Sprintf("%s=%s", kv.Key, kv.Value)
 				session.Env = append(session.Env, env)
-				req.Reply(true, nil)
+				_ = req.Reply(true, nil)
 			}
 		default:
-			req.Reply(false, nil)
+			_ = req.Reply(false, nil)
 		}
 	}
 }


### PR DESCRIPTION
This cleans up network/mockssh/mockssh.go:
```
network/mockssh/mockssh.go:161:20: Error return value of `newChannel.Reject` is not checked (errcheck)
                newChannel.Reject(ssh.UnknownChannelType, "unknown channel type")
                                 ^
network/mockssh/mockssh.go:181:13: Error return value of `req.Reply` is not checked (errcheck)
                        req.Reply(false, nil)
                                 ^
network/mockssh/mockssh.go:187:14: Error return value of `req.Reply` is not checked (errcheck)
                                req.Reply(false, nil)
                                         ^
network/mockssh/mockssh.go:190:14: Error return value of `req.Reply` is not checked (errcheck)
                                req.Reply(true, nil)
                                         ^
network/mockssh/mockssh.go:197:14: Error return value of `req.Reply` is not checked (errcheck)
                                req.Reply(false, nil)
network/mockssh/mockssh.go:201:14: Error return value of `req.Reply` is not checked (errcheck)
                                req.Reply(true, nil)
                                         ^
network/mockssh/mockssh.go:204:13: Error return value of `req.Reply` is not checked (errcheck)
                        req.Reply(false, nil)
```

Fixes part of https://github.com/coreos/coreos-assembler/issues/1813