### PR TITLE
digitalocean: set uncompressed-{size,sha256}

### DIFF
--- a/src/cosalib/digitalocean.py
+++ b/src/cosalib/digitalocean.py
@@ -1,7 +1,9 @@
+import os
 import shutil
 
 from cosalib.cmdlib import (
-    run_verbose
+    run_verbose,
+    sha256sum_file
 )
 
 
@@ -10,10 +12,16 @@ def mutate_digitalocean(path):
     # supports .gz and .bz2 compression but not .xz.  .bz2 is a bit tighter
     # but isn't used for any other artifact.  Manually gzip the artifact
     # here.  cmd-compress will skip recompressing it later.
+    sha256 = sha256sum_file(path)
+    size = os.stat(path).st_size
     temp_path = f"{path}.gz"
     with open(temp_path, "wb") as fh:
         run_verbose(['gzip', '-9c', path], stdout=fh)
     shutil.move(temp_path, path)
+    return {
+        'uncompressed-sha256': sha256,
+        'uncompressed-size': size,
+    }
 
 
 def digitalocean_run_ore(build, args):


### PR DESCRIPTION
cmd-compress doesn't process the DO artifact because we special-case gzip compression in the mutate callback.  But the artifact is still a regular compressed disk image, so we should still set the uncompressed size/sha256.  Have the mutate callback do that as well.

Do not apply a similar change to the GCP `tar.gz` artifact, since the uncompressed tarball isn't useful on its own.