### PR TITLE
Split off `make staticanalysis`, add ci/prow.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,9 @@ gangplank:
 gangplank-check:
 	cd gangplank && $(MAKE) test
 
+staticanalysis:
+	cd gangplank && $(MAKE) staticanalysis
+
 tools:
 	cd tools && $(MAKE)
 

--- a/ci/prow.sh
+++ b/ci/prow.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -xeuo pipefail
+make -j 4
+make check
+make staticanalysis

--- a/gangplank/Makefile
+++ b/gangplank/Makefile
@@ -17,7 +17,10 @@ build:
 .PHONY: fmt
 fmt:
 	gofmt -d -e -l $(shell find . -iname "*.go"  -not -path "./vendor/*")
-	golangci-lint run -v --timeout 5m ./...
+
+.PHONY: staticanalysis
+staticanalysis:
+	golangci-lint run -v ./...
 
 .PHONY: test
 test: fmt


### PR DESCRIPTION
The golangci-lint can be expensive and our arbitrary `--timeout 5m`
is causing builds to fail in quay.io.

xref https://github.com/coreos/coreos-assembler/issues/1972

Add a `ci/prow.sh` so we can only do the static analysis on pull
requests, separate from container builds from the `Dockerfile`.