### PR TITLE
cmdlib: always run rpm-ostree composes with umask 0022

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -422,7 +422,9 @@ impl_rpmostree_compose() {
 
     # this is the heart of the privs vs no privs dual path
     if has_privileges; then
-        sudo -E "$@"
+        # we hardcode a umask of 0022 here to make sure that composes are run
+        # with a consistent value, regardless of the environment
+        (umask 0022 && sudo -E "$@")
     else
         # "cache2" has an explicit label so we can find it in qemu easily
         if [ ! -f "${workdir}"/cache/cache2.qcow2 ]; then
@@ -537,7 +539,10 @@ EOF
     fi
 
     # this is the command run in the supermin container
-    echo "$@" > "${tmp_builddir}"/cmd.sh
+    # we hardcode a umask of 0022 here to make sure that composes are run
+    # with a consistent value, regardless of the environment
+    echo "umask 0022" > "${tmp_builddir}"/cmd.sh
+    echo "$@" >> "${tmp_builddir}"/cmd.sh
 
     touch "${runvm_console}"
     kola_args=(kola qemuexec -m 2048 --auto-cpus -U --workdir none \


### PR DESCRIPTION
Let's settle on 0022 as the umask we use to run rpm-ostree composes.
That way, we get consistent results regardless of our setup in the
build/dev environment and other parts of cosa.

This fixes liberal umasks like 0002 leaking into the bwrap environment
of scriptlets rpm-ostree runs and affecting the mode of files these
scriptlets create.

See: https://github.com/coreos/fedora-coreos-tracker/issues/829