### PR TITLE
[4.6] build.sh: freeze kernel to 5.9.16-100.fc32

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -32,6 +32,9 @@ configure_yum_repos() {
 }
 
 install_rpms() {
+    local builddeps
+    local frozendeps
+
     # First, a general update; this is best practice.  We also hit an issue recently
     # where qemu implicitly depended on an updated libusbx but didn't have a versioned
     # requires https://bugzilla.redhat.com/show_bug.cgi?id=1625641
@@ -47,8 +50,10 @@ install_rpms() {
     # development version.
     builddeps=$(grep -v '^#' "${srcdir}"/src/build-deps.txt)
 
+    # Freeze kernel due to https://github.com/coreos/coreos-assembler/issues/2003
+    frozendeps=$(echo https://kojipkgs.fedoraproject.org//packages/kernel/5.9.16/100.fc32/"${arch}"/kernel-{core,modules}-5.9.16-100.fc32."${arch}".rpm)
     # Process our base dependencies + build dependencies and install
-    (echo "${builddeps}" && "${srcdir}"/src/print-dependencies.sh) | xargs yum -y install
+    (echo "${frozendeps}" && echo "${builddeps}" && "${srcdir}"/src/print-dependencies.sh) | xargs yum -y install
 
     # https://github.com/coreos/coreos-assembler/issues/1496
     yum -y downgrade cryptsetup-2.3.0-1.fc32


### PR DESCRIPTION
The 5.10 kernel causes a regression where we lose virtio ports on s390x,
which breaks builds. Instead of freezing it only on s390x, let's just do
it across the board to be consistent.

(cherry picked from commit e08e7665bbfee7aa00fe9889b4933fdab711fd4c)