### PR TITLE
build: Parse image.yaml early on and convert to JSON

### DIFF
--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -145,16 +145,9 @@ if [ "${image_type}" = dasd ] || [ "${image_type}" = metal4k ]; then
     ignition_platform_id=metal
 fi
 
-yaml2json() {
-    python3 -c 'import sys, json, yaml; json.dump(yaml.safe_load(sys.stdin), sys.stdout)' < "$1" > "$2"
-}
-
-# Convert the image.yaml to JSON so that it can be more easily parsed
-# by the shell script in create_disk.sh.
-yaml2json "${image_yaml}" image-config.json
 yaml2json "/usr/lib/coreos-assembler/image-default.yaml" image-default.json
 # Combine with the defaults
-cat image-default.json image-config.json | jq -s add > image-configured.json
+cat image-default.json "${image_json}" | jq -s add > image-configured.json
 
 # We do some extra handling of the rootfs here; it feeds into size estimation.
 rootfs_type=$(jq -re .rootfs < image-configured.json)

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -144,6 +144,11 @@ pick_yaml_or_else_json() {
     fi
 }
 
+# Given a YAML file at first path, write it as JSON to file at second path
+yaml2json() {
+    python3 -c 'import sys, json, yaml; json.dump(yaml.safe_load(sys.stdin), sys.stdout)' < "$1" > "$2"
+}
+
 prepare_build() {
     preflight
     preflight_kvm
@@ -173,9 +178,13 @@ prepare_build() {
 
     image_yaml="${workdir}/tmp/image.yaml"
     flatten_image_yaml_to_file "${configdir}/image.yaml" "${image_yaml}"
+    # Convert the image.yaml to JSON so that it can be more easily parsed
+    # by the shell script in create_disk.sh.
+    image_json="${workdir}/tmp/image.json"
+    yaml2json "${image_yaml}" "${image_json}"
 
     export workdir configdir manifest manifest_lock manifest_lock_overrides manifest_lock_arch_overrides
-    export fetch_stamp
+    export fetch_stamp image_json
 
     if ! [ -f "${manifest}" ]; then
         fatal "Failed to find ${manifest}"


### PR DESCRIPTION
Conceptually `image.yaml` is the configuration for coreos-assembler
specifically, distinct from `manifest` and `overlay` etc. which
end up being fed into rpm-ostree.

First, this is part of addressing
https://github.com/coreos/rpm-ostree/pull/2842#discussion_r635542478
so that e.g. we can migrate the `name:` into this file instead
of the rpm-ostree manifest.

But I also want to hook other things off here, such as whether
to use the new ostree-container format instead of our tar-of-archive-repo.