### PR TITLE
cmd-* : multi-arch fixes after f34 move.

### DIFF
--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -436,12 +436,12 @@ def generate_iso():
         shutil.move(os.path.join(tmpisoimagespxe, kernel_img), kernel_dest)
         kernel_img = 'kernel.img'
 
-        # combine kernel, initramfs and cmdline using lorax/mk-s390-cdboot tool
-        run_verbose(['/usr/bin/mk-s390-cdboot',
-                     '-i', kernel_dest,
+        # combine kernel, initramfs and cmdline using the mk-s390image tool
+        run_verbose(['/usr/bin/mk-s390image',
+                     kernel_dest,
+                     os.path.join(tmpisoimages, 'cdboot.img'),
                      '-r', iso_initramfs,
-                     '-p', os.path.join(tmpisoimages, 'cdboot.prm'),
-                     '-o', os.path.join(tmpisoimages, 'cdboot.img')])
+                     '-p', os.path.join(tmpisoimages, 'cdboot.prm')])
         # generate .addrsize file for LPAR
         with open(os.path.join(tmpisoimages, 'initrd.addrsize'), 'wb') as addrsize:
             addrsize_data = struct.pack(">iiii", 0, int(INITRD_ADDRESS, 16), 0,

--- a/src/cmd-kola
+++ b/src/cmd-kola
@@ -17,8 +17,12 @@ import yaml
 BASIC_SCENARIOS = ["firmware=uefi", "firmware=uefi-secure"]
 arch = platform.machine()
 
+qemu_cmd = f"qemu-system-{arch}"
+if arch == "ppc64le":
+    qemu_cmd = "qemu-system-ppc64"
+
 # time bomb for above XXX
-nvme_help = subprocess.check_output(['qemu-kvm', '-device', 'nvme,help'],
+nvme_help = subprocess.check_output([qemu_cmd, '-device', 'nvme,help'],
                                     encoding='utf-8')
 if 'bootindex' in nvme_help:
     raise Exception("NVMe now supports bootindex property; re-enable NVMe testing")


### PR DESCRIPTION
Fix cmd-buildextend-live for s390x to use mk-s390image instead of mk-s390-cdboot. Apparently there was a bug in cdboot where it would overwrite the kernel with the initrd if the intrd was too large.
Fix cmd-kola to use qemu-system-{arch} instead of qemu-kvm to check for nvme bootindex as qemu-kvm is not present on non x86 arches