### PR TITLE
grub: read from md/md-boot if it exists

### DIFF
--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -333,8 +333,8 @@ install_uefi() {
     mkdir -p "${vendordir}"
 	cat > ${vendordir}/grub.cfg << 'EOF'
 search --label boot --set prefix
-set prefix=($prefix)
-configfile $prefix/grub2/grub.cfg
+set prefix=($prefix)/grub2
+configfile $prefix/grub.cfg
 boot
 EOF
     install_grub_cfg

--- a/src/grub.cfg
+++ b/src/grub.cfg
@@ -1,5 +1,25 @@
 set pager=1
-search --label boot --set boot
+if [ -e (md/md-boot) ]; then
+  # fcct currently creates /boot RAID with superblock 1.0, which allows
+  # component partitions to be read directly as filesystems.  This is
+  # necessary because transposefs doesn't yet rerun grub2-install on BIOS,
+  # so GRUB still expects /boot to be a partition on the first disk.
+  #
+  # There are two consequences:
+  # 1. On BIOS and UEFI, the search command might pick an individual RAID
+  #    component, but we want it to use the full RAID in case there are bad
+  #    sectors etc.  The undocumented --hint option is supposed to support
+  #    this sort of override, but it doesn't seem to work, so we set $boot
+  #    directly.
+  # 2. On BIOS, the "normal" module has already been loaded from an
+  #    individual RAID component, and $prefix still points there.  We want
+  #    future module loads to come from the RAID, so we reset $prefix.
+  #    (On UEFI, the stub grub.cfg has already set $prefix properly.)
+  set boot=md/md-boot
+  set prefix=($boot)/grub2
+else
+  search --label boot --set boot
+fi
 set root=$boot
 
 if [ -f ${config_directory}/grubenv ]; then


### PR DESCRIPTION
If `/boot` is on a RAID, have GRUB read from that RAID as much as possible, rather than a component partition.  This allows us to be more resilient to bad sectors or flaky drives.

Enable RAID support in the BIOS GRUB image.

Fixes [RHBZ 1909455](https://bugzilla.redhat.com/show_bug.cgi?id=1909455).  Discussion in coreos/fedora-coreos-config#718 and design doc update in coreos/enhancements#4.  Followup in https://github.com/coreos/fedora-coreos-tracker/issues/702.