### PR TITLE
[rhcos-4.8] testiso: handle --qemu-multipath for ISO tests

### DIFF
--- a/mantle/cmd/kola/qemuexec.go
+++ b/mantle/cmd/kola/qemuexec.go
@@ -267,7 +267,8 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 	}
 	for _, size := range addDisks {
 		if err := builder.AddDisk(&platform.Disk{
-			Size: size,
+			Size:          size,
+			MultiPathDisk: kola.QEMUOptions.MultiPathDisk,
 		}); err != nil {
 			return errors.Wrapf(err, "adding additional disk")
 		}

--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -142,7 +142,7 @@ func init() {
 	cmdTestIso.Flags().BoolVarP(&instInsecure, "inst-insecure", "S", false, "Do not verify signature on metal image")
 	cmdTestIso.Flags().BoolVarP(&nopxe, "no-pxe", "P", false, "Skip testing live installer PXE")
 	cmdTestIso.Flags().BoolVarP(&noiso, "no-iso", "", false, "Skip testing live installer ISO")
-	cmdTestIso.Flags().BoolVar(&console, "console", false, "Display qemu console to stdout, turn off automatic initramfs failure checking")
+	cmdTestIso.Flags().BoolVar(&console, "console", false, "Connect qemu console to terminal, turn off automatic initramfs failure checking")
 	cmdTestIso.Flags().BoolVar(&pxeAppendRootfs, "pxe-append-rootfs", false, "Append rootfs to PXE initrd instead of fetching at runtime")
 	cmdTestIso.Flags().StringSliceVar(&pxeKernelArgs, "pxe-kargs", nil, "Additional kernel arguments for PXE")
 	// FIXME move scenarioISOLiveLogin into the defaults once https://github.com/coreos/fedora-coreos-config/pull/339#issuecomment-613000050 is fixed

--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -168,24 +168,19 @@ func newQemuBuilder(outdir string) (*platform.QemuBuilder, *conf.Conf, error) {
 		sectorSize = 4096
 	}
 
+	disk := platform.Disk{
+		Size:       "12G", // Arbitrary
+		SectorSize: sectorSize,
+	}
+
 	//TBD: see if we can remove this and just use AddDisk and inject bootindex during startup
 	if system.RpmArch() == "s390x" || system.RpmArch() == "aarch64" {
 		// s390x and aarch64 need to use bootindex as they don't support boot once
-		err := builder.AddDisk(&platform.Disk{
-			Size: "12G", // Arbitrary
-
-			SectorSize: sectorSize,
-		})
-		if err != nil {
+		if err := builder.AddDisk(&disk); err != nil {
 			return nil, nil, err
 		}
 	} else {
-		err := builder.AddPrimaryDisk(&platform.Disk{
-			Size: "12G", // Arbitrary
-
-			SectorSize: sectorSize,
-		})
-		if err != nil {
+		if err := builder.AddPrimaryDisk(&disk); err != nil {
 			return nil, nil, err
 		}
 	}

--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -499,7 +499,7 @@ func testLiveIso(ctx context.Context, inst platform.Install, outdir string, offl
 	targetConfig := *virtioJournalConfig
 	targetConfig.AddSystemdUnit("coreos-test-installer.service", signalCompletionUnit, conf.Enable)
 
-	mach, err := inst.InstallViaISOEmbed(nil, liveConfig, targetConfig, offline)
+	mach, err := inst.InstallViaISOEmbed(nil, liveConfig, targetConfig, outdir, offline)
 	if err != nil {
 		return errors.Wrapf(err, "running iso install")
 	}

--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -85,6 +85,7 @@ var allScenarios = map[string]bool{
 
 var liveOKSignal = "live-test-OK"
 var liveSignalOKUnit = fmt.Sprintf(`[Unit]
+Description=TestISO Signal Install Completion
 Requires=dev-virtio\\x2dports-testisocompletion.device
 OnFailure=emergency.target
 OnFailureJobMode=isolate
@@ -103,6 +104,7 @@ RequiredBy=coreos-installer.target
 `, liveOKSignal)
 
 var downloadCheck = `[Unit]
+Description=TestISO Verify CoreOS Installer Download
 After=coreos-installer.service
 Before=coreos-installer.target
 # Can be dropped with coreos-installer v0.5.1
@@ -124,6 +126,7 @@ RequiredBy=coreos-installer-reboot.service
 
 var signalCompleteString = "coreos-installer-test-OK"
 var signalCompletionUnit = fmt.Sprintf(`[Unit]
+Description=TestISO Signal Completion
 Requires=dev-virtio\\x2dports-testisocompletion.device
 OnFailure=emergency.target
 OnFailureJobMode=isolate

--- a/mantle/platform/metal.go
+++ b/mantle/platform/metal.go
@@ -535,8 +535,10 @@ func (inst *Install) runPXE(kern *kernelSetup, offline bool) (*InstalledMachine,
 }
 
 func (inst *Install) InstallViaISOEmbed(kargs []string, liveIgnition, targetIgnition conf.Conf, outdir string, offline bool) (*InstalledMachine, error) {
-	if inst.CosaBuild.Meta.BuildArtifacts.Metal == nil {
+	if !inst.Native4k && inst.CosaBuild.Meta.BuildArtifacts.Metal == nil {
 		return nil, fmt.Errorf("Build %s must have a `metal` artifact", inst.CosaBuild.Meta.OstreeVersion)
+	} else if inst.Native4k && inst.CosaBuild.Meta.BuildArtifacts.Metal4KNative == nil {
+		return nil, fmt.Errorf("Build %s must have a `metal4k` artifact", inst.CosaBuild.Meta.OstreeVersion)
 	}
 	if inst.CosaBuild.Meta.BuildArtifacts.LiveIso == nil {
 		return nil, fmt.Errorf("Build %s must have a live ISO", inst.CosaBuild.Meta.Name)

--- a/mantle/platform/metal.go
+++ b/mantle/platform/metal.go
@@ -72,6 +72,7 @@ var (
 	}
 
 	bootStartedUnit = fmt.Sprintf(`[Unit]
+	Description=TestISO Boot Started
 	Requires=dev-virtio\\x2dports-bootstarted.device
 	OnFailure=emergency.target
 	OnFailureJobMode=isolate
@@ -622,6 +623,7 @@ func (inst *Install) InstallViaISOEmbed(kargs []string, liveIgnition, targetIgni
 
 	installerUnit := fmt.Sprintf(`
 [Unit]
+Description=TestISO CoreOS Installer
 After=network-online.target
 Wants=network-online.target
 OnFailure=emergency.target

--- a/mantle/platform/metal.go
+++ b/mantle/platform/metal.go
@@ -669,7 +669,7 @@ WantedBy=multi-user.target
 		return nil, err
 	}
 
-	if err := qemubuilder.AddIso(srcisopath, "bootindex=2"); err != nil {
+	if err := qemubuilder.AddIso(srcisopath, "bootindex=3"); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Backport of https://github.com/coreos/coreos-assembler/pull/2172 because we'll need coverage for https://github.com/coreos/fedora-coreos-config/pull/1011 when we backport that to 4.8.