### PR TITLE
devshell: Break out of pipe loop on error

### DIFF
--- a/mantle/cmd/kola/devshell.go
+++ b/mantle/cmd/kola/devshell.go
@@ -164,10 +164,14 @@ func runDevShellSSH(ctx context.Context, builder *platform.QemuBuilder, conf *co
 		for {
 			readyMsg, err := readTrimmedLine(readyReader)
 			if err != nil {
-				errchan <- err
+				if err != io.EOF {
+					errchan <- err
+				}
+				break
 			}
 			if !strings.Contains(readyMsg, "Started OpenSSH server daemon") {
 				errchan <- fmt.Errorf("Unexpected journal message: %s", readyMsg)
+				break
 			}
 			var s struct{}
 			readychan <- s


### PR DESCRIPTION
Bug in previous commit, we need to stop reading when we
hit an error, and also don't fall through.