### PR TITLE
kola: turn --no-default-checks into --allow-default-checks-failures

### DIFF
--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -63,7 +63,7 @@ func init() {
 	bv(&kola.NoNet, "no-net", false, "Don't run tests that require an Internet connection")
 	ssv(&kola.Tags, "tag", []string{}, "Test tag to run. Can be specified multiple times.")
 	bv(&kola.Options.SSHOnTestFailure, "ssh-on-test-failure", false, "SSH into a machine when tests fail")
-	bv(&kola.Options.SuppressDefaultChecks, "no-default-checks", false, "Disable default checks for failed systemd units and SELinux AVC denials")
+	bv(&kola.Options.AllowDefaultChecksFailures, "allow-default-checks-failures", false, "Checks for failed systemd units and SELinux AVC denials but don't fail on them")
 	sv(&kola.Options.Stream, "stream", "", "CoreOS stream ID (e.g. for Fedora CoreOS: stable, testing, next)")
 	sv(&kola.Options.CosaWorkdir, "workdir", "", "coreos-assembler working directory")
 	sv(&kola.Options.CosaBuildId, "build", "", "coreos-assembler build ID")

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -885,7 +885,7 @@ func getClusterSemver(flight platform.Flight, outputDir string) (*semver.Version
 
 	cfg := &platform.RuntimeConfig{
 		OutputDir:        testDir,
-		AllowFailedUnits: Options.SuppressDefaultChecks,
+		AllowFailedUnits: Options.AllowDefaultChecksFailures,
 	}
 
 	cluster, err := flight.NewCluster(cfg)

--- a/mantle/platform/platform.go
+++ b/mantle/platform/platform.go
@@ -185,8 +185,8 @@ type Options struct {
 	// inside of RenderUserData
 	OSContainer string
 
-	SSHOnTestFailure      bool
-	SuppressDefaultChecks bool
+	SSHOnTestFailure           bool
+	AllowDefaultChecksFailures bool
 }
 
 // RuntimeConfig contains cluster-specific configuration.
@@ -436,27 +436,47 @@ func CheckMachine(ctx context.Context, m Machine) error {
 		return fmt.Errorf("not a supported instance: %v", string(out))
 	}
 
-	if !m.RuntimeConf().AllowFailedUnits {
-		// ensure no systemd units failed during boot
-		out, stderr, err = m.SSH("systemctl --no-legend --state failed list-units")
-		if err != nil {
-			return fmt.Errorf("systemctl: %s: %v: %s", out, err, stderr)
+	err = checkFailedSystemdUnits(ctx, m)
+	if err != nil {
+		if !m.RuntimeConf().AllowFailedUnits {
+			return err
 		}
-		if len(out) > 0 {
-			return fmt.Errorf("some systemd units failed:\n%s", out)
+		plog.Error(err)
+	}
+
+	err = checkSelinuxDenials(ctx, m)
+	if err != nil {
+		if !m.RuntimeConf().AllowFailedUnits {
+			return err
 		}
-		// Also no SELinux denials; RHCOS currently ships auditd, FCOS doesn't, so handle
-		// both places.
-		out, stderr, err = m.SSH("if test -f /var/log/audit/audit.log; then grep 'avc.*denied' /var/log/audit/audit.log || true; else journalctl -q --no-pager --grep='avc.*denied' _TRANSPORT=audit || true; fi")
-		if err != nil {
-			return fmt.Errorf("failed to query audit logs: %s: %v: %s", out, err, stderr)
-		}
-		if len(out) > 0 {
-			return fmt.Errorf("Found SELinux AVC denials:\n%s", out)
-		}
+		plog.Error(err)
 	}
 
 	return ctx.Err()
+}
+
+func checkFailedSystemdUnits(ctx context.Context, m Machine) error {
+	// ensure no systemd units failed during boot
+	out, stderr, err := m.SSH("systemctl --no-legend --state failed list-units")
+	if err != nil {
+		return fmt.Errorf("systemctl: %s: %v: %s", out, err, stderr)
+	}
+	if len(out) > 0 {
+		return fmt.Errorf("some systemd units failed:\n%s", out)
+	}
+	return nil
+}
+
+func checkSelinuxDenials(ctx context.Context, m Machine) error {
+	// RHCOS currently ships auditd, FCOS doesn't, so handle both places.
+	out, stderr, err := m.SSH("if test -f /var/log/audit/audit.log; then grep 'avc.*denied' /var/log/audit/audit.log || true; else journalctl -q --no-pager --grep='avc.*denied' _TRANSPORT=audit || true; fi")
+	if err != nil {
+		return fmt.Errorf("failed to query audit logs: %s: %v: %s", out, err, stderr)
+	}
+	if len(out) > 0 {
+		return fmt.Errorf("Found SELinux AVC denials:\n%s", out)
+	}
+	return nil
 }
 
 type machineInfo struct {


### PR DESCRIPTION
This switch is still new, so let's just rename it without providing an
alias. The end goal is the same (to allow not failing on broken systemd
units and SELinux violations), but the difference is that we still do
the checks and just log it if failures are found.

This allows humans looking at the logs to verify that only what they
expected to fail actually failed. (For CI/pipelines, long-term I think
we should instead teach kola how to allow only specific failures through
via `kola-denylist.yaml`.)