### PR TITLE
Disable FWNMI for POWER

### DIFF
--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -966,7 +966,7 @@ func baseQemuArgs() []string {
 	case "ppc64le":
 		ret = []string{
 			"qemu-system-ppc64",
-			"-machine", "pseries,kvm-type=HV,vsmt=8," + accel,
+			"-machine", "pseries,kvm-type=HV,vsmt=8,cap-fwnmi=off," + accel,
 		}
 	default:
 		panic(fmt.Sprintf("RpmArch %s combo not supported for qemu ", system.RpmArch()))

--- a/src/libguestfish.sh
+++ b/src/libguestfish.sh
@@ -22,7 +22,7 @@ if [ "$arch" = "ppc64le" ] ; then
     qemu_wrapper=${tmp_qemu_wrapper}/qemu-wrapper.sh
 	cat <<-'EOF' > "${qemu_wrapper}"
 	#!/bin/bash -
-	exec qemu-system-ppc64 "$@" -machine pseries,accel=kvm:tcg,vsmt=8
+	exec qemu-system-ppc64 "$@" -machine pseries,accel=kvm:tcg,vsmt=8,cap-fwnmi=off
 	EOF
     chmod +x "${qemu_wrapper}"
     export LIBGUESTFS_HV="${qemu_wrapper}"


### PR DESCRIPTION
POWER build are failing with the error:
Error: Firmware Assisted Non-Maskable Interrupts(FWNMI) not supported by
KVM.

For more info check QEMU #ec010c00665

Signed-off-by: Renata Ravanelli <rravanel@redhat.com>