### PR TITLE
buildextend-live: hybridize live ISO for UEFI boot

### DIFF
--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -505,9 +505,10 @@ def generate_iso():
 
     run_verbose(genisoargs)
 
-    # Add MBR for x86_64 legacy (BIOS) boot when ISO is copied to a USB stick
+    # Add MBR, and GPT with ESP, for x86_64 BIOS/UEFI boot when ISO is
+    # copied to a USB stick
     if basearch == "x86_64":
-        run_verbose(['/usr/bin/isohybrid', tmpisofile])
+        run_verbose(['/usr/bin/isohybrid', '--uefi', tmpisofile])
 
     isoinfo = run_verbose(['isoinfo', '-lR', '-i', tmpisofile],
                           stdout=subprocess.PIPE, text=True).stdout


### PR DESCRIPTION
For BIOS systems, we're already adding an MBR and boot sector to the ISO image so it can be dd'ed to a USB stick and booted as a hard disk.  For UEFI systems, we're already generating an ESP and setting it as an additional El Torito image.  For some UEFI firmware (e.g. EDK II) that seems to be sufficient, but we should also create a GPT with an ESP wrapping that El Torito image, for firmware that doesn't support El Torito on hard disks.

For https://github.com/coreos/fedora-coreos-tracker/issues/707.