### PR TITLE
mantle: clean up platform/machine/packet

### DIFF
--- a/mantle/platform/machine/packet/cluster.go
+++ b/mantle/platform/machine/packet/cluster.go
@@ -121,7 +121,7 @@ func (pc *cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 
 func (pc *cluster) vmname() string {
 	b := make([]byte, 5)
-	rand.Read(b)
+	rand.Read(b) //nolint
 	return fmt.Sprintf("%s-%x", pc.Name()[0:13], b)
 }
 


### PR DESCRIPTION
This cleans up platform/machine/packet/cluster.go:
```
platform/machine/packet/cluster.go:124:11: Error return value of `rand.Read` is not checked (errcheck)
        rand.Read(b)
                 ^
```

Fixes part of https://github.com/coreos/coreos-assembler/issues/1813