### PR TITLE
mantle: clean up platform/journal

### DIFF
--- a/mantle/platform/journal.go
+++ b/mantle/platform/journal.go
@@ -93,7 +93,7 @@ func (j *Journal) Start(ctx context.Context, m Machine, oldBootId string) error 
 	if j.cancel != nil {
 		j.cancel()
 		j.cancel = nil
-		j.recorder.Wait() // Just need to consume the status.
+		_ = j.recorder.Wait() // Just need to consume the status.
 	}
 	ctx, cancel := context.WithCancel(ctx)
 


### PR DESCRIPTION
This cleans up platform/journal.go:
```
platform/journal.go:96:18: Error return value of `j.recorder.Wait` is not checked (errcheck)
                j.recorder.Wait() // Just need to consume the status.
                               ^
```

Fixes part of https://github.com/coreos/coreos-assembler/issues/1813

The error is not vital, so just assign to blank in order to pass the golang-lint ci.