### PR TITLE
testiso: handle --qemu-multipath for ISO tests

### DIFF
--- a/mantle/cmd/kola/qemuexec.go
+++ b/mantle/cmd/kola/qemuexec.go
@@ -300,7 +300,8 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 	}
 	for _, size := range addDisks {
 		if err := builder.AddDisk(&platform.Disk{
-			Size: size,
+			Size:          size,
+			MultiPathDisk: kola.QEMUOptions.MultiPathDisk,
 		}); err != nil {
 			return errors.Wrapf(err, "adding additional disk")
 		}


### PR DESCRIPTION
Now when using `--qemu-multipath`, the ISO-based install scenarios will
test installing on top of a multipathed device.

This will exercise the OS side of first boot support for multipath:
coreos/fedora-coreos-config#1011

Note here we don't use `coreos-installer iso kargs` to add the
`rd.multipath` karg. First, we don't strictly need multipathing enabled
from the initrd of the live environment, so we instead test manually
enabling it in the real root (which is in fact a precursor for
eventually supporting custom configs). Second, the ISO tests right now
don't leverage embedded kargs at all (apart from the harness itself
adding `console=ttyS0`), so it seems unrealistic to mix and match.

I think we should though have a new `iso-kargs-install` scenario now
which uses ISO kargs to inject `coreos.inst.*` (and then also
`rd.multipath` in the `--qemu-multipath` case) kargs since it's a good
low-friction alternative to embedding Ignition configs for simple cases.
(And also actually document it.)
