### PR TITLE
Gangplank: allow for cross-namespace execution

### DIFF
--- a/gangplank/cmd/pod.go
+++ b/gangplank/cmd/pod.go
@@ -44,6 +44,9 @@ var (
 	// cosaSrvDir is used as the scratch directory builds.
 	cosaSrvDir string
 
+	// cosaNamespace when defined will launch the pod in another namespace
+	cosaNamespace string
+
 	// automaticBuildStages is used to create automatic build stages
 	automaticBuildStages []string
 )
@@ -60,6 +63,7 @@ func init() {
 	cmdPod.Flags().StringVarP(&cosaWorkDir, "workDir", "w", "", "podman mode - workdir to use")
 	cmdPod.Flags().StringVarP(&serviceAccount, "serviceaccount", "a", "", "service account to use")
 
+	cmdPod.Flags().StringVarP(&cosaNamespace, "namespace", "N", "", "use a different namespace")
 	cmdPod.Flags().StringSliceVar(&generateCommands, "singleCmd", []string{}, "commands to run in stage")
 	cmdPod.Flags().StringSliceVar(&generateSingleRequires, "singleReq", []string{}, "artifacts to require")
 }
@@ -70,10 +74,10 @@ func init() {
 func runPod(c *cobra.Command, args []string) {
 	defer cancel()
 
-	cluster := ocp.NewCluster(true, "")
+	cluster := ocp.NewCluster(true, cosaNamespace, "")
 
 	if cosaViaPodman {
-		cluster = ocp.NewCluster(false, "")
+		cluster = ocp.NewCluster(false, cosaNamespace, "")
 		cluster.SetPodman(cosaSrvDir)
 		if cosaOverrideImage == "" {
 			cosaOverrideImage = cosaDefaultImage

--- a/gangplank/ocp/cosa-pod.go
+++ b/gangplank/ocp/cosa-pod.go
@@ -170,10 +170,10 @@ func NewCosaPodder(
 		}
 
 		if err := cp.addVolumesFromSecretLabels(); err != nil {
-			return nil, fmt.Errorf("failed to add secret volumes and mounts: %w", err)
+			log.WithError(err).Errorf("failed to add secret volumes and mounts")
 		}
 		if err := cp.addVolumesFromConfigMapLabels(); err != nil {
-			return nil, fmt.Errorf("failed to add configMap volumes and mountsi: %w", err)
+			log.WithError(err).Errorf("failed to add volumes from config maps")
 		}
 	}
 

--- a/gangplank/ocp/sa_secrets.go
+++ b/gangplank/ocp/sa_secrets.go
@@ -199,7 +199,7 @@ func kubernetesSecretsSetup(ac *kubernetes.Clientset, ns, toDir string) ([]strin
 
 	secrets, err := ac.CoreV1().Secrets(ns).List(lo)
 	if err != nil {
-		return ret, err
+		return ret, nil
 	}
 	log.Infof("Found %d secrets to consider", len(secrets.Items))
 


### PR DESCRIPTION
This allows Gangplank to be executed is another namespace, which is needed for Prow execution.