### PR TITLE
Gangplank: Allow access in template to JobSpec and meta.json

### DIFF
--- a/gangplank/cmd/main.go
+++ b/gangplank/cmd/main.go
@@ -107,7 +107,10 @@ func main() {
 
 // runScripts reads ARGs as files and executes the rendered templates.
 func runScripts(c *cobra.Command, args []string) error {
-	if err := spec.RendererExecuter(ctx, envVars, args...); err != nil {
+	rd := &jobspec.RenderData{
+		JobSpec: &spec,
+	}
+	if err := rd.RendererExecuter(ctx, envVars, args...); err != nil {
 		log.Fatalf("Failed to execute scripts: %v", err)
 	}
 	log.Infof("Execution complete")
@@ -116,7 +119,10 @@ func runScripts(c *cobra.Command, args []string) error {
 
 // runSingle renders args as templates and executes the command.
 func runSingle(c *cobra.Command, args []string) {
-	x, err := spec.ExecuteTemplateFromString(args...)
+	rd := &jobspec.RenderData{
+		JobSpec: &spec,
+	}
+	x, err := rd.ExecuteTemplateFromString(args...)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/gangplank/ocp/worker.go
+++ b/gangplank/ocp/worker.go
@@ -182,6 +182,13 @@ func (ws *workSpec) Exec(ctx ClusterContext) error {
 		}
 	}()
 
+	// Expose the jobspec and meta.json (if its available) for templating.
+	mBuild, _, _ := cosa.ReadBuild(cosaSrvDir, "", cosa.BuilderArch())
+	rd := &spec.RenderData{
+		JobSpec: &ws.JobSpec,
+		Meta:    mBuild,
+	}
+
 	// Range over the stages and perform the actual work.
 	for _, s := range ws.ExecuteStages {
 		stage, err := ws.JobSpec.GetStage(s)
@@ -197,7 +204,7 @@ func (ws *workSpec) Exec(ctx ClusterContext) error {
 			return err
 		}
 
-		if err := stage.Execute(ctx, &ws.JobSpec, envVars); err != nil {
+		if err := stage.Execute(ctx, rd, envVars); err != nil {
 			log.WithError(err).Error("failed stage execution")
 			return err
 		}

--- a/gangplank/spec/render_test.go
+++ b/gangplank/spec/render_test.go
@@ -54,28 +54,28 @@ func wantedGot(want, got interface{}, t *testing.T) {
 }
 
 func TestJobSpec(t *testing.T) {
-	var js JobSpec
+	rd := new(RenderData)
 
-	if err := yaml.Unmarshal([]byte(MockOSJobSpec), &js); err != nil {
+	if err := yaml.Unmarshal([]byte(MockOSJobSpec), &rd.JobSpec); err != nil {
 		t.Errorf("failed to read mock jobspec")
 	}
 
-	wantedGot("mockOS-99", js.Job.BuildName, t)
+	wantedGot("mockOS-99", rd.JobSpec.Job.BuildName, t)
 
 	// Test rendering from a string
-	s, err := js.ExecuteTemplateFromString("good {{ .Job.BuildName }}")
+	s, err := rd.ExecuteTemplateFromString("good {{ .JobSpec.Job.BuildName }}")
 	wantedGot(nil, err, t)
 	wantedGot("good mockOS-99", s[0], t)
 	wantedGot(1, len(s), t)
 
 	// Test rendering for a slice of strings
-	s, err = js.ExecuteTemplateFromString("good", "{{ .Job.BuildName }}")
+	s, err = rd.ExecuteTemplateFromString("good", "{{ .JobSpec.Job.BuildName }}")
 	wantedGot(nil, err, t)
 	wantedGot("mockOS-99", s[1], t)
 	wantedGot(2, len(s), t)
 
 	// Test a failure
-	_, err = js.ExecuteTemplateFromString("this", "wont", "{{ .Work }}")
+	_, err = rd.ExecuteTemplateFromString("this", "wont", "{{ .Work }}")
 	if err == nil {
 		t.Errorf("template should not render")
 	}
@@ -84,11 +84,11 @@ func TestJobSpec(t *testing.T) {
 	f, err := ioutil.TempFile("", "meh")
 	defer os.Remove(f.Name())
 	wantedGot(nil, err, t)
-	err = ioutil.WriteFile(f.Name(), []byte("echo {{ .Job.BuildName }}"), 0444)
+	err = ioutil.WriteFile(f.Name(), []byte("echo {{ .JobSpec.Job.BuildName }}"), 0444)
 	wantedGot(nil, err, t)
 
 	ctx := context.Background()
-	err = js.RendererExecuter(ctx, []string{}, f.Name())
+	err = rd.RendererExecuter(ctx, []string{}, f.Name())
 	wantedGot(nil, err, t)
 
 }


### PR DESCRIPTION
This change extends the templating by using a new struct `RenderData` to hold both the JobSpec and discovered meta.json. The JobSpec fields accessible via `{{.JobSpec.<PATH>}}` and meta.json as `{{.Meta.<PATH>}}`

This change should make the work for creating synthetic publication commands via templates. 

TODO: this lays the foundation for having Gangplank operate on different builds, not just the latest.

Signed-off-by: Ben Howard <ben.howard@redhat.com>