### PR TITLE
[WIP] Gangplank: enable cloud publication of artifacts

### DIFF
--- a/gangplank/cmd/pod.go
+++ b/gangplank/cmd/pod.go
@@ -35,6 +35,9 @@ var (
 
 	// cosaSrvDir is used as the scratch directory builds.
 	cosaSrvDir string
+
+	// cosaSrcDir is a source directory that is tarballed to be used by unbounded pods
+	cosaSrcDir string
 )
 
 func init() {
@@ -44,6 +47,7 @@ func init() {
 	cmdPod.Flags().StringVarP(&cosaOverrideImage, "image", "i", "", "use an alternative image")
 	cmdPod.Flags().StringVarP(&cosaWorkDir, "workDir", "w", "", "podman mode - workdir to use")
 	cmdPod.Flags().StringVarP(&cosaSrvDir, "srvDir", "S", "", "podman mode - directory to mount as /srv")
+	cmdPod.Flags().StringVarP(&cosaSrcDir, "cosaSrcDir", "d", "", "directory to tarball to use as build source in /srv")
 	cmdPod.Flags().StringVarP(&serviceAccount, "serviceaccount", "a", "", "service account to use")
 }
 
@@ -68,7 +72,7 @@ func runPod(c *cobra.Command, args []string) {
 
 	clusterCtx := ocp.NewClusterContext(ctx, cluster)
 
-	pb, err := ocp.NewPodBuilder(clusterCtx, cosaOverrideImage, serviceAccount, specFile, cosaWorkDir)
+	pb, err := ocp.NewPodBuilder(clusterCtx, cosaOverrideImage, serviceAccount, specFile, cosaWorkDir, cosaSrcDir)
 	if err != nil {
 		log.Fatalf("failed to define builder pod: %v", err)
 	}

--- a/gangplank/cosa/build.go
+++ b/gangplank/cosa/build.go
@@ -96,7 +96,7 @@ func buildParser(r io.Reader) (*Build, error) {
 	return cosaBuild, nil
 }
 
-// ParseBuild parses the meta.json and reutrns a build
+// ParseBuild parses the meta.json and returns a build
 func ParseBuild(path string) (*Build, error) {
 	f, err := os.Open(path)
 	if err != nil {

--- a/gangplank/ocp/bc.go
+++ b/gangplank/ocp/bc.go
@@ -23,6 +23,7 @@ import (
 	"github.com/coreos/gangplank/spec"
 	buildapiv1 "github.com/openshift/api/build/v1"
 	log "github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
 )
 
 var (
@@ -207,7 +208,7 @@ binary build interface.`)
 	c := 0
 	for _, s := range bc.JobSpec.Stages {
 		if c == 0 {
-			stageCmdIDs[0] = []string{s.ID}
+			stageCmdIDs[0] = append(stageCmdIDs[0], s.ID)
 			continue
 		}
 		if s.OwnPod && len(stageCmdIDs[c]) != 0 {
@@ -291,6 +292,9 @@ binary build interface.`)
 		if err != nil {
 			return err
 		}
+
+		// Add the buildid to the env vars to be used in the publication
+		eVars = append(eVars, v1.EnvVar{Name: "COSA_BUILD", Value: buildID})
 
 		index := n + 1
 		cpod, err := NewCosaPodder(ctx, apiBuild, index)

--- a/gangplank/ocp/cosa-pod.go
+++ b/gangplank/ocp/cosa-pod.go
@@ -321,9 +321,6 @@ func clusterRunner(ctx ClusterContext, cp *cosaPod, envVars []v1.EnvVar) error {
 				"status":  resp.Status.Phase,
 			})
 			switch sp := status.Phase; sp {
-			case v1.PodSucceeded:
-				l.Infof("Pod successfully completed")
-				return nil
 			case v1.PodRunning:
 				l.Infof("Pod successfully completed")
 				for _, c := range pod.Spec.InitContainers {
@@ -338,6 +335,9 @@ func clusterRunner(ctx ClusterContext, cp *cosaPod, envVars []v1.EnvVar) error {
 						l.WithField("err", err).Error("failed to open logging")
 					}
 				}
+			case v1.PodSucceeded:
+				l.Infof("Pod successfully completed")
+				return nil
 			case v1.PodFailed:
 				l.WithField("message", status.Message).Error("Pod failed")
 				time.Sleep(1 * time.Minute)

--- a/gangplank/ocp/filer.go
+++ b/gangplank/ocp/filer.go
@@ -216,6 +216,27 @@ func (m *minioServer) ensureBucketExists(ctx context.Context, bucket string) err
 	return nil
 }
 
+func (m *minioServer) deleteBucket(ctx context.Context, bucket string) error {
+	mc, err := m.client()
+	if err != nil {
+		return err
+	}
+
+	be, err := mc.BucketExists(ctx, bucket)
+	if err != nil {
+		return err
+	}
+
+	if !be {
+		return nil
+	}
+
+	if err := mc.RemoveBucket(ctx, bucket); err != nil {
+		return fmt.Errorf("Failed to remove bucket: %w", err)
+	}
+	return nil
+}
+
 // fetcher retrieves an object from a Minio server
 func (m *minioServer) fetcher(ctx context.Context, bucket, object string, dest io.Writer) error {
 	if m.Host == "" {

--- a/gangplank/ocp/pod.go
+++ b/gangplank/ocp/pod.go
@@ -50,6 +50,7 @@ type podBuild struct {
 	projectNamespace string
 	serviceAccount   string
 	workDir          string
+	srcDir           string
 }
 
 // PodBuilder is the manual/unbounded Build interface.
@@ -78,7 +79,7 @@ func (pb *podBuild) Exec(ctx ClusterContext) error {
 }
 
 // NewPodBuilder returns a ClusterPodBuilder ready for execution.
-func NewPodBuilder(ctx ClusterContext, image, serviceAccount, jsF, workDir string) (PodBuilder, error) {
+func NewPodBuilder(ctx ClusterContext, image, serviceAccount, jsF, workDir, srcDir string) (PodBuilder, error) {
 	// Directly inject the jobspec
 	js, err := spec.JobSpecFromFile(jsF)
 	if jsF != "" && err != nil {
@@ -95,6 +96,7 @@ func NewPodBuilder(ctx ClusterContext, image, serviceAccount, jsF, workDir strin
 		js:             &js,
 		serviceAccount: serviceAccount,
 		workDir:        workDir,
+		srcDir:         srcDir,
 	}
 
 	if err := pb.setInCluster(); err != nil {
@@ -118,6 +120,7 @@ func NewPodBuilder(ctx ClusterContext, image, serviceAccount, jsF, workDir strin
 	}
 	bc.JobSpec = js
 	bc.JobSpecFile = jsF
+	bc.SrvDir = srcDir
 
 	pb.bc = bc
 	return pb, nil

--- a/gangplank/ocp/worker.go
+++ b/gangplank/ocp/worker.go
@@ -189,6 +189,7 @@ func (ws *workSpec) Exec(ctx ClusterContext) error {
 	for _, s := range ws.ExecuteStages {
 		log.Infof("Executing Stage: %s", s)
 		stage, err := ws.JobSpec.GetStage(s)
+
 		log.Infof("Stage commands: %v", stage.Commands)
 		if err != nil {
 			e = err

--- a/gangplank/spec/jobspec.go
+++ b/gangplank/spec/jobspec.go
@@ -47,9 +47,10 @@ type Artifacts struct {
 // Aliyun is nested under CloudsCfgs and describes where
 // the Aliyun/Alibaba artifacts should be uploaded to.
 type Aliyun struct {
-	Bucket  string   `yaml:"bucket,omitempty"`
-	Enabled bool     `yaml:"enabled,omitempty"`
-	Regions []string `yaml:"regions,omitempty"`
+	Bucket    string   `yaml:"bucket,omitempty"`
+	Enabled   bool     `yaml:"enabled,omitempty" envVar:"ALIYUN_ENABLED"`
+	Regions   []string `yaml:"regions,omitempty" envVar:"ALIYUN_REGIONS"`
+	ExtraArgs string   `yaml:"extra_args" envVar:"ALIYUN_EXTRA_ARGS"`
 }
 
 // Archives describes the location of artifacts to push to
@@ -65,10 +66,11 @@ type Archives struct {
 //  Public: when true, mark as public
 //  Regions: name of AWS regions to push to.
 type Aws struct {
-	Enabled bool     `yaml:"enabled,omitempty"`
-	AmiPath string   `yaml:"ami_path,omitempty"`
-	Public  bool     `yaml:"public,omitempty"`
-	Regions []string `yaml:"regions,omitempty"`
+	Enabled   bool     `yaml:"enabled,omitempty"`
+	AmiPath   string   `yaml:"ami_path,omitempty" envVar:"AWS_AMI_PATH"`
+	Public    bool     `yaml:"public,omitempty" envVar:"AWS_PUBLIC"`
+	Regions   []string `yaml:"regions,omitempty" envVar:"AWS_REGIONS"`
+	ExtraArgs string   `yaml:"extra_args" envVar:"AWS_EXTRA_ARGS"`
 }
 
 // Azure describes upload options for Azure images.
@@ -79,10 +81,11 @@ type Aws struct {
 //   StorageLocation: name of the Azure region, i.e. us-east-1
 type Azure struct {
 	Enabled          bool   `yaml:"enabled,omitempty"`
-	ResourceGroup    string `yaml:"resource_group,omitempty"`
-	StorageAccount   string `yaml:"storage_account,omitempty"`
-	StorageContainer string `yaml:"storage_container,omitempty"`
-	StorageLocation  string `yaml:"storage_location,omitempty"`
+	ResourceGroup    string `yaml:"resource_group,omitempty" envVar:"AZURE_RESOURCE_GROUP"`
+	StorageAccount   string `yaml:"storage_account,omitempty" envVar:"AZURE_STORAGE_ACCOUNT"`
+	StorageContainer string `yaml:"storage_container,omitempty" envVar:"AZURE_STORAGE_CONTAINER"`
+	StorageLocation  string `yaml:"storage_location,omitempty" envVar:"AZURE_STORAGE_LOCATION"`
+	ExtraArgs        string `yaml:"extra_args" envVar:"AZURE_EXTRA_ARGS"`
 }
 
 // Brew is the RHEL Koji instance for storing artifacts.
@@ -110,9 +113,10 @@ type CloudsCfgs struct {
 //   Enabled: when true, publish to GCP
 //   Project: name of the GCP project to use
 type Gcp struct {
-	Bucket  string `yaml:"bucket,omitempty"`
-	Enabled bool   `yaml:"enabled,omitempty"`
-	Project string `yaml:"project,omitempty"`
+	Bucket    string `yaml:"bucket,omitempty" envVar:"GCP_BUCKET"`
+	Enabled   bool   `yaml:"enabled,omitempty`
+	Project   string `yaml:"project,omitempty" envVar:"GCP_PROJECT"`
+	ExtraArgs string `yaml:"extra_args" envVar:"GCP_EXTRA_ARGS"`
 }
 
 // Job refers to the Jenkins options

--- a/gangplank/spec/jobspec.go
+++ b/gangplank/spec/jobspec.go
@@ -22,7 +22,6 @@ import (
 // JobSpec is the root-level item for the JobSpec.
 type JobSpec struct {
 	Archives    Archives    `yaml:"archives,omitempty"`
-	CloudsCfgs  CloudsCfgs  `yaml:"clouds_cfgs,omitempty"`
 	Job         Job         `yaml:"job,omitempty"`
 	Oscontainer Oscontainer `yaml:"oscontainer,omitempty"`
 	Recipe      Recipe      `yaml:"recipe,omitempty"`
@@ -46,11 +45,14 @@ type Artifacts struct {
 
 // Aliyun is nested under CloudsCfgs and describes where
 // the Aliyun/Alibaba artifacts should be uploaded to.
+//   Bucket: name of Aliyun bucket to store image in
+//   Enabled: when true, publish to GCP
+//   Regions: name of Aliyun regions to push to.
 type Aliyun struct {
-	Bucket    string   `yaml:"bucket,omitempty"`
-	Enabled   bool     `yaml:"enabled,omitempty" envVar:"ALIYUN_ENABLED"`
-	Regions   []string `yaml:"regions,omitempty" envVar:"ALIYUN_REGIONS"`
-	ExtraArgs string   `yaml:"extra_args" envVar:"ALIYUN_EXTRA_ARGS"`
+	// Commented fields are common fields and found in PublishArtifact struct
+	// Bucket    string   `yaml:"bucket,omitempty"`
+	// Enabled   bool     `yaml:"enabled,omitempty" envVar:"ENABLED"`
+	// Regions   []string `yaml:"regions,omitempty" envVar:"REGIONS"`
 }
 
 // Archives describes the location of artifacts to push to
@@ -66,26 +68,26 @@ type Archives struct {
 //  Public: when true, mark as public
 //  Regions: name of AWS regions to push to.
 type Aws struct {
-	Enabled   bool     `yaml:"enabled,omitempty"`
-	AmiPath   string   `yaml:"ami_path,omitempty" envVar:"AWS_AMI_PATH"`
-	Public    bool     `yaml:"public,omitempty" envVar:"AWS_PUBLIC"`
-	Regions   []string `yaml:"regions,omitempty" envVar:"AWS_REGIONS"`
-	ExtraArgs string   `yaml:"extra_args" envVar:"AWS_EXTRA_ARGS"`
+	// Commented fields are common fields and found in PublishArtifact struct
+	// Enabled bool     `yaml:"enabled,omitempty" envVar:"ENABLED"`
+	// Regions []string `yaml:"regions,omitempty" envVar:"REGIONS"`
+	AmiPath string `yaml:"ami_path,omitempty" envVar:"AMI_PATH"`
+	Public  bool   `yaml:"public,omitempty" envVar:"PUBLIC"`
 }
 
 // Azure describes upload options for Azure images.
-//   Enabled: upload if true
+//   Enabled: upload if true (common see)
 //   ResourceGroup: the name of the Azure resource group
 //   StorageAccount: name of the storage account
 //   StorageContainer: name of the storage container
 //   StorageLocation: name of the Azure region, i.e. us-east-1
 type Azure struct {
-	Enabled          bool   `yaml:"enabled,omitempty"`
-	ResourceGroup    string `yaml:"resource_group,omitempty" envVar:"AZURE_RESOURCE_GROUP"`
-	StorageAccount   string `yaml:"storage_account,omitempty" envVar:"AZURE_STORAGE_ACCOUNT"`
-	StorageContainer string `yaml:"storage_container,omitempty" envVar:"AZURE_STORAGE_CONTAINER"`
-	StorageLocation  string `yaml:"storage_location,omitempty" envVar:"AZURE_STORAGE_LOCATION"`
-	ExtraArgs        string `yaml:"extra_args" envVar:"AZURE_EXTRA_ARGS"`
+	// Commented fields are common fields and found in PublishArtifact struct
+	// Enabled          bool   `yaml:"enabled,omitempty" envVar:"ENABLED"`
+	ResourceGroup    string `yaml:"resource_group,omitempty" envVar:"RESOURCE_GROUP"`
+	StorageAccount   string `yaml:"storage_account,omitempty" envVar:"STORAGE_ACCOUNT"`
+	StorageContainer string `yaml:"storage_container,omitempty" envVar:"STORAGE_CONTAINER"`
+	StorageLocation  string `yaml:"storage_location,omitempty" envVar:"STORAGE_LOCATION"`
 }
 
 // Brew is the RHEL Koji instance for storing artifacts.
@@ -99,24 +101,15 @@ type Brew struct {
 	Tag       string `yaml:"tag,omitempty"`
 }
 
-// CloudsCfgs (yes Clouds) is a nested struct of all
-// supported cloudClonfigurations.
-type CloudsCfgs struct {
-	Aliyun Aliyun `yaml:"aliyun,omitempty"`
-	Aws    Aws    `yaml:"aws,omitempty"`
-	Azure  Azure  `yaml:"azure,omitempty"`
-	Gcp    Gcp    `yaml:"gcp,omitempty"`
-}
-
-// Gcp describes deploiying to the GCP environment
+// Gcp describes deploying to the GCP environment
 //   Bucket: name of GCP bucket to store image in
 //   Enabled: when true, publish to GCP
 //   Project: name of the GCP project to use
 type Gcp struct {
-	Bucket    string `yaml:"bucket,omitempty" envVar:"GCP_BUCKET"`
-	Enabled   bool   `yaml:"enabled,omitempty`
-	Project   string `yaml:"project,omitempty" envVar:"GCP_PROJECT"`
-	ExtraArgs string `yaml:"extra_args" envVar:"GCP_EXTRA_ARGS"`
+	// Commented fields are common fields and found in PublishArtifact struct
+	// Bucket    string `yaml:"bucket,omitempty" envVar:"BUCKET"`
+	// Enabled   bool   `yaml:"enabled,omitempty envVar:"ENABLED"`
+	Project string `yaml:"project,omitempty" envVar:"PROJECT"`
 }
 
 // Job refers to the Jenkins options

--- a/gangplank/spec/jobspec.go
+++ b/gangplank/spec/jobspec.go
@@ -86,8 +86,8 @@ type Azure struct {
 	// Enabled          bool   `yaml:"enabled,omitempty" envVar:"ENABLED"`
 	ResourceGroup    string `yaml:"resource_group,omitempty" envVar:"RESOURCE_GROUP"`
 	StorageAccount   string `yaml:"storage_account,omitempty" envVar:"STORAGE_ACCOUNT"`
-	StorageContainer string `yaml:"storage_container,omitempty" envVar:"STORAGE_CONTAINER"`
-	StorageLocation  string `yaml:"storage_location,omitempty" envVar:"STORAGE_LOCATION"`
+	StorageContainer string `yaml:"storage_container,omitempty" envVar:"CONTAINER"`
+	StorageLocation  string `yaml:"storage_location,omitempty" envVar:"LOCATION"`
 }
 
 // Brew is the RHEL Koji instance for storing artifacts.
@@ -109,7 +109,7 @@ type Gcp struct {
 	// Commented fields are common fields and found in PublishArtifact struct
 	// Bucket    string `yaml:"bucket,omitempty" envVar:"BUCKET"`
 	// Enabled   bool   `yaml:"enabled,omitempty envVar:"ENABLED"`
-	Project string `yaml:"project,omitempty" envVar:"PROJECT"`
+	Project string `yaml:"project,omitempty" envVar:"PROJECT_NAME"`
 }
 
 // Job refers to the Jenkins options

--- a/gangplank/spec/publication.go
+++ b/gangplank/spec/publication.go
@@ -1,0 +1,60 @@
+package spec
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+// PublishArtifact describes a cloud artifact that will
+// be pushed to the cloud.
+type PublishArtifact struct {
+	// Variable names that occur in more than one cloud struct must be declared
+	// here because the inline will cause a panic when unmarshalling
+
+	// Common to all clouds
+	Name      string `yaml:"cloud"`
+	Enabled   bool   `yaml:"enabled" envVar:"ENABLED"`
+	ExtraArgs string `yaml:"extra_args,omitempty" envVar:"EXTRA_ARGS"`
+
+	// Cloud specific
+	Aliyun Aliyun `yaml:",inline"`
+	Aws    Aws    `yaml:",inline"`
+	Azure  Azure  `yaml:",inline"`
+	Gcp    Gcp    `yaml:",inline"`
+
+	// Common to Gcp, Aws, and Aliyun
+	Bucket  string   `yaml:"bucket,omitempty" envVar:"BUCKET"`
+	Regions []string `yaml:"regions,omitempty" enVar:"REGIONS"`
+}
+
+// GetEnvVars returns envVars
+func (p *PublishArtifact) GetEnvVars() (envVars []string) {
+	var getNestedEnvTags func(interface{})
+
+	getNestedEnvTags = func(i interface{}) {
+		typ := reflect.TypeOf(i)
+		val := reflect.ValueOf(i)
+		if typ.Kind() == reflect.Struct {
+			for j := 0; j < typ.NumField(); j++ {
+				field := typ.Field(j)
+				fieldValue := val.Field(j)
+				if field.Type.Kind() == reflect.Struct {
+					getNestedEnvTags(fieldValue.Interface())
+				} else {
+					tag := field.Tag.Get("envVar")
+					if tag == "" {
+						continue
+					}
+					if !val.Field(j).IsZero() {
+						envVars = append(envVars, fmt.Sprintf("COSA_%s_%s=%v", strings.ToUpper(p.Name), tag, fieldValue.Interface()))
+					}
+				}
+			}
+		}
+	}
+
+	getNestedEnvTags(*p)
+
+	return envVars
+}

--- a/gangplank/spec/stages.go
+++ b/gangplank/spec/stages.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -75,16 +74,7 @@ type Stage struct {
 	PostAlways bool `yaml:"post_always"`
 
 	// Publication
-	PublishArtifacts PublishArtifact `yaml:"publish_artifacts,flow"`
-}
-
-// PublishArtifact describes a cloud artifact that will
-// be pushed to the cloud
-type PublishArtifact struct {
-	Aliyun Aliyun `yaml:"aliyun,omitempty"`
-	Aws    Aws    `yaml:"aws,omitempty"`
-	Azure  Azure  `yaml:"azure,omitempty"`
-	Gcp    Gcp    `yaml:"gcp,omitempty"`
+	PublishArtifacts []*PublishArtifact `yaml:"publish_artifacts,flow"`
 }
 
 // cosaBuildCmds checks if b is a buildable artifact type and then
@@ -120,38 +110,8 @@ func (s *Stage) getCommands() ([]string, error) {
 	return ret, nil
 }
 
-func (s *Stage) getPublishArtifacts() PublishArtifact {
+func (s *Stage) getPublishArtifacts() []*PublishArtifact {
 	return s.PublishArtifacts
-}
-
-func (s *Stage) getPublishArtifactEnvVars() []string {
-	var envVars []string
-	var deeper func(i interface{})
-
-	deeper = func(i interface{}) {
-		typ := reflect.TypeOf(i)
-		val := reflect.ValueOf(i)
-
-		if typ.Kind() == reflect.Struct {
-			for j := 0; j < typ.NumField(); j++ {
-				if typ.Field(j).Type.Kind() == reflect.Struct {
-					deeper(val.Field(j).Interface())
-				} else {
-					log.Info("name: ", typ.Field(j).Name)
-					log.Info("val: ", val.Field(j))
-					tag := typ.Field(j).Tag.Get("envVar")
-					if tag == "" {
-						continue
-					}
-					envVars = append(envVars, fmt.Sprintf("%s=%s", tag, val.Field(j)))
-
-				}
-			}
-		}
-	}
-
-	deeper(s.getPublishArtifacts())
-	return envVars
 }
 
 // Execute runs the commands of a stage.
@@ -178,7 +138,11 @@ func (s *Stage) Execute(ctx context.Context, js *JobSpec, envVars []string) erro
 		return err
 	}
 	defer os.RemoveAll(tmpd)
-	envVars = append(envVars, s.getPublishArtifactEnvVars()...)
+
+	publishArtifacts := s.getPublishArtifacts()
+	for _, pa := range publishArtifacts {
+		envVars = append(envVars, pa.GetEnvVars()...)
+	}
 
 	// Render the pre and post scripts.
 	prepScript := filepath.Join(tmpd, "prep.sh")

--- a/src/cosalib/aliyun.py
+++ b/src/cosalib/aliyun.py
@@ -130,6 +130,13 @@ def aliyun_run_ore(build, args):
 
 
 def aliyun_cli(parser):
-    parser.add_argument("--bucket", help="OSS Bucket")
-    parser.add_argument("--name-suffix", help="Suffix for uploaded image name")
+    parser.add_argument(
+        "--bucket",
+        env_var="ALIYUN_BUCKET",
+        help="OSS Bucket"
+    )
+    parser.add_argument(
+        "--name-suffix",
+        help="Suffix for uploaded image name"
+    )
     return parser

--- a/src/cosalib/aws.py
+++ b/src/cosalib/aws.py
@@ -152,10 +152,25 @@ def aws_run_ore(build, args):
 
 
 def aws_cli(parser):
-    parser.add_argument("--bucket", help="S3 Bucket")
-    parser.add_argument("--name-suffix", help="Suffix for name")
-    parser.add_argument("--grant-user", help="Grant user launch permission",
-                        nargs="*", default=[])
-    parser.add_argument("--grant-user-snapshot", help="Grant user snapshot volume permission",
-                        nargs="*", default=[])
+    parser.add_argument(
+        "--bucket",
+        env_var="AWS_BUCKET",
+        help="S3 Bucket"
+    )
+    parser.add_argument(
+        "--name-suffix",
+        help="Suffix for name"
+    )
+    parser.add_argument(
+        "--grant-user",
+        help="Grant user launch permission",
+        nargs="*",
+        default=[]
+    )
+    parser.add_argument(
+        "--grant-user-snapshot",
+        help="Grant user snapshot volume permission",
+        nargs="*",
+        default=[]
+    )
     return parser

--- a/src/cosalib/azure.py
+++ b/src/cosalib/azure.py
@@ -79,7 +79,8 @@ def azure_cli(parser):
     parser.add_argument(
         '--auth',
         help='Path to Azure auth file',
-        default=os.environ.get("AZURE_AUTH"))
+        default=os.environ.get("AZURE_AUTH")
+    )
     parser.add_argument(
         '--container',
         help='Storage location to write to',


### PR DESCRIPTION
This is a rough PR that contains two features.  The first feature is the ability to tarball a directory to be used in a build in unbounded pod mode (use case is the same as passing `--dir=` when starting a buildconfig.  The second feature is enabling publication of cloud artifacts to the various cloud providers.