### PR TITLE
buildextend-live: fix off-by-one calculating karg embed area size; change magic number

### DIFF
--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -576,7 +576,7 @@ def generate_iso():
             for i, fn in enumerate(files_with_karg_embed_areas):
                 offset_in_file = files_with_karg_embed_areas[fn]
                 offsets[i + 1] = file_offset_in_iso(isoinfo, os.path.basename(fn)) + offset_in_file
-            isofh.write(struct.pack(KARGSFMT, b'corekarg', karg_embed_area_length, *offsets))
+            isofh.write(struct.pack(KARGSFMT, b'coreKarg', karg_embed_area_length, *offsets))
             # Magic number + offset + length
             isofh.write(struct.pack(INITRDFMT, b'coreiso+', offset, initrd_ignition_padding))
             print(f'Embedded {initrd_ignition_padding} bytes Ignition config space at {offset}')

--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -347,7 +347,7 @@ def generate_iso():
             if buf != newbuf:
                 karg_area_start = re.search(r'@@KERNEL-ARGS@@', buf)
                 buf = newbuf
-                karg_area_end = re.search(r'(#+) COREOS_KARG_EMBED_AREA\n', buf)
+                karg_area_end = re.search(r'(#+)# COREOS_KARG_EMBED_AREA\n', buf)
                 if karg_area_end is not None:
                     file_kargs = buf[karg_area_start.start():karg_area_end.start()]
                     if len(cmdline) == 0:

--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -534,7 +534,7 @@ def generate_iso():
     #
     # Recently, we also play a similar trick for injecting kernel arguments: we
     # store the location of "karg embed areas" at the end of the System Area
-    # (in the 64 bytes before the 24 bytes for the initrd info). This is then
+    # (in the 72 bytes before the 24 bytes for the initrd info). This is then
     # picked up by `coreos-installer iso embed-kargs`.
     if basearch != "s390x":
         # size of System Area section at start of ISO9660 images


### PR DESCRIPTION
We need to omit the last comment character from the karg embed area so a maximum-size embed doesn't cause the bootloader to try to execute `COREOS_KARG_EMBED_AREA` as a command.

While we're here, change the karg embed area magic number so ISOs built without the previous commit or b48e428 can be rejected by coreos-installer.