### PR TITLE
gangplank: fix a few issues with tar invocation

### DIFF
--- a/gangplank/ocp/return.go
+++ b/gangplank/ocp/return.go
@@ -208,7 +208,7 @@ func uploadPathAsTarBall(ctx context.Context, bucket, object, path, workDir stri
 	args := append(
 		prefix,
 		fmt.Sprintf("umask 000; tar -cf %s %s; stat %s; gzip --fast %s;",
-			path, path, tmpf.Name(), tmpf.Name()))
+			tmpf.Name(), path, tmpf.Name(), tmpf.Name()))
 	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
 	cmd.Dir = workDir
 	cmd.Stderr = os.Stderr

--- a/gangplank/ocp/return.go
+++ b/gangplank/ocp/return.go
@@ -186,6 +186,7 @@ func uploadPathAsTarBall(ctx context.Context, bucket, object, path, workDir stri
 		return err
 	}
 	tmpf.Close()
+	_ = os.Remove(tmpf.Name()) // we just want the file name
 	tmpfgz := fmt.Sprintf("%s.gz", tmpf.Name())
 
 	defer func() {


### PR DESCRIPTION
```
commit 217c582655058e82b66278cb292e486a0229be6f
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Thu May 20 16:59:40 2021 -0400

    gangplank: let tar create the file
    
    I was getting a permission denied when the file already existed.
    Let's delete the temporary file and let tar create it instead.

commit 3fbbb145933a5363ae3917786ea495a4b4e687d4
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Thu May 20 16:03:45 2021 -0400

    gangplank: fix arguments to tar for tarball creation
    
    Was passing in the directory and not the target file name
    to `-f`.

```