### PR TITLE
deps.txt: add python3-createrepo_c

### DIFF
--- a/src/deps.txt
+++ b/src/deps.txt
@@ -13,7 +13,7 @@ sudo
 dumb-init
 
 # For composes
-rpm-ostree createrepo_c openssh-clients
+rpm-ostree createrepo_c openssh-clients python3-createrepo_c
 dnf-utils
 
 # For generating ISO images


### PR DESCRIPTION
Prep for https://github.com/coreos/coreos-assembler/pull/2028. (Had to
split this out because Prow tests don't rebuild the container from
scratch but use the buildroot image.)