### PR TITLE
Gangplank: minio tweaks for the Elder Arches

### DIFF
--- a/gangplank/ocp/filer.go
+++ b/gangplank/ocp/filer.go
@@ -487,17 +487,24 @@ func (m *minioServer) isLocalNewer(bucket, object string, path string) (bool, er
 	if err != nil {
 		return true, err
 	}
-
-	f, err := os.Stat(path)
+	modTime, err := getLocalFileStamp(path)
 	if err != nil {
 		return false, err
 	}
-
-	modTime := f.ModTime().UTC().UnixNano()
 	if modTime > curStamp {
 		return true, nil
 	}
 	return false, nil
+}
+
+// getLocalFileStamp returns the local file mod time in UTC Unix epic nanoseconds.
+func getLocalFileStamp(path string) (int64, error) {
+	f, err := os.Stat(path)
+	if err != nil {
+		return 0, err
+	}
+	modTime := f.ModTime().UTC().UnixNano()
+	return modTime, nil
 }
 
 // getStamp returns the stamp. If the file does not exist remotely the stamp of

--- a/gangplank/ocp/remotes_test.go
+++ b/gangplank/ocp/remotes_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -85,11 +86,23 @@ func TestRemote(t *testing.T) {
 	}
 	log.Infof("stamp is %d", stamp)
 
+	time.Sleep(1 * time.Second) // ensure that this is older
 	if err := ioutil.WriteFile(destF, []byte("udpated"), 0644); err != nil {
 		t.Fatalf("Failed to update the file")
 	}
 	newer, err := m.isLocalNewer(testBucket, "test", destF)
+	if err != nil {
+		t.Fatalf("failed to get remote stamp: %v", err)
+	}
+	cur, err := getLocalFileStamp(destF)
+	if err != nil {
+		t.Fatalf("failed to get local stamp: %v", err)
+	}
+	stamp, err = m.getStamp(testBucket, "test")
+	if err != nil {
+		t.Fatalf("failed to get remote stamp; %v", err)
+	}
 	if !newer {
-		t.Fatalf("file should be newer: %v", err)
+		t.Fatalf("local file should be newer: local stamp %d should be larger than remote %d", cur, stamp)
 	}
 }


### PR DESCRIPTION
The elder Arches (s390x and ppc64, although technically ppc64el is a newer variant) have hit a few snags with Minio. 

These commits are aimed at making the startup of minio more robust by checking that minio is ready before returning from `start()` as well as adding extra checks on the newness logic for remote files. 