### PR TITLE
 Use coreos/stream-metadata-go

### DIFF
--- a/mantle/cmd/kola/kola.go
+++ b/mantle/cmd/kola/kola.go
@@ -633,7 +633,7 @@ func getParentFcosBuildBase(stream string) (string, error) {
 		parentVersion = index.Releases[n-1].Version
 	}
 
-	return fcos.GetCosaBuildUrl(stream, parentVersion), nil
+	return fcos.GetCosaBuildURL(stream, parentVersion), nil
 }
 
 func runRunUpgrade(cmd *cobra.Command, args []string) error {

--- a/mantle/fcos/metadata.go
+++ b/mantle/fcos/metadata.go
@@ -19,142 +19,18 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
+
+	"github.com/coreos/stream-metadata-go/fedoracoreos"
+	fcosinternals "github.com/coreos/stream-metadata-go/fedoracoreos/internals"
+	"github.com/coreos/stream-metadata-go/release"
+	"github.com/coreos/stream-metadata-go/stream"
 
 	"github.com/coreos/mantle/system"
 )
 
-const buildHostUrl = "https://builds.coreos.fedoraproject.org/"
-const canonicalReleaseIndexLocation = "prod/streams/%s/releases.json"
-const canonicalStreamMetadataLocation = "streams/%s.json"
-
-// XXX: dedupe with fedora-coreos-stream-generator
-
-// This models the release index:
-// https://github.com/coreos/fedora-coreos-tracker/tree/master/metadata/release-index
-type ReleaseIndex struct {
-	Note     string                `json:"note"` // used to note to users not to consume the release metadata index
-	Releases []ReleaseIndexRelease `json:"releases"`
-	Metadata ReleaseIndexMetadata  `json:"metadata"`
-	Stream   string                `json:"stream"`
-}
-
-type ReleaseIndexRelease struct {
-	CommitHash []ReleaseCommit `json:"commits"`
-	Version    string          `json:"version"`
-	Endpoint   string          `json:"metadata"`
-}
-
-type ReleaseIndexMetadata struct {
-	LastModified string `json:"last-modified"`
-}
-
-// This models release metadata:
-// https://github.com/coreos/fedora-coreos-tracker/tree/master/metadata/release
-type Release struct {
-	Architectures map[string]ReleaseArchitecture `json:"architectures"`
-}
-
-type ReleaseArchitecture struct {
-	Commit string                  `json:"commit"`
-	Media  map[string]ReleaseMedia `json:"media"`
-}
-
-type ReleaseMedia struct {
-	Images map[string]ReleaseAMI `json:"images"`
-}
-
-type ReleaseAMI struct {
-	Image string `json:"image"`
-}
-
-type ReleaseCommit struct {
-	Architecture string `json:"architecture"`
-	Checksum     string `json:"checksum"`
-}
-
-// This models stream metadata:
-// https://github.com/coreos/fedora-coreos-tracker/tree/master/metadata/stream
-type StreamMetadata struct {
-	Stream        string                 `json:"stream"`
-	Metadata      Metadata               `json:"metadata"`
-	Architectures map[string]*StreamArch `json:"architectures"`
-}
-
-// StreamArch release details for x86_64 architetcure
-type StreamArch struct {
-	Artifacts StreamArtifacts `json:"artifacts"`
-	Images    *StreamImages   `json:"images,omitempty"`
-}
-
-// StreamArtifacts contains shipped artifacts list
-type StreamArtifacts struct {
-	Aliyun       *StreamMediaDetails `json:"aliyun,omitempty"`
-	Aws          *StreamMediaDetails `json:"aws,omitempty"`
-	Azure        *StreamMediaDetails `json:"azure,omitempty"`
-	Digitalocean *StreamMediaDetails `json:"digitalocean,omitempty"`
-	Exoscale     *StreamMediaDetails `json:"exoscale,omitempty"`
-	Gcp          *StreamMediaDetails `json:"gcp,omitempty"`
-	Metal        *StreamMediaDetails `json:"metal,omitempty"`
-	Openstack    *StreamMediaDetails `json:"openstack,omitempty"`
-	Packet       *StreamMediaDetails `json:"packet,omitempty"`
-	Qemu         *StreamMediaDetails `json:"qemu,omitempty"`
-	Virtualbox   *StreamMediaDetails `json:"virtualbox,omitempty"`
-	Vmware       *StreamMediaDetails `json:"vmware,omitempty"`
-}
-
-// StreamMediaDetails contains image artifact and release detail
-type StreamMediaDetails struct {
-	Release string                  `json:"release"`
-	Formats map[string]*ImageFormat `json:"formats"`
-}
-
-// StreamImages contains images available in cloud providers
-type StreamImages struct {
-	Aws          *StreamAwsImage   `json:"aws,omitempty"`
-	Azure        *StreamCloudImage `json:"azure,omitempty"`
-	Gcp          *StreamCloudImage `json:"gcp,omitempty"`
-	Digitalocean *StreamCloudImage `json:"digitalocean,omitempty"`
-	Packet       *StreamCloudImage `json:"packet,omitempty"`
-}
-
-// StreamCloudImage image for Cloud provider
-type StreamCloudImage struct {
-	Image string `json:"image,omitempty"`
-}
-
-// StreamAwsImage Aws images
-type StreamAwsImage struct {
-	Regions map[string]*StreamAwsAMI `json:"regions,omitempty"`
-}
-
-// StreamAwsAMI aws AMI detail
-type StreamAwsAMI struct {
-	Release string `json:"release"`
-	Image   string `json:"image"`
-}
-
-// Metadata for stream
-type Metadata struct {
-	LastModified string `json:"last-modified"`
-}
-
-// ImageFormat contains Disk image details
-type ImageFormat struct {
-	Disk      *ImageType `json:"disk,omitempty"`
-	Kernel    *ImageType `json:"kernel,omitempty"`
-	Initramfs *ImageType `json:"initramfs,omitempty"`
-	Rootfs    *ImageType `json:"rootfs,omitempty"`
-}
-
-// ImageType contains image detail
-type ImageType struct {
-	Location  string `json:"location"`
-	Signature string `json:"signature"`
-	Sha256    string `json:"sha256"`
-}
-
-func fetchURL(url string) ([]byte, error) {
-	res, err := http.Get(url)
+func fetchURL(u url.URL) ([]byte, error) {
+	res, err := http.Get(u.String())
 	if err != nil {
 		return nil, err
 	}
@@ -168,14 +44,15 @@ func fetchURL(url string) ([]byte, error) {
 	return body, nil
 }
 
-func FetchAndParseCanonicalReleaseIndex(stream string) (*ReleaseIndex, error) {
-	url := buildHostUrl + fmt.Sprintf(canonicalReleaseIndexLocation, stream)
+// FetchAndParseCanonicalReleaseIndex returns a release index
+func FetchAndParseCanonicalReleaseIndex(stream string) (*release.Index, error) {
+	url := fcosinternals.GetReleaseIndexURL(stream)
 	body, err := fetchURL(url)
 	if err != nil {
 		return nil, err
 	}
 
-	var index *ReleaseIndex
+	var index *release.Index
 	if err = json.Unmarshal(body, &index); err != nil {
 		return nil, err
 	}
@@ -183,22 +60,24 @@ func FetchAndParseCanonicalReleaseIndex(stream string) (*ReleaseIndex, error) {
 	return index, nil
 }
 
-func FetchAndParseCanonicalStreamMetadata(stream string) (*StreamMetadata, error) {
-	url := buildHostUrl + fmt.Sprintf(canonicalStreamMetadataLocation, stream)
+// FetchAndParseCanonicalStreamMetadata returns a stream
+func FetchAndParseCanonicalStreamMetadata(streamName string) (*stream.Stream, error) {
+	url := fedoracoreos.GetStreamURL(streamName)
 	body, err := fetchURL(url)
 	if err != nil {
 		return nil, err
 	}
 
-	var meta *StreamMetadata
-	if err = json.Unmarshal(body, &meta); err != nil {
+	var s *stream.Stream
+	if err = json.Unmarshal(body, &s); err != nil {
 		return nil, err
 	}
 
-	return meta, nil
+	return s, nil
 }
 
-func FetchCanonicalStreamArtifacts(stream, architecture string) (*StreamArtifacts, error) {
+// FetchCanonicalStreamArtifacts returns a stream artifacts
+func FetchCanonicalStreamArtifacts(stream, architecture string) (*stream.Arch, error) {
 	metadata, err := FetchAndParseCanonicalStreamMetadata(stream)
 	if err != nil {
 		return nil, fmt.Errorf("fetching stream metadata: %v", err)
@@ -207,24 +86,11 @@ func FetchCanonicalStreamArtifacts(stream, architecture string) (*StreamArtifact
 	if !ok {
 		return nil, fmt.Errorf("stream metadata missing architecture %q", architecture)
 	}
-	return &arch.Artifacts, nil
+	return &arch, nil
 }
 
-func GetPlatformDiskArtifact(platform *StreamMediaDetails, format string) (*ImageType, error) {
-	if platform == nil {
-		return nil, fmt.Errorf("stream metadata missing expected platform")
-	}
-	artifacts, ok := platform.Formats[format]
-	if !ok {
-		return nil, fmt.Errorf("stream metadata missing %q format", format)
-	}
-	if artifacts.Disk == nil {
-		return nil, fmt.Errorf("stream metadata missing %q disk image", format)
-	}
-	return artifacts.Disk, nil
-}
-
-// GetCosaBuildUrl returns a URL prefix for the coreos-assembler build.
-func GetCosaBuildUrl(stream, buildid string) string {
-	return buildHostUrl + fmt.Sprintf("prod/streams/%s/builds/%s/%s/", stream, buildid, system.RpmArch())
+// GetCosaBuildURL returns a URL prefix for the coreos-assembler build.
+func GetCosaBuildURL(stream, buildid string) string {
+	u := fcosinternals.GetCosaBuild(stream, buildid, system.RpmArch())
+	return u.String()
 }

--- a/mantle/go.mod
+++ b/mantle/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/coreos/ignition/v2 v2.8.1
 	github.com/coreos/ioprogress v0.0.0-20151023204047-4637e494fd9b
 	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
+	github.com/coreos/stream-metadata-go v0.0.0-20210107232620-d808ce9d237c
 	github.com/digitalocean/go-libvirt v0.0.0-20200810224808-b9c702499bf7 // indirect
 	github.com/digitalocean/go-qemu v0.0.0-20200529005954-1b453d036a9c
 	github.com/digitalocean/godo v1.33.0

--- a/mantle/go.sum
+++ b/mantle/go.sum
@@ -103,6 +103,8 @@ github.com/coreos/ioprogress v0.0.0-20151023204047-4637e494fd9b h1:mpeSDqY0vMUyJ
 github.com/coreos/ioprogress v0.0.0-20151023204047-4637e494fd9b/go.mod h1:JIWRG8HSwVYUrjdR/JsFg7DEby0nhQcWFPIQvXJyih8=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f h1:lBNOc5arjvs8E5mO2tbpBpLoyyu8B6e44T7hJy6potg=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
+github.com/coreos/stream-metadata-go v0.0.0-20210107232620-d808ce9d237c h1:7VO10dpKljeaYJUQtObhqjNxpuTCUDELTviJsGy9OeM=
+github.com/coreos/stream-metadata-go v0.0.0-20210107232620-d808ce9d237c/go.mod h1:RTjQyHgO/G37oJ3qnqYK6Z4TPZ5EsaabOtfMjVXmgko=
 github.com/coreos/vcontext v0.0.0-20190529201340-22b159166068 h1:y2aHj7QqyAJ6YBBONTAr17YxHHiogDkYnTsJvFNhxwY=
 github.com/coreos/vcontext v0.0.0-20190529201340-22b159166068/go.mod h1:E+6hug9bFSe0KZ2ZAzr8M9F5JlArJjv5D1JS7KSkPKE=
 github.com/coreos/vcontext v0.0.0-20201120045928-b0e13dab675c h1:jA28WeORitsxGFVWhyWB06sAG2HbLHPQuHwDydhU2CQ=
@@ -323,6 +325,7 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5 h1:LnC5Kc/wtumK+WB441p7ynQJzVuNRJiqddSIE3IlSEQ=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
@@ -682,6 +685,7 @@ gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20190502103701-55513cacd4ae/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/mantle/platform/api/packet/api.go
+++ b/mantle/platform/api/packet/api.go
@@ -131,11 +131,20 @@ func New(opts *Options) (*API, error) {
 		if err != nil {
 			return nil, err
 		}
-		disk, err := fcos.GetPlatformDiskArtifact(artifacts.Metal, "raw.xz")
-		if err != nil {
-			return nil, err
+
+		metal, ok := artifacts.Artifacts["metal"]
+		if !ok {
+			return nil, fmt.Errorf("stream metadata missing metal image")
 		}
-		opts.ImageURL = disk.Location
+		f, ok := metal.Formats["raw.xz"]
+		if !ok {
+			return nil, fmt.Errorf("stream metadata missing raw.xz format")
+		}
+		d := f.Disk
+		if d == nil {
+			return nil, fmt.Errorf("stream metadata missing raw.xz format disk")
+		}
+		opts.ImageURL = d.Location
 	}
 
 	client := packngo.NewClient("github.com/coreos/coreos-assembler", opts.ApiKey, nil)

--- a/mantle/vendor/github.com/coreos/stream-metadata-go/LICENSE
+++ b/mantle/vendor/github.com/coreos/stream-metadata-go/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/mantle/vendor/github.com/coreos/stream-metadata-go/fedoracoreos/fcos.go
+++ b/mantle/vendor/github.com/coreos/stream-metadata-go/fedoracoreos/fcos.go
@@ -1,0 +1,27 @@
+// Package fedoracoreos contains APIs defining well-known
+// streams for Fedora CoreOS and a method to retrieve
+// the URL for a stream endpoint.
+package fedoracoreos
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/coreos/stream-metadata-go/fedoracoreos/internals"
+)
+
+const (
+	// StreamStable is the default stream
+	StreamStable = "stable"
+	// StreamTesting is what is intended to land in stable
+	StreamTesting = "testing"
+	// StreamNext usually tracks the next Fedora major version
+	StreamNext = "next"
+)
+
+// GetStreamURL returns the URL for the given stream
+func GetStreamURL(stream string) url.URL {
+	u := internals.GetBaseURL()
+	u.Path = fmt.Sprintf("streams/%s.json", stream)
+	return u
+}

--- a/mantle/vendor/github.com/coreos/stream-metadata-go/fedoracoreos/internals/fcosinternals.go
+++ b/mantle/vendor/github.com/coreos/stream-metadata-go/fedoracoreos/internals/fcosinternals.go
@@ -1,0 +1,33 @@
+// Package internals contains functions for accessing
+// the underlying "releases" and coreos-assembler builds
+// backing streams.  General user code should avoid
+// this package and use streams.
+package internals
+
+import (
+	"fmt"
+	"net/url"
+)
+
+// GetBaseURL returns the base URL
+func GetBaseURL() url.URL {
+	return url.URL{
+		Scheme: "https",
+		Host:   "builds.coreos.fedoraproject.org",
+	}
+}
+
+// GetReleaseIndexURL returns the URL for the release index of a given stream.
+// Avoid this unless you have a specific need to test a specific release.
+func GetReleaseIndexURL(stream string) url.URL {
+	u := GetBaseURL()
+	u.Path = fmt.Sprintf("prod/streams/%s/releases.json", stream)
+	return u
+}
+
+// GetCosaBuild returns the coreos-assembler build URL
+func GetCosaBuild(stream, buildID, arch string) url.URL {
+	u := GetBaseURL()
+	u.Path = fmt.Sprintf("prod/streams/%s/builds/%s/%s/", stream, buildID, arch)
+	return u
+}

--- a/mantle/vendor/github.com/coreos/stream-metadata-go/release/release.go
+++ b/mantle/vendor/github.com/coreos/stream-metadata-go/release/release.go
@@ -1,0 +1,102 @@
+package release
+
+// Metadata is common metadata that contains last-modified
+type Metadata struct {
+	LastModified string `json:"last-modified"`
+}
+
+// Index models the release index:
+// https://github.com/coreos/fedora-coreos-tracker/tree/master/metadata/release-index
+type Index struct {
+	Note     string         `json:"note"` // used to note to users not to consume the release metadata index
+	Releases []IndexRelease `json:"releases"`
+	Metadata Metadata       `json:"metadata"`
+	Stream   string         `json:"stream"`
+}
+
+// IndexRelease is a "release pointer" from a release index
+type IndexRelease struct {
+	Commits     []IndexReleaseCommit `json:"commits"`
+	Version     string               `json:"version"`
+	MetadataURL string               `json:"metadata"`
+}
+
+// IndexReleaseCommit describes an ostree commit plus architecture
+type IndexReleaseCommit struct {
+	Architecture string `json:"architecture"`
+	Checksum     string `json:"checksum"`
+}
+
+// ImageFormat contains all artifacts for a single OS image
+type ImageFormat struct {
+	Disk      *Artifact `json:"disk,omitempty"`
+	Kernel    *Artifact `json:"kernel,omitempty"`
+	Initramfs *Artifact `json:"initramfs,omitempty"`
+	Rootfs    *Artifact `json:"rootfs,omitempty"`
+}
+
+// Artifact represents one image file, plus its metadata
+type Artifact struct {
+	Location  string `json:"location"`
+	Signature string `json:"signature"`
+	Sha256    string `json:"sha256"`
+}
+
+// GcpImage represents a GCP cloud image
+type GcpImage struct {
+	Project string `json:"project,omitempty"`
+	Family  string `json:"family,omitempty"`
+	Name    string `json:"name,omitempty"`
+}
+
+// Release contains details from release.json
+type Release struct {
+	Release       string          `json:"release"`
+	Stream        string          `json:"stream"`
+	Metadata      Metadata        `json:"metadata"`
+	Architectures map[string]Arch `json:"architectures"`
+}
+
+// Arch release details
+type Arch struct {
+	Commit string `json:"commit"`
+	Media  Media  `json:"media"`
+}
+
+// Media contains release details for various platforms
+type Media struct {
+	Aliyun       *PlatformBase `json:"aliyun"`
+	Aws          *PlatformAws  `json:"aws"`
+	Azure        *PlatformBase `json:"azure"`
+	Digitalocean *PlatformBase `json:"digitalocean"`
+	Exoscale     *PlatformBase `json:"exoscale"`
+	Gcp          *PlatformGcp  `json:"gcp"`
+	Ibmcloud     *PlatformBase `json:"ibmcloud"`
+	Metal        *PlatformBase `json:"metal"`
+	Openstack    *PlatformBase `json:"openstack"`
+	Qemu         *PlatformBase `json:"qemu"`
+	Vmware       *PlatformBase `json:"vmware"`
+	Vultr        *PlatformBase `json:"vultr"`
+}
+
+// PlatformBase with no cloud images
+type PlatformBase struct {
+	Artifacts map[string]ImageFormat `json:"artifacts"`
+}
+
+// PlatformAws contains AWS image information
+type PlatformAws struct {
+	PlatformBase
+	Images map[string]CloudImage `json:"images"`
+}
+
+// PlatformGcp GCP image detail
+type PlatformGcp struct {
+	PlatformBase
+	Image *GcpImage `json:"image"`
+}
+
+// CloudImage generic image detail
+type CloudImage struct {
+	Image string `json:"image"`
+}

--- a/mantle/vendor/github.com/coreos/stream-metadata-go/stream/stream.go
+++ b/mantle/vendor/github.com/coreos/stream-metadata-go/stream/stream.go
@@ -1,0 +1,64 @@
+package stream
+
+// Metadata for a release or stream
+type Metadata struct {
+	LastModified string `json:"last-modified"`
+}
+
+// ImageFormat contains all artifacts for a single OS image
+type ImageFormat struct {
+	Disk      *Artifact `json:"disk,omitempty"`
+	Kernel    *Artifact `json:"kernel,omitempty"`
+	Initramfs *Artifact `json:"initramfs,omitempty"`
+	Rootfs    *Artifact `json:"rootfs,omitempty"`
+}
+
+// Artifact represents one image file, plus its metadata
+type Artifact struct {
+	Location  string `json:"location"`
+	Signature string `json:"signature"`
+	Sha256    string `json:"sha256"`
+}
+
+// GcpImage represents a GCP cloud image
+type GcpImage struct {
+	Project string `json:"project,omitempty"`
+	Family  string `json:"family,omitempty"`
+	Name    string `json:"name,omitempty"`
+}
+
+// Stream contains artifacts available in a stream
+type Stream struct {
+	Stream        string          `json:"stream"`
+	Metadata      Metadata        `json:"metadata"`
+	Architectures map[string]Arch `json:"architectures"`
+}
+
+// Architecture release details
+type Arch struct {
+	Artifacts map[string]PlatformArtifacts `json:"artifacts"`
+	Images    Images                       `json:"images,omitempty"`
+}
+
+// PlatformArtifacts contains images for a platform
+type PlatformArtifacts struct {
+	Release string                 `json:"release"`
+	Formats map[string]ImageFormat `json:"formats"`
+}
+
+// Images contains images available in cloud providers
+type Images struct {
+	Aws *AwsImage `json:"aws,omitempty"`
+	Gcp *GcpImage `json:"gcp,omitempty"`
+}
+
+// AwsImage represents an image across all AWS regions
+type AwsImage struct {
+	Regions map[string]AwsRegionImage `json:"regions,omitempty"`
+}
+
+// AwsRegionImage represents an image in one AWS region
+type AwsRegionImage struct {
+	Release string `json:"release"`
+	Image   string `json:"image"`
+}

--- a/mantle/vendor/modules.txt
+++ b/mantle/vendor/modules.txt
@@ -167,6 +167,11 @@ github.com/coreos/ioprogress
 # github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
 github.com/coreos/pkg/capnslog
 github.com/coreos/pkg/multierror
+# github.com/coreos/stream-metadata-go v0.0.0-20210107232620-d808ce9d237c
+github.com/coreos/stream-metadata-go/fedoracoreos
+github.com/coreos/stream-metadata-go/fedoracoreos/internals
+github.com/coreos/stream-metadata-go/release
+github.com/coreos/stream-metadata-go/stream
 # github.com/coreos/vcontext v0.0.0-20201120045928-b0e13dab675c
 github.com/coreos/vcontext/json
 github.com/coreos/vcontext/path


### PR DESCRIPTION

The idea is https://github.com/cgwalters/stream-metadata-go/
moves to the coreos/ GH org and becomes the canonical place
for this stuff, shared between our own internal tools as well
as used by 3rd parties.

