### PR TITLE
Gangplank needs CGO for Gangway

### DIFF
--- a/gangplank/Makefile
+++ b/gangplank/Makefile
@@ -13,7 +13,7 @@ ARCH:=$(shell uname -m)
 pkgs := $(shell go list -mod=vendor ./...)
 .PHONY: build
 build:
-	cd "${my_dir}/cmd/gangway" && env CGO_ENABLED=0 go build  -ldflags "${ldflags}" -tags usergo,netgo,!podman,!minio -mod vendor -v -o ${my_dir}/bin/gangway
+	cd "${my_dir}/cmd/gangway" && go build -ldflags "${ldflags}" -tags !podman,!minio -mod vendor -v -o ${my_dir}/bin/gangway
 	cd "${my_dir}/cmd/gangplank" && go build -ldflags "${ldflags}" -tags podman,minio -mod vendor -v -o ${my_dir}/bin/gangplank .
 
 .PHONY: docs

--- a/gangplank/spec/stages.go
+++ b/gangplank/spec/stages.go
@@ -372,8 +372,6 @@ func addShorthandToStage(artifact string, stage *Stage) {
 				RequestArtifacts: []string{"ostree"},
 				RequestCache:     true,
 				RequestCacheRepo: true,
-				ReturnCache:      true,
-				ReturnCacheRepo:  true,
 			}
 		case "extensions":
 			return &Stage{


### PR DESCRIPTION
Since the gangway binary executes commands, disabling CGO is breaking
all sorts of commands like tar. In a deep dive, I suspect that this is a
problem with the syscall for ForkExec, although I can't pinpoint it.
Regardless, switching from static for Gangway fixes shell-out commands
while preserving the reason for the switch in the first place.

The tl;dr is that we're in for some fun with the recent changes to
container runtimes with permissions.