### PR TITLE
Fully drop support for building images with root-on-LUKS

### DIFF
--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -43,7 +43,6 @@ live_exclude_kargs = set([
     'console',               # no serial console by default on ISO
     'ignition.platform.id',  # we hardcode "metal"
     'ostree',                # dracut finds the tree automatically
-    'rhcos.root',            # This one is set in RHCOS for the legacy LUKS path
 ])
 
 # Parse args and dispatch

--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -79,14 +79,9 @@ getconfig_def() {
     jq -re .'"'$k'"'//'"'${default}'"' < ${config}
 }
 
-# First parse the old luks_rootfs flag (a custom "stringified bool")
-if test "$(getconfig luks_rootfs)" = "yes"; then
-    rootfs_type=luks
-else
-    rootfs_type=$(getconfig rootfs)
-fi
+rootfs_type=$(getconfig rootfs)
 case "${rootfs_type}" in
-    xfs|ext4verity|luks|btrfs) ;;
+    xfs|ext4verity|btrfs) ;;
     *) echo "Invalid rootfs type: ${rootfs_type}" 1>&2; exit 1;;
 esac
 
@@ -160,48 +155,6 @@ esac
 udevtrig
 
 root_dev="${disk}${ROOTPN}"
-if [ "${rootfs_type}" = "luks" ]; then
-    root_dev=/dev/mapper/crypt_root
-    sgdisk -c ${ROOTPN}:luks_root "${disk}"
-
-    touch tmp.key
-    # Create the LUKS partition using the null_cipher and a sentinal
-    # UUID similiar to the one used by coreos-gpt-setup. This is used
-    # by ignition-dracut-reecrypt.  We use argon2i as it's the cryptsetup
-    # default today, but explicitly specify just 512Mb in order to support
-    # booting on smaller systems.
-    cryptsetup luksFormat \
-        -q \
-        --type luks2 \
-        --pbkdf argon2i \
-        --pbkdf-memory 524288 \
-        --label="crypt_rootfs" \
-        --cipher=cipher_null \
-        --key-file=tmp.key \
-        --uuid='00000000-0000-4000-a000-000000000002' \
-        "${disk}${ROOTPN}"
-
-    # 'echo ""' acts as a test that you can use an empty
-    # password. You can actually use _any_ string.
-    echo "" | cryptsetup luksOpen \
-        --allow-discards \
-        "${disk}${ROOTPN}" crypt_root \
-        --key-file=-
-
-    udevtrig
-
-    cryptsetup token import \
-        "${disk}${ROOTPN}" \
-        --token-id 9 \
-        --key-slot=0 \
-        <<<'{"type": "coreos", "keyslots": ["0"], "key": "", "ostree_ref": "'${ref}'"}'
-
-    # This enabled discards, which is probably not a great idea for
-    # those avoiding three-letter acronyms. For the vast majority of users
-    # this is fine. See warning at:
-    # https://gitlab.com/cryptsetup/cryptsetup/wikis/FrequentlyAskedQuestions
-    extrakargs="${extrakargs} rd.luks.options=discard"
-fi
 
 bootargs=
 case "${bootfs}" in
@@ -235,7 +188,7 @@ case "${rootfs_type}" in
     btrfs)
         mkfs.btrfs -L root "${root_dev}" -U "${rootfs_uuid}"
         ;;
-    xfs|luks|"")
+    xfs|"")
         mkfs.xfs "${root_dev}" -L root -m reflink=1 -m uuid="${rootfs_uuid}"
         ;;
     *)

--- a/src/gf-fsck
+++ b/src/gf-fsck
@@ -28,10 +28,6 @@ for pt in $partitions; do
 done
 
 # And fsck the main rootfs
-rootfstype=$(coreos_gf vfs-type /dev/sda4)
-if [ "${rootfstype}" = "crypto_LUKS" ]; then
-    coreos_gf luks-open /dev/sda4 luks-00000000-0000-4000-a000-000000000002
-fi
 root=$(coreos_gf findfs-label root)
 coreos_gf debug sh "fsck.xfs -f -n ${root}"
 

--- a/src/osmet-pack
+++ b/src/osmet-pack
@@ -54,24 +54,9 @@ coreinst=${1:-}
 
 set -x
 
-# Also hardcoded in redhat-coreos/.../coreos-cryptfs
-rhcos_luks_header_size_sectors=32768
-
 mkdir -p /sysroot
 rootfs=/dev/disk/by-id/virtio-osmet-part4
-roottype=$(blkid -p -s TYPE -o value "${rootfs}")
-real_rootdev=
-if [ "${roottype}" = "crypto_LUKS" ]; then
-  dev_size=$(($(blockdev --getsize ${rootfs}) - rhcos_luks_header_size_sectors))
-  # Unlike coreos-cryptfs we use the concise syntax which allows us to mark the blockdev
-  # as read-only, which is required for XFS to actually honor `-o ro` not replaying
-  # the journal.
-  dmsetup create --concise "rhcos-luks-root-nocrypt,,,ro,0 ${dev_size} linear ${rootfs} ${rhcos_luks_header_size_sectors}"
-  mount -o ro /dev/disk/by-label/root /sysroot
-  real_rootdev="${rootfs},${rhcos_luks_header_size_sectors}"
-else
-  mount -o ro "${rootfs}" /sysroot
-fi
+mount -o ro "${rootfs}" /sysroot
 osname=$(ls /sysroot/ostree/deploy)
 deploydir=$(find "/sysroot/ostree/deploy/$osname/deploy" -mindepth 1 -maxdepth 1 -type d)
 # shellcheck disable=SC1090
@@ -97,7 +82,6 @@ esac
 RUST_BACKTRACE=full ${coreinst} osmet pack /dev/disk/by-id/virtio-osmet \
     --description "${description}" \
     --checksum "${checksum}" \
-    ${real_rootdev:+--real-rootdev ${real_rootdev}} \
     --output /tmp/osmet.bin $fast
 
 mv /tmp/osmet.bin "${osmet_dest}"


### PR DESCRIPTION
This is obsolete now that RHCOS has moved to LUKS-via-Ignition:
https://github.com/openshift/os/pull/436

Let's remove those paths to clean up the code.