### PR TITLE
mantle: clean up platform/api/aws

### DIFF
--- a/mantle/platform/api/aws/ec2.go
+++ b/mantle/platform/api/aws/ec2.go
@@ -200,7 +200,9 @@ func (a *API) CreateInstances(name, keyname, userdata string, count uint64) ([]*
 		return true, nil
 	})
 	if err != nil {
-		a.TerminateInstances(ids)
+		if errTerminate := a.TerminateInstances(ids); errTerminate != nil {
+			return nil, fmt.Errorf("terminating instances failed: %v after instances failed to run: %v", errTerminate, err)
+		}
 		return nil, fmt.Errorf("waiting for instances to run: %v", err)
 	}
 


### PR DESCRIPTION
This cleans up platform/api/aws/ec2.go:
```
platform/api/aws/ec2.go:203:23: Error return value of `a.TerminateInstances` is not checked (errcheck)
                a.TerminateInstances(ids)
                                    ^
```

Fixes part of https://github.com/coreos/coreos-assembler/issues/1813