### PR TITLE
Add uncompressed-sha256 to release -> stream translation

### DIFF
--- a/mantle/go.mod
+++ b/mantle/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/coreos/ignition/v2 v2.9.0
 	github.com/coreos/ioprogress v0.0.0-20151023204047-4637e494fd9b
 	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
-	github.com/coreos/stream-metadata-go v0.0.0-20210115160721-ba77d4e64952
+	github.com/coreos/stream-metadata-go v0.0.0-20210120211222-7575c72c6f05
 	github.com/digitalocean/go-libvirt v0.0.0-20200810224808-b9c702499bf7 // indirect
 	github.com/digitalocean/go-qemu v0.0.0-20200529005954-1b453d036a9c
 	github.com/digitalocean/godo v1.33.0

--- a/mantle/go.sum
+++ b/mantle/go.sum
@@ -110,6 +110,8 @@ github.com/coreos/stream-metadata-go v0.0.0-20210107232620-d808ce9d237c/go.mod h
 github.com/coreos/stream-metadata-go v0.0.0-20210112152733-52b38c241a3d h1:a65dhEcT+kL9Bf5pDpdoOMdT5w0VjwUXE+XO2MoFuSg=
 github.com/coreos/stream-metadata-go v0.0.0-20210115160721-ba77d4e64952 h1:t7IgMcyflINfXWPISnHTXwa/F+NxLgWGRGejoyfHUII=
 github.com/coreos/stream-metadata-go v0.0.0-20210115160721-ba77d4e64952/go.mod h1:RTjQyHgO/G37oJ3qnqYK6Z4TPZ5EsaabOtfMjVXmgko=
+github.com/coreos/stream-metadata-go v0.0.0-20210120211222-7575c72c6f05 h1:GXgmcV54WyU3LDXRwf3vXtgkmajMHoYfQ/qCuPblr4A=
+github.com/coreos/stream-metadata-go v0.0.0-20210120211222-7575c72c6f05/go.mod h1:RTjQyHgO/G37oJ3qnqYK6Z4TPZ5EsaabOtfMjVXmgko=
 github.com/coreos/vcontext v0.0.0-20190529201340-22b159166068 h1:y2aHj7QqyAJ6YBBONTAr17YxHHiogDkYnTsJvFNhxwY=
 github.com/coreos/vcontext v0.0.0-20190529201340-22b159166068/go.mod h1:E+6hug9bFSe0KZ2ZAzr8M9F5JlArJjv5D1JS7KSkPKE=
 github.com/coreos/vcontext v0.0.0-20201120045928-b0e13dab675c h1:jA28WeORitsxGFVWhyWB06sAG2HbLHPQuHwDydhU2CQ=

--- a/mantle/vendor/github.com/coreos/stream-metadata-go/release/release.go
+++ b/mantle/vendor/github.com/coreos/stream-metadata-go/release/release.go
@@ -88,9 +88,10 @@ type ImageFormat struct {
 
 // Artifact represents one image file, plus its metadata
 type Artifact struct {
-	Location  string `json:"location"`
-	Signature string `json:"signature"`
-	Sha256    string `json:"sha256"`
+	Location           string `json:"location"`
+	Signature          string `json:"signature"`
+	Sha256             string `json:"sha256"`
+	UncompressedSha256 string `json:"uncompressed-sha256,omitempty"`
 }
 
 // CloudImage generic image detail

--- a/mantle/vendor/github.com/coreos/stream-metadata-go/release/translate.go
+++ b/mantle/vendor/github.com/coreos/stream-metadata-go/release/translate.go
@@ -9,9 +9,10 @@ func mapArtifact(ra *Artifact) *stream.Artifact {
 		return nil
 	}
 	return &stream.Artifact{
-		Location:  ra.Location,
-		Signature: ra.Signature,
-		Sha256:    ra.Sha256,
+		Location:           ra.Location,
+		Signature:          ra.Signature,
+		Sha256:             ra.Sha256,
+		UncompressedSha256: ra.UncompressedSha256,
 	}
 }
 

--- a/mantle/vendor/github.com/coreos/stream-metadata-go/stream/stream.go
+++ b/mantle/vendor/github.com/coreos/stream-metadata-go/stream/stream.go
@@ -37,9 +37,10 @@ type ImageFormat struct {
 
 // Artifact represents one image file, plus its metadata
 type Artifact struct {
-	Location  string `json:"location"`
-	Signature string `json:"signature"`
-	Sha256    string `json:"sha256"`
+	Location           string `json:"location"`
+	Signature          string `json:"signature"`
+	Sha256             string `json:"sha256"`
+	UncompressedSha256 string `json:"uncompressed-sha256"`
 }
 
 // Images contains images available in cloud providers

--- a/mantle/vendor/modules.txt
+++ b/mantle/vendor/modules.txt
@@ -167,7 +167,7 @@ github.com/coreos/ioprogress
 # github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
 github.com/coreos/pkg/capnslog
 github.com/coreos/pkg/multierror
-# github.com/coreos/stream-metadata-go v0.0.0-20210115160721-ba77d4e64952
+# github.com/coreos/stream-metadata-go v0.0.0-20210120211222-7575c72c6f05
 github.com/coreos/stream-metadata-go/fedoracoreos
 github.com/coreos/stream-metadata-go/fedoracoreos/internals
 github.com/coreos/stream-metadata-go/release

--- a/src/cmd-generate-release-meta
+++ b/src/cmd-generate-release-meta
@@ -104,7 +104,8 @@ def append_build(out, input_):
         return {
             "location": base_url,
             "signature": "{}.sig".format(base_url),
-            "sha256": i.get("sha256")
+            "sha256": i.get("sha256"),
+            "uncompressed-sha256": i.get("uncompressed-sha256")
         }
 
     print(f"{out['stream']} stream")


### PR DESCRIPTION
This updates the vendor of stream-metadata-go and adds
translation for `uncompressed-sha256` so we can use it in
`openshift-install`.

See https://github.com/coreos/stream-metadata-go/pull/11