### PR TITLE
ocp: use a cluster role for Gangplank

### DIFF
--- a/ocp/cosa-bc.yaml
+++ b/ocp/cosa-bc.yaml
@@ -41,56 +41,20 @@ objects:
     name: ${SA}
   name: ${SA}
 
-- apiVersion: authorization.openshift.io/v1
-  kind: Role
-  metadata:
-    name: ${SA}_secrets
-  rules:
-  - apiGroups:
-    - ""
-    resources:
-    - secrets
-    verbs:
-    - watch
-    - get
-    - list
-
-- apiVersion: v1
-  groupNames: null
+# Gangplank uses similar permissions to Jenkins
+- apiVersion: rbac.authorization.k8s.io/v1
   kind: RoleBinding
   metadata:
-    name: ${SA}_secrets
+    name: coreos-builder-editor-0
   roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
     name: edit
   subjects:
   - kind: ServiceAccount
     name: ${SA}
 
-- apiVersion: rbac.authorization.k8s.io/v1
-  kind: Role
-  metadata:
-    name:  ${SA}_cosa-reader
-  rules:
-  - apiGroups:
-    - ""
-    resources:
-    - pods
-    verbs:
-    - get
-    - watch
-    - list
-    - create
-
-- kind: RoleBinding
-  apiVersion: rbac.authorization.k8s.io/v1
-  metadata:
-    name: ${SA}_cosa-reader
-  roleRef:
-    name: ${SA}_cosa-reader
-  subjects:
-  - kind: ServiceAccount
-    name: ${SA}
-
+# Create the basic build config
 - apiVersion: build.openshift.io/v1
   kind: BuildConfig
   metadata:


### PR DESCRIPTION
Rather than using a buggy-custom role, we should use a standard cluster
role for the Gangplank processes.

This is the same role used for Prow permissions via https://github.com/openshift/release/pull/17257/commits/5d284363583f7cae00143129bbd181c64d7e13fd