### PR TITLE
koji: Backport - Attach architecture with name in the meta.json

### DIFF
--- a/src/cmd-koji-upload
+++ b/src/cmd-koji-upload
@@ -401,7 +401,7 @@ class Reserve(_KojiBase):
         release = datetime.datetime.utcnow().strftime("%H%M%S")
 
         data = {
-            "name": build.build_name,
+            "name": f"{build.build_name}-{build.basearch}",
             "release": release,
             "version": f"{build.build_id.replace('-', '.')}",
             "cg": "coreos-assembler",
@@ -606,7 +606,7 @@ class Upload(_KojiBase):
                         }
                     }
                 },
-                "name": self.build.build_name,
+                "name": f"{self.build.build_name}-{self.build.basearch}",
                 "release": self._release,
                 "owner": self._owner,
                 "source": source['origin'],


### PR DESCRIPTION
Backport from main #2159
- It allows brew to use package name as packagename-arch,
- This change is necessary to create one package for each arch in brew tree.

Signed-off-by: Renata Ravanelli <rravanel@redhat.com>