### PR TITLE
cmdlib: use find instead of stat

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -650,7 +650,7 @@ prepare_git_artifacts() {
     local checksum name size
     checksum=$(sha256sum "${tarball}" | awk '{print$1}')
     name=$(basename "${tarball}")
-    size=$(stat --format=%s "${tarball}")
+    size=$(find "${tarball}" -printf %s)
     # shellcheck disable=SC2046 disable=SC2086
     cat > "${json}" <<EOC
 {


### PR DESCRIPTION
While we wait for a more complete solution for #1954 in the form of
changes to the PSI cluster, let's use an alternative way to determine
the size of the tarball.

The `find` syntax was suggested by ShellCheck - https://github.com/koalaman/shellcheck/wiki/SC2012