### PR TITLE
Remove cosa_cmd function

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -51,7 +51,3 @@ pod(image: imageName + ":latest", kvm: true, memory: "10Gi") {
         """)
     }
 }
-
-def cosa_cmd(args) {
-    shwrap("cd /srv && sudo -u builder cosa ${args}")
-}


### PR DESCRIPTION
After the refactor done to use coreos-ci-lib we
don't need this anymore.

Signed-off-by: Renata Ravanelli <rravanel@redhat.com>