### PR TITLE
Gangplank: shareable minio via minio only mode

### DIFF
--- a/gangplank/cmd/minio.go
+++ b/gangplank/cmd/minio.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/coreos/gangplank/ocp"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+/*
+	In enviroments (such as Jenkins) were something else handles the visiualization
+	of stages, using the inherent stages in Gangplank can produced jumbled garbage.
+
+	Each Gangpplank worker requires a Minio Server running on the coordinating host/pod.
+	The `gangplank minio` command allows for starting a Minio instance and then saving
+	the configuration to allow for a shared `minio` instance.
+
+	When using a shared instance, you must use `cosa build --delay-meta-merge`.
+
+	Example start
+		nohup gangplank minio -m /tmp/minio.cfg -d /srv &
+
+	Example worker accessing minio:
+		gangplank pod -m /tmp/minio.cfg --spec test.spec
+
+	When running in minio mode, Gangplank will continue to run until it is sig{kill,term}ed.
+
+*/
+
+var cmdMinio = &cobra.Command{
+	Use:   "minio",
+	Short: "Start running a minio server",
+	Run:   runMinio,
+}
+
+var (
+	// minioCfgFile is an ocp.minioServerCfg file
+	minioCfgFile string
+
+	// minioServeDir is the directory that Gangplank runs minio from
+	minioServeDir string
+)
+
+func init() {
+	cmdRoot.AddCommand(cmdMinio)
+	cmdRoot.PersistentFlags().StringVarP(&minioCfgFile, "minioCfgFile", "m", "", "location of where to create of external minio config file")
+	cmdMinio.Flags().StringVarP(&minioServeDir, "minioServeDir", "d", "", "location to service minio from")
+}
+
+func runMinio(c *cobra.Command, args []string) {
+	defer cancel()
+	defer ctx.Done()
+
+	if minioCfgFile == "" {
+		log.Fatal("must define --minioCfgfile to run in Minio mode")
+	}
+	if minioServeDir == "" {
+		log.Fatal("must define the workdir to serve minio from")
+	}
+	if _, err := os.Stat(minioCfgFile); err == nil {
+		log.Fatalf("existing minio configuration exists, refusing to overwrite")
+	}
+
+	m, err := ocp.StartStandaloneMinioServer(ctx, minioServeDir, minioCfgFile)
+	if err != nil {
+		log.WithError(err).Fatalf("failed to start minio server")
+	}
+	defer m.Kill()
+
+	log.Info("Waiting for kill signal for minio")
+
+	sig := make(chan os.Signal, 4)
+	signal.Notify(sig, os.Interrupt, syscall.SIGTERM, syscall.SIGUSR1, syscall.SIGUSR2)
+
+	select {
+	case <-sig:
+		m.Kill()
+	case <-ctx.Done():
+		m.Kill()
+	}
+
+}

--- a/gangplank/cmd/pod.go
+++ b/gangplank/cmd/pod.go
@@ -107,6 +107,8 @@ func runPod(c *cobra.Command, args []string) {
 		}
 	}
 
+	spec.Job.MinioCfgFile = minioCfgFile
+
 	if cosaWorkDirContext {
 		for _, d := range []string{cosaWorkDir, cosaSrvDir} {
 			if d == "" {

--- a/gangplank/ocp/filer.go
+++ b/gangplank/ocp/filer.go
@@ -4,19 +4,23 @@ import (
 
 	// minio is needed for moving files around in OpenShift.
 
+	"bufio"
 	"context"
 	"crypto/rand"
 	"crypto/sha256"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net"
 	"os"
 	"os/exec"
 	"os/signal"
 	"path/filepath"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
@@ -33,52 +37,77 @@ import (
 		  functionality outside the ocp package.
 */
 
-var (
-	// myHostName used for determining the hostname
-	myHostName string
-)
-
-const (
-	// MinioRegion is a "fake" region
-	MinioRegion = "darkarts-1"
-)
-
-func init() {
-	hname, err := ioutil.ReadFile("/proc/sys/kernel/hostname")
-	if err == nil {
-		myHostName = strings.TrimSpace(string(hname))
-	}
-}
-
 // minioServer describes a Minio S3 Object stoarge to start.
 type minioServer struct {
-	AccessKey    string `json:"accesskey"`
-	SecretKey    string `json:"secretkey"`
-	Host         string `json:"host"`
-	Port         int    `json:"port"`
+	AccessKey      string `json:"accesskey"`
+	SecretKey      string `json:"secretkey"`
+	Host           string `json:"host"`
+	Port           int    `json:"port"`
+	ExternalServer bool   `json:"external_server"` //indicates that a server should not be started
+	Region         string `json:"region"`
+
 	dir          string
 	minioOptions minio.Options
 	cmd          *exec.Cmd
 }
 
-// newMinioSever defines an ephemeral minio config. To prevent random pods/people
-// accessing or relying on the server, we use entirely random keys.
-func newMinioServer() *minioServer {
+// StartStanaloneMinioServer starts a standalone minio server.
+func StartStandaloneMinioServer(ctx context.Context, srvDir, cfgFile string) (*minioServer, error) {
+	m := newMinioServer("")
+	m.dir = srvDir
+
+	if err := m.start(ctx); err != nil {
+		return nil, err
+	}
+
+	m.ExternalServer = true
+	if err := m.WriteToFile(cfgFile); err != nil {
+		return nil, fmt.Errorf("failed to write configuration for minio: %v", err)
+	}
+
+	return m, nil
+}
+
+// newMinioSever defines an ephemeral minioServer from a config or creates a new one.
+// To prevent random pods/people accessing or relying on the server, we use entirely random keys.
+func newMinioServer(cfgFile string) *minioServer {
+	if cfgFile != "" {
+		m, err := minioCfgFromFile(cfgFile)
+		if err != nil {
+			log.WithError(err).Fatalf("failed read minio cfg from %s", cfgFile)
+		}
+		log.Infof("Minio configuration defined from %s", cfgFile)
+		return &m
+	}
+
+	// If Gangplank is running in cluster, then get the IP address. Using
+	// hostnames can be problematic.
+	host := getHostname()
+	ac, ns, err := k8sInClusterClient()
+	if err == nil && ac != nil {
+		ip, err := getPodIP(ac, ns, host)
+		if err == nil {
+			host = ip
+		}
+	}
+
+	log.Info("Defining a new minio server")
 	minioAccessKey, _ := randomString(12)
 	minioSecretKey, _ := randomString(12)
 
 	return &minioServer{
-		AccessKey: minioAccessKey,
-		SecretKey: minioSecretKey,
-		Host:      "",
-		Port:      9000,
-		dir:       cosaSrvDir,
+		AccessKey:      minioAccessKey,
+		SecretKey:      minioSecretKey,
+		Host:           host,
+		dir:            cosaSrvDir,
+		ExternalServer: false,
 		minioOptions: minio.Options{
 			Creds:  credentials.NewStaticV4(minioAccessKey, minioSecretKey, ""),
 			Secure: false,
-			Region: MinioRegion,
+			Region: fmt.Sprintf("cosaHost-%s", getHostname()),
 		},
 	}
+
 }
 
 // GetClient returns a Minio Client
@@ -87,33 +116,30 @@ func (m *minioServer) client() (*minio.Client, error) {
 		&minio.Options{
 			Creds:  credentials.NewStaticV4(m.AccessKey, m.SecretKey, ""),
 			Secure: false,
-			Region: MinioRegion,
+			Region: m.Region,
 		},
 	)
 }
 
-// start a MinioServer based on the configuration.
+// start a MinioServer based on the configuration. If the minioServer is external,
+// then is this noop.
 func (m *minioServer) start(ctx context.Context) error {
-	// COSA_POD_ID should be set via the BuildConfig
-	// using a pod reference, i.e:
-	// env:
-	//	- name: COSA_POD_IP
-	//	  valueFrom:
-	// 	    fieldRef:
-	//     	 fieldPath: status.podIP
-	if m.cmd != nil {
-		return errors.New("minio is already running")
+
+	// If the server is external, we test it before proceeding.
+	if m.ExternalServer {
+		if err := m.ensureBucketExists(ctx, "builds"); err != nil {
+			return fmt.Errorf("failed to query Minio/S3 server: %v", err)
+		}
+		log.Info("Minio Server is listening and ready")
+		return nil
 	}
 
 	if m.Host == "" {
-		host, ok := os.LookupEnv("COSA_POD_IP")
-		if ok {
-			log.Infof("Minio will use envVar defined hostname %s", host)
-			m.Host = strings.TrimSpace(host)
-		} else {
-			log.Infof("Minio will use kernel provided hostname %s", myHostName)
-			m.Host = myHostName
-		}
+		m.Host = getHostname()
+	}
+
+	if m.Port == 0 {
+		m.Port = getPortOrNext(9000)
 	}
 
 	l := log.WithFields(log.Fields{
@@ -131,7 +157,8 @@ func (m *minioServer) start(ctx context.Context) error {
 		return errors.New("failed to find minio")
 	}
 
-	args := []string{mpath, "server", m.dir}
+	addr := fmt.Sprintf(":%d", m.Port)
+	args := []string{mpath, "server", "--address", addr, m.dir}
 	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		Foreground: false,           // Background the process
@@ -154,20 +181,33 @@ func (m *minioServer) start(ctx context.Context) error {
 		}).Error("Failed to start minio")
 	}
 
+	time.Sleep(1 * time.Second)
+	if cmd == nil || (cmd.ProcessState != nil && cmd.ProcessState.Exited()) {
+		return fmt.Errorf("minio started but exited")
+	}
+
+	if cmd.ProcessState != nil && cmd.ProcessState.Exited() {
+		stdoutStderr, _ := cmd.CombinedOutput()
+		l.WithFields(log.Fields{
+			"err": err,
+			"out": stdoutStderr,
+		}).Error("Failed to start minio")
+	}
+
 	// Ensure the process gets terminated on shutdown
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, os.Interrupt, syscall.SIGTERM, syscall.SIGUSR1, syscall.SIGUSR2)
 	go func() {
 		<-sigs
-		m.kill()
+		m.Kill()
 	}()
 
 	m.cmd = cmd
 	return err
 }
 
-// kill terminates the minio server.
-func (m *minioServer) kill() {
+// Kill terminates the minio server.
+func (m *minioServer) Kill() {
 	if m.cmd == nil {
 		return
 	}
@@ -177,13 +217,14 @@ func (m *minioServer) kill() {
 	_ = syscall.Kill(-m.cmd.Process.Pid, syscall.SIGTERM)
 
 	// Wait for the command to end.
-	_ = m.cmd.Wait()
+	if m.cmd != nil {
+		_ = m.cmd.Wait()
+	}
 
 	// Purge the minio files since they are used per-session.
 	if err := os.RemoveAll(filepath.Join(m.dir, ".minio.sys")); err != nil {
 		log.WithError(err).Error("failed to remove minio files")
 	}
-
 }
 
 func randomString(n int) (string, error) {
@@ -213,7 +254,7 @@ func (m *minioServer) ensureBucketExists(ctx context.Context, bucket string) err
 		return nil
 	}
 
-	err = mc.MakeBucket(ctx, bucket, minio.MakeBucketOptions{Region: MinioRegion})
+	err = mc.MakeBucket(ctx, bucket, minio.MakeBucketOptions{Region: m.Region})
 	if err != nil {
 		return fmt.Errorf("failed call to create bucket: %w", err)
 	}
@@ -271,7 +312,6 @@ func (m *minioServer) putter(ctx context.Context, bucket, object, fpath string, 
 	}
 	l := log.WithFields(log.Fields{
 		"bucket":    bucket,
-		"creator":   myHostName,
 		"from":      fpath,
 		"func":      "putter",
 		"object":    object,
@@ -320,8 +360,7 @@ func (m *minioServer) putter(ctx context.Context, bucket, object, fpath string, 
 		minio.PutObjectOptions{
 			// When uploaded, user-metadata will be X-Amz-Meta-<key>
 			UserMetadata: map[string]string{
-				"creator": myHostName,
-				"sha256":  sha256,
+				"sha256": sha256,
 			},
 		},
 	)
@@ -344,4 +383,72 @@ func calcSha256(f io.Reader) (string, error) {
 		return "", nil
 	}
 	return fmt.Sprintf("%x", h.Sum(nil)), nil
+}
+
+// checkPort checks if a port is open
+func checkPort(port int) error {
+	ln, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	if err != nil {
+		return err
+	}
+	defer ln.Close() //nolint
+	return nil
+}
+
+// getNextPort iterates and finds the next available port
+func getPortOrNext(port int) int {
+	for {
+		if err := checkPort(port); err == nil {
+			return port
+		}
+		port++
+	}
+}
+
+// minioCfgFromFile returns a minio configuration from a file
+func minioCfgFromFile(f string) (mk minioServer, err error) {
+	in, err := os.Open(f)
+	if err != nil {
+		return mk, err
+	}
+	defer in.Close()
+	b := bufio.NewReader(in)
+	return minioCfgReader(b)
+}
+
+// WriteJSON returns the jobspec
+func (m *minioServer) WriteJSON(w io.Writer) error {
+	encode := json.NewEncoder(w)
+	encode.SetIndent("", "  ")
+	return encode.Encode(*m)
+}
+
+// minioKeysFromFile writes the minio keys to a file
+func (m *minioServer) WriteToFile(f string) error {
+	out, err := os.OpenFile(f, os.O_CREATE|os.O_WRONLY|os.O_EXCL, 0644)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	return m.WriteJSON(out)
+}
+
+// minioKeysReader takes an io.Reader and returns a minio cfg
+func minioCfgReader(in io.Reader) (m minioServer, err error) {
+	d, err := ioutil.ReadAll(in)
+	if err != nil {
+		return m, err
+	}
+
+	err = json.Unmarshal(d, &m)
+	if err != nil {
+		return m, err
+	}
+	return m, err
+}
+
+// getHostname gets the current hostname
+func getHostname() string {
+	data, _ := ioutil.ReadFile("/proc/sys/kernel/hostname")
+	return strings.TrimSpace(string(data))
 }

--- a/gangplank/ocp/pod.go
+++ b/gangplank/ocp/pod.go
@@ -64,7 +64,7 @@ var _ PodBuilder = &podBuild{}
 
 const (
 	podBuildLabel      = "gangplank.coreos-assembler.coreos.com"
-	podBuildAnnotation = podBuildLabel + "%s"
+	podBuildAnnotation = podBuildLabel + "-%s"
 	podBuildRunnerTag  = "cosa-podBuild-runner"
 )
 
@@ -106,6 +106,15 @@ func NewPodBuilder(ctx ClusterContext, image, serviceAccount, workDir string, js
 	bc, err := newBC(ctx, &Cluster{})
 	if err != nil {
 		return nil, err
+	}
+
+	if pb.ipaddr != "" {
+		log.WithFields(log.Fields{
+			"host name": pb.hostname,
+			"ip addr":   pb.ipaddr,
+		}).Info("Using IP address for remote minio instances")
+		bc.HostPod = pb.hostname
+		bc.HostIP = pb.ipaddr
 	}
 
 	// Create a new clean copy of the jobpsec

--- a/gangplank/ocp/remotes_test.go
+++ b/gangplank/ocp/remotes_test.go
@@ -32,14 +32,14 @@ func TestRemote(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	m := newMinioServer()
+	m := newMinioServer("")
 	m.dir = srvd
 	log.Infof("Testing with key %s:%s", m.AccessKey, m.SecretKey)
 
 	if err := m.start(ctx); err != nil {
 		t.Fatalf("failed to start test minio server: %v", err)
 	}
-	defer m.kill()
+	defer m.Kill()
 
 	r := RemoteFile{
 		Bucket: testBucket,

--- a/gangplank/spec/jobspec.go
+++ b/gangplank/spec/jobspec.go
@@ -135,6 +135,7 @@ type Job struct {
 	IsProduction  bool   `yaml:"is_production,omitempty" json:"is_production,omitempty"`
 	StrictMode    bool   `yaml:"strict,omitempty" json:"strict,omitempty"`
 	VersionSuffix string `yaml:"version_suffix,omitempty" json:"version_suffix,omitempty"`
+	MinioCfgFile  string // not exported
 }
 
 // Recipe describes where to get the build recipe/config, i.e fedora-coreos-config


### PR DESCRIPTION
With our current CI stages for RHCOS and FCOS builds, each build
generates logs per-stage. Gangplank is perfectly capable of running
stages itself and keeping logs straight. However, in our CI runners,
those stages would visually appear as single "stage."

To allow for multiple Gangplanks to run:
- A new CLI target of `minio` launches minio and writes its
  configuration to disk
- Other Gangplank instances can `-m <cfg file>` to access tthe
  standalone Minio.
- Gangplank no longer requires port 9000. Instead, the first port at or
  above 9000 is used.
- Relavant tests have been introduced.

For the Jenkins pipelines, I envision having Minio running in its own pod.  For Prow, multiarch and ART builds, I envision Gangplank running as it does today and using a bespoke Jobspec. 

Signed-off-by: Ben Howard <ben.howard@redhat.com>