### PR TITLE
buildroot: Add libasan, libtsan and parallel+gjs

### DIFF
--- a/src/buildroot-reqs.txt
+++ b/src/buildroot-reqs.txt
@@ -25,8 +25,13 @@ util-linux
 which
 xz
 
-# For rpm-ostree's CI at least
+# For rust projects like rpm-ostree
 rustfmt
 
+# Used by ostree/rpm-ostree CI
+parallel gjs
+
 # Also, add clang since it's useful at least in CI for C/C++ projects
-clang
+clang lld
+# All C/C++ projects should have CI that uses the sanitizers
+libubsan libasan libtsan


### PR DESCRIPTION
I want to get a sanitizer build of ostree/rpm-ostree going
again, let's add these to the CI buildroot.

Also pull in parallel/gjs which are used by both projects, so
we can avoid using package installs in the CI happy path.