### PR TITLE
kola/spawn: Add support for stream metadata for rhcos

### DIFF
--- a/mantle/rhcos/metadata.go
+++ b/mantle/rhcos/metadata.go
@@ -1,0 +1,90 @@
+// Copyright 2021 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rhcos
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+
+	"github.com/coreos/stream-metadata-go/stream"
+
+	"github.com/coreos/mantle/system"
+)
+
+const (
+	// If the branch ever renames this will break
+	StreamLatest = "master"
+)
+
+func fetchURL(u url.URL) ([]byte, error) {
+	res, err := http.Get(u.String())
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := ioutil.ReadAll(res.Body)
+	res.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	return body, nil
+}
+
+func getStreamURL(stream string) url.URL {
+	u := url.URL{
+		Scheme: "https",
+		Host:   "raw.githubusercontent.com",
+		Path:   "",
+	}
+	u.Path = fmt.Sprintf("openshift/installer/%s/data/data/rhcos-stream.json", stream)
+	return u
+}
+
+// FetchStreamMetadata returns a stream
+func FetchStreamMetadata(streamName string) (*stream.Stream, error) {
+	u := getStreamURL(streamName)
+	body, err := fetchURL(u)
+	if err != nil {
+		return nil, err
+	}
+	var s *stream.Stream
+	if err = json.Unmarshal(body, &s); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// FetchStreamArtifacts returns a stream artifacts
+func FetchStreamArtifacts(stream, architecture string) (*stream.Arch, error) {
+	metadata, err := FetchStreamMetadata(stream)
+	if err != nil {
+		return nil, fmt.Errorf("fetching stream metadata: %v", err)
+	}
+	arch, ok := metadata.Architectures[architecture]
+	if !ok {
+		return nil, fmt.Errorf("stream metadata missing architecture %q", architecture)
+	}
+	return &arch, nil
+}
+
+// FetchStreamThisArchitecture returns artifacts for the current architecture from
+// the given stream.
+func FetchStreamThisArchitecture(stream string) (*stream.Arch, error) {
+	return FetchStreamArtifacts(stream, system.RpmArch())
+}


### PR DESCRIPTION
Now that we have stream metadata for RHCOS, this closes a huge
gap in that we now have a convenient command to spawn an RHCOS
instance shell in AWS:

```
$ kola spawn -b rhcos --stream master -p aws
Resolved distro=rhcos stream=master platform=aws to release=48.83.202103221318-0 (region us-east-1, ami ami-0146091f9e1b5ec3f)
...
[bound] -bash-4.4$ rpm-ostree status
State: idle
Deployments:
* ostree://328a44d7c259ca1e3ed31ae020f09d922f460be998657a92f684f6760443077b
                   Version: 48.83.202103221318-0 (2021-03-22T13:22:02Z)
[bound] -bash-4.4$
```