### PR TITLE
mantle/qemu: hack around SELinux violation in virtio journal service

### DIFF
--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -1236,7 +1236,9 @@ func (builder *QemuBuilder) VirtioJournal(config *conf.Conf, queryArguments stri
 	[Service]
 	Type=simple
 	StandardOutput=file:/dev/virtio-ports/mantlejournal
-	ExecStart=/usr/bin/journalctl -q -b -f -o json --no-tail %s
+	# Wrap in /bin/bash to hack around SELinux
+	# https://bugzilla.redhat.com/show_bug.cgi?id=1942198
+	ExecStart=/usr/bin/bash -c "journalctl -q -b -f -o json --no-tail %s"
 	[Install]
 	RequiredBy=multi-user.target
 	`, queryArguments)


### PR DESCRIPTION
In f34, the SELinux policy prevents a systemd service with
`ExecStart=journalctl` from watching the journal logs, which means that
our `mantle-virtio-journal-stream.service` doesn't work. This in turn
breaks `cosa run`'s SSH logic.

Hack around this by just wrapping it in a bash instance.

For more information, see the linked RHBZ.