### PR TITLE
mantle: clean up network/ntp

### DIFF
--- a/mantle/network/ntp/protocol_test.go
+++ b/mantle/network/ntp/protocol_test.go
@@ -87,7 +87,9 @@ func TestHeaderMarshal(t *testing.T) {
 func BenchmarkHeaderMarshal(b *testing.B) {
 	h := testData[0].Header
 	for i := 0; i < b.N; i++ {
-		h.MarshalBinary()
+		if _, err := h.MarshalBinary(); err != nil {
+			b.Error(err)
+		}
 	}
 }
 
@@ -97,7 +99,9 @@ func TestHeaderUnmarshal(t *testing.T) {
 			t.Errorf("testData[%d].Raw is invalid", i)
 		}
 		h := Header{}
-		h.UnmarshalBinary(d.Raw)
+		if err := h.UnmarshalBinary(d.Raw); err != nil {
+			t.Errorf("testData[%d] unmarshal binary Raw failed: %v", i, err)
+		}
 		if diff := pretty.Compare(d.Header, h); diff != "" {
 			t.Errorf("testData[%d] failed: %v", i, diff)
 		}
@@ -108,7 +112,9 @@ func BenchmarkHeaderUnmarshal(b *testing.B) {
 	h := Header{}
 	d := testData[0].Raw
 	for i := 0; i < b.N; i++ {
-		h.UnmarshalBinary(d)
+		if err := h.UnmarshalBinary(d); err != nil {
+			b.Error(err)
+		}
 	}
 }
 


### PR DESCRIPTION
This cleans up network/ntp/protocol_test.go:
```
network/ntp/protocol_test.go:90:18: Error return value of `h.MarshalBinary` is not checked (errcheck)
                h.MarshalBinary()
                               ^
network/ntp/protocol_test.go:100:20: Error return value of `h.UnmarshalBinary` is not checked (errcheck)
                h.UnmarshalBinary(d.Raw)
                                 ^
network/ntp/protocol_test.go:111:20: Error return value of `h.UnmarshalBinary` is not checked (errcheck)
                h.UnmarshalBinary(d)
                                 ^
```

Fixes part of https://github.com/coreos/coreos-assembler/issues/1813