### PR TITLE
cmdlib.sh: show full console output on qemuexec error

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -542,6 +542,10 @@ EOF
         fatal "Couldn't find rc file; failure inside supermin init?"
     fi
     rc="$(cat "${rc_file}")"
+    # if there's a failure, we might as well provide more info to help debug
+    if [ "${rc}" != 0 ]; then
+        cat "${runvm_console}"
+    fi
     return "${rc}"
 }
 


### PR DESCRIPTION
Multi-arch is hitting an issue right now where there *is* an rc file,
but somehow no output from the command (bash failing to execute the
`cmd.sh` perhaps?). Let's just print the full logs to help debugging.