### PR TITLE
mantle: clean up platform/machine

### DIFF
--- a/mantle/platform/machine/do/cluster.go
+++ b/mantle/platform/machine/do/cluster.go
@@ -97,7 +97,9 @@ func (dc *cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 
 func (dc *cluster) vmname() string {
 	b := make([]byte, 5)
-	rand.Read(b)
+	if _, err := rand.Read(b); err != nil {
+		plog.Errorf("failed to generate a random vmname: %v", err)
+	}
 	return fmt.Sprintf("%s-%x", dc.Name()[0:13], b)
 }
 

--- a/mantle/platform/machine/openstack/cluster.go
+++ b/mantle/platform/machine/openstack/cluster.go
@@ -89,7 +89,9 @@ func (oc *cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 
 func (oc *cluster) vmname() string {
 	b := make([]byte, 5)
-	rand.Read(b)
+	if _, err := rand.Read(b); err != nil {
+		plog.Errorf("failed to generate a random vmname: %v", err)
+	}
 	return fmt.Sprintf("%s-%x", oc.Name()[0:13], b)
 }
 

--- a/mantle/platform/machine/packet/cluster.go
+++ b/mantle/platform/machine/packet/cluster.go
@@ -121,7 +121,9 @@ func (pc *cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 
 func (pc *cluster) vmname() string {
 	b := make([]byte, 5)
-	rand.Read(b)
+	if _, err := rand.Read(b); err != nil {
+		plog.Errorf("failed to generate a random vmname: %v", err)
+	}
 	return fmt.Sprintf("%s-%x", pc.Name()[0:13], b)
 }
 


### PR DESCRIPTION
This cleans up platform/machine:
```
platform/machine/do/cluster.go:100:11: Error return value of `rand.Read` is not checked (errcheck)
        rand.Read(b)
                 ^
platform/machine/packet/cluster.go:124:11: Error return value of `rand.Read` is not checked (errcheck)
        rand.Read(b)
                 ^
platform/machine/openstack/cluster.go:92:11: Error return value of `rand.Read` is not checked (errcheck)
        rand.Read(b)
                 ^
```

Fixes part of https://github.com/coreos/coreos-assembler/issues/1813

Put the same issue into one PR to make it clear. 
Since it's no harm to log the error with detailed information, update to log the errors.