### PR TITLE
Gangplank: improved dependencies for base builds 

### DIFF
--- a/gangplank/cmd/minio.go
+++ b/gangplank/cmd/minio.go
@@ -11,8 +11,8 @@ import (
 )
 
 /*
-	In enviroments (such as Jenkins) were something else handles the visiualization
-	of stages, using the inherent stages in Gangplank can produced jumbled garbage.
+	In enviroments where something else handles the visiualization of stages (such as Jenkins)
+	using the inherent stages in Gangplank can produced jumbled garbage.
 
 	Each Gangpplank worker requires a Minio Server running on the coordinating host/pod.
 	The `gangplank minio` command allows for starting a Minio instance and then saving

--- a/gangplank/ocp/const.go
+++ b/gangplank/ocp/const.go
@@ -10,4 +10,19 @@ const (
 
 	// secretLabelName is the label to search for secrets to automatically use
 	secretLabelName = "coreos-assembler.coreos.com/secret"
+
+	// cosaSrvCache is the location of the cache files
+	cosaSrvCache = "/srv/cache"
+
+	// cosaSrvTmpRepo is the location the repo files
+	cosaSrvTmpRepo = "/srv/tmp/repo"
+
+	// cacheTarballName is the name of the file used when Stage.{Require,Return}Cache is true
+	cacheTarballName = "cache.tar.gz"
+
+	// cacheRepoTarballName is the name of the file used when Stage.{Require,Return}RepoCache is true
+	cacheRepoTarballName = "repo.tar.gz"
+
+	// cacheBucket is used for storing the cache
+	cacheBucket = "cache"
 )

--- a/gangplank/ocp/filer_test.go
+++ b/gangplank/ocp/filer_test.go
@@ -59,7 +59,7 @@ func TestFiler(t *testing.T) {
 	}
 
 	testBucket = "tb1"
-	if err = m.putter(c, testBucket, "test", tfp, false); err != nil {
+	if err = m.putter(c, testBucket, "test", tfp); err != nil {
 		t.Errorf("error: %v", err)
 	}
 

--- a/gangplank/ocp/return_test.go
+++ b/gangplank/ocp/return_test.go
@@ -1,0 +1,98 @@
+package ocp
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func init() {
+	// tarballCreateCommand uses sudo which is inappropriate/unneeded for
+	// running our tests.
+	tarballCreatePrefix = tarballCreatePrefix[1:]
+}
+
+func TestTarballRemote(t *testing.T) {
+	tmpd, _ := ioutil.TempDir("", "remotes")
+	srvd := filepath.Join(tmpd, "serve")
+	srcd := filepath.Join(tmpd, "src")
+	destd := filepath.Join(tmpd, "dest")
+	defer os.RemoveAll(tmpd) //nolint
+
+	for _, d := range []string{srvd, srcd, destd} {
+		if err := os.MkdirAll(d, 0777); err != nil {
+			t.Fatalf("failed to create tmpdir")
+		}
+	}
+
+	// create the fake directory to tar up
+	for i := 0; i < 10; i++ {
+		tld := filepath.Join(srcd, fmt.Sprintf("%d", i))
+		if err := os.MkdirAll(tld, 0777); err != nil {
+			t.Fatalf("failed to create dir: %v", err)
+		}
+		for x := 0; x < 10; x++ {
+			rstring, _ := randomString(10 * i * x * i)
+			if err := ioutil.WriteFile(filepath.Join(tld, fmt.Sprintf("%d", x)), []byte(rstring), 0644); err != nil {
+				t.Fatalf("failed to create entry: %v", err)
+			}
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	m := newMinioServer("")
+	m.dir = srvd
+	log.Infof("Testing with key %s:%s", m.AccessKey, m.SecretKey)
+	_ = m.start(ctx)
+	defer m.Kill()
+
+	returner := &Return{
+		Minio: m,
+	}
+
+	if err := returnPathTarBall(ctx, cacheBucket, "test.tar.gz", srcd, returner); err != nil {
+		t.Fatalf("Failed create tarball: %v", err)
+	}
+
+	remoteFile := &RemoteFile{
+		Minio:            m,
+		Bucket:           cacheBucket,
+		Object:           "test.tar.gz",
+		Compressed:       true,
+		ForceExtractPath: destd,
+	}
+
+	if err := remoteFile.Extract(ctx, destd); err != nil {
+		t.Fatalf("failed to extract tarball: %v", err)
+	}
+
+	walkSrcFn := func(path string, info os.FileInfo, e error) error {
+		if e != nil {
+			return e
+		}
+		if info.IsDir() || path == destd {
+			return nil
+		}
+		srcPath := strings.TrimPrefix(path, destd)
+		dest, err := os.Stat(srcPath)
+		if err != nil {
+			return fmt.Errorf("failed to query %s for %s: %v", srcPath, path, err)
+		}
+		if dest.Size() != info.Size() {
+			return fmt.Errorf("%s size difference:\n want: %d\n  got: %d\n", path, info.Size(), dest.Size())
+		}
+		return nil
+	}
+
+	if err := filepath.Walk(destd, walkSrcFn); err != nil {
+		t.Fatalf("failed to validate tarball: %v", err)
+	}
+}


### PR DESCRIPTION
In order to have Gangplank handle building metal and oscontainer builds,
its needs to have more nuanced dependencies.

This change introduces two concepts:
- {Returns,Requires,Requests}{Cache,CacheRepo} to the stage definition. When
  defined, {Returns,Requires,Requests}Cache will return/request a tarball of
  /srv/repo, while {Return,Requires}CacheRepo will handle /srv/tmp/repo
- RequestArtifacts are optional dependencies are artifacts can be requested,\
  but are required.

The cache and repo tarballs can be saved between builds and serves the
same functional goal of the cache qemu disk. This should help with RHCOS
build pipeline which is does not persist a cache.
