### PR TITLE
cmdlib: fix impl_rpmostree_compose for POWER

### DIFF
--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -72,6 +72,7 @@ if [[ "$basearch" != "s390x" && $image_type == dasd ]]; then
     fatal "$basearch is not supported for building dasd images"
 fi
 
+# shellcheck disable=SC2031
 export LIBGUESTFS_BACKEND=direct
 export IMAGE_TYPE="${image_type}"
 prepare_build

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -414,7 +414,8 @@ impl_rpmostree_compose() {
         # "cache2" has an explicit label so we can find it in qemu easily
         if [ ! -f "${workdir}"/cache/cache2.qcow2 ]; then
             qemu-img create -f qcow2 cache2.qcow2.tmp 10G
-            LIBGUESTFS_BACKEND=direct virt-format --filesystem=xfs --label=cosa-cache -a cache2.qcow2.tmp &&
+            (source /usr/lib/coreos-assembler/libguestfish.sh
+            virt-format --filesystem=xfs --label=cosa-cache -a cache2.qcow2.tmp)
             mv -T cache2.qcow2.tmp "${workdir}"/cache/cache2.qcow2
         fi
         # And remove the old one

--- a/src/libguestfish.sh
+++ b/src/libguestfish.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 
 
 # We don't want to use libvirt for this, it inhibits debugging
+# shellcheck disable=SC2031
 export LIBGUESTFS_BACKEND=direct
 
 arch=$(uname -m)


### PR DESCRIPTION
POWER builds are failing to run `coreos-assembler buildextend-extensions` due libguestfish call

 - POWER needs to use the libguestfish wrapper in order to fix
the SMT value.
- For more info check: https://github.com/coreos/coreos-assembler/pull/1553

Signed-off-by: Renata Ravanelli <rravanel@redhat.com>