### PR TITLE
mantle: clean up platform/api/azure/network

### DIFF
--- a/mantle/platform/api/azure/network.go
+++ b/mantle/platform/api/azure/network.go
@@ -109,11 +109,13 @@ func (a *API) GetIPAddresses(name, publicIPName, resourceGroup string) (string, 
 	}
 
 	configs := *nic.InterfacePropertiesFormat.IPConfigurations
+
 	for _, conf := range configs {
 		if conf.PrivateIPAddress == nil {
 			return "", "", fmt.Errorf("PrivateIPAddress is nil")
+		} else {
+			return publicIP, *conf.PrivateIPAddress, nil
 		}
-		return publicIP, *conf.PrivateIPAddress, nil
 	}
 	return "", "", fmt.Errorf("no ip configurations found")
 }


### PR DESCRIPTION
This cleans up platform/api/azure/network.go:
```
platform/api/azure/network.go:116:3: SA4004: the surrounding loop is unconditionally terminated (staticcheck)
                return publicIP, *conf.PrivateIPAddress, nil
                ^
```

Fixes part of https://github.com/coreos/coreos-assembler/issues/1813

I think it's great before changes. Added `else` to pass golang-ci lint.