### PR TITLE
Gangplank: refactor job control and logging to fix hangs

### DIFF
--- a/gangplank/cmd/build.go
+++ b/gangplank/cmd/build.go
@@ -19,8 +19,6 @@ package main
 
 import (
 	"context"
-	"fmt"
-	"time"
 
 	"github.com/coreos/gangplank/ocp"
 	log "github.com/sirupsen/logrus"
@@ -46,21 +44,6 @@ func init() {
 func runOCP(c *cobra.Command, args []string) {
 	defer cancel()
 	defer ctx.Done()
-
-	// Terminal "keep alive" helper. When following logs via the `oc` commands,
-	// cloud-deployed will send an EOF. To get around the EOF, the func sends a
-	// null character that is not printed to the screen or reflected in the logs.
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			default:
-				fmt.Print("\x00")
-				time.Sleep(1 * time.Second)
-			}
-		}
-	}()
 
 	b, err := ocp.NewBuilder(ctx)
 	if err != nil {

--- a/gangplank/ocp/k8s.go
+++ b/gangplank/ocp/k8s.go
@@ -168,7 +168,7 @@ func getPodIP(cs *kubernetes.Clientset, podNamespace, podName string) (string, e
 	for {
 		events, ok := <-w.ResultChan()
 		if !ok {
-			return "", fmt.Errorf("Failed query for pod IP on pod/%s", podName)
+			return "", fmt.Errorf("failed query for pod IP on pod/%s", podName)
 		}
 		resp := events.Object.(*v1.Pod)
 		if resp.Status.PodIP != "" {


### PR DESCRIPTION
This fixes two big problems encountered while putting Gangplank into
production:
- hangs caused by orphaned go-routines after an os interrupt (ctrl-c)
- when running in-cluster, errors would not break execution

The job control code was refactored to ensure only one part of the code
handled the issuance of termination from all termination signals (context,
os interrupt or error handling). Instead, a termination channel signals
worker go-routines that they should terminate and individual go-routines
no longer care about context or os signals. Further, the
workerFunction() was simplified and now only takes a termination channel
as the argument.

The in-cluster pod watch function was simplified and cleaned up as well.
If a pod failed early or was unschedudable, then Gangplank would hang. To
fix this, Gangplank now understands more nuanced failure states.

Logging was another source of hangs. The code was a bit messy and the
cleaned up code is now broken over multiple functions.

Signed-off-by: Ben Howard <ben.howard@redhat.com>