### PR TITLE
mantle: fix mountpoint details to address `boot-mirror` tests failure

### DIFF
--- a/mantle/kola/tests/misc/raid.go
+++ b/mantle/kola/tests/misc/raid.go
@@ -161,9 +161,9 @@ func checkIfMountpointIsRaid(c cluster.TestCluster, m platform.Machine, mountpoi
 		c.Fatalf("couldn't unmarshal lsblk output: %v", err)
 	}
 
-	foundRoot := checkIfMountpointIsRaidWalker(c, l.Blockdevices, mountpoint)
-	if !foundRoot {
-		c.Fatalf("didn't find root mountpoint in lsblk output")
+	foundDevice := checkIfMountpointIsRaidWalker(c, l.Blockdevices, mountpoint)
+	if !foundDevice {
+		c.Fatalf("didn't find %q mountpoint in lsblk output", mountpoint)
 	}
 }
 
@@ -179,8 +179,8 @@ func checkIfMountpointIsRaidWalker(c cluster.TestCluster, bs []blockdevice, moun
 			}
 			return true
 		}
-		foundRoot := checkIfMountpointIsRaidWalker(c, b.Children, mountpoint)
-		if foundRoot {
+		foundDevice := checkIfMountpointIsRaidWalker(c, b.Children, mountpoint)
+		if foundDevice {
 			return true
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/coreos/fedora-coreos-tracker/issues/838

On `Fedora-34` and previous releases, `lsblk` displays only one mount point, however, there's a change in the way `Mountpoints` being displayed on `Fedora-35`, which breaks backward compatibility. 
For example:
```
[core@cosa-devsh ~]$ cat /etc/os-release | grep "VERSION="
VERSION="34.20210524.dev.0 (CoreOS Prerelease)"
[core@cosa-devsh ~]$ lsblk --json
{
   "blockdevices": [
      {"name":"sr0", "maj:min":"11:0", "rm":true, "size":"1024M", "ro":false, "type":"rom", "mountpoint":null},
      {"name":"vda", "maj:min":"252:0", "rm":false, "size":"10G", "ro":false, "type":"disk", "mountpoint":null,
         "children": [
            {"name":"vda1", "maj:min":"252:1", "rm":false, "size":"1M", "ro":false, "type":"part", "mountpoint":null},
            {"name":"vda2", "maj:min":"252:2", "rm":false, "size":"127M", "ro":false, "type":"part", "mountpoint":null},
            {"name":"vda3", "maj:min":"252:3", "rm":false, "size":"384M", "ro":false, "type":"part", "mountpoint":"/boot"},
            {"name":"vda4", "maj:min":"252:4", "rm":false, "size":"9.5G", "ro":false, "type":"part", "mountpoint":"/sysroot"}
         ]
      }
   ]
}

[core@cosa-devsh ~]$ cat /etc/os-release | grep "VERSION="
VERSION="35.20210521.dev.0 (CoreOS Prerelease)"
<snip> lsblk --json 
{
               "name": "vda4",
               "maj:min": "252:4",
               "rm": false,
               "size": "9.5G",
               "ro": false,
               "type": "part",
               "mountpoints": [
                   "/var", "/usr", "/etc", "/", "/sysroot"
               ]
  }
```
This fix provides a temporary solution until upstream addresses the actual concern.