### PR TITLE
mantle: clean up network/ssh

### DIFF
--- a/mantle/network/ssh.go
+++ b/mantle/network/ssh.go
@@ -114,7 +114,9 @@ func NewSSHAgent(dialer Dialer) (*SSHAgent, error) {
 			if err != nil {
 				return
 			}
-			go agent.ServeAgent(a, conn)
+			go func() {
+				_ = agent.ServeAgent(a, conn)
+			}()
 		}
 	}()
 


### PR DESCRIPTION
This cleans up network/ssh.go:
```
network/ssh.go:117:23: Error return value of `agent.ServeAgent` is not checked (errcheck)
                        go agent.ServeAgent(a, conn)
                                           ^
```

Fixes part of https://github.com/coreos/coreos-assembler/issues/1813