### PR TITLE
Gangplank: use minio for origin gangplank file io

### DIFF
--- a/gangplank/cmd/gangplank/generate.go
+++ b/gangplank/cmd/gangplank/generate.go
@@ -72,8 +72,7 @@ func setCliSpec() {
 		if spec.Recipe.Repos == nil {
 			spec.AddRepos()
 		}
-		if minioSshRemoteHost != "" {
-			log.WithField("ssh host", minioSshRemoteHost).Info("Minio will be forwarded to remote host")
+		if minioSshRemoteHost != "" && minioCfgFile == "" {
 			spec.Job.MinioSSHForward = minioSshRemoteHost
 			spec.Job.MinioSSHUser = minioSshRemoteUser
 			spec.Job.MinioSSHKey = minioSshRemoteKey

--- a/gangplank/cmd/gangplank/pod.go
+++ b/gangplank/cmd/gangplank/pod.go
@@ -94,25 +94,31 @@ func runPod(c *cobra.Command, args []string) {
 
 	if cosaViaPodman {
 		if cosaPodmanRemote != "" {
-			os.Setenv(podmanRemoteEnvVar, cosaPodmanRemote)
-			minioSshRemoteHost = containerHost()
-			if strings.Contains(minioSshRemoteHost, "@") {
-				parts := strings.Split(minioSshRemoteHost, "@")
-				minioSshRemoteHost = parts[1]
-				minioSshRemoteUser = parts[0]
-			}
 			if cosaPodmanRemoteSshKey != "" {
 				os.Setenv(podmanSshKeyEnvVar, cosaPodmanRemoteSshKey)
-				minioSshRemoteKey = cosaPodmanRemoteSshKey
 			}
-			log.WithFields(log.Fields{
-				"remote user":     minioSshRemoteUser,
-				"ssh key":         cosaPodmanRemoteSshKey,
-				"ssh foward host": minioSshRemoteHost,
-				"container host":  cosaPodmanRemote,
-			}).Info("Minio will be forwarded to remote host")
-		}
+			os.Setenv(podmanRemoteEnvVar, cosaPodmanRemote)
 
+			if minioCfgFile == "" {
+				minioSshRemoteHost = containerHost()
+				if strings.Contains(minioSshRemoteHost, "@") {
+					parts := strings.Split(minioSshRemoteHost, "@")
+					minioSshRemoteHost = parts[1]
+					minioSshRemoteUser = parts[0]
+					minioSshRemoteKey = cosaPodmanRemoteSshKey
+				}
+				log.WithFields(log.Fields{
+					"remote user":    minioSshRemoteUser,
+					"remote key":     cosaPodmanRemoteSshKey,
+					"container host": minioSshRemoteHost,
+				}).Info("Minio will be forwarded to remote host")
+			}
+
+			log.WithFields(log.Fields{
+				"ssh key":        cosaPodmanRemoteSshKey,
+				"container host": cosaPodmanRemote,
+			}).Info("Podman container will be executed on a remote host")
+		}
 		cluster = ocp.NewCluster(false)
 		cluster.SetPodman(cosaSrvDir)
 	}

--- a/gangplank/cmd/gangplank/pod.go
+++ b/gangplank/cmd/gangplank/pod.go
@@ -110,7 +110,7 @@ func runPod(c *cobra.Command, args []string) {
 				log.WithFields(log.Fields{
 					"remote user":    minioSshRemoteUser,
 					"remote key":     cosaPodmanRemoteSshKey,
-					"container host": minioSshRemoteHost,
+					"remote host": minioSshRemoteHost,
 				}).Info("Minio will be forwarded to remote host")
 			}
 

--- a/gangplank/cosa/build.go
+++ b/gangplank/cosa/build.go
@@ -71,7 +71,6 @@ func BuilderArch() string {
 // ReadBuild returns a build upon finding a meta.json. Returns a Build, the path string
 // to the build, and an error (if any). If the buildID is not set, "latest" is assumed.
 func ReadBuild(dir, buildID, arch string) (*Build, string, error) {
-	log.WithField("dir", dir).Info("Looking for builds")
 	if arch == "" {
 		arch = BuilderArch()
 	}
@@ -93,7 +92,7 @@ func ReadBuild(dir, buildID, arch string) (*Build, string, error) {
 	}
 
 	p := filepath.Join(dir, "builds", buildID, arch)
-	f, err := os.Open(filepath.Join(p, CosaMetaJSON))
+	f, err := Open(filepath.Join(p, CosaMetaJSON))
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to open %s to read meta.json: %w", p, err)
 	}
@@ -107,22 +106,28 @@ func ReadBuild(dir, buildID, arch string) (*Build, string, error) {
 	// into the memory model of the build
 	if b != nil && b.CosaDelayedMetaMerge {
 		log.Info("Searching for extra meta.json files")
-		err = filepath.Walk(p, func(path string, fi os.FileInfo, _ error) error {
+		files := walkFn(p)
+		for {
+			fi, ok := <-files
+			if !ok {
+				break
+			}
 			if fi == nil || fi.IsDir() || fi.Name() == CosaMetaJSON {
-				return nil
+				continue
 			}
 			if !IsMetaJSON(fi.Name()) {
-				return nil
+				continue
 			}
 			log.WithField("extra meta.json", fi.Name()).Info("found meta")
-			f, err := os.Open(filepath.Join(p, fi.Name()))
-
+			f, err := Open(filepath.Join(p, fi.Name()))
 			if err != nil {
-				return err
+				return b, p, err
 			}
 			defer f.Close()
-			return b.mergeMeta(f)
-		})
+			if err := b.mergeMeta(f); err != nil {
+				return b, p, err
+			}
+		}
 	}
 
 	return b, p, err
@@ -140,7 +145,7 @@ func buildParser(r io.Reader) (*Build, error) {
 
 // ParseBuild parses the meta.json and reutrns a build
 func ParseBuild(path string) (*Build, error) {
-	f, err := os.Open(path)
+	f, err := Open(path)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to open %s", path)
 	}
@@ -152,7 +157,7 @@ func ParseBuild(path string) (*Build, error) {
 	return b, err
 }
 
-// WriteMeta records the meta-data
+// WriteMeta records the meta-data. Writes are local only.
 func (build *Build) WriteMeta(path string, validate bool) error {
 	if validate {
 		if err := build.Validate(); len(err) != 0 {

--- a/gangplank/cosa/builds.go
+++ b/gangplank/cosa/builds.go
@@ -1,8 +1,9 @@
 package cosa
 
 import (
+	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -34,12 +35,17 @@ type buildsJSON struct {
 
 func getBuilds(dir string) (*buildsJSON, error) {
 	path := filepath.Join(dir, "builds", CosaBuildsJSON)
-	d, err := ioutil.ReadFile(path)
+	f, err := Open(path)
 	if err != nil {
 		return nil, ErrNoBuildsFound
 	}
+	d := []byte{}
+	bufD := bytes.NewBuffer(d)
+	if _, err := io.Copy(bufD, f); err != nil {
+		return nil, err
+	}
 	b := &buildsJSON{}
-	if err := json.Unmarshal(d, b); err != nil {
+	if err := json.Unmarshal(bufD.Bytes(), b); err != nil {
 		return nil, err
 	}
 	return b, nil

--- a/gangplank/cosa/cosa_reader.go
+++ b/gangplank/cosa/cosa_reader.go
@@ -3,7 +3,6 @@ package cosa
 import (
 	"context"
 	"io"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -95,10 +94,22 @@ type objectInfo struct {
 	name string
 }
 
+// TODO: drop with GoLang 1.16. This is a backport of the interface from 1.16.
+// var _ os.FileInfo = &objectInfo{}
+type fileMode uint32
+type fileInfo interface {
+	Name() string       // base name of the file
+	Size() int64        // length in bytes for regular files; system-dependent for others
+	Mode() fileMode     // file mode bits
+	ModTime() time.Time // modification time
+	IsDir() bool        // abbreviation for Mode().IsDir()
+	Sys() interface{}   // underlying data source (can return nil)
+}
+
 // objectInfo implements the os.FileInfo interface.
 // This allows for abstracting any file or object to be compared as if they were
 // local files regardless of location.
-var _ os.FileInfo = &objectInfo{}
+var _ fileInfo = &objectInfo{}
 
 // IsDir implements the os.FileInfo IsDir func. For minio objects,
 // the answer is always false.
@@ -114,7 +125,7 @@ func (ao *objectInfo) ModTime() time.Time {
 
 // Mode implements the os.FileInfo Mode func. Since there is not simple
 // way to convert an ACL into Unix permisions, it blindly returns 0644.
-func (ao *objectInfo) Mode() fs.FileMode {
+func (ao *objectInfo) Mode() fileMode {
 	return 0644
 }
 
@@ -155,14 +166,14 @@ func SetIOBackendFile() {
 }
 
 // walkerFn is a function that implements the walk func
-type walkerFn func(string) <-chan os.FileInfo
+type walkerFn func(string) <-chan fileInfo
 
 // walkFn is used to walk paths
 var walkFn walkerFn = defaultWalkFunc
 
 // defaultWalkFunc walks over a directory and returns a channel of os.FileInfo
-func defaultWalkFunc(p string) <-chan os.FileInfo {
-	ret := make(chan os.FileInfo)
+func defaultWalkFunc(p string) <-chan fileInfo {
+	ret := make(chan fileInfo)
 	go func() {
 		defer close(ret) //nolint
 		_ = filepath.Walk(p, func(path string, info os.FileInfo, err error) error {
@@ -186,8 +197,8 @@ func defaultWalkFunc(p string) <-chan os.FileInfo {
 // createMinioWalkFunc creates a new func a minio client. The returned function
 // will list the remote objects and return os.FileInfo compliant interfaces.
 func createMinioWalkFunc(m *minio.Client) walkerFn {
-	return func(p string) <-chan os.FileInfo {
-		ret := make(chan os.FileInfo)
+	return func(p string) <-chan fileInfo {
+		ret := make(chan fileInfo)
 		go func() {
 			defer close(ret) //nolint
 

--- a/gangplank/cosa/cosa_reader.go
+++ b/gangplank/cosa/cosa_reader.go
@@ -1,0 +1,216 @@
+package cosa
+
+import (
+	"context"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/minio/minio-go/v7"
+	"github.com/pkg/errors"
+)
+
+/*
+	cosa_reader.go provides an interface for interacting with
+	files through an "ioBackender." Any struct that inmplements ioBackender
+	can read meta-data.
+
+*/
+
+// default ioBackend is file backend
+var ioBackend ioBackender = new(ioBackendFile)
+
+// ioBackendMinio is an ioBackender.
+var _ ioBackender = &ioBackendMinio{}
+
+// newBackend returns a new backend
+func newBackend() ioBackender {
+	var newBackender ioBackender = ioBackend
+	return newBackender
+}
+
+// Open calls the backend's open function.
+func Open(p string) (io.ReadCloser, error) {
+	nb := newBackend()
+	return nb.Open(p)
+}
+
+// ioBackender is the basic interface.
+type ioBackender interface {
+	Open(string) (io.ReadCloser, error)
+}
+
+// ioBackendFile is a file based backend
+type ioBackendFile struct {
+	*os.File
+	path string
+}
+
+// Open implements ioBackender Open interface.
+func (i *ioBackendFile) Open(p string) (io.ReadCloser, error) {
+	f, err := os.Open(p)
+	i.File = f
+	i.path = p
+	return f, err
+}
+
+func (i *ioBackendFile) Name() string {
+	return i.path
+}
+
+// ioBackendMinio is a minio based backend
+type ioBackendMinio struct {
+	ctx  context.Context
+	m    *minio.Client
+	obj  *minio.Object
+	name string
+}
+
+var ErrNoMinioClient = errors.New("minio client is not defined")
+
+// Open implements ioBackender's and os.File's Open interface.
+func (im *ioBackendMinio) Open(p string) (io.ReadCloser, error) {
+	if im.m == nil {
+		return nil, ErrNoMinioClient
+	}
+	parts := strings.Split(p, "/")
+	path := strings.Join(parts[1:], "/")
+	obj, err := im.m.GetObject(im.ctx, parts[0], path, minio.GetObjectOptions{})
+	if err != nil {
+		return nil, err
+	}
+	im.obj = obj
+	im.name = p
+
+	return obj, nil
+}
+
+// objectInfo holds basic information about either a file object
+// or a remote minio object.
+type objectInfo struct {
+	info minio.ObjectInfo
+	name string
+}
+
+// objectInfo implements the os.FileInfo interface.
+// This allows for abstracting any file or object to be compared as if they were
+// local files regardless of location.
+var _ os.FileInfo = &objectInfo{}
+
+// IsDir implements the os.FileInfo IsDir func. For minio objects,
+// the answer is always false.
+func (ao *objectInfo) IsDir() bool {
+	return false
+}
+
+// ModTime implements the os.FileInfo ModTime func. The returned value
+// is remote aodification time.
+func (ao *objectInfo) ModTime() time.Time {
+	return ao.info.LastModified
+}
+
+// Mode implements the os.FileInfo Mode func. Since there is not simple
+// way to convert an ACL into Unix permisions, it blindly returns 0644.
+func (ao *objectInfo) Mode() fs.FileMode {
+	return 0644
+}
+
+// Name implements the os.FileInfo interface Name func.
+func (ao *objectInfo) Name() string {
+	return filepath.Base(ao.name)
+}
+
+// Size implements the os.FileInfo size func.
+func (ao *objectInfo) Size() int64 {
+	return ao.info.Size
+}
+
+// Sys implements the os.FileInfo interface Sys func. The interface spec allows
+// for returning a nil.
+func (ao *objectInfo) Sys() interface{} {
+	return nil
+}
+
+// SetIOBackendMinio sets the backend to minio. The client must be provided
+// by the caller, including authorization.
+func SetIOBackendMinio(ctx context.Context, m *minio.Client) error {
+	if m == nil {
+		return errors.New("minio client must not be nil")
+	}
+	backend := &ioBackendMinio{
+		m:   m,
+		ctx: ctx,
+	}
+	ioBackend = backend
+	walkFn = createMinioWalkFunc(m)
+	return nil
+}
+
+// SetIOBackendFile sets the backend to the default file backend.
+func SetIOBackendFile() {
+	ioBackend = new(ioBackendFile)
+}
+
+// walkerFn is a function that implements the walk func
+type walkerFn func(string) <-chan os.FileInfo
+
+// walkFn is used to walk paths
+var walkFn walkerFn = defaultWalkFunc
+
+// defaultWalkFunc walks over a directory and returns a channel of os.FileInfo
+func defaultWalkFunc(p string) <-chan os.FileInfo {
+	ret := make(chan os.FileInfo)
+	go func() {
+		defer close(ret) //nolint
+		_ = filepath.Walk(p, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return nil
+			}
+			ret <- &objectInfo{
+				name: filepath.Join(p, info.Name()),
+				info: minio.ObjectInfo{
+					Key:          info.Name(),
+					Size:         info.Size(),
+					LastModified: info.ModTime(),
+				},
+			}
+			return nil
+		})
+	}()
+	return ret
+}
+
+// createMinioWalkFunc creates a new func a minio client. The returned function
+// will list the remote objects and return os.FileInfo compliant interfaces.
+func createMinioWalkFunc(m *minio.Client) walkerFn {
+	return func(p string) <-chan os.FileInfo {
+		ret := make(chan os.FileInfo)
+		go func() {
+			defer close(ret) //nolint
+
+			parts := strings.Split(p, "/")
+			bucket := parts[0]
+			ao := minio.ListObjectsOptions{
+				Recursive: true,
+			}
+			if len(parts) > 0 {
+				ao.Prefix = filepath.Join(parts[1:]...)
+			}
+			info := m.ListObjects(context.Background(), bucket, ao)
+			for {
+				val, ok := <-info
+				if !ok {
+					return
+				}
+				ret <- &objectInfo{
+					info: val,
+					name: filepath.Join(bucket, val.Key),
+				}
+			}
+		}()
+		return ret
+	}
+}

--- a/gangplank/ocp/filer.go
+++ b/gangplank/ocp/filer.go
@@ -160,6 +160,10 @@ func (m *minioServer) start(ctx context.Context) error {
 			return err
 		}
 
+		if m.ExternalServer {
+			return nil
+		}
+
 		if m.overSSH != nil {
 			m.overSSH.port = m.Port
 			log.WithField("host", m.overSSH.Host).Info("Setting up remote SSH forwarding")


### PR DESCRIPTION
This change enables the use of a remote Minio or S3 object store and breaks the need for running Gangplank where the files are returned. For example, if running Gangplank over SSH it may be more desirable to have the workers return the results to a remote location.

The idea came from @dustymabe using Gangplank over low-bandwidth SSH connections (e.g. the 'hood coffee shop). 

Example:
```
$ cat minio.cfg
{
  "accesskey": "F0rTh3Luv0fLoki",
  "secretkey": "SrlyLikeWhy?",
  "host": "horcrux.dev",
  "port": 9000,
  "external_server": true,
  "region": ""
}

$ gangplank pod --podman -m minio.cfg -A base
```