### PR TITLE
gangplank: use consistent verbs and tenses in yaml

### DIFF
--- a/docs/gangplank/usage.md
+++ b/docs/gangplank/usage.md
@@ -181,13 +181,13 @@ To illustrate this, consider:
   - oscontainer
   request_cache_repo: true
   request_cache: true
-  returns_cache: true
-  returns_cache_repo: true
+  return_cache: true
+  return_cache_repo: true
 - id: oscontainer
   build_artifacts:
   - ostree
-  requires_cache: true
-  requires_cache_repo: true
+  require_cache: true
+  require_cache_repo: true
 - id: clouds
   concurrent_execution: true
   build_artifacts:

--- a/gangplank/ocp/bc.go
+++ b/gangplank/ocp/bc.go
@@ -247,7 +247,7 @@ binary build interface.`)
 
 		l := log.WithFields(log.Fields{
 			"stage":              s.ID,
-			"required_artifacts": s.RequireArtifacts,
+			"require_artifacts": s.RequireArtifacts,
 		})
 
 		cpod, err := NewCosaPodder(podCtx, apiBuild, idx)

--- a/gangplank/spec/stages.go
+++ b/gangplank/spec/stages.go
@@ -50,12 +50,12 @@ type Stage struct {
 	// required artifact is missing (per the meta.json), the stage
 	// will not be executed. RequireArticts _implies_ sending builds/builds.json
 	// and builds/<BUILDID>/meta.json.
-	RequireArtifacts []string `yaml:"requires_artifacts,flow,omitempty" json:"requires_artifacts,omitempty"`
+	RequireArtifacts []string `yaml:"require_artifacts,flow,omitempty" json:"require_artifacts,omitempty"`
 
 	// RequestArtifacts are files that are provided if they are there. Examples include
 	// 'caches' for `/srv/cache` and `/srv/tmp/repo` tarballs or `ostree` which are really useful
 	// for base builds.
-	RequestArtifacts []string `yaml:"optional_artifacts,flow,omitempty" json:"optional_artifacts,omitempty"`
+	RequestArtifacts []string `yaml:"request_artifacts,flow,omitempty" json:"request_artifacts,omitempty"`
 
 	// BuildArtifacts produces "known" artifacts. The special "base"
 	// will produce an OSTree and QCOWs.


### PR DESCRIPTION
Make the yaml verb and tenses more consistent to make it easier for the users of gangplank to avoid mistakes.