### PR TITLE
create_disk: fix ref handling when not targeting latest build

### DIFF
--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -270,13 +270,12 @@ ostree admin init-fs --modern $rootfs
 if [ "${rootfs_type}" = "ext4verity" ]; then
     ostree config --repo=$rootfs/ostree/repo set ex-fsverity.required 'true'
 fi
-deploy_ref=
+time ostree pull-local --repo $rootfs/ostree/repo "$ostree" "$commit"
 if test -n "${remote_name}"; then
     deploy_ref="${remote_name}:${ref}"
-    time ostree pull-local --repo $rootfs/ostree/repo --remote="${remote_name}" "$ostree" "$ref"
+    ostree refs --repo $rootfs/ostree/repo --create "${deploy_ref}" "${commit}"
 else
     deploy_ref=$commit
-    time ostree pull-local --repo $rootfs/ostree/repo "$ostree" "$commit"
 fi
 ostree admin os-init "$os_name" --sysroot $rootfs
 # Note that $ignition_firstboot is interpreted by grub at boot time,


### PR DESCRIPTION
If we're doing e.g. `buildextend-qemu` against a build which isn't the
latest one, `create_disk` would still deploy the latest one (or more
accurately, whatever the ref is currently pointing to in the `tmp/repo`
OSTree repo). This used to work, so we probably regressed at some point.

Let's just always pull by commit, and then in the remote case create a
remote ref for it.