### PR TITLE
Revert "mantle: Check for SELinux AVCs just like systemd failed units"

### DIFF
--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -63,7 +63,6 @@ func init() {
 	bv(&kola.NoNet, "no-net", false, "Don't run tests that require an Internet connection")
 	ssv(&kola.Tags, "tag", []string{}, "Test tag to run. Can be specified multiple times.")
 	bv(&kola.Options.SSHOnTestFailure, "ssh-on-test-failure", false, "SSH into a machine when tests fail")
-	bv(&kola.Options.SuppressDefaultChecks, "no-default-checks", false, "Disable default checks for failed systemd units and SELinux AVC denials")
 	sv(&kola.Options.Stream, "stream", "", "CoreOS stream ID (e.g. for Fedora CoreOS: stable, testing, next)")
 	sv(&kola.Options.CosaWorkdir, "workdir", "", "coreos-assembler working directory")
 	sv(&kola.Options.CosaBuildId, "build", "", "coreos-assembler build ID")

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -883,12 +883,9 @@ func getClusterSemver(flight platform.Flight, outputDir string) (*semver.Version
 		return nil, err
 	}
 
-	cfg := &platform.RuntimeConfig{
-		OutputDir:        testDir,
-		AllowFailedUnits: Options.SuppressDefaultChecks,
-	}
-
-	cluster, err := flight.NewCluster(cfg)
+	cluster, err := flight.NewCluster(&platform.RuntimeConfig{
+		OutputDir: testDir,
+	})
 	if err != nil {
 		return nil, errors.Wrapf(err, "creating cluster for semver check")
 	}

--- a/mantle/platform/platform.go
+++ b/mantle/platform/platform.go
@@ -185,8 +185,7 @@ type Options struct {
 	// inside of RenderUserData
 	OSContainer string
 
-	SSHOnTestFailure      bool
-	SuppressDefaultChecks bool
+	SSHOnTestFailure bool
 }
 
 // RuntimeConfig contains cluster-specific configuration.

--- a/mantle/platform/platform.go
+++ b/mantle/platform/platform.go
@@ -445,15 +445,6 @@ func CheckMachine(ctx context.Context, m Machine) error {
 		if len(out) > 0 {
 			return fmt.Errorf("some systemd units failed:\n%s", out)
 		}
-		// Also no SELinux denials; RHCOS currently ships auditd, FCOS doesn't, so handle
-		// both places.
-		out, stderr, err = m.SSH("if test -f /var/log/audit/audit.log; then grep 'avc.*denied' /var/log/audit/audit.log || true; else journalctl -q --no-pager --grep='avc.*denied' _TRANSPORT=audit || true; fi")
-		if err != nil {
-			return fmt.Errorf("failed to query audit logs: %s: %v: %s", out, err, stderr)
-		}
-		if len(out) > 0 {
-			return fmt.Errorf("Found SELinux AVC denials:\n%s", out)
-		}
 	}
 
 	return ctx.Err()


### PR DESCRIPTION
This reverts commit fe010b25a5ec4f4e16999e926f90b4995e8525eb.

This is causing us a lot of pain because there isn't a way to override
failures.

We'll re-add it once we have that ability.