### PR TITLE
Gangplank: use git date and last change for version

### DIFF
--- a/gangplank/Makefile
+++ b/gangplank/Makefile
@@ -1,5 +1,6 @@
 my_dir := $(abspath $(shell dirname $(lastword $(MAKEFILE_LIST))))
-version = $(shell date +%Y-%m-%d).$(shell git rev-parse --short HEAD)~$(shell test -n "`git status -s`" && echo dirty || echo clean)
+state = $(shell test -n "`git status -s`" && echo dirty || echo clean)
+version = $(shell cd .. && git log -n 1 --date=short --pretty=format:%cs.%h~${state} -- gangplank)
 cosa_dir = $(shell test -d /usr/lib/coreos-assembler && echo /usr/lib/coreos-assembler)
 ldflags=-X main.version=${version} -X main.cosaDir=${cosa_dir}
 


### PR DESCRIPTION
This fixes a problem where a newer version of other COSA components
causes a Gangplank to change its build date and commit tag. Instead, the
commit date and the last commit short hash of the last Gangplank change
will be used.