### PR TITLE
Add support for manifest-lock.fast-track.yaml

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -226,7 +226,7 @@ prepare_git_artifacts "${configdir_gitrepo}" "${PWD}/coreos-assembler-config.tar
 
 extra_compose_args=()
 
-for lock in "${manifest_lock}" "${manifest_lock_overrides}" "${manifest_lock_arch_overrides}"; do
+for lock in "${manifest_lock}" "${manifest_lock_fast_track}" "${manifest_lock_overrides}" "${manifest_lock_arch_overrides}"; do
     if [ -f "${lock}" ]; then
         extra_compose_args+=("--ex-lockfile=${lock}")
     fi

--- a/src/cmd-fetch
+++ b/src/cmd-fetch
@@ -88,13 +88,13 @@ if [ -n "${UPDATE_LOCKFILE}" ]; then
     # Include the overrides in the resulting lockfile here; otherwise, we
     # might not even be able to get a depsolve solely from the non-lockfile
     # repos.
-    for lock in "${manifest_lock_overrides}" "${manifest_lock_arch_overrides}"; do
+    for lock in "${manifest_lock_fast_track}" "${manifest_lock_overrides}" "${manifest_lock_arch_overrides}"; do
       if [ -f "${lock}" ]; then
           args+=" --ex-lockfile=${lock}"
       fi
     done
 else
-    for lock in "${manifest_lock}" "${manifest_lock_overrides}" "${manifest_lock_arch_overrides}"; do
+    for lock in "${manifest_lock}" "${manifest_lock_fast_track}" "${manifest_lock_overrides}" "${manifest_lock_arch_overrides}"; do
         if [ -f "${lock}" ]; then
             args+=" --ex-lockfile=${lock}"
         fi

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -167,6 +167,7 @@ prepare_build() {
     # for the base lockfile, we default to JSON since that's what rpm-ostree
     # actually outputs
     manifest_lock=$(pick_yaml_or_else_json "${configdir}/manifest-lock.${basearch}" json)
+    manifest_lock_fast_track=${configdir}/manifest-lock.fast-track.yaml
     manifest_lock_overrides=$(pick_yaml_or_else_json "${configdir}/manifest-lock.overrides")
     manifest_lock_arch_overrides=$(pick_yaml_or_else_json "${configdir}/manifest-lock.overrides.${basearch}")
     fetch_stamp="${workdir}"/cache/fetched-stamp
@@ -174,7 +175,7 @@ prepare_build() {
     image_yaml="${workdir}/tmp/image.yaml"
     flatten_image_yaml_to_file "${configdir}/image.yaml" "${image_yaml}"
 
-    export workdir configdir manifest manifest_lock manifest_lock_overrides manifest_lock_arch_overrides
+    export workdir configdir manifest manifest_lock manifest_lock_fast_track manifest_lock_overrides manifest_lock_arch_overrides
     export fetch_stamp
 
     if ! [ -f "${manifest}" ]; then


### PR DESCRIPTION
This new lockfile will help us make the distinction in FCOS between
packages we want to fast-track and those we want to pin for other
reasons (e.g. avoiding a regression).

Prep for automating the "graduation" of fast-tracked packages.