### PR TITLE
kola: stop requesting 8G of RAM for all external tests on ppc64le and aarch64

### DIFF
--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -673,8 +673,8 @@ ExecStart=%s
 	// to make sure that we don't run out of it. Currently ppc64le and aarch64 use 64k pages.
 	switch system.RpmArch() {
 	case "ppc64le", "aarch64":
-		if targetMeta.MinMemory < 8192 {
-			targetMeta.MinMemory = 8192
+		if targetMeta.MinMemory <= 4096 {
+			targetMeta.MinMemory = targetMeta.MinMemory * 2
 		}
 	}
 


### PR DESCRIPTION
With #1768, on ppc64le and aarch64, we now request 8G of RAM for *all*
external tests, even trivial ones like `misc-ro`.

We already have platform defaults in `platform/qemu`. Let's rely on
those if the test doesn't declare any memory requirements (this is done
implicitly by this code by having 0 * 2 still being 0). If it *does*,
then as a heuristic, just multiply by 2 for ppc64le and aarch64 to a max
of 8G.

Obviously long term, we need to clean this up by having the test provide
a more symbolic requirement rather than a specific memory amount. (This
could be "flavours", or it could just be e.g. tags like
"reprovisions-root"). (There's also [the zram
change](https://github.com/coreos/fedora-coreos-config/pull/768) which
should help a lot lowering the memory requirements for
root-reprovisioning tests.)

But for now at least, this heuristic will help with Power builds hitting
memory limits too easily.