### PR TITLE
ocp: add 'oc' bin to OCP Dockerfile and fix Makefile

### DIFF
--- a/ocp/Dockerfile.buildconfig
+++ b/ocp/Dockerfile.buildconfig
@@ -1,4 +1,8 @@
+FROM quay.io/openshift/origin-cli AS openshift-origin
+
 FROM quay.io/coreos-assembler/coreos-assembler:latest
+
+COPY --from=openshift-origin /usr/bin/oc /usr/bin
 
 WORKDIR /srv/
 USER builder

--- a/ocp/Makefile
+++ b/ocp/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build-bc-image build-dev
 build-bc-image:
-	cd ../ && buildah bud -f ocp/Dockerfile -t quay.io/coreos-assembler/coreos-assembler:ocp
+	cd ../ && buildah bud -f ocp/Dockerfile.buildconfig -t quay.io/coreos-assembler/coreos-assembler:ocp
 
 build-dev:
 	cd ../ && buildah bud -f ocp/Dockerfile.dev -t quay.io/coreos-assembler/coreos-assembler:ocp-dev


### PR DESCRIPTION
Plan E for Prow via Gangplank is to use a custom build strategy via `oc
start-build` due to permission issues. This change ensures that OCP
build images has the OC binary.