### PR TITLE
cmdlib: use new repo-packages for overrides

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -336,7 +336,10 @@ EOF
         # the same RPMs: the `dnf repoquery` below is to pick the latest one
         dnf repoquery  --repofrompath=tmp,"file://${overridesdir}/rpm" \
             --disablerepo '*' --enablerepo tmp --refresh --latest-limit 1 \
-            --exclude '*.src' --qf '%{NAME}\t%{EVR}\t%{ARCH}' --quiet | python3 -c '
+            --exclude '*.src' --qf '%{NAME}\t%{EVR}\t%{ARCH}' --quiet \
+                > "${tmp_overridesdir}/overrides.txt"
+        # yes, don't need cat, but it's more legible that way
+        cat "${tmp_overridesdir}/overrides.txt" | python3 -c '
 import sys, json
 lockfile = {"packages": {}}
 for line in sys.stdin:
@@ -349,6 +352,9 @@ json.dump(lockfile, sys.stdout)' > "${local_overrides_lockfile}"
         cat >> "${override_manifest}" <<EOF
 repos:
   - coreos-assembler-local-overrides
+repo-packages:
+  - repo: coreos-assembler-local-overrides
+    packages: [$(cut -f1 "${tmp_overridesdir}/overrides.txt")]
 EOF
         cat > "${tmp_overridesdir}"/coreos-assembler-local-overrides.repo <<EOF
 [coreos-assembler-local-overrides]


### PR DESCRIPTION
Use the new rpm-ostree support for repo-packages to make sure that
rpm-ostree picks the packages from our repo. This is even more explicit
than what we had before with the lockfile which just restricts the
NEVRA. In theory we could drop both the lockfile and `cost` hack now and
put the NEVRAs in the `repo-packages` entry, but meh... they don't
really hurt and we can look at doing that in a follow-up.

More importantly, this will also be required for overrides to work
correctly once rpm-ostree supports modules so that we can easily
override modular and non-modular packages alike.