### PR TITLE
Gangplank: add podless mode

### DIFF
--- a/gangplank/cmd/commonflags.go
+++ b/gangplank/cmd/commonflags.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	flag "github.com/spf13/pflag"
+)
+
+// Flags has the configuration flags.
+var specCommonFlags = flag.NewFlagSet("", flag.ContinueOnError)
+
+func init() {
+	specCommonFlags.StringSliceVar(&generateCommands, "singleCmd", []string{}, "commands to run in stage")
+	specCommonFlags.StringSliceVar(&generateSingleRequires, "singleReq", []string{}, "artifacts to require")
+	specCommonFlags.StringVarP(&cosaSrvDir, "srvDir", "S", "", "directory for /srv; in pod mount this will be bind mounted")
+}


### PR DESCRIPTION
Instead of having a useless "runCmd" target, this change enables
"podless" more for executing Gangplank directly. The use cases are:
- developers testing inside a pet-container for JobSpec testing
- Prow (while we tease out permissions)

Example invocation:
  gangplank podless --init -A base -A metal4k

When running in podless mode Gangplank only parse the jobspec and
executes the task.

Signed-off-by: Ben Howard <ben.howard@redhat.com>