### PR TITLE
mantle: clean up storage

### DIFF
--- a/mantle/storage/bucket.go
+++ b/mantle/storage/bucket.go
@@ -26,6 +26,7 @@ import (
 
 	"golang.org/x/net/context"
 	"google.golang.org/api/googleapi"
+	"google.golang.org/api/option"
 	"google.golang.org/api/storage/v1"
 )
 
@@ -50,7 +51,7 @@ type Bucket struct {
 }
 
 func NewBucket(client *http.Client, bucketURL string) (*Bucket, error) {
-	service, err := storage.New(client)
+	service, err := storage.NewService(context.Background(), option.WithHTTPClient(client))
 	if err != nil {
 		return nil, err
 	}

--- a/mantle/storage/object_test.go
+++ b/mantle/storage/object_test.go
@@ -27,7 +27,6 @@ const (
 </head></html>
 `
 	testPageCRC  = "xH9jaw=="
-	testPageMD5  = "2a6rirkVBEsl0bzTOzNtzA=="
 	testPageSize = 83
 )
 
@@ -86,7 +85,9 @@ func TestCRCSumAndEq(t *testing.T) {
 	if err := crcSum(&a, r); err != nil {
 		t.Fatal(err)
 	}
-	r.Seek(0, 0)
+	if _, err := r.Seek(0, 0); err != nil {
+		t.Error(err)
+	}
 	if err := crcSum(&b, r); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This cleans up storage package:
```
storage/bucket.go:53:18: SA1019: storage.New is deprecated: please use NewService instead. To provide a custom HTTP client, use option.WithHTTPClient. If you are using google.golang.org/api/googleapis/transport.APIKey, use option.WithAPIKey with NewService instead.  (staticcheck)
        service, err := storage.New(client)
                        ^
storage/object_test.go:30:2: `testPageMD5` is unused (deadcode)
        testPageMD5  = "2a6rirkVBEsl0bzTOzNtzA=="
        ^
storage/object_test.go:89:8: Error return value of `r.Seek` is not checked (errcheck)
        r.Seek(0, 0)
              ^
```

Fixes part of https://github.com/coreos/coreos-assembler/issues/1813