### PR TITLE
Revert "cmd-kola: temporarily stop testing on NVMe"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /root/containerbuild
 COPY ./src/print-dependencies.sh ./src/deps*.txt ./src/vmdeps*.txt ./src/build-deps.txt /root/containerbuild/src/
 COPY ./build.sh /root/containerbuild/
 RUN ./build.sh configure_yum_repos
-RUN ./build.sh install_rpms  # nocache 20210518
+RUN ./build.sh install_rpms  # nocache 20210521
 
 # Ok copy in the rest of them for the next few steps
 COPY ./ /root/containerbuild/

--- a/src/cmd-kola
+++ b/src/cmd-kola
@@ -11,21 +11,8 @@ import yaml
 # Just test these boot to start with.  In the future we should at least
 # do ostree upgrades with uefi etc.  But we don't really need the *full*
 # suite...if podman somehow broke with nvme or uefi I'd be amazed and impressed.
-# XXX: temporarily don't run on NVMe due to:
-# https://bugzilla.redhat.com/show_bug.cgi?id=1956429
-# BASIC_SCENARIOS = ["nvme=true", "firmware=uefi", "firmware=uefi-secure"]
-BASIC_SCENARIOS = ["firmware=uefi", "firmware=uefi-secure"]
+BASIC_SCENARIOS = ["nvme=true", "firmware=uefi", "firmware=uefi-secure"]
 arch = platform.machine()
-
-qemu_cmd = f"qemu-system-{arch}"
-if arch == "ppc64le":
-    qemu_cmd = "qemu-system-ppc64"
-
-# time bomb for above XXX
-nvme_help = subprocess.check_output([qemu_cmd, '-device', 'nvme,help'],
-                                    encoding='utf-8')
-if 'bootindex' in nvme_help:
-    raise Exception("NVMe now supports bootindex property; re-enable NVMe testing")
 
 cosa_dir = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, cosa_dir)

--- a/src/cmd-kola
+++ b/src/cmd-kola
@@ -11,7 +11,10 @@ import yaml
 # Just test these boot to start with.  In the future we should at least
 # do ostree upgrades with uefi etc.  But we don't really need the *full*
 # suite...if podman somehow broke with nvme or uefi I'd be amazed and impressed.
-BASIC_SCENARIOS = ["nvme=true", "firmware=uefi", "firmware=uefi-secure"]
+# XXX: nvme=true is is currently disabled due to a regression. See:
+# https://github.com/coreos/coreos-assembler/issues/2184
+# BASIC_SCENARIOS = ["nvme=true", "firmware=uefi", "firmware=uefi-secure"]
+BASIC_SCENARIOS = ["firmware=uefi", "firmware=uefi-secure"]
 arch = platform.machine()
 
 cosa_dir = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
This reverts commit ade62766e487db586d2f4c893fb4553b2c7abf07.

The NVMe fix was backported:
https://bugzilla.redhat.com/show_bug.cgi?id=1956429
https://bodhi.fedoraproject.org/updates/FEDORA-2021-303ad002d2

Rather than wait until the bomb goes off, I tagged the qemu build into
f34-coreos-continuous so we can defuse it now.