### PR TITLE
Gangplank: support for overrides and inline repository definitions

### DIFF
--- a/gangplank/ocp/remotes.go
+++ b/gangplank/ocp/remotes.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 
 	"github.com/coreos/gangplank/cosa"
+	"github.com/coreos/gangplank/spec"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -98,8 +99,11 @@ func (r *RemoteFile) Extract(ctx context.Context, path string) error {
 	return decompress(tmpf, path)
 }
 
-// decompress takes an open file and extracts its to directory.
-func decompress(in *os.File, dir string) error {
+// decompress is a spec TarDecompressorFunc
+var _ spec.TarDecompressorFunc = decompress
+
+// decompress takes an io.ReadCloser extracts its to directory.
+func decompress(in io.ReadCloser, dir string) error {
 	log.Info("Receiving binary source from STDIN as archive ...")
 	args := []string{"-x", "-v", "-o", "-m", "-f", "-", "-C", dir}
 	cmd := exec.Command("bsdtar", args...)

--- a/gangplank/ocp/return_test.go
+++ b/gangplank/ocp/return_test.go
@@ -58,7 +58,7 @@ func TestTarballRemote(t *testing.T) {
 		Minio: m,
 	}
 
-	if err := returnPathTarBall(ctx, cacheBucket, "test.tar.gz", srcd, returner); err != nil {
+	if err := uploadPathAsTarBall(ctx, cacheBucket, "test.tar.gz", srcd, "", returner); err != nil {
 		t.Fatalf("Failed create tarball: %v", err)
 	}
 

--- a/gangplank/ocp/worker.go
+++ b/gangplank/ocp/worker.go
@@ -261,14 +261,14 @@ func (ws *workSpec) Exec(ctx ClusterContext) error {
 
 		if stage.ReturnCache {
 			l.WithField("tarball", cacheTarballName).Infof("Sending %s back as a tarball", cosaSrvCache)
-			if err := returnPathTarBall(ctx, cacheBucket, cacheTarballName, cosaSrvCache, ws.Return); err != nil {
+			if err := uploadPathAsTarBall(ctx, cacheBucket, cacheTarballName, cosaSrvCache, "", ws.Return); err != nil {
 				return err
 			}
 		}
 
 		if stage.ReturnCacheRepo {
 			l.WithField("tarball", cacheRepoTarballName).Infof("Sending %s back as a tarball", cosaSrvTmpRepo)
-			if err := returnPathTarBall(ctx, cacheBucket, cacheRepoTarballName, cosaSrvTmpRepo, ws.Return); err != nil {
+			if err := uploadPathAsTarBall(ctx, cacheBucket, cacheRepoTarballName, cosaSrvTmpRepo, "", ws.Return); err != nil {
 				return err
 			}
 		}

--- a/gangplank/spec/cli.go
+++ b/gangplank/spec/cli.go
@@ -45,6 +45,9 @@ func init() {
 	}
 }
 
+// strPtr is a helper for returning a string pointer
+func strPtr(s string) *string { return &s }
+
 // AddCliFlags returns the pflag set for use in the CLI.
 func (js *JobSpec) AddCliFlags(cmd *pflag.FlagSet) {
 
@@ -75,7 +78,7 @@ func (js *JobSpec) AddRepos() {
 			js.Recipe.Repos = append(
 				js.Recipe.Repos,
 				&Repo{
-					URL: r,
+					URL: &r,
 				})
 		}
 	}

--- a/gangplank/spec/jobspec_test.go
+++ b/gangplank/spec/jobspec_test.go
@@ -23,20 +23,33 @@ func TestURL(t *testing.T) {
 	}{
 		{
 			desc:    "good repo",
-			repo:    Repo{URL: "http://mirrors.kernel.org/fedora-buffet/archive/fedora/linux/releases/30/Everything/source/tree/media.repo"},
+			repo:    Repo{URL: strPtr("http://mirrors.kernel.org/fedora-buffet/archive/fedora/linux/releases/30/Everything/source/tree/media.repo")},
 			wantErr: false,
 		},
 		{
 			desc: "named repo",
 			repo: Repo{
 				Name: "test",
-				URL:  "http://mirrors.kernel.org/fedora-buffet/archive/fedora/linux/releases/30/Everything/source/tree/media.repo"},
+				URL:  strPtr("http://mirrors.kernel.org/fedora-buffet/archive/fedora/linux/releases/30/Everything/source/tree/media.repo")},
 			wantErr: false,
 		},
 		{
 			desc:    "bad repo",
-			repo:    Repo{URL: "http://fedora.com/this/will/not/exist/no/really/it/shouldnt"},
+			repo:    Repo{URL: strPtr("http://fedora.com/this/will/not/exist/no/really/it/shouldnt")},
 			wantErr: true,
+		},
+		{
+			desc:    "inline repo",
+			repo:    Repo{Inline: strPtr("meh this is a repo")},
+			wantErr: false,
+		},
+		{
+			desc: "named inline repo",
+			repo: Repo{
+				Name:   "named inline repo",
+				Inline: strPtr("meh this is a repo"),
+			},
+			wantErr: false,
 		},
 	}
 
@@ -50,7 +63,13 @@ func TestURL(t *testing.T) {
 			wantPath := filepath.Join(tmpd, fmt.Sprintf("%s.repo", c.repo.Name))
 			if c.repo.Name == "" {
 				h := sha256.New()
-				_, _ = h.Write([]byte(c.repo.URL))
+				var data []byte
+				if c.repo.URL != nil {
+					data = []byte(*c.repo.URL)
+				} else {
+					data = []byte(*c.repo.Inline)
+				}
+				_, _ = h.Write(data)
 				wantPath = filepath.Join(tmpd, fmt.Sprintf("%x.repo", h.Sum(nil)))
 			}
 			if wantPath != path {

--- a/gangplank/spec/override.go
+++ b/gangplank/spec/override.go
@@ -1,0 +1,144 @@
+package spec
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// Override describes RPMs or Tarballs to include as an override in the OSTree compose.
+type Override struct {
+	// URI is a string prefixed with "file://" or "http(s)://" and a path.
+	URI string `yaml:"uri,omitempty" json:"uri,omitempty"`
+
+	// Rpm indicates that the file is RPM and should be placed in overrides/rpm
+	Rpm *bool `yaml:"rpm,omitempty" json:"rpm,omitempty"`
+
+	// Tarball indicates that the file is a tarball and will be extracted to overrides.
+	Tarball *bool `yaml:"tarball,omitempty" json:"tarball,omitempty"`
+
+	// Tarball type is an override Tarball type
+	TarballType *string `yaml:"tarball_type,omitempty" json:"tarball_type,omitempty"`
+}
+
+const (
+	TarballTypeAll    = "all"
+	TarballTypeRpms   = "rpms"
+	TarballTypeRpm    = "rpm"
+	TarballTypeRootfs = "rootfs"
+	overrideBasePath  = "overrides"
+)
+
+// writePath gets the path that the file should be extract to
+func (o *Override) writePath(basePath string) (string, error) {
+	obase := filepath.Join(basePath, overrideBasePath)
+
+	if o.Rpm != nil && *o.Rpm {
+		return filepath.Join(obase, "rpm", filepath.Base(o.URI)), nil
+	}
+
+	if o.Tarball == nil {
+		return "", fmt.Errorf("override must be either tarball or RPM")
+	}
+
+	// assume that the tarball type is all
+	if o.TarballType == nil {
+		return obase, nil
+	}
+
+	switch *o.TarballType {
+	case TarballTypeAll:
+		return obase, nil
+	case TarballTypeRpms, TarballTypeRpm:
+		return filepath.Join(obase, TarballTypeRpm), nil
+	case TarballTypeRootfs:
+		return filepath.Join(obase, TarballTypeRootfs), nil
+	default:
+		return "", fmt.Errorf("tarball type %s is unknown", *o.TarballType)
+	}
+}
+
+// TarDecompressorFunc is a function that handles decompressing a file.
+type TarDecompressorFunc func(io.ReadCloser, string) error
+
+// Fetch reads the source and writes it to disk. The decompressor function
+// is likely lazy, but allows for testing.
+func (o *Override) Fetch(l *log.Entry, path string, wf TarDecompressorFunc) error {
+	nl := l.WithFields(log.Fields{
+		"uri":  o.URI,
+		"path": path,
+	})
+
+	if o.URI == "" {
+		return errors.New("uri is undefined for override")
+	}
+
+	parts := strings.Split(o.URI, "://")
+	if len(parts) == 1 {
+		return fmt.Errorf("path lack URI identifer: %s", o.URI)
+	}
+
+	writePath, err := o.writePath(path)
+	if err != nil {
+		return err
+	}
+
+	basePath := writePath
+	if o.Rpm != nil && *o.Rpm {
+		basePath = filepath.Dir(basePath)
+	}
+
+	nl = nl.WithField("target path", writePath)
+
+	nl.Warn("creating target dir")
+	if err := os.MkdirAll(basePath, 0755); err != nil {
+		nl.WithError(err).Error("failed to create target path")
+		return fmt.Errorf("unable to create target dir %s: %v", basePath, err)
+	}
+
+	var in io.ReadCloser
+	switch parts[0] {
+	case "file":
+		f, err := os.Open(parts[1])
+		if err != nil {
+			l.WithError(err).Error("failed to open file")
+			return err
+		}
+		in = f
+	case "https", "http":
+		resp, err := http.Get(o.URI)
+		if err != nil {
+			l.WithError(err).Error("failed to open remote address")
+			return err
+		}
+		if resp.StatusCode < 200 || resp.StatusCode > 305 {
+			return fmt.Errorf("unable to fetch resource status code %d: %s", resp.StatusCode, resp.Status)
+		}
+		in = resp.Body
+	}
+	defer in.Close()
+
+	// If this is a tarball, run the decompressor func and bail.
+	if o.Tarball != nil && *o.Tarball {
+		nl.Info("extracting uri to path")
+		return wf(in, writePath)
+	}
+
+	// Otherwise this an RPM -- treat it like a generic file
+	f, err := os.Create(writePath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	nl.Info("writing uri to path")
+	_, err = io.Copy(f, in)
+	nl.Info("success")
+	return err
+}

--- a/gangplank/spec/override_test.go
+++ b/gangplank/spec/override_test.go
@@ -1,0 +1,88 @@
+package spec
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestOverridePathing(t *testing.T) {
+	trueVar := true
+
+	testCases := []struct {
+		o       *Override
+		desc    string
+		want    string
+		wantErr bool
+	}{
+		{
+			o: &Override{
+				URI: "incorrect://whocares",
+			},
+			desc:    "invalid no type",
+			wantErr: true,
+		},
+		{
+			o: &Override{
+				URI: "file://someplace.rpm",
+				Rpm: &trueVar,
+			},
+			want:    "test/overrides/rpm/someplace.rpm",
+			desc:    "file rpm",
+			wantErr: false,
+		},
+		{
+			o: &Override{
+				URI: "https://someplace.rpm",
+				Rpm: &trueVar,
+			},
+			want:    "test/overrides/rpm/someplace.rpm",
+			desc:    "net-based rpm",
+			wantErr: false,
+		},
+		{
+			o: &Override{
+				URI:         "http://tarball-of-doom.tar",
+				Tarball:     &trueVar,
+				TarballType: strPtr("all"),
+			},
+			want:    "test/overrides",
+			desc:    "tarball of all",
+			wantErr: false,
+		},
+		{
+			o: &Override{
+				URI:         "http://cuddly-demogorgrans.tar",
+				Tarball:     &trueVar,
+				TarballType: strPtr("rootfs"),
+			},
+			want:    "test/overrides/rootfs",
+			desc:    "tarball of rootfs",
+			wantErr: false,
+		},
+		{
+			o: &Override{
+				URI:         "http://tormented-rpms.tar",
+				Tarball:     &trueVar,
+				TarballType: strPtr("rpms"),
+			},
+			want:    "test/overrides/rpm",
+			desc:    "tarball of rpms",
+			wantErr: false,
+		},
+	}
+
+	for idx, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", idx, tc.desc), func(t *testing.T) {
+			got, err := tc.o.writePath("test")
+			if err != nil && !tc.wantErr {
+				t.Fatalf("%s errored unexpectedly", tc.desc)
+			}
+			if err == nil && tc.wantErr {
+				t.Fatalf("%s exepcted error", tc.desc)
+			}
+			if tc.want != got {
+				t.Errorf("%s failed:\n  want: %s\n   got: %s\n", tc.desc, tc.want, got)
+			}
+		})
+	}
+}

--- a/gangplank/spec/stages.go
+++ b/gangplank/spec/stages.go
@@ -92,6 +92,9 @@ type Stage struct {
 
 	// KolaTests are shorthands for testing.
 	KolaTests []string `yaml:"kola_tests,omitempty" json:"kola_tests,omitempty"`
+
+	// Overrides is a list of Overrides to apply to the OS tree
+	Overrides []Override `yaml:"overrides,omitempty" json:"overrides,omitempty"`
 }
 
 // These are the only hard-coded commands that Gangplank understand.


### PR DESCRIPTION
These changes make using Gangplank easier to use by third parties (such as ART and the Node team) by:
- providing for inline definitions of repositories in the jobspec
- providing a method of pushing overrides rootfs and rpm overrides

The goal is to help ART produce embargoed/clandestine builds and the Node/Runtime teams be able to produce custom machine-os-content with overrides or phashet builds that can be used in E2E tests. 