### PR TITLE
mantle: clean up system

### DIFF
--- a/mantle/system/copy_test.go
+++ b/mantle/system/copy_test.go
@@ -33,6 +33,9 @@ func checkFile(t *testing.T, path string, data []byte, mode os.FileMode) {
 	if info.Mode() != mode {
 		t.Fatalf("Unexpected mode: %s != %s %s", info.Mode(), mode, path)
 	}
+	if err != nil {
+		t.Error(err)
+	}
 
 	newData, err := ioutil.ReadAll(file)
 	if err != nil {

--- a/mantle/system/ns/exec.go
+++ b/mantle/system/ns/exec.go
@@ -15,6 +15,7 @@
 package ns
 
 import (
+	"fmt"
 	"github.com/vishvananda/netns"
 
 	"github.com/coreos/mantle/system/exec"
@@ -32,42 +33,72 @@ func Command(ns netns.NsHandle, name string, arg ...string) *Cmd {
 	}
 }
 
-func (cmd *Cmd) CombinedOutput() ([]byte, error) {
+func (cmd *Cmd) CombinedOutput() (bytes []byte, err error) {
 	nsExit, err := Enter(cmd.NsHandle)
 	if err != nil {
 		return nil, err
 	}
-	defer nsExit()
+	defer func() {
+		e := nsExit()
+		if err != nil {
+			err = fmt.Errorf("%v; %v", err, e)
+		} else {
+			err = e
+		}
+	}()
 
-	return cmd.ExecCmd.CombinedOutput()
+	bytes, err = cmd.ExecCmd.CombinedOutput()
+	return bytes, err
 }
 
-func (cmd *Cmd) Output() ([]byte, error) {
+func (cmd *Cmd) Output() (bytes []byte, err error) {
 	nsExit, err := Enter(cmd.NsHandle)
 	if err != nil {
 		return nil, err
 	}
-	defer nsExit()
+	defer func() {
+		e := nsExit()
+		if err != nil {
+			err = fmt.Errorf("%v; %v", err, e)
+		} else {
+			err = e
+		}
+	}()
 
-	return cmd.ExecCmd.Output()
+	bytes, err = cmd.ExecCmd.Output()
+	return bytes, err
 }
 
-func (cmd *Cmd) Run() error {
+func (cmd *Cmd) Run() (err error) {
 	nsExit, err := Enter(cmd.NsHandle)
 	if err != nil {
 		return err
 	}
-	defer nsExit()
+	defer func() {
+		e := nsExit()
+		if err != nil {
+			err = fmt.Errorf("%v; %v", err, e)
+		} else {
+			err = e
+		}
+	}()
 
 	return cmd.ExecCmd.Run()
 }
 
-func (cmd *Cmd) Start() error {
+func (cmd *Cmd) Start() (err error) {
 	nsExit, err := Enter(cmd.NsHandle)
 	if err != nil {
 		return err
 	}
-	defer nsExit()
+	defer func() {
+		e := nsExit()
+		if err != nil {
+			err = fmt.Errorf("%v; %v", err, e)
+		} else {
+			err = e
+		}
+	}()
 
 	return cmd.ExecCmd.Start()
 }


### PR DESCRIPTION
This cleans up system package:
```
system/copy_test.go:32:8: ineffectual assignment to `err` (ineffassign)
        info, err := file.Stat()
              ^
system/ns/enter.go:63:17: Error return value of `netns.Set` is not checked (errcheck)
        defer netns.Set(origns)
                       ^
system/ns/exec.go:40:14: Error return value of `nsExit` is not checked (errcheck)
        defer nsExit()
                    ^
system/ns/exec.go:50:14: Error return value of `nsExit` is not checked (errcheck)
        defer nsExit()
                    ^
system/ns/exec.go:60:14: Error return value of `nsExit` is not checked (errcheck)
        defer nsExit()
                    ^
system/ns/exec.go:70:14: Error return value of `nsExit` is not checked (errcheck)
        defer nsExit()
                    ^
```

Fixes part of https://github.com/coreos/coreos-assembler/issues/1813