### PR TITLE
mantle: clean up platform/machine/gcloud

### DIFF
--- a/mantle/platform/machine/gcloud/machine.go
+++ b/mantle/platform/machine/gcloud/machine.go
@@ -107,7 +107,9 @@ func (gm *machine) saveConsole() error {
 		return err
 	}
 	defer f.Close()
-	f.WriteString(gm.console)
+	if _, err := f.WriteString(gm.console); err != nil {
+		return err
+	}
 
 	return nil
 }


### PR DESCRIPTION
This cleans up platform/machine/gcloud/machine.go:
```
platform/machine/gcloud/machine.go:110:15: Error return value of `f.WriteString` is not checked (errcheck)
        f.WriteString(gm.console)
                     ^
```

Fixes part of https://github.com/coreos/coreos-assembler/issues/1813