### PR TITLE
Gangplank: drop need for CGO devel libraries

### DIFF
--- a/gangplank/.gitignore
+++ b/gangplank/.gitignore
@@ -1,4 +1,3 @@
 bin/*
 srv/*
-.vscode/*
 **/.minio.sys/*

--- a/gangplank/.vscode/settings.json
+++ b/gangplank/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "go buildtags": "containers_image_openpgp",
+    "go.toolsEnvVars": {
+         "CGO_ENABLED": "0"
+     }
+}

--- a/gangplank/Makefile
+++ b/gangplank/Makefile
@@ -3,7 +3,7 @@ state = $(shell test -n "`git status -s`" && echo dirty || echo clean)
 version = $(shell cd .. && git log -n 1 --date=short --pretty=format:%cs.%h~${state} -- gangplank)
 cosa_dir = $(shell test -d /usr/lib/coreos-assembler && echo /usr/lib/coreos-assembler)
 ldflags=-X main.version=${version} -X main.cosaDir=${cosa_dir}
-
+buildtags=containers_image_openpgp
 export PATH := $(my_dir)/bin:$(shell readlink -f ../tools/bin):$(PATH)
 
 PREFIX ?= /usr
@@ -13,8 +13,9 @@ ARCH:=$(shell uname -m)
 pkgs := $(shell go list -mod=vendor ./...)
 .PHONY: build
 build:
-	cd "${my_dir}/cmd/gangway" && go build -ldflags "${ldflags}" -tags gangway -mod vendor -v -o ${my_dir}/bin/gangway
-	cd "${my_dir}/cmd/gangplank" && go build -ldflags "${ldflags}" -mod vendor -v -o ${my_dir}/bin/gangplank .
+	cd "${my_dir}/cmd/gangway" && go build -ldflags "${ldflags}" -tags ${buildtags},gangway -mod vendor -v -o ${my_dir}/bin/gangway
+	cd "${my_dir}/cmd/gangplank" && env CGO_ENABLED=0 \
+		go build -ldflags "${ldflags}" -tags ${buildtags} -mod vendor -v -o ${my_dir}/bin/gangplank .
 
 .PHONY: docs
 docs:
@@ -27,12 +28,13 @@ fmt:
 
 .PHONY: staticanalysis
 staticanalysis:
-	golangci-lint run -v ./...
+	golangci-lint run -v --build-tags ${buildtags},gangway ./...
+	env CGO_ENABLED=0 golangci-lint run -v --build-tags ${buildtags},gangway ./...
 
 .PHONY: test
 test: fmt
-	go test -mod=vendor -tags ${test_tags} -v  -i ${pkgs} && \
-	go test -mod=vendor -tags ${test_tags} -v -cover ${pkgs}
+	go test -mod=vendor -tags ${buildtags},gangway -v ${pkgs} && \
+	env CGO_ENABLED=0 go test -mod=vendor -tags ${buildtags},!gangway -v -cover ${pkgs}
 
 .PHONY: clean
 clean:

--- a/src/build-deps.txt
+++ b/src/build-deps.txt
@@ -1,8 +1,2 @@
 # Used by mantle
 golang
-
-# Used by Gangplank
-gpgme-devel
-btrfs-progs-devel
-device-mapper-devel
-libblockdev-btrfs-devel


### PR DESCRIPTION
When Gangplank gain awareness of how to run local podman, a bunch of
devel libraries came along for the ride (gpgme, btrfs-progrs,
device-mapper and libblock) all of which are not used by Gangplank. This
commit corrects the unfortante side effect.

Signed-off-by: Ben Howard <ben.howard@redhat.com>