### PR TITLE
Dockerfile: defenestrate Quay.io cache for new rpm-ostree release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /root/containerbuild
 # Only need a few of our scripts for the first few steps
 COPY ./src/print-dependencies.sh ./src/deps*.txt ./src/vmdeps*.txt ./src/build-deps.txt /root/containerbuild/src/
 COPY ./build.sh /root/containerbuild/
-RUN ./build.sh configure_yum_repos # nocache 20210311
+RUN ./build.sh configure_yum_repos # nocache 20210318
 RUN ./build.sh install_rpms
 
 # Ok copy in the rest of them for the next few steps


### PR DESCRIPTION
I want to get v2021.3 into cosa for
https://github.com/coreos/fedora-coreos-config/pull/884.