### PR TITLE
cmd-artifact-disk: fix cosa artifact-disk manual

### DIFF
--- a/src/cmd-artifact-disk
+++ b/src/cmd-artifact-disk
@@ -43,7 +43,7 @@ def artifact_cli():
     targets.append("manual")
 
     parser = BuildCli()
-    subparsers = parser.add_subparsers()
+    subparsers = parser.add_subparsers(dest="command")
 
     # Options for finding the build.
     parser.add_argument("--force", action='store_true',
@@ -90,7 +90,7 @@ def artifact_cli():
     if build_target:
         builder = get_builder(build_target, args.buildroot, args.build,
                               force=args.force, schema=args.schema)
-    elif "manual" in args:
+    elif args.command == "manual":
         kwargs = {
             'force': args.force,
             'image_format': args.image_format,


### PR DESCRIPTION
Fixing:
```
cosa artifact-disk manual --image_format xxx --image_suffix xxx --platform xxx
```

The command above did not work because of an error in arg parsing:
`"manual" in args` was always `false`, because `manual` was the name of a subparser,
not an arg of the parser.
