### PR TITLE
kola/tests: Enable Tang tests for ppc64le and aarch64

### DIFF
--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -670,9 +670,12 @@ ExecStart=%s
 	config.AddSystemdUnit(KoletExtTestUnit, unit, conf.NoState)
 
 	// Architectures using 64k pages use slightly more memory, ask for more than requested
-	// to make sure that we don't run out of it. Currently only ppc64le uses 64k pages.
-	if system.RpmArch() == "ppc64le" && targetMeta.MinMemory < 8192 {
-		targetMeta.MinMemory = 8192
+	// to make sure that we don't run out of it. Currently ppc64le and aarch64 use 64k pages.
+	switch system.RpmArch() {
+	case "ppc64le", "aarch64":
+		if targetMeta.MinMemory < 8192 {
+			targetMeta.MinMemory = 8192
+		}
 	}
 
 	t := &register.Test{

--- a/mantle/kola/tests/ignition/luks.go
+++ b/mantle/kola/tests/ignition/luks.go
@@ -33,7 +33,7 @@ func init() {
 		Flags:                []register.Flag{},
 		Distros:              []string{"rhcos"},
 		Platforms:            []string{"qemu-unpriv"},
-		ExcludeArchitectures: []string{"s390x", "ppc64le", "aarch64"}, // no TPM support for s390x, ppc64le, aarch64 in qemu
+		ExcludeArchitectures: []string{"s390x"}, // no TPM backend support for s390x
 		Tags:                 []string{"luks", "tpm", "tang", "sss", kola.NeedsInternetTag},
 	})
 	register.RegisterTest(&register.Test{
@@ -43,7 +43,7 @@ func init() {
 		Flags:                []register.Flag{},
 		Distros:              []string{"rhcos"},
 		Platforms:            []string{"qemu-unpriv"},
-		ExcludeArchitectures: []string{"s390x", "ppc64le", "aarch64"}, // no TPM support for s390x, ppc64le, aarch64 in qemu
+		ExcludeArchitectures: []string{"s390x"}, // no TPM backend support for s390x
 		Tags:                 []string{"luks", "tpm", "tang", "sss", kola.NeedsInternetTag},
 	})
 }
@@ -219,6 +219,11 @@ func runTest(c cluster.TestCluster, tpm2 bool, threshold int, killTangAfterFirst
 
 	opts := platform.MachineOptions{
 		MinMemory: 4096,
+	}
+	// ppc64le and aarch64 use 64K pages
+	switch system.RpmArch() {
+	case "ppc64le", "aarch64":
+		opts.MinMemory = 8192
 	}
 	m, err := c.NewMachineWithOptions(ignition, opts)
 	if err != nil {

--- a/mantle/kola/tests/rhcos/upgrade.go
+++ b/mantle/kola/tests/rhcos/upgrade.go
@@ -33,7 +33,7 @@ func init() {
 		FailFast:             true,
 		Tags:                 []string{"upgrade"},
 		Distros:              []string{"rhcos"},
-		ExcludeArchitectures: []string{"s390x"}, // no TPM backend support for s390x
+		ExcludeArchitectures: []string{"s390x", "aarch64"}, // no TPM backend support for s390x and upgrade test not valid for aarch64
 		UserDataV3: conf.Ignition(`{
 			"ignition": {
 				"version": "3.0.0"
@@ -60,6 +60,7 @@ func init() {
 		FailFast:             true,
 		Tags:                 []string{"upgrade"},
 		Distros:              []string{"rhcos"},
+		ExcludeArchitectures: []string{"aarch64"}, //upgrade test not valid for aarch64
 		UserDataV3: conf.Ignition(`{
                         "ignition": {
                                 "version": "3.0.0"

--- a/mantle/kola/tests/rhcos/upgrade.go
+++ b/mantle/kola/tests/rhcos/upgrade.go
@@ -33,7 +33,7 @@ func init() {
 		FailFast:             true,
 		Tags:                 []string{"upgrade"},
 		Distros:              []string{"rhcos"},
-		ExcludeArchitectures: []string{"s390x", "ppc64le", "aarch64"}, // no TPM support for s390x, ppc64le, aarch64 in qemu
+		ExcludeArchitectures: []string{"s390x"}, // no TPM backend support for s390x
 		UserDataV3: conf.Ignition(`{
 			"ignition": {
 				"version": "3.0.0"
@@ -56,10 +56,10 @@ func init() {
 		Run:         rhcosUpgradeBasic,
 		ClusterSize: 1,
 		// if renaming this, also rename the command in kolet-httpd.service below
-		Name:     "rhcos.upgrade.basic",
-		FailFast: true,
-		Tags:     []string{"upgrade"},
-		Distros:  []string{"rhcos"},
+		Name:                 "rhcos.upgrade.basic",
+		FailFast:             true,
+		Tags:                 []string{"upgrade"},
+		Distros:              []string{"rhcos"},
 		UserDataV3: conf.Ignition(`{
                         "ignition": {
                                 "version": "3.0.0"

--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -495,10 +495,8 @@ func (builder *QemuBuilder) supportsFwCfg() bool {
 
 // supportsSwtpm if the target system supports a virtual TPM device
 func (builder *QemuBuilder) supportsSwtpm() bool {
-	switch system.RpmArch() {
-	// add back ppc64le as f32/f31's qemu doesn't yet support tpm device emulation
-	// can be removed when cosa is rebased on top of f33/qemu5.0 and also aarch64
-	case "s390x", "ppc64le", "aarch64":
+	if system.RpmArch() == "s390x" {
+		// ppc64le and aarch64 support TPM as of f33. s390x does not support a backend for TPM
 		return false
 	}
 	return true


### PR DESCRIPTION
With the move to f33, TPM is supported in qemu for ppc64le and aarch64. s390x does not support a
TPM backend, so that is still disabled. Had to adjust memory for aarch64 because it also uses 64K
pages.