### PR TITLE
build.sh: freeze kernel to 5.9.16-200.fc33

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -32,6 +32,9 @@ configure_yum_repos() {
 }
 
 install_rpms() {
+    local builddeps
+    local frozendeps
+
     # First, a general update; this is best practice.  We also hit an issue recently
     # where qemu implicitly depended on an updated libusbx but didn't have a versioned
     # requires https://bugzilla.redhat.com/show_bug.cgi?id=1625641
@@ -47,8 +50,10 @@ install_rpms() {
     # development version.
     builddeps=$(grep -v '^#' "${srcdir}"/src/build-deps.txt)
 
+    # Freeze kernel due to https://github.com/coreos/coreos-assembler/issues/2003
+    frozendeps=$(echo https://kojipkgs.fedoraproject.org//packages/kernel/5.9.16/200.fc33/"${arch}"/kernel-{core,modules}-5.9.16-200.fc33."${arch}".rpm)
     # Process our base dependencies + build dependencies and install
-    (echo "${builddeps}" && "${srcdir}"/src/print-dependencies.sh) | xargs yum -y install
+    (echo "${frozendeps}" && echo "${builddeps}" && "${srcdir}"/src/print-dependencies.sh) | xargs yum -y install
 
     # Commented out for now, see above
     #dnf remove -y ${builddeps}


### PR DESCRIPTION
The 5.10 kernel causes a regression where we lose virtio ports on s390x,
which breaks builds. Instead of freezing it only on s390x, let's just do
it across the board to be consistent.

