### PR TITLE
Gangplank: fix shorthands for pseudo artifacts

### DIFF
--- a/gangplank/spec/stage_test.go
+++ b/gangplank/spec/stage_test.go
@@ -221,3 +221,35 @@ func TestStageYaml(t *testing.T) {
 		}
 	}
 }
+
+func TestIsArtifactValid(t *testing.T) {
+	testCases := []struct {
+		artifact string
+		want     bool
+	}{
+		{
+			artifact: "base",
+			want:     true,
+		},
+		{
+			artifact: "AWS",
+			want:     true,
+		},
+		{
+			artifact: "finalize",
+			want:     true,
+		},
+		{
+			artifact: "mandrake+root",
+			want:     false,
+		},
+	}
+	for idx, tc := range testCases {
+		t.Run(fmt.Sprintf("test-%d-%s", idx, tc.artifact), func(t *testing.T) {
+			got := isValidArtifactShortHand(tc.artifact)
+			if got != tc.want {
+				t.Errorf("artifact %s should return %v but got %v", tc.artifact, tc.want, got)
+			}
+		})
+	}
+}

--- a/gangplank/spec/stages.go
+++ b/gangplank/spec/stages.go
@@ -563,17 +563,35 @@ func addShorthandToStage(artifact string, stage *Stage) {
 	stage.RequestArtifacts = unique(realOptional)
 }
 
+// isValidArtifactShortHand checks if the shortand is valid
+func isValidArtifactShortHand(a string) bool {
+	valid := false
+	for _, v := range strings.Split(strings.ToLower(a), "+") {
+		if cosa.CanArtifact(v) {
+			valid = true
+		}
+		for _, ps := range pseudoStages {
+			if v == ps {
+				valid = true
+				break
+			}
+		}
+	}
+	return valid
+}
+
 // GenerateStages creates stages.
 func (j *JobSpec) GenerateStages(fromNames, testNames []string, singleStage bool) error {
 	j.DelayedMetaMerge = true
 	j.Job.StrictMode = true
 
 	for _, k := range fromNames {
-		if !cosa.CanArtifact(k) {
+		if !isValidArtifactShortHand(k) {
 			return fmt.Errorf("artifact %s is an invalid artifact", k)
 		}
 	}
 	for _, k := range testNames {
+		k = strings.ToLower(k)
 		if _, ok := kolaTestDefinitions[k]; !ok {
 			return fmt.Errorf("kola test %s is an invalid kola name", k)
 		}


### PR DESCRIPTION
Prior commit broke the shorthands for "base" and "finalize"