### PR TITLE
mantle: clean up platform/api/gcloud/api

### DIFF
--- a/mantle/platform/api/gcloud/api.go
+++ b/mantle/platform/api/gcloud/api.go
@@ -16,6 +16,8 @@
 package gcloud
 
 import (
+	"context"
+	"google.golang.org/api/option"
 	"io/ioutil"
 	"net/http"
 	"time"
@@ -71,6 +73,9 @@ func New(opts *Options) (*API, error) {
 			plog.Fatal(err)
 		}
 		client, err = auth.GoogleClientFromJSONKey(b)
+		if err != nil {
+			plog.Error(err)
+		}
 	} else {
 		client, err = auth.GoogleClient()
 	}
@@ -79,14 +84,16 @@ func New(opts *Options) (*API, error) {
 		return nil, err
 	}
 
-	capi, err := compute.New(client)
+	ctx := context.Background()
+
+	computeService, err := compute.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
 		return nil, err
 	}
 
 	api := &API{
 		client:  client,
-		compute: capi,
+		compute: computeService,
 		options: opts,
 	}
 


### PR DESCRIPTION
This cleans up platform/api/gcloud/api.go:
```
platform/api/gcloud/api.go:73:11: ineffectual assignment to `err` (ineffassign)
                client, err = auth.GoogleClientFromJSONKey(b)
                        ^
platform/api/gcloud/api.go:82:15: SA1019: compute.New is deprecated: please use NewService instead. To provide a custom HTTP client, use option.WithHTTPClient. If you are using google.golang.org/api/googleapis/transport.APIKey, use option.WithAPIKey with NewService instead.  (staticcheck)
        capi, err := compute.New(client)
                     ^
```

Fixes part of https://github.com/coreos/coreos-assembler/issues/1813