### PR TITLE
Drop support for no longer used `ostree-commit.tar`

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -149,10 +149,7 @@ previous_commit=
 previous_ostree_tarfile_path=
 if [ -n "${previous_build}" ]; then
     previous_commit=$(jq -r '.["ostree-commit"]' < "${previous_builddir}/meta.json")
-    previous_ostree_tarfile_path=$(jq -r '.images.ostree.path' < "${previous_builddir}/meta.json")
-    if [ "${previous_ostree_tarfile_path}" = "null" ]; then
-        previous_ostree_tarfile_path=ostree-commit.tar
-    fi
+    previous_ostree_tarfile_path=$(jq -re '.images.ostree.path' < "${previous_builddir}/meta.json")
 fi
 echo "Previous commit: ${previous_commit:-none}"
 

--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -614,9 +614,7 @@ def generate_iso():
     print(f"Updated: {buildmeta_path}")
 
 
-commit_tar_name = 'ostree-commit.tar'
-if 'ostree' in buildmeta['images']:
-    commit_tar_name = buildmeta['images']['ostree']['path']
+commit_tar_name = buildmeta['images']['ostree']['path']
 commit_tar = os.path.join(builddir, commit_tar_name)
 import_ostree_commit(repo, buildmeta_commit, commit_tar)
 

--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -123,10 +123,7 @@ if [ "${rev_parsed}" != "${commit}" ]; then
     echo "Cache for build ${build} is gone"
     echo "Importing commit ${commit} into temporary OSTree repo"
     mkdir -p tmp/repo
-    commit_tar_name=$(jq -r .images.ostree.path < "${builddir}/meta.json")
-    if [ "${commit_tar_name}" = null ]; then
-        commit_tar_name=ostree-commit.tar
-    fi
+    commit_tar_name=$(jq -re .images.ostree.path < "${builddir}/meta.json")
     tar -C tmp/repo -xf "${builddir}/${commit_tar_name}"
     ostree_repo=$PWD/tmp/repo
 fi

--- a/src/cmd-buildprep
+++ b/src/cmd-buildprep
@@ -78,9 +78,7 @@ def main():
     buildmeta = load_json(f'builds/{builddir}/meta.json')
 
     if args.ostree:
-        f = 'ostree-commit.tar'
-        if 'ostree' in buildmeta['images']:
-            f = buildmeta['images']['ostree']['path']
+        f = buildmeta['images']['ostree']['path']
         fetcher.fetch(f'{builddir}/{f}')
 
     # and finally the symlink

--- a/src/cmd-upload-oscontainer
+++ b/src/cmd-upload-oscontainer
@@ -72,9 +72,7 @@ if not os.path.isdir(tmprepo) and os.path.exists(tmprepo):
 # the tarfile
 if not os.path.exists(tmprepo):
     os.makedirs(tmprepo, exist_ok=True)
-    ostree_commit_tar = 'ostree-commit.tar'
-    if 'ostree' in meta['images']:
-        ostree_commit_tar = meta['images']['ostree']['path']
+    ostree_commit_tar = meta['images']['ostree']['path']
     subprocess.check_call(['tar', '-xf',
                            f'{latest_build_path}/{ostree_commit_tar}',
                            '-C', tmprepo])


### PR DESCRIPTION
This has been reshuffled a few times, and I plan to do so again
using the new `rpm-ostree ex-container export` bits.  Remove
the now long dead `ostree-commit.tar` bits; the schema has required
the `ostree` entry in `meta.json` for a long time now (since FCOS
from the start, and as of OpenShift 4.3+).