### PR TITLE
Gangplank: allow multiple builds in the builds dir

### DIFF
--- a/gangplank/cosa/build.go
+++ b/gangplank/cosa/build.go
@@ -100,7 +100,7 @@ func ReadBuild(dir, buildID, arch string) (*Build, string, error) {
 			if fi == nil || fi.IsDir() || fi.Name() == CosaMetaJSON {
 				return nil
 			}
-			if !reMetaJSON.Match([]byte(fi.Name())) {
+			if !IsMetaJSON(fi.Name()) {
 				return nil
 			}
 			log.WithField("extra meta.json", fi.Name()).Info("found meta")
@@ -255,4 +255,10 @@ func (b *Build) mergeMeta(r io.Reader) error {
 	dec := json.NewDecoder(r)
 	dec.DisallowUnknownFields()
 	return dec.Decode(b)
+}
+
+// IsMetaJSON is a helper for identifying if a file is meta.json
+func IsMetaJSON(path string) bool {
+	b := filepath.Base(path)
+	return reMetaJSON.Match([]byte(b))
 }

--- a/gangplank/cosa/schema_test.go
+++ b/gangplank/cosa/schema_test.go
@@ -223,34 +223,34 @@ func TestMergeMeta(t *testing.T) {
 
 func TestMetaRegEx(t *testing.T) {
 	testCases := []struct {
-		data  []byte
+		data  string
 		match bool
 	}{
 		{
-			data:  []byte("meta.json"),
+			data:  "meta.json",
 			match: true,
 		},
 		{
-			data:  []byte("meta.test.json"),
+			data:  "meta.test.json",
 			match: true,
 		},
 		{
-			data:  []byte("commitmmeta.json"),
+			data:  "commitmmeta.json",
 			match: false,
 		},
 		{
-			data:  []byte("meta.json.bk"),
+			data:  "meta.json.bk",
 			match: false,
 		},
 		{
-			data:  []byte("metafoo.json"),
+			data:  "metafoo.json",
 			match: false,
 		},
 	}
 
 	for idx, c := range testCases {
 		t.Run(fmt.Sprintf("regex test %d %q", idx, string(c.data)), func(t *testing.T) {
-			matched := reMetaJSON.Match(c.data)
+			matched := IsMetaJSON(c.data)
 			if matched != c.match {
 				t.Errorf("%s:\n want: %v\n  got: %v\n", string(c.data), c.match, matched)
 			}

--- a/gangplank/ocp/bc.go
+++ b/gangplank/ocp/bc.go
@@ -215,7 +215,7 @@ binary build interface.`)
 		l := log.WithFields(log.Fields{
 			"prior build": lastBuild.BuildID,
 			"path":        lastBuild,
-			"to path":     filepath.Join("srv", "bulds", keyPath),
+			"to path":     filepath.Join("srv", "builds", keyPath),
 		})
 		l.Info("found prior build")
 		remoteFiles = append(

--- a/gangplank/ocp/return.go
+++ b/gangplank/ocp/return.go
@@ -70,7 +70,7 @@ func (r *Return) Run(ctx context.Context) error {
 		srcPath := filepath.Join(path, f.Name())
 
 		// Check if this a meta type
-		if strings.HasSuffix(f.Name(), ".json") {
+		if isKnownBuildMeta(f.Name()) {
 			upload[upKey] = srcPath
 		}
 		// Check if this a known build artifact
@@ -113,4 +113,25 @@ func (r *Return) Run(ctx context.Context) error {
 		}
 	}
 	return e
+}
+
+// isKnownBuildMeta checks if n is known and should be fetched and returned
+// by pods via Minio.
+func isKnownBuildMeta(n string) bool {
+	// check for specially named files
+	if strings.HasPrefix(n, "manifest-lock.generated") ||
+		n == "ostree-commit-object" ||
+		n == "commitmeta.json" {
+		return true
+	}
+	// check for meta*json files
+	if cosa.IsMetaJSON(n) {
+		return true
+	}
+
+	if n == "builds.json" {
+		return true
+	}
+
+	return false
 }


### PR DESCRIPTION
Gangplank has never handled running `cosa build` against the same build
directory well. This fixes that by ensuring that all builds have known
build meta (ostree-commit-object, manifest-lock, and commitmeta.json)
uploaded to the worker pods.