### PR TITLE
kola/qemuexec: add support for directly passing Butane configs

### DIFF
--- a/mantle/cmd/kola/qemuexec.go
+++ b/mantle/cmd/kola/qemuexec.go
@@ -78,7 +78,7 @@ func init() {
 	cmdQemuExec.Flags().BoolVar(&directIgnition, "ignition-direct", false, "Do not parse Ignition, pass directly to instance")
 	cmdQemuExec.Flags().BoolVar(&devshell, "devshell", false, "Enable development shell")
 	cmdQemuExec.Flags().BoolVarP(&devshellConsole, "devshell-console", "c", false, "Connect directly to serial console in devshell mode")
-	cmdQemuExec.Flags().StringVarP(&ignition, "ignition", "i", "", "Path to ignition config")
+	cmdQemuExec.Flags().StringVarP(&ignition, "ignition", "i", "", "Path to Ignition config")
 	cmdQemuExec.Flags().StringArrayVar(&bindro, "bind-ro", nil, "Mount readonly via 9pfs a host directory (use --bind-ro=/path/to/host,/var/mnt/guest")
 	cmdQemuExec.Flags().StringArrayVar(&bindrw, "bind-rw", nil, "Same as above, but writable")
 	cmdQemuExec.Flags().BoolVarP(&forceConfigInjection, "inject-ignition", "", false, "Force injecting Ignition config using guestfs")
@@ -123,7 +123,7 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 	}
 	if devshell {
 		if directIgnition {
-			return fmt.Errorf("Cannot use devshell with direct ignition")
+			return fmt.Errorf("Cannot use devshell with --ignition-direct")
 		}
 		if kola.QEMUOptions.DiskImage == "" && kolaPlatform == "qemu" {
 			return fmt.Errorf("No disk image provided")
@@ -145,7 +145,7 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 	}
 
 	if directIgnition && ignition == "" {
-		return fmt.Errorf("Cannot use ignition-direct without a path to an Ignition config")
+		return fmt.Errorf("Cannot use --ignition-direct without --ignition")
 	}
 	if !directIgnition && ignition != "" {
 		buf, err := ioutil.ReadFile(ignition)
@@ -171,7 +171,7 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 
 	if len(ignitionFragments) > 0 {
 		if directIgnition {
-			return fmt.Errorf("Cannot use fragments with direct ignition")
+			return fmt.Errorf("Cannot use --add-ignition with --ignition-direct")
 		}
 		ensureConfig()
 		err := renderFragments(ignitionFragments, config)
@@ -184,7 +184,7 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 	defer builder.Close()
 	for _, b := range bindro {
 		if directIgnition {
-			return fmt.Errorf("Cannot use mounts with direct ignition")
+			return fmt.Errorf("Cannot use --bind-ro with --ignition-direct")
 		}
 		src, dest, err := parseBindOpt(b)
 		if err != nil {
@@ -196,7 +196,7 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 	}
 	for _, b := range bindrw {
 		if directIgnition {
-			return fmt.Errorf("Cannot use mounts with direct ignition")
+			return fmt.Errorf("Cannot use --bind-rw with --ignition-direct")
 		}
 		src, dest, err := parseBindOpt(b)
 		if err != nil {
@@ -268,7 +268,7 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 	}
 	if config != nil {
 		if directIgnition {
-			return fmt.Errorf("Cannot use fragments/mounts with direct ignition")
+			return fmt.Errorf("Cannot use --add-ignition, --bind-ro, or --bind-rw with --ignition-direct")
 		}
 		builder.SetConfig(config)
 	} else if directIgnition {

--- a/mantle/cmd/kola/qemuexec.go
+++ b/mantle/cmd/kola/qemuexec.go
@@ -157,6 +157,9 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Cannot use --bind-rw with --ignition-direct")
 	}
 
+	builder := platform.NewBuilder()
+	defer builder.Close()
+
 	if !directIgnition && ignition != "" {
 		buf, err := ioutil.ReadFile(ignition)
 		if err != nil {
@@ -187,8 +190,6 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	builder := platform.NewBuilder()
-	defer builder.Close()
 	for _, b := range bindro {
 		src, dest, err := parseBindOpt(b)
 		if err != nil {

--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -471,6 +471,15 @@ func (builder *QemuBuilder) SetConfig(config *conf.Conf) {
 	builder.ignitionSet = true
 }
 
+// Small wrapper around ioutil.Tempfile() to avoid leaking our tempdir to
+// others.
+func (builder *QemuBuilder) TempFile(pattern string) (*os.File, error) {
+	if err := builder.ensureTempdir(); err != nil {
+		return nil, err
+	}
+	return ioutil.TempFile(builder.tempdir, pattern)
+}
+
 // renderIgnition lazily renders a parsed config if one is set
 func (builder *QemuBuilder) renderIgnition() error {
 	if !builder.ignitionSet || builder.ignitionRendered {


### PR DESCRIPTION
Add a new `--butane` option analogous to `--ignition` which
automatically converts the Butane config to an Ignition config.