### PR TITLE
Gangplank: make use of sudo for tarball creation optional

### DIFF
--- a/gangplank/ocp/bc.go
+++ b/gangplank/ocp/bc.go
@@ -799,7 +799,7 @@ func getStageFiles(buildID string,
 
 		tball := fmt.Sprintf("overrides-%s.tar.gz", overrideToken)
 		if err := uploadPathAsTarBall(
-			context.Background(), cacheBucket, tball, ".", tmpD,
+			context.Background(), cacheBucket, tball, ".", tmpD, false,
 			&Return{Minio: m}); err != nil {
 			return nil, nil, err
 		}

--- a/gangplank/ocp/return_test.go
+++ b/gangplank/ocp/return_test.go
@@ -12,12 +12,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func init() {
-	// tarballCreateCommand uses sudo which is inappropriate/unneeded for
-	// running our tests.
-	tarballCreatePrefix = tarballCreatePrefix[1:]
-}
-
 func TestTarballRemote(t *testing.T) {
 	tmpd, _ := ioutil.TempDir("", "remotes")
 	srvd := filepath.Join(tmpd, "serve")
@@ -58,7 +52,7 @@ func TestTarballRemote(t *testing.T) {
 		Minio: m,
 	}
 
-	if err := uploadPathAsTarBall(ctx, cacheBucket, "test.tar.gz", srcd, "", returner); err != nil {
+	if err := uploadPathAsTarBall(ctx, cacheBucket, "test.tar.gz", srcd, "", false, returner); err != nil {
 		t.Fatalf("Failed create tarball: %v", err)
 	}
 

--- a/gangplank/ocp/worker.go
+++ b/gangplank/ocp/worker.go
@@ -261,14 +261,14 @@ func (ws *workSpec) Exec(ctx ClusterContext) error {
 
 		if stage.ReturnCache {
 			l.WithField("tarball", cacheTarballName).Infof("Sending %s back as a tarball", cosaSrvCache)
-			if err := uploadPathAsTarBall(ctx, cacheBucket, cacheTarballName, cosaSrvCache, "", ws.Return); err != nil {
+			if err := uploadPathAsTarBall(ctx, cacheBucket, cacheTarballName, cosaSrvCache, "", true, ws.Return); err != nil {
 				return err
 			}
 		}
 
 		if stage.ReturnCacheRepo {
 			l.WithField("tarball", cacheRepoTarballName).Infof("Sending %s back as a tarball", cosaSrvTmpRepo)
-			if err := uploadPathAsTarBall(ctx, cacheBucket, cacheRepoTarballName, cosaSrvTmpRepo, "", ws.Return); err != nil {
+			if err := uploadPathAsTarBall(ctx, cacheBucket, cacheRepoTarballName, cosaSrvTmpRepo, "", true, ws.Return); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
OCP4 does not allow for the use of Gangplank.