### PR TITLE
gangplank: followups to podman remote support

### DIFF
--- a/gangplank/cmd/gangplank/commonflags.go
+++ b/gangplank/cmd/gangplank/commonflags.go
@@ -21,8 +21,8 @@ var (
 	// minioSshRemoteUser is the name of the SSH user to use with minioSshRemoteHost
 	minioSshRemoteUser string
 
-	// minioSshRemotePassword is the password of the SSH user to use with minioSshRemoteHost
-	minioSshRemotePassword string
+	// minioSshRemoteKey is the SSH key to use with minioSshRemoteHost
+	minioSshRemoteKey string
 )
 
 // cosaKolaTests are used to generate automatic Kola stages.
@@ -37,5 +37,5 @@ func init() {
 	user, _ := user.Current()
 	sshFlags.StringVar(&minioSshRemoteHost, "forwardMinioSSH", containerHost(), "forward and use minio to ssh host")
 	sshFlags.StringVar(&minioSshRemoteUser, "sshUser", user.Username, "name of SSH; used with forwardMinioSSH")
-	sshFlags.StringVar(&minioSshRemotePassword, "sshPass", "", "password for remote SSH; used with forwardMinioSSH")
+	sshFlags.StringVar(&minioSshRemoteKey, "sshKey", "", "path to SSH key; used with forwardMinioSSH")
 }

--- a/gangplank/cmd/gangplank/generate.go
+++ b/gangplank/cmd/gangplank/generate.go
@@ -76,6 +76,7 @@ func setCliSpec() {
 			log.WithField("ssh host", minioSshRemoteHost).Info("Minio will be forwarded to remote host")
 			spec.Job.MinioSSHForward = minioSshRemoteHost
 			spec.Job.MinioSSHUser = minioSshRemoteUser
+			spec.Job.MinioSSHKey = minioSshRemoteKey
 		}
 		if minioCfgFile != "" {
 			spec.Job.MinioCfgFile = minioCfgFile

--- a/gangplank/cmd/gangplank/pod.go
+++ b/gangplank/cmd/gangplank/pod.go
@@ -39,7 +39,7 @@ var (
 	cosaViaPodman bool
 
 	// Run podman remotely
-	cosaViaRemotePodman, _ = os.LookupEnv(podmanRemoteEnvVar)
+	cosaViaRemotePodman string
 
 	// cosaWorkDir is used for podman mode and is where the "builds" directory will live
 	cosaWorkDir string
@@ -67,7 +67,7 @@ func init() {
 	spec.AddCliFlags(cmdPod.Flags())
 	cmdPod.Flags().BoolVar(&cosaWorkDirContext, "setWorkDirCtx", false, "set workDir's selinux content")
 	cmdPod.Flags().BoolVarP(&cosaViaPodman, "podman", "", false, "use podman to execute task")
-	cmdPod.Flags().StringVar(&cosaViaRemotePodman, "remote", "", "address of the remote podman to execute task")
+	cmdPod.Flags().StringVar(&cosaViaRemotePodman, "remote", os.Getenv(podmanRemoteEnvVar), "address of the remote podman to execute task")
 	cmdPod.Flags().StringVarP(&cosaImage, "image", "i", "", "use an alternative image")
 	cmdPod.Flags().StringVarP(&cosaWorkDir, "workDir", "w", "", "podman mode - workdir to use")
 	cmdPod.Flags().StringVar(&serviceAccount, "serviceaccount", "", "service account to use")

--- a/gangplank/ocp/ssh.go
+++ b/gangplank/ocp/ssh.go
@@ -17,6 +17,7 @@ import (
 type SSHForwardPort struct {
 	Host string
 	User string
+	Key  string
 
 	// port is not exported
 	port int
@@ -32,6 +33,7 @@ func getSshMinioForwarder(j *spec.JobSpec) *SSHForwardPort {
 	return &SSHForwardPort{
 		Host: j.Job.MinioSSHForward,
 		User: j.Job.MinioSSHUser,
+		Key:  j.Job.MinioSSHKey,
 	}
 }
 
@@ -55,6 +57,10 @@ func sshForwarder(ctx context.Context, cfg *SSHForwardPort) (chan<- bool, error)
 			"-o", "StrictHostKeyChecking=no",
 			"-N", "-R",
 			fmt.Sprintf("%d:127.0.0.1:%d", cfg.port, cfg.port), host,
+		}
+
+		if cfg.Key != "" {
+			args = append(args, "-i", cfg.Key)
 		}
 
 		cmd = exec.CommandContext(ctx, args[0], args[1:]...)

--- a/gangplank/ocp/ssh.go
+++ b/gangplank/ocp/ssh.go
@@ -49,7 +49,11 @@ func sshForwarder(ctx context.Context, cfg *SSHForwardPort) (chan<- bool, error)
 		if cfg.User != "" && !strings.Contains(cfg.Host, "@") {
 			host = fmt.Sprintf("%s@%s", cfg.User, cfg.Host)
 		}
-		args := []string{"ssh", "-o", "ServerAliveInterval=15", "-o", "ServerAliveCountMax=5", "-N", "-R",
+		args := []string{"ssh",
+			"-o", "ServerAliveInterval=15",
+			"-o", "ServerAliveCountMax=5",
+			"-o", "StrictHostKeyChecking=no",
+			"-N", "-R",
 			fmt.Sprintf("%d:127.0.0.1:%d", cfg.port, cfg.port), host,
 		}
 

--- a/gangplank/spec/jobspec.go
+++ b/gangplank/spec/jobspec.go
@@ -122,6 +122,7 @@ type Job struct {
 	// Runtime config options for SSH. Not exported for safety.
 	MinioSSHForward string
 	MinioSSHUser    string
+	MinioSSHKey     string
 }
 
 // Recipe describes where to get the build recipe/config, i.e fedora-coreos-config


### PR DESCRIPTION
```
commit 430e2c0d686a18cc2a2c947d1c8d64ef64ca95e0
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Tue Jun 1 15:16:32 2021 -0400

    gangplank: pod --podman --remote: fully support SSH key path
    
    This adds in the plumbing to support using an SSH key to authenticate
    with a remote podman instance. Using an SSH Agent worked before but pure
    keyfile based auth needed a few fixups.

commit fc5bbd73ace0f91ee999c6a714f73d6e1cfa0604
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Tue Jun 1 14:26:03 2021 -0400

    gangplank: ssh: set StrictHostKeyChecking=no on port forward
    
    In fresh container environments no user would have had the chance
    to interactively respond "yes". Let's just set StrictHostKeyChecking=no
    unless there is a better alternative.

commit 52f8c8fd3ce0da2735e00717ab0ea4e9ce49cc07
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Tue Jun 1 14:23:52 2021 -0400

    gangplank: fix default value for gangplank pod --podman --remote
    
    Previously the value (even though it was set before) would get reset
    back to "" by the flag parsing because "" was set as the default value
    there.
```
