### PR TITLE
Gangplank: allow for creating multiple artifacts in the same stage

### DIFF
--- a/gangplank/spec/stages.go
+++ b/gangplank/spec/stages.go
@@ -312,7 +312,7 @@ func addShorthandToStage(artifact string, stage *Stage) {
 
 	working := quickStage(artifact)
 
-	// remove is helper for removing the first from a slice
+	// remove is helper for removing the first matching item from a slice
 	remove := func(slice []string, key string) ([]string, bool) {
 		for x := 0; x < len(slice); x++ {
 			if slice[x] == key {

--- a/gangplank/spec/stages.go
+++ b/gangplank/spec/stages.go
@@ -359,7 +359,7 @@ func addShorthandToStage(artifact string, stage *Stage) {
 	}
 	stage.BuildArtifacts = unique(newOrder)
 
-	// If the syntetic stages requires an artifact, but also builds it
+	// If the synthetic stages requires an artifact, but also builds it
 	// then we need to remove it from the the requires.
 	realRequires := stage.RequireArtifacts
 


### PR DESCRIPTION
When creating synthetic stages via the commandline, only a single
artifact can be built in a stage. This change allows for N artifacts to
be created in the same stage. Builds are orderd.

```
    $ gangplank generate -A base+metal4k+metal -A aws -A gcp -A finalize
    INFO[0000] Gangplank: COSA OpenShift job runner, 2021-03-17.4b525923~dirty
    # Generated by Gangplank CLI
    # 2021-03-17T19:52:27-06:00
    job:
      strict: true
    recipe:
      git_ref: testing-devel
      git_url: https://github.com/coreos/fedora-coreos-config
    stages:
    - id: Generated Stage in Execution Order 1
      description: Stage 1 execution for base,metal4k,metal
      build_artifacts: [metal4k, metal, base]
      execution_order: 1
    - id: Generated Stage in Execution Order 3
      description: Stage 3 execution for aws
      requires_artifacts: [qemu]
      build_artifacts: [aws]
      execution_order: 3
    - id: Generated Stage in Execution Order 3
      description: Stage 3 execution for gcp
      requires_artifacts: [qemu]
      build_artifacts: [gcp]
      execution_order: 3
    - id: Generated Stage in Execution Order 999
      description: Stage 999 execution for finalize
      build_artifacts: [finalize]
      execution_order: 999
    delay_meta_merge: true
```

Note: the `+` is needs since Cobra splits on `,` so  `-A <arg1>,<arg2>` is equivalent to `-A <arg1> -A <arg2>`