### PR TITLE
Fix reservation name

### DIFF
--- a/src/cmd-koji-upload
+++ b/src/cmd-koji-upload
@@ -401,7 +401,7 @@ class Reserve(_KojiBase):
         release = datetime.datetime.utcnow().strftime("%H%M%S")
 
         data = {
-            "name": build.build_name,
+            "name": f"{build.build_name}-{build.basearch}",
             "release": release,
             "version": f"{build.build_id.replace('-', '.')}",
             "cg": "coreos-assembler",


### PR DESCRIPTION
Reservation data name must match with build name, otherwise
the name reservation will be used as package name.

Signed-off-by: Renata Ravanelli <rravanel@redhat.com>