### PR TITLE
Gangplank: installation repos via JobSpec or CLI

### DIFF
--- a/gangplank/ocp/cosa-pod.go
+++ b/gangplank/ocp/cosa-pod.go
@@ -651,8 +651,7 @@ func podmanRunner(ctx ClusterContext, cp *cosaPod, envVars []v1.EnvVar) error {
 		_ = lb.Attach(streams, "", resize)
 	}()
 
-	rc, err := lb.Wait()
-	if rc != 0 {
+	if rc, _ := lb.Wait(); rc != 0 {
 		return errors.New("work pod failed")
 	}
 	return nil

--- a/gangplank/ocp/worker.go
+++ b/gangplank/ocp/worker.go
@@ -159,6 +159,18 @@ func (ws *workSpec) Exec(ctx ClusterContext) error {
 		}
 	}
 
+	// Populate `src/config/<name.repo>`
+	for _, r := range ws.JobSpec.Recipe.Repos {
+		path, err := r.Writer(filepath.Join("src", "config"))
+		if err != nil {
+			return fmt.Errorf("failed to write remote repo: %v", err)
+		}
+		log.WithFields(log.Fields{
+			"path": path,
+			"url":  r.URL,
+		}).Info("Wrote repo definition from url")
+	}
+
 	// Ensure on shutdown that we record information that might be
 	// needed for prosperity. First, build artifacts are sent off the
 	// remote object storage. Then meta.json is written to /dev/console

--- a/gangplank/spec/jobspec_test.go
+++ b/gangplank/spec/jobspec_test.go
@@ -1,0 +1,70 @@
+package spec
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestURL(t *testing.T) {
+	tmpd, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatalf("unable to create tmpdir")
+	}
+	defer os.RemoveAll(tmpd) //nolint
+
+	cases := []struct {
+		repo    Repo
+		desc    string
+		wantErr bool
+	}{
+		{
+			desc:    "good repo",
+			repo:    Repo{URL: "http://mirrors.kernel.org/fedora-buffet/archive/fedora/linux/releases/30/Everything/source/tree/media.repo"},
+			wantErr: false,
+		},
+		{
+			desc: "named repo",
+			repo: Repo{
+				Name: "test",
+				URL:  "http://mirrors.kernel.org/fedora-buffet/archive/fedora/linux/releases/30/Everything/source/tree/media.repo"},
+			wantErr: false,
+		},
+		{
+			desc:    "bad repo",
+			repo:    Repo{URL: "http://fedora.com/this/will/not/exist/no/really/it/shouldnt"},
+			wantErr: true,
+		},
+	}
+
+	for idx, c := range cases {
+		t.Run(fmt.Sprintf("%s case %d", t.Name(), idx), func(t *testing.T) {
+			path, err := c.repo.Writer(tmpd)
+			if c.wantErr && err == nil {
+				t.Fatalf("%s: wanted error, got none", c.desc)
+			}
+
+			wantPath := filepath.Join(tmpd, fmt.Sprintf("%s.repo", c.repo.Name))
+			if c.repo.Name == "" {
+				h := sha256.New()
+				_, _ = h.Write([]byte(c.repo.URL))
+				wantPath = filepath.Join(tmpd, fmt.Sprintf("%x.repo", h.Sum(nil)))
+			}
+			if wantPath != path {
+				t.Fatalf("%s path test:\n wanted: %s\n    got: %s", c.desc, wantPath, path)
+			}
+
+			fi, err := os.Stat(path)
+			if err != nil {
+				t.Fatalf("%s: expected repo %s to be written", c.desc, path)
+			}
+
+			if fi.Size() == 0 && !c.wantErr {
+				t.Fatalf("%s is not expected to be zero size", path)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This gives Gangplank the ability to fetch and use a remote yum/dnf
repository via the jobspec OR a CLI flag.

Example:
   gangplank pod -A base --repo http://base-4-8-rhel8.ocp.svc.cluster.local

All worker pods will have the repo(s) exposed at `src/config/*.repo`.

Signed-off-by: Ben Howard <ben.howard@redhat.com>