### PR TITLE
build.sh: support git.tar.gz in container build dir

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -102,6 +102,12 @@ write_archive_info() {
     . "${srcdir}/src/cmdlib.sh"
     mkdir -p /cosa /lib/coreos-assembler
     touch -f /lib/coreos-assembler/.clean
+    # this is an alternative way to tackle the "OpenShift really doesn't like
+    # .git" issue by sneaking it into the build via a nested tarfile
+    if test -f git.tar.gz; then
+      tar -xf git.tar.gz
+      rm git.tar.gz
+    fi
     prepare_git_artifacts "${srcdir}" /cosa/coreos-assembler-git.tar.gz /cosa/coreos-assembler-git.json
 }
 


### PR DESCRIPTION
The `OPENSHIFT_GIT_HACK` workaround doesn't work well in some situations
because (1) it assumes that there even is a reachable git repo from
which to re-clone the repo; for dev machines using e.g. `--from-dir=.`,
this is not the case, and (2) it introduces a race where the git ref
might have moved forward since the build started, effectively yielding a
src tree with a mix of "old" and "new" files (though it does use `rsync
--ignore-existing` at least).

Specifically, in the `--from-dir=.` workflow, it would be much cleaner
conceptually if it just worked purely from what was copied in and didn't
try to fetch more source code from a remote.

Let's support a convention where if there is a `git.tar.gz` in the
container build directory, we unzip that and delete it.

(I think it wouldn't be too hard either to support building without a
git directory to help this case, though it's definitely useful to have
git information and it's nice to not have to think the missing case.)