### PR TITLE
Gangplank: Prepare for Distributed Builds

### DIFF
--- a/gangplank/cmd/pod.go
+++ b/gangplank/cmd/pod.go
@@ -87,11 +87,16 @@ func runPod(c *cobra.Command, args []string) {
 	}
 
 	if cosaWorkDirContext {
-		log.WithField("work dir", cosaWorkDir).Infof("Applying selinux %q content", cosaWorkDirSelinuxLabel)
-		args := []string{"chcon", "-R", cosaWorkDirSelinuxLabel, cosaWorkDir}
-		cmd := exec.CommandContext(ctx, args[0], args[1:]...)
-		if err := cmd.Run(); err != nil {
-			log.WithError(err).Fatalf("failed set workdir contenxt")
+		for _, d := range []string{cosaWorkDir, cosaSrvDir} {
+			if d == "" {
+				continue
+			}
+			log.WithField("dir", d).Infof("Applying selinux %q content", cosaWorkDirSelinuxLabel)
+			args := []string{"chcon", "-R", cosaWorkDirSelinuxLabel, d}
+			cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+			if err := cmd.Run(); err != nil {
+				log.WithError(err).Fatalf("failed set dir context on %s", d)
+			}
 		}
 	}
 

--- a/gangplank/ocp/cosa-pod.go
+++ b/gangplank/ocp/cosa-pod.go
@@ -632,8 +632,12 @@ func podmanRunner(ctx ClusterContext, cp *cosaPod, envVars []v1.EnvVar) error {
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, os.Interrupt, syscall.SIGTERM, syscall.SIGUSR1, syscall.SIGUSR2)
 	go func() {
-		<-sigs
-		ender()
+		select {
+		case <-sigs:
+			ender()
+		case <-ctx.Done():
+			ender()
+		}
 	}()
 
 	l.WithFields(log.Fields{


### PR DESCRIPTION
To prepare for doing distributed builds via Gangplank, stages need to be
simplified. Previously, work assigned to pods was a calculated from all stages;
this proved to be buggy. Rather, each stage is assigned its own pod.

Further enhancements:
- If a stage fails, remaining stages are aborted.
- If a required artifact is defined, stages will wait for it to appear
  on the master pod. A future PR will will build on this.
- SHA256 and size is used to determine whether to upload a remote file
  that already exists when overwrite is set to true.
- Minio's working files are pruned after minio is completely shutdown.
- The finalize does not require any artifacts.
- Cloud stages only require qemu.

Signed-off-by: Ben Howard <ben.howard@redhat.com>