### PR TITLE
mantle: clean up network/nsdialer

### DIFF
--- a/mantle/network/nsdialer.go
+++ b/mantle/network/nsdialer.go
@@ -46,7 +46,9 @@ func (d *NsDialer) Dial(network, address string) (net.Conn, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer nsExit()
+	defer func() {
+		_ = nsExit()
+	}()
 
 	return d.RetryDialer.Dial(network, address)
 }


### PR DESCRIPTION
This cleans up network/nsdialer.go:
```
network/nsdialer.go:49:14: Error return value of `nsExit` is not checked (errcheck)
        defer nsExit()
                    ^
```

Fixes part of https://github.com/coreos/coreos-assembler/issues/1813