### PR TITLE
kola: Fix localbuild detection

### DIFF
--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -247,12 +247,14 @@ func syncOptionsImpl(useCosa bool) error {
 				kola.CosaBuild = localbuild
 				foundCosa = true
 			}
-		} else {
+		} else if kola.QEMUOptions.DiskImage == "" {
 			localbuild, err := sdk.GetLocalFastBuildQemu()
 			if err != nil {
 				return err
 			}
-			kola.QEMUOptions.DiskImage = localbuild
+			if localbuild != "" {
+				kola.QEMUOptions.DiskImage = localbuild
+			}
 		}
 	}
 


### PR DESCRIPTION
This should fix rpm-ostree CI that was broken by
https://github.com/coreos/coreos-assembler/pull/2040

Basically we need to ignore the empty string (meaning "not found")
as a return value if there's no local build.

Also while we're here, strengthen the check to not even look
for a local build if the qemu disk is already set.