### PR TITLE
Gangplank: use UUID in pod mode

### DIFF
--- a/gangplank/go.mod
+++ b/gangplank/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/containers/libpod v1.9.3
 	github.com/containers/storage v1.20.2
+	github.com/google/uuid v1.1.1
 	github.com/minio/minio-go/v7 v7.0.6
 	github.com/opencontainers/runc v1.0.0-rc90
 	github.com/opencontainers/runtime-spec v1.0.3-0.20200520003142-237cc4f519e2

--- a/gangplank/ocp/pod.go
+++ b/gangplank/ocp/pod.go
@@ -8,9 +8,9 @@ import (
 	"net"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/coreos/gangplank/spec"
+	"github.com/google/uuid"
 	buildapiv1 "github.com/openshift/api/build/v1"
 	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
@@ -216,7 +216,8 @@ func (pb *podBuild) setInCluster() error {
 func (pb *podBuild) generateAPIBuild() error {
 	// Create just _enough_ of the OpenShift BuildConfig spec
 	// Create a "ci" build.openshift.io/v1 specification.
-	podBuildNumber := time.Now().Format("20060102150405")
+	u := uuid.New()
+	podBuildNumber := u.String()
 	a := buildapiv1.Build{}
 
 	// Create annotations


### PR DESCRIPTION
This fixes a problem where two instances of Gangplank running in Minio
mode can start with the same pseudo build number.