### PR TITLE
plume/cosa2stream: Add --nosignatures

### DIFF
--- a/mantle/cmd/plume/cosa2stream.go
+++ b/mantle/cmd/plume/cosa2stream.go
@@ -44,6 +44,7 @@ var (
 		SilenceUsage: true,
 	}
 
+	nosignatures  bool
 	streamBaseURL string
 	streamName    string
 	distro        string
@@ -55,6 +56,7 @@ func init() {
 	cmdCosaBuildToStream.Flags().StringVar(&streamName, "name", "", "Stream name")
 	cmdCosaBuildToStream.Flags().StringVar(&distro, "distro", "", "Distribution (fcos, rhcos)")
 	cmdCosaBuildToStream.Flags().StringVar(&target, "target", "", "Modify this file in place (default: no source, print to stdout)")
+	cmdCosaBuildToStream.Flags().BoolVar(&nosignatures, "no-signatures", false, "Omit signatures (useful to generate pre-release stream metadata)")
 	root.AddCommand(cmdCosaBuildToStream)
 }
 
@@ -89,6 +91,9 @@ func runCosaBuildToStream(cmd *cobra.Command, args []string) error {
 	}
 	if streamBaseURL != "" {
 		childArgs = append(childArgs, "--stream-baseurl="+streamBaseURL)
+	}
+	if nosignatures {
+		childArgs = append(childArgs, "--no-signatures")
 	}
 
 	for _, arg := range args {

--- a/src/cmd-generate-release-meta
+++ b/src/cmd-generate-release-meta
@@ -46,6 +46,7 @@ parser.add_argument("--stream-name", help="Override the stream ID (default is de
 parser.add_argument("--stream-baseurl", help="Override prefix URL for stream content", default=FCOS_STREAM_ENDPOINT)
 parser.add_argument("--output", help="Output to file; default is build directory")
 parser.add_argument("--url", help="URL to a coreos-assembler meta.json", default=[], action='append')
+parser.add_argument("--no-signatures", help="Disable signature references", action='store_true')
 args = parser.parse_args()
 
 
@@ -108,9 +109,12 @@ def append_build(out, input_):
 
     def artifact(i):
         base_url = url_builder(out.get('stream'), out.get('release'), arch, i.get('path'))
+        sig = "{}.sig".format(base_url)
+        if args.no_signatures:
+            sig = ''
         return {
             "location": base_url,
-            "signature": "{}.sig".format(base_url),
+            "signature": sig,
             "sha256": i.get("sha256"),
             "uncompressed-sha256": i.get("uncompressed-sha256")
         }


### PR DESCRIPTION
For RHCOS We don't yet have this in place by the time we go to pin in
the installer; we may end up relying on the installer's GPG
signature covering the stream metadata.