### PR TITLE
Gangplank: make podman mode errors fatal

### DIFF
--- a/gangplank/ocp/bc.go
+++ b/gangplank/ocp/bc.go
@@ -289,6 +289,9 @@ binary build interface.`)
 				// Include any *json file
 				jsonPath := filepath.Join(cosaSrvDir, "builds", buildPath)
 				_ = filepath.Walk(jsonPath, func(path string, info os.FileInfo, err error) error {
+					if info == nil {
+						return nil
+					}
 					n := filepath.Base(info.Name())
 					if !(strings.HasPrefix(n, "meta") && strings.HasSuffix(n, ".json")) {
 						log.WithField("file", n).Warning("excluded")

--- a/gangplank/ocp/cosa-pod.go
+++ b/gangplank/ocp/cosa-pod.go
@@ -646,5 +646,14 @@ func podmanRunner(ctx ClusterContext, cp *cosaPod, envVars []v1.EnvVar) error {
 		"stdErr": stdErr.Name(),
 	}).Info("binding stdio to continater")
 	resize := make(chan remotecommand.TerminalSize)
-	return lb.Attach(streams, "", resize)
+
+	go func() {
+		_ = lb.Attach(streams, "", resize)
+	}()
+
+	rc, err := lb.Wait()
+	if rc != 0 {
+		return errors.New("work pod failed")
+	}
+	return nil
 }


### PR DESCRIPTION
This prevents Podman mode from swallowing errors and continuing execution. 