### PR TITLE
cmd-generate-release-meta: fix field name

### DIFF
--- a/src/cmd-generate-release-meta
+++ b/src/cmd-generate-release-meta
@@ -47,7 +47,7 @@ def gather_buildmeta_from_workdir():
     builds = Builds()
     # default to latest build if not specified
     if args.build_id:
-        buildid = args.build
+        buildid = args.build_id
     else:
         buildid = builds.get_latest()
     print(f"Creating release.json for build {buildid}")


### PR DESCRIPTION
Should be `build_id`, not `build`. See:
https://github.com/coreos/fedora-coreos-streams/issues/247#issuecomment-762360677