### PR TITLE
mantle: Check for SELinux AVCs just like systemd failed units

### DIFF
--- a/mantle/platform/platform.go
+++ b/mantle/platform/platform.go
@@ -443,6 +443,15 @@ func CheckMachine(ctx context.Context, m Machine) error {
 		if len(out) > 0 {
 			return fmt.Errorf("some systemd units failed:\n%s", out)
 		}
+		// Also no SELinux denials; RHCOS currently ships auditd, FCOS doesn't, so handle
+		// both places.
+		out, stderr, err = m.SSH("if test -f /var/log/audit/audit.log; then grep 'avc.*denied' /var/log/audit/audit.log || true; else journalctl -q --no-pager --grep='avc.*denied' _TRANSPORT=audit || true; fi")
+		if err != nil {
+			return fmt.Errorf("failed to query audit logs: %s: %v: %s", out, err, stderr)
+		}
+		if len(out) > 0 {
+			return fmt.Errorf("Found SELinux AVC denials:\n%s", out)
+		}
 	}
 
 	return ctx.Err()


### PR DESCRIPTION
We shouldn't ship an OS that boots up and has a SELinux denial
by default; it makes us look less than fully competent.

The motivation for this is
https://bugzilla.redhat.com/show_bug.cgi?id=1900898

Though it turns out we do have a SELinux denial in FCOS by
default now, that's
https://bugzilla.redhat.com/show_bug.cgi?id=1903335
So this can only merge once that's fixed.