### PR TITLE
Disable shellcheck SC1091 in src/osmet-pack

### DIFF
--- a/src/osmet-pack
+++ b/src/osmet-pack
@@ -59,7 +59,7 @@ rootfs=/dev/disk/by-id/virtio-osmet-part4
 mount -o ro "${rootfs}" /sysroot
 osname=$(ls /sysroot/ostree/deploy)
 deploydir=$(find "/sysroot/ostree/deploy/$osname/deploy" -mindepth 1 -maxdepth 1 -type d)
-# shellcheck disable=SC1090
+# shellcheck disable=SC1090,SC1091
 description=$(. "${deploydir}/etc/os-release" && echo "${PRETTY_NAME}")
 
 if [ -z "${coreinst}" ]; then


### PR DESCRIPTION
Shellcheck fails with SC1091 when executing make check.

Signed-off-by: Jan Schintag <jan.schintag@de.ibm.com>