### PR TITLE
Gangplank: optimize return check logic

### DIFF
--- a/gangplank/ocp/return.go
+++ b/gangplank/ocp/return.go
@@ -74,20 +74,17 @@ func (r *Return) Run(ctx context.Context, ws *workSpec) error {
 		// Check if this a meta type
 		if isKnownBuildMeta(f.Name()) {
 			upload[upKey] = srcPath
+			continue
 		}
 
 		// Check if this a known build artifact that was not fetched
 		if _, ok := b.IsArtifact(filepath.Base(f.Name())); ok {
-			fetched := false
 			for _, v := range ws.RemoteFiles {
 				if upKey == v.Object {
 					log.WithField("local path", f.Name()).Debug("skipping upload of file that was fetched")
-					fetched = true
-					continue
+					upload[upKey] = srcPath
+					break
 				}
-			}
-			if !fetched {
-				upload[upKey] = srcPath
 			}
 		}
 	}


### PR DESCRIPTION
The return logic was a bit...obtuse. This optimizes the return logic.

Signed-off-by: Ben Howard <ben.howard@redhat.com>