### PR TITLE
plume: Allow architecture divergence for releases

### DIFF
--- a/mantle/go.sum
+++ b/mantle/go.sum
@@ -112,6 +112,7 @@ github.com/coreos/stream-metadata-go v0.0.0-20210115160721-ba77d4e64952 h1:t7IgM
 github.com/coreos/stream-metadata-go v0.0.0-20210115160721-ba77d4e64952/go.mod h1:RTjQyHgO/G37oJ3qnqYK6Z4TPZ5EsaabOtfMjVXmgko=
 github.com/coreos/stream-metadata-go v0.0.0-20210120211222-7575c72c6f05 h1:GXgmcV54WyU3LDXRwf3vXtgkmajMHoYfQ/qCuPblr4A=
 github.com/coreos/stream-metadata-go v0.0.0-20210120211222-7575c72c6f05/go.mod h1:RTjQyHgO/G37oJ3qnqYK6Z4TPZ5EsaabOtfMjVXmgko=
+github.com/coreos/stream-metadata-go v0.0.0-20210121193119-2fbf8747cee7 h1:6LNM7FalzC7155uc5ecuUmD1x70QsOexZYGVHnLc4OE=
 github.com/coreos/vcontext v0.0.0-20190529201340-22b159166068 h1:y2aHj7QqyAJ6YBBONTAr17YxHHiogDkYnTsJvFNhxwY=
 github.com/coreos/vcontext v0.0.0-20190529201340-22b159166068/go.mod h1:E+6hug9bFSe0KZ2ZAzr8M9F5JlArJjv5D1JS7KSkPKE=
 github.com/coreos/vcontext v0.0.0-20201120045928-b0e13dab675c h1:jA28WeORitsxGFVWhyWB06sAG2HbLHPQuHwDydhU2CQ=

--- a/src/cmd-generate-release-meta
+++ b/src/cmd-generate-release-meta
@@ -20,10 +20,10 @@ def ensure_dup(inp, out, inp_key, out_key):
     to be equal to the inp dictionaries inp_key value, if it does exist
     ensure the values are equal between the two dictionaries
     '''
-    if out.get(out_key, None) is None:
-        out[out_key] = inp.get(inp_key)
-    if out.get(out_key) != inp.get(inp_key):
-        raise Exception("Input Files do not appear to be for the same release")
+    inv = inp.get(inp_key)
+    v = out.setdefault(out_key, inv)
+    if v != inv:
+        raise Exception(f"Input Files do not appear to be for the same release ({v} != {inv})")
 
 
 def url_builder(stream, version, arch, path):


### PR DESCRIPTION
Trying to port `openshift-install` we have all 3 of x86_64/s390x/ppc64le,
but they have different build IDs.

Now this works:
```
$ plume cosa2stream --name rhcos-4.7 https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7/47.83.202012030221-0/x86_64/meta.json https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7-s390x/47.83.202012030410-0/s390x/meta.json https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7-ppc64le/47.83.202012030110-0/ppc64le/meta.json | jq .
```