### PR TITLE
dockerignore: exclude kola_temp directory

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+# kola_temp can include socket files that the build process does not like
+/mantle/_kola_temp


### PR DESCRIPTION
I ran into a gnarly error building the image locally when I had a
`mantle/_kola_temp` directory present.  The tail of the message:

`error generating tar header for /mantle/_kola_temp/agent.1924868 (): archive/tar: sockets not supported`

Using dockerignore to exclude the directory prevents this error from
being encountered.
