### PR TITLE
buildextend-live: fix crash when running on !x86_64

### DIFF
--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -356,7 +356,7 @@ def generate_iso():
                         raise Exception(f'Default cmdline is different: "{cmdline}" != "{file_kargs}"')
 
                     length = karg_area_end.start() + len(karg_area_end[1]) - karg_area_start.start()
-                    files_with_karg_embed_areas[filename] = karg_area_start.start()
+                    files_with_karg_embed_areas[dstfile] = karg_area_start.start()
                     if karg_embed_area_length == 0:
                         karg_embed_area_length = length
                     elif length != karg_embed_area_length:
@@ -541,6 +541,12 @@ def generate_iso():
 
         # number of karg files we allow for in the format
         MAX_KARG_FILES = 6
+
+        # prune out karg files which don't exist anymore
+        files_with_karg_embed_areas = {k: v for (k, v) in
+                                       files_with_karg_embed_areas.items() if
+                                       os.path.exists(k)}
+
         assert len(files_with_karg_embed_areas) <= MAX_KARG_FILES
 
         # these can really never change without ratcheting on the
@@ -568,7 +574,7 @@ def generate_iso():
 
             for i, fn in enumerate(files_with_karg_embed_areas):
                 offset_in_file = files_with_karg_embed_areas[fn]
-                offsets[i + 1] = file_offset_in_iso(isoinfo, fn) + offset_in_file
+                offsets[i + 1] = file_offset_in_iso(isoinfo, os.path.basename(fn)) + offset_in_file
             isofh.write(struct.pack(KARGSFMT, b'corekarg', karg_embed_area_length, *offsets))
             # Magic number + offset + length
             isofh.write(struct.pack(INITRDFMT, b'coreiso+', offset, initrd_ignition_padding))

--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -366,11 +366,12 @@ def generate_iso():
             shutil.copystat(srcfile, dstfile)
             print(f'{srcfile} -> {dstfile}')
 
-    assert(karg_embed_area_length > len(cmdline))
-    with open(os.path.join(tmpisoroot, '.cmdline'), 'w') as fh:
-        fh.write('#' * karg_embed_area_length)
-        fh.seek(0)
-        fh.write(cmdline)
+    if len(files_with_karg_embed_areas) > 0:
+        assert(karg_embed_area_length > len(cmdline))
+        with open(os.path.join(tmpisoroot, '.cmdline'), 'w') as fh:
+            fh.write('#' * karg_embed_area_length)
+            fh.seek(0)
+            fh.write(cmdline)
 
     # These sections are based on lorax templates
     # see https://github.com/weldr/lorax/tree/master/share/templates.d/99-generic

--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -73,7 +73,7 @@ if not os.path.isdir(srcdir_prefix):
 workdir = os.path.abspath(os.getcwd())
 builddir = builds.get_build_dir(args.build)
 buildmeta_path = os.path.join(builddir, 'meta.json')
-buildmeta = GenericBuildMeta(workdir=workdir)
+buildmeta = GenericBuildMeta(workdir=workdir, build=args.build)
 
 # used to lock
 build_semaphore = os.path.join(buildmeta.build_dir, ".live.building")


### PR DESCRIPTION
E.g. on PowerPC, we delete a bunch of files from the ISO which we don't
need. This throws off the dictionary mapping we previously built which
assumes all the files with karg embed areas still exist.

Add a filtering step to drop the files which no longer exist before
writing out the header in the System Area.

