### PR TITLE
Add support for `include: <path>` key in image.yaml

### DIFF
--- a/docs/working.md
+++ b/docs/working.md
@@ -48,6 +48,8 @@ This YAML file configures the output disk images.  Supported keys are:
 
 - `size`: Size in GB for cloud images (OpenStack, AWS, etc.)  Required.
 - `extra-kargs`: List of kernel arguments.
+- `include`: path to another YAML file to include. List values are appended. For other type,
+  the values in the sourcing config win.
 
 It's likely in the future we will extend this to support e.g. a separate `/var`
 partition or configuring the filesystem types.  If you want to do anything like

--- a/src/cmd-build
+++ b/src/cmd-build
@@ -197,7 +197,7 @@ ks_path="${configdir}"/image.ks
 if [ -f "${ks_path}" ]; then
     fatal "Kickstart support was removed; migrate to image.yaml"
 fi
-image_input="${configdir}"/image.yaml
+image_input="${image_yaml}"
 if ! [ -f "${image_input}" ]; then
     fatal "Failed to find ${image_input}"
 fi

--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -14,12 +14,11 @@ import sys
 import tarfile
 import tempfile
 import time
-import yaml
 import glob
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from cosalib.builds import Builds
-from cosalib.cmdlib import run_verbose, sha256sum_file
+from cosalib.cmdlib import run_verbose, sha256sum_file, flatten_image_yaml
 from cosalib.cmdlib import import_ostree_commit, get_basearch
 from cosalib.meta import GenericBuildMeta
 
@@ -60,8 +59,7 @@ if not args.build:
     args.build = builds.get_latest()
 print(f"Targeting build: {args.build}")
 
-with open('src/config/image.yaml') as fh:
-    image_yaml = yaml.safe_load(fh)
+image_yaml = flatten_image_yaml('src/config/image.yaml')
 squashfs_compression = 'lz4' if args.fast else image_yaml.get('squashfs-compression', 'zstd')
 
 srcdir_prefix = "src/config/live/"

--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -151,7 +151,7 @@ yaml2json() {
 
 # Convert the image.yaml to JSON so that it can be more easily parsed
 # by the shell script in create_disk.sh.
-yaml2json "$configdir/image.yaml" image-config.json
+yaml2json "${image_yaml}" image-config.json
 yaml2json "/usr/lib/coreos-assembler/image-default.yaml" image-default.json
 # Combine with the defaults
 cat image-default.json image-config.json | jq -s add > image-configured.json
@@ -185,7 +185,7 @@ case "${image_type}" in
         rootfs_size=0
         ;;
     qemu)
-        image_size="$(python3 -c 'import sys, yaml; print(yaml.safe_load(sys.stdin)["size"])' < "$configdir/image.yaml")G"
+        image_size="$(python3 -c 'import sys, yaml; print(yaml.safe_load(sys.stdin)["size"])' < "${image_yaml}")G"
         rootfs_size="${rootfs_size}M"
         ;;
     *) fatal "unreachable image_type ${image_type}";;
@@ -196,7 +196,7 @@ if [ "${image_type}" == metal4k ]; then
 fi
 
 set -x
-kargs="$(python3 -c 'import sys, yaml; args = yaml.safe_load(sys.stdin).get("extra-kargs", []); print(" ".join(args))' < "$configdir/image.yaml")"
+kargs="$(python3 -c 'import sys, yaml; args = yaml.safe_load(sys.stdin).get("extra-kargs", []); print(" ".join(args))' < "${image_yaml}")"
 tty="console=tty0 console=${DEFAULT_TERMINAL},115200n8"
 # On each s390x hypervisor, a tty would be automatically detected by the kernel
 # and systemd, there is no need to specify one. However, we keep DEFAULT_TERMINAL

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -171,6 +171,9 @@ prepare_build() {
     manifest_lock_arch_overrides=$(pick_yaml_or_else_json "${configdir}/manifest-lock.overrides.${basearch}")
     fetch_stamp="${workdir}"/cache/fetched-stamp
 
+    image_yaml="${workdir}/tmp/image.yaml"
+    flatten_image_yaml_to_file "${configdir}/image.yaml" "${image_yaml}"
+
     export workdir configdir manifest manifest_lock manifest_lock_overrides manifest_lock_arch_overrides
     export fetch_stamp
 
@@ -754,4 +757,14 @@ builds = Builds('${workdir:-$(pwd)}')
 builds.insert_build('${buildid}')
 builds.bump_timestamp()
 print('Build ${buildid} was inserted')")
+}
+
+flatten_image_yaml_to_file() {
+    local srcfile=$1; shift
+    local outfile=$1; shift
+    (python3 -c "
+import sys
+sys.path.insert(0, '${DIR}')
+from cosalib import cmdlib
+cmdlib.flatten_image_yaml_to_file('${srcfile}', '${outfile}')")
 }

--- a/tests/test_cosalib_cmdlib.py
+++ b/tests/test_cosalib_cmdlib.py
@@ -187,3 +187,34 @@ def test_merge_dicts(tmpdir):
     assert m[1] == "yup"
     assert x[2] == m[2]
     assert m[3] == z[3]
+
+
+def test_flatten_image_yaml(tmpdir):
+    fn = f"{tmpdir}/image.yaml"
+    with open(fn, 'w') as f:
+        f.write("""
+size: 10
+extra-kargs:
+  - foobar
+unique-key-a: true
+""")
+    o = cmdlib.flatten_image_yaml(fn)
+    assert o['size'] == 10
+    assert o['extra-kargs'] == ['foobar']
+    assert o['unique-key-a']
+
+    with open(fn, 'a') as f:
+        f.write("include: image-base.yaml")
+    base_fn = f"{tmpdir}/image-base.yaml"
+    with open(base_fn, 'w') as f:
+        f.write("""
+size: 8
+extra-kargs:
+  - bazboo
+unique-key-b: true
+""")
+    o = cmdlib.flatten_image_yaml(fn)
+    assert o['size'] == 10
+    assert o['extra-kargs'] == ['foobar', 'bazboo']
+    assert o['unique-key-a']
+    assert o['unique-key-b']


### PR DESCRIPTION
This will be needed in FCOS to make it easier to have kernel arguments
that are specific to some streams, while still sharing the bulk of
`image.yaml`:

https://github.com/coreos/fedora-coreos-tracker/issues/292#issuecomment-806099932