### PR TITLE
mantle: clean up platform/api/gcloud/compute

### DIFF
--- a/mantle/platform/api/gcloud/compute.go
+++ b/mantle/platform/api/gcloud/compute.go
@@ -26,7 +26,9 @@ import (
 
 func (a *API) vmname() string {
 	b := make([]byte, 10)
-	rand.Read(b)
+	if _, err := rand.Read(b); err != nil {
+		plog.Error(err)
+	}
 	return fmt.Sprintf("%s-%x", a.options.BaseName, b)
 }
 


### PR DESCRIPTION
This cleans up platform/api/gcloud/compute.go:
```
platform/api/gcloud/compute.go:29:11: Error return value of `rand.Read` is not checked (errcheck)
        rand.Read(b)
                 ^
```

Fixes part of https://github.com/coreos/coreos-assembler/issues/1813