### PR TITLE
mantle: clean up platform/api/gcloud/pending

### DIFF
--- a/mantle/platform/api/gcloud/pending.go
+++ b/mantle/platform/api/gcloud/pending.go
@@ -54,7 +54,7 @@ func (p *Pending) Wait() error {
 	for {
 		op, err = p.do.Do()
 		if err == nil {
-			err := p.Progress(p.desc, time.Now().Sub(start), op)
+			err := p.Progress(p.desc, time.Since(start), op)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
This cleans up platform/api/gcloud/pending.go:
```
platform/api/gcloud/pending.go:57:30: S1012: should use `time.Since` instead of `time.Now().Sub` (gosimple)
                        err := p.Progress(p.desc, time.Now().Sub(start), op)
```

Fixes part of https://github.com/coreos/coreos-assembler/issues/1813