### PR TITLE
You won't believe this one simple trick to clear out the Quay.io cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /root/containerbuild
 COPY ./src/print-dependencies.sh ./src/deps*.txt ./src/vmdeps*.txt ./src/build-deps.txt /root/containerbuild/src/
 COPY ./build.sh /root/containerbuild/
 RUN ./build.sh configure_yum_repos
-RUN ./build.sh install_rpms  # nocache 20210408
+RUN ./build.sh install_rpms  # nocache 20210413
 
 # Ok copy in the rest of them for the next few steps
 COPY ./ /root/containerbuild/


### PR DESCRIPTION
I'd like to get rpm-ostree v2021.4 into cosa for the advisory bits:
https://github.com/coreos/rpm-ostree/pull/2695

And the SRPM locking:
https://github.com/coreos/rpm-ostree/pull/2680