### PR TITLE
kola: Add --no-default-checks

### DIFF
--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -63,6 +63,7 @@ func init() {
 	bv(&kola.NoNet, "no-net", false, "Don't run tests that require an Internet connection")
 	ssv(&kola.Tags, "tag", []string{}, "Test tag to run. Can be specified multiple times.")
 	bv(&kola.Options.SSHOnTestFailure, "ssh-on-test-failure", false, "SSH into a machine when tests fail")
+	bv(&kola.Options.SuppressDefaultChecks, "no-default-checks", false, "Disable default checks for failed systemd units and SELinux AVC denials")
 	sv(&kola.Options.Stream, "stream", "", "CoreOS stream ID (e.g. for Fedora CoreOS: stable, testing, next)")
 	sv(&kola.Options.CosaWorkdir, "workdir", "", "coreos-assembler working directory")
 	sv(&kola.Options.CosaBuildId, "build", "", "coreos-assembler build ID")

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -878,9 +878,12 @@ func getClusterSemver(flight platform.Flight, outputDir string) (*semver.Version
 		return nil, err
 	}
 
-	cluster, err := flight.NewCluster(&platform.RuntimeConfig{
-		OutputDir: testDir,
-	})
+	cfg := &platform.RuntimeConfig{
+		OutputDir:        testDir,
+		AllowFailedUnits: Options.SuppressDefaultChecks,
+	}
+
+	cluster, err := flight.NewCluster(cfg)
 	if err != nil {
 		return nil, errors.Wrapf(err, "creating cluster for semver check")
 	}

--- a/mantle/platform/platform.go
+++ b/mantle/platform/platform.go
@@ -185,7 +185,8 @@ type Options struct {
 	// inside of RenderUserData
 	OSContainer string
 
-	SSHOnTestFailure bool
+	SSHOnTestFailure      bool
+	SuppressDefaultChecks bool
 }
 
 // RuntimeConfig contains cluster-specific configuration.


### PR DESCRIPTION
This will allow us to e.g. bypass SELinux denials when we need
to, e.g.  https://github.com/coreos/fedora-coreos-tracker/issues/751

The intention is that for FCOS releases we would drive this declaratively
in the pipeline, something like a:

```
kola:
  no-default-checks: 33.20210201.3.0
```

to automatically suppress checks for builds with that version number.