### PR TITLE
build/gcp: Add uncompressed-checksum

### DIFF
--- a/src/cosalib/digitalocean.py
+++ b/src/cosalib/digitalocean.py
@@ -1,29 +1,3 @@
-import os
-import shutil
-
-from cosalib.cmdlib import (
-    run_verbose,
-    sha256sum_file
-)
-
-
-def mutate_digitalocean(path):
-    # DigitalOcean can import custom images directly from a URL, and
-    # supports .gz and .bz2 compression but not .xz.  .bz2 is a bit tighter
-    # but isn't used for any other artifact.  Manually gzip the artifact
-    # here.  cmd-compress will skip recompressing it later.
-    sha256 = sha256sum_file(path)
-    size = os.stat(path).st_size
-    temp_path = f"{path}.gz"
-    with open(temp_path, "wb") as fh:
-        run_verbose(['gzip', '-9c', path], stdout=fh)
-    shutil.move(temp_path, path)
-    return {
-        'uncompressed-sha256': sha256,
-        'uncompressed-size': size,
-    }
-
-
 def digitalocean_run_ore(build, args):
     print("""
 Images are not published to DigitalOcean.  This command is a placeholder.

--- a/src/cosalib/qemuvariants.py
+++ b/src/cosalib/qemuvariants.py
@@ -21,9 +21,6 @@ from cosalib.cmdlib import (
     run_verbose,
     sha256sum_file
 )
-from cosalib.digitalocean import (
-    mutate_digitalocean
-)
 
 
 # BASEARCH is the current machine architecture
@@ -74,7 +71,7 @@ VARIANTS = {
         "image_format": "qcow2",
         "image_suffix": "qcow2.gz",
         "platform": "digitalocean",
-        "mutate-callback": mutate_digitalocean,
+        "gzip": True
     },
     "gcp": {
         # See https://cloud.google.com/compute/docs/import/import-existing-image#requirements_for_the_image_file


### PR DESCRIPTION
build/gcp: Add uncompressed-checksum

I'm working on https://github.com/cgwalters/coreos-diskimage-rehydrator/
and a goal is to regenerate *exactly* the artifacts.  But right
now because we gzip the GCP tarball at build time, we don't
have `uncompressed-sha256` in the metadata.  Which means the
rehydrator can't verify it.

Add a declarative way to express that an artifact needs to be gzipped.

---

digitalocean: Use new `gzip: True` field

Now there's no need for custom code, which means we can drop
the OO-inversion of having generic code import "subclass" code
too.

---

build: Remove mutate-callback

No need for this anymore, and it was mixing declarative with
a generic imperative escape hatch.  Since this code is trying
to be declarative let's do that.

---

