### PR TITLE
mantle: clean up platform/api/azure/storage_mit

### DIFF
--- a/mantle/platform/api/azure/storage_mit.go
+++ b/mantle/platform/api/azure/storage_mit.go
@@ -191,6 +191,9 @@ func getBlobMetaData(client storage.BlobStorageClient, containerName, blobName s
 	if md5Hash != "" {
 		return nil, BlobExistsError(blobName)
 	}
+	if err != nil {
+		return nil, err
+	}
 
 	blobMetaData, err := metadata.NewMetadataFromBlob(client, containerName, blobName)
 	if err != nil {


### PR DESCRIPTION
This cleans up platform/api/azure/storage_mit.go:
```
platform/api/azure/storage_mit.go:190:11: ineffectual assignment to `err` (ineffassign)
        md5Hash, err := getBlobMD5Hash(client, containerName, blobName)
                 ^
```

Fixes part of https://github.com/coreos/coreos-assembler/issues/1813