### PR TITLE
cmdlib: strip write bit for group+other on all overlay files

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -267,6 +267,11 @@ commit_overlay() {
     name=$1
     path=$2
     respath=$(realpath "${path}")
+    # Only keep write bit for owner for all overlay files/dirs. This modifies
+    # the source config, but meh... git doesn't track it anyway and it's easier
+    # than using ostree's --statoverride when dealing with executable files.
+    # See: https://github.com/ostreedev/ostree/issues/2368
+    chmod -cR go-w "${respath}"
     echo -n "Committing ${name}: ${path} ... "
     ostree commit --repo="${tmprepo}" --tree=dir="${respath}" -b "${name}" \
         --owner-uid 0 --owner-gid 0 --no-xattrs --no-bindings --parent=none \


### PR DESCRIPTION
We should match the rest of the OS, even for /usr content which is ro
anyway. Doing it in cosa means we get consistent modes regardless of
what the umask was in the build/dev environment when the repo was
cloned.

See: https://github.com/coreos/fedora-coreos-tracker/issues/829