### PR TITLE
Allow for setting virtual_size per qemu variant

### DIFF
--- a/src/cmd-artifact-disk
+++ b/src/cmd-artifact-disk
@@ -75,6 +75,7 @@ def artifact_cli():
                         help="Ignition platform to set image to")
     manual.add_argument("--convert_options",
                         help="qemu-img options")
+    manual.add_argument("--virtual-size", help="Virtual Size to use")
 
     args = parser.parse_args()
 
@@ -97,6 +98,7 @@ def artifact_cli():
             'image_suffix': args.image_suffix,
             'platform': args.platform,
             'schema': args.schema,
+            'virtual_size': args.virtual_size,
         }
         if args.convert_options:
             kwargs["convert_options"] = {'-o': f'{args.convert_options}'}

--- a/src/cosalib/qemuvariants.py
+++ b/src/cosalib/qemuvariants.py
@@ -96,6 +96,7 @@ VARIANTS = {
     "ibmcloud": {
         "image_format": "qcow2",
         "platform": "ibmcloud",
+        "virtual_size": "100G",
     },
     "openstack": {
         "image_format": "qcow2",
@@ -150,6 +151,7 @@ class QemuVariantImage(_Build):
             convert_options: optional qemu arguments
             platform: the name of the image.
             platform_image_name: in case you want to use a different name
+            virtual_size: in case you want to explicitly set a virtual size
 
         Alternatively, you can provide "variant=<variant>" and defaults will be
         used.
@@ -166,6 +168,7 @@ class QemuVariantImage(_Build):
         self.force = kwargs.get("force", False)
         self.tar_members = kwargs.pop("tar_members", None)
         self.tar_flags = kwargs.pop("tar_flags", [DEFAULT_TAR_FLAGS])
+        self.virtual_size = kwargs.pop("virtual_size", None)
 
         # this is used in case the image has a different disk
         # name than the platform
@@ -229,6 +232,13 @@ class QemuVariantImage(_Build):
 
         log.info(f"Staging temp image: {work_img}")
         self.set_platform()
+
+        # Resizing if requested
+        if self.virtual_size is not None:
+            resize_cmd = ['qemu-img', 'resize',
+                          self.tmp_image, self.virtual_size]
+            run_verbose(resize_cmd)
+
         cmd = ['qemu-img', 'convert', '-f', 'qcow2', '-O',
                self.image_format, self.tmp_image]
         for k, v in self.convert_options.items():


### PR DESCRIPTION
## Description

Add the ability to set the virtual size in the qemu variant configuration or via a switch in manual mode when using `cmd-artifact-disk`. This also sets the default virtual size for `ibmcloud` artifacts to 100G per request.

## Test
Done via a local build off the main branch.

```
$ cosa build qemu
<snip/>
$ cosa buildextend-ibmcloud
<snip/>
$ cosa buildextend-openstack
<snip/>
[coreos-assembler]$ find . -name "*qcow2*"
./builds/.../rhcos-48...-qemu.x86_64.qcow2
./builds/.../rhcos-48...-ibmcloud.x86_64.qcow2
./builds/.../rhcos-48...-openstack.x86_64.qcow2
$ for x in `find . -name "*qcow2*"`; do echo -n `basename $x` " "; qemu-img info $x | grep "virtual size"; done
rhcos-48...-qemu.x86_64.qcow2      virtual size: 16 GiB (17179869184 bytes)
rhcos-48...-ibmcloud.x86_64.qcow2  virtual size: 100 GiB (107374182400 bytes)
rhcos-48...-openstack.x86_64.qcow2 virtual size: 16 GiB (17179869184 bytes)
```
