### PR TITLE
buildroot: Add clang-analyzer

### DIFF
--- a/src/buildroot-reqs.txt
+++ b/src/buildroot-reqs.txt
@@ -35,3 +35,5 @@ parallel gjs
 clang lld
 # All C/C++ projects should have CI that uses the sanitizers
 libubsan libasan libtsan
+# And all C/C++ projects should use clang-analyzer
+clang-analyzer


### PR DESCRIPTION
Like ASAN/UBSAN, static analysis should be part of every C/C++
project.