### PR TITLE
mantle: clean up platform/machine/openstack/cluster

### DIFF
--- a/mantle/platform/machine/openstack/cluster.go
+++ b/mantle/platform/machine/openstack/cluster.go
@@ -89,7 +89,7 @@ func (oc *cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 
 func (oc *cluster) vmname() string {
 	b := make([]byte, 5)
-	rand.Read(b)
+	rand.Read(b) //nolint
 	return fmt.Sprintf("%s-%x", oc.Name()[0:13], b)
 }
 


### PR DESCRIPTION
This cleans up platform/machine/openstack/cluster.go:
```
platform/machine/openstack/cluster.go:92:11: Error return value of `rand.Read` is not checked (errcheck)
        rand.Read(b)
                 ^
```

Fixes part of https://github.com/coreos/coreos-assembler/issues/1813