### PR TITLE
grub: make boot RAID check Petitboot-compatible

### DIFF
--- a/src/grub.cfg
+++ b/src/grub.cfg
@@ -1,5 +1,6 @@
 set pager=1
-if [ -e (md/md-boot) ]; then
+# petitboot doesn't support -e and doesn't support an empty path part
+if [ -d (md/md-boot)/grub2 ]; then
   # fcct currently creates /boot RAID with superblock 1.0, which allows
   # component partitions to be read directly as filesystems.  This is
   # necessary because transposefs doesn't yet rerun grub2-install on BIOS,


### PR DESCRIPTION
Petitboot doesn't support `-e` and doesn't support testing for a bare device without a path component.

https://bugzilla.redhat.com/show_bug.cgi?id=1915540#c7