### PR TITLE
mantle: clean up platform/machine/aws

### DIFF
--- a/mantle/platform/machine/aws/machine.go
+++ b/mantle/platform/machine/aws/machine.go
@@ -149,7 +149,9 @@ func (am *machine) saveConsole(origConsole string) error {
 		return err
 	}
 	defer f.Close()
-	f.WriteString(am.console)
+	if _, err := f.WriteString(am.console); err != nil {
+		return err
+	}
 
 	return nil
 }


### PR DESCRIPTION
This cleans up platform/machine/aws/machine.go :
```
platform/machine/aws/machine.go:152:15: Error return value of `f.WriteString` is not checked (errcheck)
        f.WriteString(am.console)
                     ^
```

Fixes part of https://github.com/coreos/coreos-assembler/issues/1813