### PR TITLE
cmd/init: ignore dotfiles in working directory

### DIFF
--- a/src/cmd-init
+++ b/src/cmd-init
@@ -73,7 +73,7 @@ fi
 
 # If the current working dir is not empty then error out
 # unless force provided
-if [ "$FORCE" != "1" ] && [ -n "$(ls -A ./)" ]; then
+if [ "$FORCE" != "1" ] && [ -n "$(ls ./)" ]; then
    fatal "init: current directory is not empty, override with --force"
 fi
 


### PR DESCRIPTION
This skips dotfiles from empty directory check logic in init. That
way, it allows using coreos-assembler together with existing `.envrc`
local configuration.

Ref: https://direnv.net/