### PR TITLE
kola/podman.base: drop cgroupsv2-unsupported `podman run` resource switches

### DIFF
--- a/mantle/kola/tests/podman/podman.go
+++ b/mantle/kola/tests/podman/podman.go
@@ -263,15 +263,13 @@ func podmanResources(c cluster.TestCluster) {
 		// why we use 128m for memory
 		pCmd("--memory=128m --memory-swap=128m"),
 		pCmd("--memory-reservation=10m"),
-		pCmd("--kernel-memory=10m"),
 		pCmd("--cpu-shares=100"),
 		pCmd("--cpu-period=1000"),
 		pCmd("--cpuset-cpus=0"),
 		pCmd("--cpuset-mems=0"),
 		pCmd("--cpu-quota=1000"),
 		pCmd("--blkio-weight=10"),
-		pCmd("--memory=128m --oom-kill-disable=true"),
-		pCmd("--memory-swappiness=50"),
+		pCmd("--memory=128m"),
 		pCmd("--shm-size=1m"),
 	} {
 		cmd := podmanCmd


### PR DESCRIPTION
Those aren't supported in cgroups v2. Rather than make them conditional,
let's just drop them since we'll move over everything to cgroups v2
soon-ish anyway.

Closes: https://github.com/coreos/fedora-coreos-tracker/issues/791