### PR TITLE
mantle: clean up platform/machine/openstack/machine

### DIFF
--- a/mantle/platform/machine/openstack/machine.go
+++ b/mantle/platform/machine/openstack/machine.go
@@ -128,7 +128,9 @@ func (om *machine) saveConsole() error {
 		return err
 	}
 	defer f.Close()
-	f.WriteString(om.console)
+	if _, err := f.WriteString(om.console); err != nil {
+		return err
+	}
 
 	return nil
 }


### PR DESCRIPTION
This cleans up platform/machine/openstack/machine.go:
```
platform/machine/openstack/machine.go:131:15: Error return value of `f.WriteString` is not checked (errcheck)
        f.WriteString(om.console)
                     ^
```

Fixes part of https://github.com/coreos/coreos-assembler/issues/1813