### PR TITLE
Use coreos-ci-lib to run parallel commands

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -27,10 +27,8 @@ pod(image: imageName + ":latest", kvm: true, memory: "10Gi") {
     fcosKolaTestIso(cosaDir: "/srv", extraArgs4k: "--no-pxe")
 
     stage("Build Cloud Images") {
-        def clouds = ["Aliyun", "AWS", "Azure", "DigitalOcean", "Exoscale", "GCP", "IBMCloud", "OpenStack", "VMware", "Vultr"]
-        parallel clouds.inject([:]) { d, i -> d[i] = {
-            cosa_cmd("buildextend-${i.toLowerCase()}")
-        }; d }
+        cosaParallelCmds(cosaDir: "/srv", commands: ["Aliyun", "AWS", "Azure", "DigitalOcean", "Exoscale", "GCP",
+                                                     "IBMCloud", "OpenStack", "VMware", "Vultr"])
 
         // quick schema validation
         utils.cosaCmd(cosaDir: "/srv", args: "meta --get name")


### PR DESCRIPTION
 - Use coreos-ci-lib to eliminate code duplicity across the CIs

Signed-off-by: Renata Ravanelli <rravanel@redhat.com>