### PR TITLE
buildextend-live: make metal4k image optional if --fast

### DIFF
--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -215,11 +215,13 @@ def generate_iso():
     tmpisofile = os.path.join(tmpdir, iso_name)
 
     img_metal_obj = buildmeta.get_artifact_meta("metal", unmerged=True)["images"].get("metal")
-    img_metal4k_obj = buildmeta.get_artifact_meta("metal4k", unmerged=True)["images"].get("metal4k")
-    if img_metal_obj is None or img_metal4k_obj is None:
-        raise Exception("Live image generation requires `metal` and `metal4k` images")
+    if img_metal_obj is None:
+        raise Exception("Live image generation requires `metal` image")
     img_metal = os.path.join(builddir, img_metal_obj['path'])
     img_metal_checksum = img_metal_obj['sha256']
+    img_metal4k_obj = buildmeta.get_artifact_meta("metal4k", unmerged=True)["images"].get("metal4k")
+    if img_metal4k_obj is None:
+        raise Exception("Live image generation requires `metal4k` image")
     img_metal4k = os.path.join(builddir, img_metal4k_obj['path'])
     img_metal4k_checksum = img_metal4k_obj['sha256']
 
@@ -266,11 +268,11 @@ def generate_iso():
 
     # Add osmet files
     tmp_osmet = os.path.join(tmpinitrd_rootfs, img_metal_obj['path'] + '.osmet')
-    tmp_osmet4k = os.path.join(tmpinitrd_rootfs, img_metal4k_obj['path'] + '.osmet')
     print('Generating osmet file for 512b metal image')
     run_verbose(['/usr/lib/coreos-assembler/osmet-pack',
                  img_metal, '512', tmp_osmet, img_metal_checksum,
                  'fast' if args.fast else 'normal'])
+    tmp_osmet4k = os.path.join(tmpinitrd_rootfs, img_metal4k_obj['path'] + '.osmet')
     print('Generating osmet file for 4k metal image')
     run_verbose(['/usr/lib/coreos-assembler/osmet-pack',
                  img_metal4k, '4096', tmp_osmet4k, img_metal4k_checksum,

--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -215,12 +215,12 @@ def generate_iso():
     tmpisofile = os.path.join(tmpdir, iso_name)
 
     img_metal_obj = buildmeta.get_artifact_meta("metal", unmerged=True)["images"].get("metal")
-    if img_metal_obj is None:
+    if not img_metal_obj:
         raise Exception("Live image generation requires `metal` image")
     img_metal = os.path.join(builddir, img_metal_obj['path'])
     img_metal_checksum = img_metal_obj['sha256']
     img_metal4k_obj = buildmeta.get_artifact_meta("metal4k", unmerged=True)["images"].get("metal4k")
-    if img_metal4k_obj is None:
+    if not img_metal4k_obj:
         if not args.fast:
             raise Exception("Live image generation requires `metal4k` image (use --fast to ignore)")
         else:
@@ -276,7 +276,7 @@ def generate_iso():
     run_verbose(['/usr/lib/coreos-assembler/osmet-pack',
                  img_metal, '512', tmp_osmet, img_metal_checksum,
                  'fast' if args.fast else 'normal'])
-    if img_metal4k_obj is not None:
+    if img_metal4k_obj:
         tmp_osmet4k = os.path.join(tmpinitrd_rootfs, img_metal4k_obj['path'] + '.osmet')
         print('Generating osmet file for 4k metal image')
         run_verbose(['/usr/lib/coreos-assembler/osmet-pack',

--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -221,9 +221,13 @@ def generate_iso():
     img_metal_checksum = img_metal_obj['sha256']
     img_metal4k_obj = buildmeta.get_artifact_meta("metal4k", unmerged=True)["images"].get("metal4k")
     if img_metal4k_obj is None:
-        raise Exception("Live image generation requires `metal4k` image")
-    img_metal4k = os.path.join(builddir, img_metal4k_obj['path'])
-    img_metal4k_checksum = img_metal4k_obj['sha256']
+        if not args.fast:
+            raise Exception("Live image generation requires `metal4k` image (use --fast to ignore)")
+        else:
+            print("Missing `metal4k` image; ignoring because of --fast")
+    else:
+        img_metal4k = os.path.join(builddir, img_metal4k_obj['path'])
+        img_metal4k_checksum = img_metal4k_obj['sha256']
 
     # Find the directory under `/usr/lib/modules/<kver>` where the
     # kernel/initrd live. It will be the 2nd entity output by
@@ -272,11 +276,12 @@ def generate_iso():
     run_verbose(['/usr/lib/coreos-assembler/osmet-pack',
                  img_metal, '512', tmp_osmet, img_metal_checksum,
                  'fast' if args.fast else 'normal'])
-    tmp_osmet4k = os.path.join(tmpinitrd_rootfs, img_metal4k_obj['path'] + '.osmet')
-    print('Generating osmet file for 4k metal image')
-    run_verbose(['/usr/lib/coreos-assembler/osmet-pack',
-                 img_metal4k, '4096', tmp_osmet4k, img_metal4k_checksum,
-                 'fast' if args.fast else 'normal'])
+    if img_metal4k_obj is not None:
+        tmp_osmet4k = os.path.join(tmpinitrd_rootfs, img_metal4k_obj['path'] + '.osmet')
+        print('Generating osmet file for 4k metal image')
+        run_verbose(['/usr/lib/coreos-assembler/osmet-pack',
+                     img_metal4k, '4096', tmp_osmet4k, img_metal4k_checksum,
+                     'fast' if args.fast else 'normal'])
 
     # Generate root squashfs
     print(f'Compressing squashfs with {squashfs_compression}')


### PR DESCRIPTION
That should make it even faster to iterate on the live ISO, because we
don't incur the upfront cost of generating a metal4k image, as well as
the recurring cost of osmet generation at each iteration.