### PR TITLE
mantle: drop PortageArch()

### DIFF
--- a/docs/mantle/plume.md
+++ b/docs/mantle/plume.md
@@ -171,7 +171,7 @@ Here is an example of doing a Fedora Cloud pre-release with plume:
   --version 30                            \
   --timestamp 20190819                    \
   --respin 0                              \
-  --board x86_64                          \
+  --arch x86_64                           \
   --compose-id Fedora-Cloud-30-20190819.0 \
   --image-type Cloud-Base                 \
   --debug
@@ -186,7 +186,7 @@ Here is an example of doing a Fedora Cloud release with plume:
   --version 30                            \
   --timestamp 20190819                    \
   --respin 0                              \
-  --board x86_64                          \
+  --arch x86_64                           \
   --compose-id Fedora-Cloud-30-20190819.0 \
   --image-type Cloud-Base                 \
   --debug

--- a/mantle/cmd/plume/fcos.go
+++ b/mantle/cmd/plume/fcos.go
@@ -24,7 +24,7 @@ var (
 	specProfile  string
 	specPolicy   string
 	specCommitId string
-	specBoard    string
+	specArch     string
 	specChannel  string
 	specVersion  string
 )

--- a/mantle/cmd/plume/fedora.go
+++ b/mantle/cmd/plume/fedora.go
@@ -26,7 +26,7 @@ var (
 	specRespin      string
 	specImageType   string
 	specTimestamp   string
-	awsFedoraBoards = []string{
+	awsFedoraArches = []string{
 		"x86_64",
 		"aarch64",
 	}
@@ -77,7 +77,7 @@ var (
 	fedoraSpecs = map[string]channelSpec{
 		"rawhide": channelSpec{
 			BaseURL: "https://koji.fedoraproject.org/compose/rawhide",
-			Boards:  awsFedoraBoards,
+			Arches:  awsFedoraArches,
 			AWS: awsSpec{
 				BaseName:        "Fedora",
 				BaseDescription: "Fedora Cloud Base AMI",
@@ -87,7 +87,7 @@ var (
 		},
 		"branched": channelSpec{
 			BaseURL: "https://koji.fedoraproject.org/compose/branched",
-			Boards:  awsFedoraBoards,
+			Arches:  awsFedoraArches,
 			AWS: awsSpec{
 				BaseName:        "Fedora",
 				BaseDescription: "Fedora Cloud Base AMI",
@@ -97,7 +97,7 @@ var (
 		},
 		"updates": channelSpec{
 			BaseURL: "https://koji.fedoraproject.org/compose/updates",
-			Boards:  awsFedoraBoards,
+			Arches:  awsFedoraArches,
 			AWS: awsSpec{
 				BaseName:        "Fedora",
 				BaseDescription: "Fedora Cloud Base AMI",
@@ -107,7 +107,7 @@ var (
 		},
 		"cloud": channelSpec{
 			BaseURL: "https://koji.fedoraproject.org/compose/cloud",
-			Boards:  awsFedoraBoards,
+			Arches:  awsFedoraArches,
 			AWS: awsSpec{
 				BaseName:        "Fedora",
 				BaseDescription: "Fedora Cloud Base AMI",
@@ -136,8 +136,8 @@ func ChannelFedoraSpec() (channelSpec, error) {
 	if specVersion == "" {
 		plog.Fatal("--version is required")
 	}
-	if len(specBoard) == 0 || specBoard == "amd64-usr" {
-		specBoard = "x86_64"
+	if specArch == "" {
+		specArch = "x86_64"
 	}
 
 	spec, ok := fedoraSpecs[specChannel]
@@ -148,15 +148,15 @@ func ChannelFedoraSpec() (channelSpec, error) {
 	if specEnv == "dev" {
 		spec.AWS.Partitions = awsFedoraDevAccountPartitions
 	}
-	boardOk := false
-	for _, board := range spec.Boards {
-		if specBoard == board {
-			boardOk = true
+	archOk := false
+	for _, arch := range spec.Arches {
+		if specArch == arch {
+			archOk = true
 			break
 		}
 	}
-	if !boardOk {
-		plog.Fatalf("Unknown board %q for channel %q", specBoard, specChannel)
+	if !archOk {
+		plog.Fatalf("Unknown arch %q for channel %q", specArch, specChannel)
 	}
 
 	return spec, nil

--- a/mantle/cmd/plume/types.go
+++ b/mantle/cmd/plume/types.go
@@ -17,8 +17,8 @@ package main
 type storageSpec struct {
 	BaseURL       string
 	Title         string // Replace the bucket name in index page titles
-	NamedPath     string // Copy to $BaseURL/$Board/$NamedPath
-	VersionPath   bool   // Copy to $BaseURL/$Board/$Version
+	NamedPath     string // Copy to $BaseURL/$Arch/$NamedPath
+	VersionPath   bool   // Copy to $BaseURL/$Arch/$Version
 	DirectoryHTML bool
 	IndexHTML     bool
 }
@@ -71,8 +71,8 @@ type awsSpec struct {
 }
 
 type channelSpec struct {
-	BaseURL      string // Copy from $BaseURL/$Board/$Version
-	Boards       []string
+	BaseURL      string // Copy from $BaseURL/$Arch/$Version
+	Arches       []string
 	Destinations []storageSpec
 	GCE          gceSpec
 	Azure        azureSpec

--- a/mantle/sdk/repo.go
+++ b/mantle/sdk/repo.go
@@ -104,11 +104,6 @@ func GetLocalBuild(root, buildid string) (*LocalBuild, error) {
 	}, nil
 }
 
-func DefaultBoard() string {
-	defaultBoard := system.PortageArch() + "-usr"
-	return string(defaultBoard)
-}
-
 // TODO replace with coreos-assembler concepts
 func BoardRoot(board string) string {
 	return ""

--- a/mantle/system/arch.go
+++ b/mantle/system/arch.go
@@ -15,32 +15,10 @@
 package system
 
 import (
-	"runtime"
-
 	"github.com/coreos/stream-metadata-go/arch"
 )
 
 // RpmArch returns the architecture in RPM terms.
 func RpmArch() string {
 	return arch.CurrentRpmArch()
-}
-
-// PortageArch returns the Gentoo portage architecture
-func PortageArch() string {
-	arch := runtime.GOARCH
-	switch arch {
-	case "386":
-		arch = "x86"
-
-	// Go and Portage agree for these.
-	case "amd64":
-	case "arm":
-	case "arm64":
-	case "ppc64":
-	case "s390x":
-	case "ppc64le":
-	default:
-		panic("No portage arch defined for " + arch)
-	}
-	return arch
 }


### PR DESCRIPTION
It's a CL remnant.  The last user is plume pre-release, which has been using it to set and then override a default command-line argument.  Fix that, and while we're here, have plume stop using the term `board`.