### PR TITLE
kola: Add support for `kola --stream stable -p aws ...`

### DIFF
--- a/mantle/fcos/metadata.go
+++ b/mantle/fcos/metadata.go
@@ -89,6 +89,12 @@ func FetchCanonicalStreamArtifacts(stream, architecture string) (*stream.Arch, e
 	return &arch, nil
 }
 
+// FetchStreamThisArchitecture returns artifacts for the current architecture from
+// the given stream.
+func FetchStreamThisArchitecture(stream string) (*stream.Arch, error) {
+	return FetchCanonicalStreamArtifacts(stream, system.RpmArch())
+}
+
 // GetCosaBuildURL returns a URL prefix for the coreos-assembler build.
 func GetCosaBuildURL(stream, buildid string) string {
 	u := fcosinternals.GetCosaBuild(stream, buildid, system.RpmArch())

--- a/mantle/platform/platform.go
+++ b/mantle/platform/platform.go
@@ -172,6 +172,7 @@ type Options struct {
 	Distribution    string
 	IgnitionVersion string
 	SystemdDropins  []SystemdDropin
+	Stream          string
 
 	CosaWorkdir string
 	CosaBuildId string


### PR DESCRIPTION
This makes use of the new stream-metadata-go bindings to
automatically fetch the latest AMI for a stream.

E.g. this full command works for me:
```
$ kola spawn --stream stable -b fcos -p aws --aws-profile openshift-dev --aws-region us-east-2
```

I added a convenience internal API to fetch the artifacts for
the current architecture, but actually in the case of AWS
we *could* launch cross-architecture - if we had `aarch64`
FCOS AMIs, which we don't yet.

I'm targeting AWS for this because the whole "find AMI ID" thing
is a great use case for dynamic streams.

Now, generalizing this more is really going to want to
dedup code with
https://github.com/coreos/fedora-coreos-stream-generator/
which will come later.