### PR TITLE
buildextend-live: make default kargs file look the same

### DIFF
--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -359,7 +359,10 @@ def generate_iso():
             shutil.copystat(srcfile, dstfile)
             print(f'{srcfile} -> {dstfile}')
 
+    assert(karg_embed_area_length > len(cmdline))
     with open(os.path.join(tmpisoroot, '.cmdline'), 'w') as fh:
+        fh.write('#' * karg_embed_area_length)
+        fh.seek(0)
         fh.write(cmdline)
 
     # These sections are based on lorax templates


### PR DESCRIPTION
I.e. make it of length `$karg_embed_area_length` with the overflow area
being `#` so that we can use the same function on the coreos-installer
side to read them.