### PR TITLE
mantle: clean up update

### DIFF
--- a/mantle/sdk/download.go
+++ b/mantle/sdk/download.go
@@ -111,7 +111,7 @@ func downloadFile(file, url string, client *http.Client) error {
 	switch resp.StatusCode {
 	case http.StatusOK:
 		if pos != 0 {
-			if _, err := dst.Seek(0, os.SEEK_SET); err != nil {
+			if _, err := dst.Seek(0, io.SeekStart); err != nil {
 				return err
 			}
 			if err := dst.Truncate(0); err != nil {
@@ -128,7 +128,7 @@ func downloadFile(file, url string, client *http.Client) error {
 			return fmt.Errorf("Bad Content-Range for %s", resp.Request.URL)
 		}
 
-		if _, err := dst.Seek(pos, os.SEEK_SET); err != nil {
+		if _, err := dst.Seek(pos, io.SeekStart); err != nil {
 			return err
 		}
 		plog.Infof("Resuming from byte %d", pos)

--- a/mantle/update/generator/full.go
+++ b/mantle/update/generator/full.go
@@ -62,7 +62,7 @@ func FullUpdate(path string) (*Procedure, error) {
 		return nil, err
 	}
 
-	if _, err := payload.Seek(0, os.SEEK_SET); err != nil {
+	if _, err := payload.Seek(0, io.SeekStart); err != nil {
 		payload.Close()
 		return nil, err
 	}

--- a/mantle/update/generator/generator_test.go
+++ b/mantle/update/generator/generator_test.go
@@ -16,6 +16,7 @@ package generator
 
 import (
 	"bytes"
+	"io"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -51,7 +52,7 @@ func TestGenerateWithoutPartition(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := f.Seek(0, os.SEEK_SET); err != nil {
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
 		t.Fatal(err)
 	}
 
@@ -104,7 +105,7 @@ func TestGenerateOneBlockPartition(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := f.Seek(0, os.SEEK_SET); err != nil {
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
 		t.Fatal(err)
 	}
 

--- a/mantle/update/generator/info.go
+++ b/mantle/update/generator/info.go
@@ -16,10 +16,8 @@ package generator
 
 import (
 	"crypto/sha256"
-	"io"
-	"os"
-
 	"github.com/golang/protobuf/proto"
+	"io"
 
 	"github.com/coreos/mantle/update/metadata"
 )
@@ -31,7 +29,7 @@ func NewInstallInfo(r io.ReadSeeker) (*metadata.InstallInfo, error) {
 		return nil, err
 	}
 
-	if _, err := r.Seek(0, os.SEEK_SET); err != nil {
+	if _, err := r.Seek(0, io.SeekStart); err != nil {
 		return nil, err
 	}
 

--- a/mantle/update/operation.go
+++ b/mantle/update/operation.go
@@ -136,7 +136,7 @@ func (op *Operation) replace(dst *os.File, src io.Reader) error {
 			length -= excess
 		}
 
-		if _, err := dst.Seek(offset, os.SEEK_SET); err != nil {
+		if _, err := dst.Seek(offset, io.SeekStart); err != nil {
 			return err
 		}
 		if _, err := io.CopyN(dst, src, length); err != nil {

--- a/mantle/update/updater.go
+++ b/mantle/update/updater.go
@@ -114,7 +114,7 @@ func (u *Updater) updateCommon(proc *metadata.InstallProcedure, procName, srcPat
 }
 
 func VerifyInfo(file *os.File, info *metadata.InstallInfo) error {
-	if _, err := file.Seek(0, os.SEEK_SET); err != nil {
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This cleans up `os.SEEK_SET is deprecated` in update package:
```
SA1019: os.SEEK_SET is deprecated: Use io.SeekStart, io.SeekCurrent, and io.SeekEnd.  (staticcheck)
```

Fixes part of https://github.com/coreos/coreos-assembler/issues/1813