### PR TITLE
buildroot: Add rust-packaging

### DIFF
--- a/src/buildroot-reqs.txt
+++ b/src/buildroot-reqs.txt
@@ -25,7 +25,8 @@ util-linux
 which
 xz
 
-# For rpm-ostree's CI at least
+# Rust stuff
+rust-packaging
 rustfmt
 
 # Also, add clang since it's useful at least in CI for C/C++ projects


### PR DESCRIPTION
So we can use it in rpm-ostree's builds like the
main Koji builds.

xref https://github.com/coreos/rpm-ostree/pull/2396