### PR TITLE
Gangplank: support pushing ostree to registries

### DIFF
--- a/docs/gangplank/usage.md
+++ b/docs/gangplank/usage.md
@@ -145,9 +145,41 @@ INFO[0000] Gangplank: COSA OpenShift job runner, 2021-03-02.9dce8136~dirty
 # 2021-03-02T17:25:42-07:00
 job:
   strict: true
+
 recipe:
   git_ref: testing-devel
   git_url: https://github.com/coreos/fedora-coreos-config
+  repos:
+   # URLs point to remote endpoint that contains the repo file
+   - <URL>
+
+# publish_ocontainer describes locations to push the oscontainer to.
+publish_oscontainer:
+    # TLS verification for build strategy builds. Defaults to true
+    # Push registry comes from the build.openshift.io's build.spec.output
+    # specification.
+    buildstrategy_tls_verify: true
+
+    # list of push locations to push osconatiner to.
+    registries:
+      # push to a cluster address using an service account token
+      # to login to the regitry (only useful in cluster)
+      - url: "first.registry.example.com/stream/name:tag"
+        secret_type: token
+        tls_verify: false
+
+      # push with an inline secret
+      - url: "second.registry.example.com/stream/name:tag",
+        secret_type: inline
+        secret: "<STRING>"
+
+      # push using an incluser secret name "builder-secret"
+      # the service account running Gangplank will need to be
+      # able to read the secret
+      - url: "third.registry.exmaple.com/stream/name:tag",
+        secret_type: cluster
+        secret: builder-secret
+
 stages:
 - id: Generated Base Stage
   build_artifacts: [base]

--- a/gangplank/ocp/ocp.go
+++ b/gangplank/ocp/ocp.go
@@ -1,18 +1,14 @@
 package ocp
 
 import (
-	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
-	"os/exec"
-	"os/user"
-	"path/filepath"
 	"strings"
 
+	"github.com/coreos/gangplank/cosa"
+	"github.com/coreos/gangplank/spec"
 	buildapiv1 "github.com/openshift/api/build/v1"
 	log "github.com/sirupsen/logrus"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 )
@@ -79,120 +75,24 @@ func getPushTagless(s string) (string, string) {
 
 // uploadCustomBuildContainer implements the custom build strategy optional step to report the results
 // to the registry as an OCI image. uploadCustomBuildContainer must be called from a worker pod.
-func uploadCustomBuildContainer(ctx ClusterContext, apiBuild *buildapiv1.Build, buildID string) error {
+// The token used is associated with the service account with the worker pod.
+func uploadCustomBuildContainer(ctx ClusterContext, tlsVerify *bool, apiBuild *buildapiv1.Build, build *cosa.Build) error {
 	if apiBuild == nil || apiBuild.Spec.Strategy.CustomStrategy == nil || apiBuild.Spec.Output.To == nil {
 		log.Debug("Build is not running as a custom build strategy or output name is not defined")
 		return nil
 	}
 
-	// Setup the environment for commands
-	u, err := user.Current()
+	err := pushOstreeToRegistry(ctx,
+		&spec.Registry{
+			URL:        apiBuild.Spec.Output.To.Name,
+			SecretType: spec.PushSecretTypeToken,
+			TLSVerify:  tlsVerify,
+		},
+		build)
+
 	if err != nil {
-		return fmt.Errorf("unable to determine my username: %v", err)
-	}
-	authPath := filepath.Join("run", "containers", u.Uid, "auth.json")
-	baseEnv := append(
-		os.Environ(),
-		"FORCE_UNPRIVILEGED=1",
-		fmt.Sprintf("REGISTRY_AUTH_FILE=%s", authPath),
-		// Tell the tools where to find the home directory
-		fmt.Sprintf("HOME=%s", cosaSrvDir),
-	)
-
-	// envVar is set during Pod creation by workSpec.getEnvVars()
-	disableTLSVerification, _ := os.LookupEnv("DISABLE_TLS_VERIFICATION")
-
-	registry, registryPath := getPushTagless(apiBuild.Spec.Output.To.Name)
-	pushPath := fmt.Sprintf("%s/%s", registry, registryPath)
-
-	l := log.WithFields(
-		log.Fields{
-			"authfile":   authPath,
-			"final push": apiBuild.Spec.Output.To.Name,
-			"push path":  pushPath,
-			"registry":   registry,
-		})
-	l.Info("Pushing to remote registry")
-
-	if token, err := ioutil.ReadFile(serviceAccountTokenFile); err == nil {
-		// Default to using the service account token to login to the registry
-		// This method is the most reliable for OCP3 and while its a hack, it ensures that the
-		// the auth is located where the tooling expects it to be.
-		l.Debug("Using token to access registry")
-		loginCmd := []string{"buildah", "login"}
-		if disableTLSVerification == "1" {
-			loginCmd = append(loginCmd, "--tls-verify=false")
-		}
-		loginCmd = append(loginCmd, "-u", "serviceaccount", "-p", string(token), registry)
-
-		cmd := exec.CommandContext(ctx, loginCmd[0], loginCmd[1:]...)
-		cmd.Env = baseEnv
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		if err := cmd.Run(); err != nil {
-			return fmt.Errorf("failed to login into registry: %v", err)
-		}
-	} else if apiBuild.Spec.Output.PushSecret != nil && apiBuild.Spec.Output.PushSecret.Name != "" {
-		// otherwise locate the build push secret. On OCP3 this is not reliable
-		l.Debug("Using named secret for registry access")
-		ac, ns, err := GetClient(ctx)
-		if err != nil {
-			return fmt.Errorf("unable to fetch push secret")
-		}
-		secret, err := ac.CoreV1().Secrets(ns).Get(apiBuild.Spec.Output.PushSecret.Name, v1.GetOptions{})
-		if err != nil {
-			return fmt.Errorf("failed to query for secret %s: %v", apiBuild.Spec.Output.PushSecret.Name, err)
-		}
-		if secret == nil {
-			return fmt.Errorf("secret is empty")
-		}
-
-		// Populate the docker config.
-		for k, v := range secret.Data {
-			if k != ".dockercfg" {
-				continue
-			}
-			log.WithFields(log.Fields{
-				"key":         string(k),
-				"secret name": secret.Name,
-			}).Info("Writing push secret")
-
-			authDir := filepath.Dir(authPath)
-			if err := os.MkdirAll(authDir, 0755); err != nil {
-				return fmt.Errorf("failed to create docker configuration directory")
-			}
-
-			if err := ioutil.WriteFile(authPath, v, 0444); err != nil {
-				return fmt.Errorf("failed writing secret %s:%s", secret.Name, k)
-			}
-		}
+		log.WithError(err).Error("failed to push to remote registry")
 	}
 
-	// pushArgs invokes cosa upload code which creates a named tag
-	pushArgs := []string{
-		"/usr/bin/coreos-assembler", "upload-oscontainer",
-		fmt.Sprintf("--name=%s", pushPath),
-	}
-	// copy the pushed image to the expected tag
-	copyArgs := []string{
-		"skopeo", "copy",
-		fmt.Sprintf("docker://%s:%s", pushPath, buildID),
-		fmt.Sprintf("docker://%s", apiBuild.Spec.Output.To.Name),
-	}
-	if disableTLSVerification == "1" {
-		copyArgs = append(copyArgs, "--src-tls-verify=false", "--dest-tls-verify=false")
-	}
-
-	for _, args := range [][]string{pushArgs, copyArgs} {
-		l.WithField("cmd", args).Debug("Calling eternal tool ")
-		cmd := exec.CommandContext(ctx, args[0], args[1:]...)
-		cmd.Stderr = os.Stderr
-		cmd.Stdout = os.Stdout
-		cmd.Env = baseEnv
-		if err := cmd.Run(); err != nil {
-			return errors.New("upload to registry failed")
-		}
-	}
-
-	return nil
+	return err
 }

--- a/gangplank/ocp/worker.go
+++ b/gangplank/ocp/worker.go
@@ -2,10 +2,12 @@ package ocp
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -14,6 +16,7 @@ import (
 	buildapiv1 "github.com/openshift/api/build/v1"
 	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // workSpec is a Builder.
@@ -240,7 +243,18 @@ func (ws *workSpec) Exec(ctx ClusterContext) error {
 		next, _, _ := cosa.ReadBuild(cosaSrvDir, "", cosa.BuilderArch())
 		if next != nil && next.BuildArtifacts != nil && (mBuild.BuildArtifacts == nil || mBuild.BuildArtifacts.Ostree.Sha256 != next.BuildArtifacts.Ostree.Sha256) {
 			log.Debug("Stage produced a new OStree")
-			if err := uploadCustomBuildContainer(ctx, ws.APIBuild, next.BuildID); err != nil {
+
+			// push for other defined registries
+			for _, v := range ws.JobSpec.PublishOscontainer.Registries {
+				if err := pushOstreeToRegistry(ctx, &v, next); err != nil {
+					log.WithError(err).Warningf("Push to registry %s failed", v.URL)
+					return err
+				}
+			}
+
+			// push for custom build strategy
+			if err := uploadCustomBuildContainer(ctx, ws.JobSpec.PublishOscontainer.BuildStrategyTLSVerify, ws.APIBuild, next); err != nil {
+				log.WithError(err).Warning("Push to BuildSpec registry failed")
 				return err
 			}
 		}
@@ -278,15 +292,161 @@ func (ws *workSpec) getEnvVars() ([]v1.EnvVar, error) {
 			Name:  CosaWorkPodEnvVarName,
 			Value: string(d),
 		},
+		{
+			Name:  "XDG_RUNTIME_DIR",
+			Value: cosaSrvDir,
+		},
 	}
-
-	if ws.JobSpec.Job.DisableTLSVerify {
-		evars = append(evars,
-			v1.EnvVar{
-				Name:  "DISABLE_TLS_VERIFICATION",
-				Value: "1",
-			})
-	}
-
 	return evars, nil
+}
+
+// pushOstreetoRegistry pushes the OStree to the defined registry location.
+func pushOstreeToRegistry(ctx ClusterContext, push *spec.Registry, build *cosa.Build) error {
+	if push == nil {
+		return errors.New("unable to push to nil registry")
+	}
+	if build == nil {
+		return errors.New("unable to push to registry: cosa build is nil")
+	}
+
+	// TODO: move this to a common validator
+	if push.URL == "" {
+		return errors.New("push registry URL is emtpy")
+	}
+
+	cluster, _ := GetCluster(ctx)
+
+	registry, registryPath := getPushTagless(push.URL)
+	pushPath := fmt.Sprintf("%s/%s", registry, registryPath)
+
+	authPath := filepath.Join("/", cosaSrvDir, ".docker", "config.json")
+	authDir := filepath.Dir(authPath)
+	if err := os.MkdirAll(authDir, 0755); err != nil {
+		return fmt.Errorf("failed to directory path for push secret")
+	}
+
+	switch v := strings.ToLower(string(push.SecretType)); v {
+	case spec.PushSecretTypeInline:
+		if err := ioutil.WriteFile(authPath, []byte(push.Secret), 0644); err != nil {
+			return fmt.Errorf("failed to write the inline secret to auth.json: %v", err)
+		}
+	case spec.PushSecretTypeCluster:
+		if !cluster.inCluster {
+			return errors.New("cluster secrets pushes are invalid out-of-cluster")
+		}
+		if err := writeDockerSecret(ctx, push.Secret, authPath); err != nil {
+			return fmt.Errorf("failed to locate the secret %s: %v", push.Secret, err)
+		}
+	case spec.PushSecretTypeToken:
+		if err := tokenRegistryLogin(ctx, push.TLSVerify, registry); err != nil {
+			return fmt.Errorf("failed to login into registry: %v", err)
+		}
+		// container XDG_RUNTIME_DIR is set to cosaSrvDir
+		authPath = filepath.Join(cosaSrvDir, "containers", "auth.json")
+	default:
+		return fmt.Errorf("secret type %s is unknown for push registries", push.SecretType)
+	}
+
+	defer func() {
+		// Remove any logins that could interfere later with subsequent pushes.
+		_ = os.RemoveAll(filepath.Join(cosaSrvDir, "containers"))
+		_ = os.RemoveAll(filepath.Join(cosaSrvDir, ".docker"))
+	}()
+
+	baseEnv := append(
+		os.Environ(),
+		"FORCE_UNPRIVILEGED=1",
+		fmt.Sprintf("REGISTRY_AUTH_FILE=%s", authPath),
+		// Tell the tools where to find the home directory
+		fmt.Sprintf("HOME=%s", cosaSrvDir),
+	)
+
+	tlsVerify := true
+	if push.TLSVerify != nil && !*push.TLSVerify {
+		tlsVerify = false
+	}
+
+	l := log.WithFields(
+		log.Fields{
+			"auth json":        authPath,
+			"final push":       push.URL,
+			"push path":        pushPath,
+			"registry":         registry,
+			"tls verification": tlsVerify,
+			"push definition":  push,
+		})
+	l.Info("Pushing to remote registry")
+
+	// pushArgs invokes cosa upload code which creates a named tag
+	pushArgs := []string{
+		"/usr/bin/coreos-assembler", "upload-oscontainer",
+		fmt.Sprintf("--name=%s", pushPath),
+	}
+	// copy the pushed image to the expected tag
+	copyArgs := []string{
+		"skopeo", "copy",
+		fmt.Sprintf("docker://%s:%s", pushPath, build.BuildID),
+		fmt.Sprintf("docker://%s", push.URL),
+	}
+
+	if !tlsVerify {
+		log.Warnf("TLS Verification has been disable for push to %s", push.URL)
+		copyArgs = append(copyArgs, "--src-tls-verify=false", "--dest-tls-verify=false")
+		baseEnv = append(baseEnv, "DISABLE_TLS_VERIFICATION=1")
+	}
+
+	for _, args := range [][]string{pushArgs, copyArgs} {
+		l.WithField("cmd", args).Debug("Calling external tool ")
+		cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+		cmd.Stderr = os.Stderr
+		cmd.Stdout = os.Stdout
+		cmd.Env = baseEnv
+		if err := cmd.Run(); err != nil {
+			return errors.New("upload to registry failed")
+		}
+	}
+	return nil
+}
+
+// writeDockerSecret writes the .dockerCfg or .dockerconfig to the correct path.
+// It accepts the cluster context, the name of the secret and the location to write to.
+func writeDockerSecret(ctx ClusterContext, clusterSecretName, authPath string) error {
+	ac, ns, err := GetClient(ctx)
+	if err != nil {
+		return fmt.Errorf("unable to fetch cluster client: %v", err)
+	}
+	secret, err := ac.CoreV1().Secrets(ns).Get(clusterSecretName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to query for secret %s: %v", apiBuild.Spec.Output.PushSecret.Name, err)
+	}
+	if secret == nil {
+		return fmt.Errorf("secret is empty")
+	}
+
+	var key string
+	switch secret.Type {
+	case v1.SecretTypeDockerConfigJson:
+		key = v1.DockerConfigJsonKey
+	case v1.SecretTypeDockercfg:
+		key = v1.DockerConfigKey
+	default:
+		return fmt.Errorf("writeDockerSecret is not supported for secret type %s", secret.Type)
+	}
+
+	data, ok := secret.Data[key]
+	if !ok {
+		return fmt.Errorf("secret %s of type %s is malformed: missing %s", secret.Name, secret.Type, key)
+	}
+
+	log.WithFields(log.Fields{
+		"local path": authPath,
+		"type":       string(secret.Type),
+		"secret key": key,
+		"name":       secret.Name,
+	}).Info("Writing push secret")
+
+	if err := ioutil.WriteFile(authPath, data, 0444); err != nil {
+		return fmt.Errorf("failed writing secret %s to %s", secret.Name, authPath)
+	}
+	return nil
 }

--- a/gangplank/spec/cli.go
+++ b/gangplank/spec/cli.go
@@ -65,9 +65,6 @@ func (js *JobSpec) AddCliFlags(cmd *pflag.FlagSet) {
 	// Define the recipe
 	cmd.StringVar(&js.Recipe.GitRef, "git-ref", js.Recipe.GitRef, "Git ref for recipe")
 	cmd.StringVar(&js.Recipe.GitURL, "git-url", js.Recipe.GitURL, "Git URL for recipe")
-
-	// Push options
-	cmd.StringVar(&js.Oscontainer.PushURL, "push-url", js.Oscontainer.PushURL, "push built images to location")
 }
 
 // AddRepos adds an repositories from the CLI

--- a/gangplank/spec/jobspec.go
+++ b/gangplank/spec/jobspec.go
@@ -29,12 +29,14 @@ import (
 
 // JobSpec is the root-level item for the JobSpec.
 type JobSpec struct {
-	Archives    Archives    `yaml:"archives,omitempty" json:"archives,omitempty"`
-	CloudsCfgs  CloudsCfgs  `yaml:"clouds_cfgs,omitempty" json:"cloud_cofgs,omitempty"`
-	Job         Job         `yaml:"job,omitempty" json:"job,omitempty"`
-	Oscontainer Oscontainer `yaml:"oscontainer,omitempty" json:"oscontainer,omitempty"`
-	Recipe      Recipe      `yaml:"recipe,omitempty" json:"recipe,omitempty"`
-	Spec        Spec        `yaml:"spec,omitempty" json:"spec,omitempty"`
+	Archives   Archives   `yaml:"archives,omitempty" json:"archives,omitempty"`
+	CloudsCfgs CloudsCfgs `yaml:"clouds_cfgs,omitempty" json:"cloud_cofgs,omitempty"`
+	Job        Job        `yaml:"job,omitempty" json:"job,omitempty"`
+	Recipe     Recipe     `yaml:"recipe,omitempty" json:"recipe,omitempty"`
+	Spec       Spec       `yaml:"spec,omitempty" json:"spec,omitempty"`
+
+	// PublishOscontainer is a list of push locations for the oscontainer
+	PublishOscontainer PublishOscontainer `yaml:"publish_oscontainer,omitempty" json:"publish_oscontainer,omitempty"`
 
 	// Stages are specific stages to be run. Stages are
 	// only supported by Gangplank; they do not appear in the
@@ -108,12 +110,11 @@ func (c *CloudsCfgs) GetCloudCfg(cloud string) (Cloud, error) {
 //   StrictMode: only run explicitly defined stages
 //   VersionSuffix: name to append, ie. devel
 type Job struct {
-	BuildName        string `yaml:"build_name,omitempty" json:"build_name,omitempty"`
-	IsProduction     bool   `yaml:"is_production,omitempty" json:"is_production,omitempty"`
-	StrictMode       bool   `yaml:"strict,omitempty" json:"strict,omitempty"`
-	VersionSuffix    string `yaml:"version_suffix,omitempty" json:"version_suffix,omitempty"`
-	DisableTLSVerify bool   `yaml:"disable_tls_verification" json:"disable_tls_verification"`
-	MinioCfgFile     string // not exported
+	BuildName     string `yaml:"build_name,omitempty" json:"build_name,omitempty"`
+	IsProduction  bool   `yaml:"is_production,omitempty" json:"is_production,omitempty"`
+	StrictMode    bool   `yaml:"strict,omitempty" json:"strict,omitempty"`
+	VersionSuffix string `yaml:"version_suffix,omitempty" json:"version_suffix,omitempty"`
+	MinioCfgFile  string // not exported
 }
 
 // Recipe describes where to get the build recipe/config, i.e fedora-coreos-config
@@ -184,10 +185,46 @@ type Spec struct {
 	GitURL string `yaml:"git_url,omitempty" json:"git_url,omitempty"`
 }
 
-// Oscontainer describes the location to push the OS Container to.
-type Oscontainer struct {
-	PushURL string `yaml:"push_url,omitempty" json:"push_url,omitempty"`
+// PublishOscontainer describes where to push the OSContainer to.
+type PublishOscontainer struct {
+	// BuildStrategyTLSVerify indicates whether to verify TLS certificates when pushing as part of a OCP Build Strategy.
+	// By default, TLS verification is turned on.
+	BuildStrategyTLSVerify *bool `yaml:"buildstrategy_tls_verify" json:"buildstrategy_tls_verify"`
+
+	// Registries is a list of locations to push to.
+	Registries []Registry `yaml:"registries" json:"regristries"`
 }
+
+// Registry describes the push locations.
+type Registry struct {
+	// URL is the location that should be used to push the secret.
+	URL string `yaml:"url" json:"url"`
+
+	// TLSVerify tells when to verify TLS. By default, its true
+	TLSVerify *bool `yaml:"tls_verify,omitempty" json:"tls_verify,omitempty"`
+
+	// SecretType is name the secret to expect, should PushSecretType*s
+	SecretType PushSecretType `yaml:"secret_type,omitempty" json:"secret_type,omitempty"`
+
+	// If the secret is inline, the string data, else, the cluster secret name
+	Secret string `yaml:"secret,omitempty" json:"secret,omitempty"`
+}
+
+// PushSecretType describes the type of push secret.
+type PushSecretType string
+
+// Supported push secret types.
+const (
+	// PushSecretTypeInline means that the secret string is a string literal
+	// of the docker auth.json.
+	PushSecretTypeInline = "inline"
+	// PushSecretTypeCluster indicates that the named secret in PushRegistry should be
+	// fetched via the service account from the cluster.
+	PushSecretTypeCluster = "cluster"
+	// PushSecretTypeToken indicates that the service account associated with the token
+	// has access to the push repository.
+	PushSecretTypeToken = "token"
+)
 
 // JobSpecReader takes and io.Reader and returns a ptr to the JobSpec and err
 func JobSpecReader(in io.Reader) (j JobSpec, err error) {


### PR DESCRIPTION
This adds the ability to push to arbitrary registries to support the
production builds for ART and ProdSec use cases.

Changes:
- Added 'publish_oscontainer' as a jobspec field
- Added 'registry' struct to describe registry publication. Each
  registry can have its own secret and TLS verification policy.

Example:
```
publish_oscontainer:
    # TLS verification for build strategy builds. Defaults to true
    buildstrategy_tls_verify: true

    # list of push locations to push osconatiner to.
    registries:
      # push to a cluster address using an service account token
      # to login to the regitry (only useful in cluster)
      - url: "first.registry.example.com/stream/name:tag"
        secret_type: token
        tls_verify: false

      # push with an inline secret
      - url: "second.registry.example.com/stream/name:tag",
        secret_type: inline
        secret: "<STRING>"

      # push using an incluser secret name "builder-secret"
      # the service account running Gangplank will need to be
      # able to read the secret
      - url: "third.registry.exmaple.com/stream/name:tag",
        secret_type: cluster
        secret: builder-secret
```
Signed-off-by: Ben Howard <ben.howard@redhat.com>