### PR TITLE
build: Link to issue if we fail to import

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -376,7 +376,10 @@ else
     ostree init --repo=repo --mode=archive
     # Pass the ref if it's set
     # shellcheck disable=SC2086
-    ostree pull-local --repo=repo "${tmprepo}" "${buildid}" ${ref}
+    if ! ostree pull-local --repo=repo "${tmprepo}" "${buildid}" ${ref}; then
+        echo '(maybe https://github.com/coreos/coreos-assembler/issues/972 ?)'
+        exit 1
+    fi
     # Don't compress; archive repos are already compressed individually and we'd
     # gain ~20M at best. We could probably have better gains if we compress the
     # whole repo in bare/bare-user mode, but that's a different story...


### PR DESCRIPTION
So we don't forget.

(There's a right fix here but hacking on the pipeline and reproducing
 the error is painful)