### PR TITLE
Schema: change size to float64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,10 @@ staticanalysis:
 tools:
 	cd tools && $(MAKE)
 
+schema:
+	$(MAKE) -C gangplank schema
+	$(MAKE) -C mantle schema-update
+
 install:
 	install -d $(DESTDIR)$(PREFIX)/lib/coreos-assembler
 	install -D -t $(DESTDIR)$(PREFIX)/lib/coreos-assembler $$(find src/ -maxdepth 1 -type f)

--- a/gangplank/cosa/v1.go
+++ b/gangplank/cosa/v1.go
@@ -14,11 +14,11 @@ type Amis struct {
 }
 
 type Artifact struct {
-	Path               string `json:"path"`
-	Sha256             string `json:"sha256"`
-	SizeInBytes        int    `json:"size,omitempty"`
-	UncompressedSha256 string `json:"uncompressed-sha256,omitempty"`
-	UncompressedSize   int    `json:"uncompressed-size,omitempty"`
+	Path               string  `json:"path"`
+	Sha256             string  `json:"sha256"`
+	SizeInBytes        float64 `json:"size,omitempty"`
+	UncompressedSha256 string  `json:"uncompressed-sha256,omitempty"`
+	UncompressedSize   int     `json:"uncompressed-size,omitempty"`
 }
 
 type Build struct {
@@ -39,6 +39,7 @@ type Build struct {
 	CosaDelayedMetaMerge      bool                  `json:"coreos-assembler.delayed-meta-merge,omitempty"`
 	CosaImageChecksum         string                `json:"coreos-assembler.image-config-checksum,omitempty"`
 	CosaImageVersion          int                   `json:"coreos-assembler.image-genver,omitempty"`
+	Extensions                *Extensions           `json:"extensions,omitempty"`
 	FedoraCoreOsParentCommit  string                `json:"fedora-coreos.parent-commit,omitempty"`
 	FedoraCoreOsParentVersion string                `json:"fedora-coreos.parent-version,omitempty"`
 	Gcp                       *Gcp                  `json:"gcp,omitempty"`
@@ -49,7 +50,13 @@ type Build struct {
 	Name                      string                `json:"name"`
 	Oscontainer               *Image                `json:"oscontainer,omitempty"`
 	OstreeCommit              string                `json:"ostree-commit"`
+	OstreeContentBytesWritten int                   `json:"ostree-content-bytes-written,omitempty"`
 	OstreeContentChecksum     string                `json:"ostree-content-checksum"`
+	OstreeNCacheHits          int                   `json:"ostree-n-cache-hits,omitempty"`
+	OstreeNContentTotal       int                   `json:"ostree-n-content-total,omitempty"`
+	OstreeNContentWritten     int                   `json:"ostree-n-content-written,omitempty"`
+	OstreeNMetadataTotal      int                   `json:"ostree-n-metadata-total,omitempty"`
+	OstreeNMetadataWritten    int                   `json:"ostree-n-metadata-written,omitempty"`
 	OstreeTimestamp           string                `json:"ostree-timestamp"`
 	OstreeVersion             string                `json:"ostree-version"`
 	OverridesActive           bool                  `json:"coreos-assembler.overrides-active,omitempty"`
@@ -87,6 +94,13 @@ type BuildArtifacts struct {
 type Cloudartifact struct {
 	Image string `json:"image"`
 	URL   string `json:"url"`
+}
+
+type Extensions struct {
+	Manifest       map[string]interface{} `json:"manifest"`
+	Path           string                 `json:"path"`
+	RpmOstreeState string                 `json:"rpm-ostree-state"`
+	Sha256         string                 `json:"sha256"`
 }
 
 type Gcp struct {

--- a/mantle/cosa/cosa_v1.go
+++ b/mantle/cosa/cosa_v1.go
@@ -14,11 +14,11 @@ type Amis struct {
 }
 
 type Artifact struct {
-	Path               string `json:"path"`
-	Sha256             string `json:"sha256"`
-	SizeInBytes        int    `json:"size,omitempty"`
-	UncompressedSha256 string `json:"uncompressed-sha256,omitempty"`
-	UncompressedSize   int    `json:"uncompressed-size,omitempty"`
+	Path               string  `json:"path"`
+	Sha256             string  `json:"sha256"`
+	SizeInBytes        float64 `json:"size,omitempty"`
+	UncompressedSha256 string  `json:"uncompressed-sha256,omitempty"`
+	UncompressedSize   int     `json:"uncompressed-size,omitempty"`
 }
 
 type Build struct {

--- a/mantle/cosa/schema_doc.go
+++ b/mantle/cosa/schema_doc.go
@@ -20,7 +20,7 @@ var generatedSchemaJSON = `{
             },
            "size": {
              "$id": "#/artifact/size",
-             "type":"integer",
+             "type":"number",
              "title":"Size in bytes"
             },
            "uncompressed-sha256": {

--- a/src/schema/v1.json
+++ b/src/schema/v1.json
@@ -15,7 +15,7 @@
             },
            "size": {
              "$id": "#/artifact/size",
-             "type":"integer",
+             "type":"number",
              "title":"Size in bytes"
             },
            "uncompressed-sha256": {


### PR DESCRIPTION
While working on Gangplank, I wanted to add in a validation function.  The problem, though, the schema converts `integars` to `int` for GoLang which caps the max size to ~2.4Gb files. The only usable type is `number` which corresponds to a `float64`. This isn't too bad consider that GoLang [1] uses `float64` when unmarshalling "json numbers" into an interface.

This also fixes drift in the Gangplank understanding of the schema.

[1] https://golang.org/pkg/encoding/json/#Unmarshal