### PR TITLE
Add COSA_SUPPRESS_DEPCHECK to turn off "rpm -q all the things"

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -71,6 +71,11 @@ has_privileges() {
 }
 
 depcheck() {
+    # Allow suppressing this so we can e.g. override
+    # rpm-ostree in CI flows without building an RPM.
+    if test -n "${COSA_SUPPRESS_DEPCHECK:-}"; then
+        return
+    fi
     local deps
     deps=$(/usr/lib/coreos-assembler/print-dependencies.sh)
     # Explicitly check the packages in one rpm -q to avoid


### PR DESCRIPTION
Working on https://github.com/coreos/rpm-ostree/pull/2619
I wanted to `yum -y remove rpm-ostree` before installing our
override binaries, but that breaks things because of this cosa
check for installed packages.

Yes...we could change the rpm-ostree CI flow to build RPMs but
that has a wide array of tradeoffs and I don't want to hard require
it.  (Among the tradeoffs for example is that RPM insists on compressing
everything into an archive, which if you're then in an edit-compile-debug
cycle you immediately uncompress, which is silly)

Also incidentally this "rpm -q all the things" is one of the top
contributors to the CLI latency on cosa commands.