### PR TITLE
Attach architecture with name in the meta.json

### DIFF
--- a/src/cmd-koji-upload
+++ b/src/cmd-koji-upload
@@ -606,7 +606,7 @@ class Upload(_KojiBase):
                         }
                     }
                 },
-                "name": self.build.build_name,
+                "name": f"{self.build.build_name}-{self.build.basearch}",
                 "release": self._release,
                 "owner": self._owner,
                 "source": source['origin'],


### PR DESCRIPTION
- It allows brew to use package name as packagename-arch,
- This change is necessary to create one package for each arch in brew tree.

Signed-off-by: Renata Ravanelli <rravanel@redhat.com>