### PR TITLE
init: do a shallow clone of git repo

### DIFF
--- a/src/cmd-init
+++ b/src/cmd-init
@@ -95,7 +95,7 @@ mkdir -p src
  if ! test -e config; then
      case "${source}" in
          /*) ln -s "${source}/${subdir}" config;;
-         *) git clone ${BRANCH:+--branch=${BRANCH}} --recurse-submodules "${source}" config
+         *) git clone ${BRANCH:+--branch=${BRANCH}} --depth=1 --shallow-submodules --recurse-submodules "${source}" config
             if [ -n "${subdir}" ]; then
                 mv config config-git
                 ln -sr config-git/"${subdir}" config


### PR DESCRIPTION
I feel like workers(bots) who are running builds for FCOS/RHCOS don't
need the full git commit history. Let's save energy and not waste the
bandwidth.