### PR TITLE
devshell: Fix previous commit

### DIFF
--- a/mantle/cmd/kola/devshell.go
+++ b/mantle/cmd/kola/devshell.go
@@ -300,7 +300,7 @@ loop:
 			// if poweroffStarted {
 			// 	break
 			// }
-			cmd := devshellSSH(sshConfigPath, sshKeyPath, "true")
+			cmd := devshellSSH(sshConfigPath, sshKeyPath)
 			cmd.Stdin = os.Stdin
 			cmd.Stdout = os.Stdout
 			cmd.Stderr = os.Stderr


### PR DESCRIPTION
I had this in a local change but missed committing it.  And nothing
in CI covers `cosa run` because it requires a tty/interactivity
right now.

Without this `cosa run` just exits because it invokes `true`
instead of waiting in a shell.