### PR TITLE
mantle: clean up cosa

### DIFF
--- a/mantle/cosa/schema_test.go
+++ b/mantle/cosa/schema_test.go
@@ -27,7 +27,7 @@ func TestSchema(t *testing.T) {
 			t.Errorf("failed to read %s: %v", df, err)
 		}
 		if b == nil {
-			t.Errorf("failed to render build")
+			t.Fatalf("failed to render build")
 		}
 
 		// Render it invalid


### PR DESCRIPTION
This cleans up cosa/schema_test.go:
```
cosa/schema_test.go:34:5: SA5011: possible nil pointer dereference (staticcheck)
                b.Name = ""
                  ^
```

Fixes part of https://github.com/coreos/coreos-assembler/issues/1813