### PR TITLE
cmdlib: Run commands external to inline file generation

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -410,13 +410,14 @@ cat > tmp/buildmeta.json <<EOF
 }
 EOF
 
+ostree_tarfile_size=$(stat --format=%s "${ostree_tarfile_path}")
 cat > tmp/images.json <<EOF
 {
   "images": {
     "ostree": {
         "path": "${ostree_tarfile_path}",
         "sha256": "${ostree_tarfile_sha256}",
-        "size": $(stat --format=%s "${ostree_tarfile_path}")
+        "size": ${ostree_tarfile_size}
     }
   }
 }

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -647,6 +647,10 @@ prepare_git_artifacts() {
 
     info "Directory ${gitd}, is from branch ${branch}, commit ${rev}"
 
+    local checksum name size
+    checksum=$(sha256sum "${tarball}" | awk '{print$1}')
+    name=$(basename "${tarball}")
+    size=$(stat --format=%s "${tarball}")
     # shellcheck disable=SC2046 disable=SC2086
     cat > "${json}" <<EOC
 {
@@ -658,11 +662,11 @@ prepare_git_artifacts() {
         "dirty": "${is_dirty}"
     },
     "file": {
-        "checksum": "$(sha256sum ${tarball} | awk '{print$1}')",
+        "checksum": "${checksum}",
         "checksum_type": "sha256",
         "format": "tar.gz",
-        "name": "$(basename ${tarball})",
-        "size": $(stat --format=%s ${tarball})
+        "name": "${name}",
+        "size": "${size}"
     }
 }
 EOC


### PR DESCRIPTION
Apparently using `$(...)` inside a heredoc loses `set -e`; another
spectacularly evil shell script trap.  Noticed in
https://github.com/coreos/coreos-assembler/issues/1954

We do want to fail if any of these commands fail, rather than
emitting invalid JSON.