### PR TITLE
gangplank: override entrypoint and command for podman mode

### DIFF
--- a/gangplank/ocp/cosa-pod.go
+++ b/gangplank/ocp/cosa-pod.go
@@ -540,6 +540,8 @@ func podmanRunner(ctx context.Context, cp *cosaPod, envVars []v1.EnvVar) error {
 			Source:      cosaSrvDir,
 		},
 	}
+	s.Entrypoint = []string{"/usr/bin/dumb-init"}
+	s.Command = []string{"/usr/bin/gangplank", "builder"}
 
 	if err := s.Validate(); err != nil {
 		l.WithError(err).Error("Validation failed")


### PR DESCRIPTION
When creating the pods in podman mode we need to override cosa's
entrypoint to run `gangplank builder` (just like the inCluster pod
creation) so gangplank can run correctly.