### PR TITLE
mantle: clean up sdk

### DIFF
--- a/mantle/sdk/repo.go
+++ b/mantle/sdk/repo.go
@@ -16,7 +16,6 @@ package sdk
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 
@@ -31,22 +30,6 @@ type LocalBuild struct {
 	Dir  string
 	Arch string
 	Meta *cosa.Build
-}
-
-func isDir(dir string) bool {
-	stat, err := os.Stat(dir)
-	return err == nil && stat.IsDir()
-}
-
-func envDir(env string) string {
-	dir := os.Getenv(env)
-	if dir == "" {
-		return ""
-	}
-	if !filepath.IsAbs(dir) {
-		log.Fatalf("%s is not an absolute path: %q", env, dir)
-	}
-	return dir
 }
 
 func IsCosaRoot(root string) (bool, error) {

--- a/mantle/sdk/verify.go
+++ b/mantle/sdk/verify.go
@@ -72,6 +72,9 @@ func generateKeyRingFromDir(dir string) (openpgp.EntityList, error) {
 	var keyring openpgp.EntityList
 
 	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
 		if !info.Mode().IsRegular() {
 			return nil
 		}


### PR DESCRIPTION
This cleans up sdk package:
```
sdk/download.go:48:15: SA1019: storage.New is deprecated: please use NewService instead. To provide a custom HTTP client, use option.WithHTTPClient. If you are using google.golang.org/api/googleapis/transport.APIKey, use option.WithAPIKey with NewService instead.  (staticcheck)
                api, err := storage.New(client)
                            ^
sdk/download.go:114:29: SA1019: os.SEEK_SET is deprecated: Use io.SeekStart, io.SeekCurrent, and io.SeekEnd.  (staticcheck)
                        if _, err := dst.Seek(0, os.SEEK_SET); err != nil {
                                                 ^
sdk/download.go:131:30: SA1019: os.SEEK_SET is deprecated: Use io.SeekStart, io.SeekCurrent, and io.SeekEnd.  (staticcheck)
                if _, err := dst.Seek(pos, os.SEEK_SET); err != nil {
                                           ^
sdk/download.go:180:6: `getUrlStream` is unused (deadcode)
func getUrlStream(url string, client *http.Client) (*http.Response, error) {
     ^
sdk/repo.go:36:6: `isDir` is unused (deadcode)
func isDir(dir string) bool {
     ^
sdk/repo.go:41:6: `envDir` is unused (deadcode)
func envDir(env string) string {
     ^
sdk/verify.go:74:64: SA4009: argument err is overwritten before first use (staticcheck)
        err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
                                                                      ^
```

Fixes part of https://github.com/coreos/coreos-assembler/issues/1813