### PR TITLE
mantle: clean up platform/api/azure/instance

### DIFF
--- a/mantle/platform/api/azure/instance.go
+++ b/mantle/platform/api/azure/instance.go
@@ -147,7 +147,9 @@ func (a *API) CreateInstance(name, userdata, sshkey, resourceGroup, storageAccou
 		return true, nil
 	})
 	if err != nil {
-		a.TerminateInstance(name, resourceGroup)
+		if errTerminate := a.TerminateInstance(name, resourceGroup); errTerminate != nil {
+			return nil, fmt.Errorf("terminating machines failed: %v after the machines failed to become active: %v", errTerminate, err)
+		}
 		return nil, fmt.Errorf("waiting for machine to become active: %v", err)
 	}
 


### PR DESCRIPTION
This cleans up platform/api/azure/instance.go:
```
platform/api/azure/instance.go:150:22: Error return value of `a.TerminateInstance` is not checked (errcheck)
                a.TerminateInstance(name, resourceGroup)
                                   ^
```

Fixes part of https://github.com/coreos/coreos-assembler/issues/1813