### PR TITLE
mantle: clean up platform/machine/qemuiso

### DIFF
--- a/mantle/platform/machine/qemuiso/cluster.go
+++ b/mantle/platform/machine/qemuiso/cluster.go
@@ -112,7 +112,9 @@ func (qc *Cluster) NewMachineWithQemuOptions(userdata *conf.UserData, options pl
 		builder.Memory = int(memory)
 	}
 
-	builder.AddIso(qc.flight.opts.IsoPath, "")
+	if err := builder.AddIso(qc.flight.opts.IsoPath, ""); err != nil {
+		return nil, errors.Wrapf(err, "adding ISO image")
+	}
 
 	for _, disk := range options.AdditionalDisks {
 		if err = builder.AddDisk(&platform.Disk{


### PR DESCRIPTION
This cleans up platform/machine/qemuiso/cluster.go:
```
platform/machine/qemuiso/cluster.go:115:16: Error return value of `builder.AddIso` is not checked (errcheck)
        builder.AddIso(qc.flight.opts.IsoPath, "")
                      ^
```

Fixes part of https://github.com/coreos/coreos-assembler/issues/1813