### PR TITLE
Add support for arch-independent lockfile overrides

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -226,7 +226,7 @@ prepare_git_artifacts "${configdir_gitrepo}" "${PWD}/coreos-assembler-config.tar
 
 extra_compose_args=()
 
-for lock in "${manifest_lock}" "${manifest_lock_overrides}"; do
+for lock in "${manifest_lock}" "${manifest_lock_arch_overrides}"; do
     if [ -f "${lock}" ]; then
         extra_compose_args+=("--ex-lockfile=${lock}")
     fi

--- a/src/cmd-build
+++ b/src/cmd-build
@@ -226,7 +226,7 @@ prepare_git_artifacts "${configdir_gitrepo}" "${PWD}/coreos-assembler-config.tar
 
 extra_compose_args=()
 
-for lock in "${manifest_lock}" "${manifest_lock_arch_overrides}"; do
+for lock in "${manifest_lock}" "${manifest_lock_overrides}" "${manifest_lock_arch_overrides}"; do
     if [ -f "${lock}" ]; then
         extra_compose_args+=("--ex-lockfile=${lock}")
     fi

--- a/src/cmd-fetch
+++ b/src/cmd-fetch
@@ -85,14 +85,16 @@ args=
 if [ -n "${UPDATE_LOCKFILE}" ]; then
     # Put this under tmprepo so it gets automatically chown'ed if needed
     args="--ex-write-lockfile-to=${tmprepo}/tmp/manifest-lock.json"
-    if [ -f "${manifest_lock_arch_overrides}" ]; then
-        # Include the overrides in the resulting lockfile here; otherwise, we
-        # might not even be able to get a depsolve solely from the non-lockfile
-        # repos.
-        args+=" --ex-lockfile=${manifest_lock_arch_overrides}"
-    fi
+    # Include the overrides in the resulting lockfile here; otherwise, we
+    # might not even be able to get a depsolve solely from the non-lockfile
+    # repos.
+    for lock in "${manifest_lock_overrides}" "${manifest_lock_arch_overrides}"; do
+      if [ -f "${lock}" ]; then
+          args+=" --ex-lockfile=${lock}"
+      fi
+    done
 else
-    for lock in "${manifest_lock}" "${manifest_lock_arch_overrides}"; do
+    for lock in "${manifest_lock}" "${manifest_lock_overrides}" "${manifest_lock_arch_overrides}"; do
         if [ -f "${lock}" ]; then
             args+=" --ex-lockfile=${lock}"
         fi

--- a/src/cmd-fetch
+++ b/src/cmd-fetch
@@ -85,14 +85,14 @@ args=
 if [ -n "${UPDATE_LOCKFILE}" ]; then
     # Put this under tmprepo so it gets automatically chown'ed if needed
     args="--ex-write-lockfile-to=${tmprepo}/tmp/manifest-lock.json"
-    if [ -f "${manifest_lock_overrides}" ]; then
+    if [ -f "${manifest_lock_arch_overrides}" ]; then
         # Include the overrides in the resulting lockfile here; otherwise, we
         # might not even be able to get a depsolve solely from the non-lockfile
         # repos.
-        args+=" --ex-lockfile=${manifest_lock_overrides}"
+        args+=" --ex-lockfile=${manifest_lock_arch_overrides}"
     fi
 else
-    for lock in "${manifest_lock}" "${manifest_lock_overrides}"; do
+    for lock in "${manifest_lock}" "${manifest_lock_arch_overrides}"; do
         if [ -f "${lock}" ]; then
             args+=" --ex-lockfile=${lock}"
         fi

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -167,10 +167,10 @@ prepare_build() {
     # for the base lockfile, we default to JSON since that's what rpm-ostree
     # actually outputs
     manifest_lock=$(pick_yaml_or_else_json "${configdir}/manifest-lock.${basearch}" json)
-    manifest_lock_overrides=$(pick_yaml_or_else_json "${configdir}/manifest-lock.overrides.${basearch}")
+    manifest_lock_arch_overrides=$(pick_yaml_or_else_json "${configdir}/manifest-lock.overrides.${basearch}")
     fetch_stamp="${workdir}"/cache/fetched-stamp
 
-    export workdir configdir manifest manifest_lock manifest_lock_overrides
+    export workdir configdir manifest manifest_lock manifest_lock_arch_overrides
     export fetch_stamp
 
     if ! [ -f "${manifest}" ]; then

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -167,10 +167,11 @@ prepare_build() {
     # for the base lockfile, we default to JSON since that's what rpm-ostree
     # actually outputs
     manifest_lock=$(pick_yaml_or_else_json "${configdir}/manifest-lock.${basearch}" json)
+    manifest_lock_overrides=$(pick_yaml_or_else_json "${configdir}/manifest-lock.overrides")
     manifest_lock_arch_overrides=$(pick_yaml_or_else_json "${configdir}/manifest-lock.overrides.${basearch}")
     fetch_stamp="${workdir}"/cache/fetched-stamp
 
-    export workdir configdir manifest manifest_lock manifest_lock_arch_overrides
+    export workdir configdir manifest manifest_lock manifest_lock_overrides manifest_lock_arch_overrides
     export fetch_stamp
 
     if ! [ -f "${manifest}" ]; then


### PR DESCRIPTION
In FCOS, we use "override" lockfiles to pin packages to certain
versions. Right now, we have separate overrides for each base arch we
(eventually want to) support. But that makes maintaining the overrides
cumbersome because of all the duplication.

Now that rpm-ostree supports this, let's make use of it. Add support for
a `manifest-lock.overrides.yaml` arch-independent override file.