### PR TITLE
Revert "cmd-kola: temporarily skip NVMe testing in basic scenarios"

### DIFF
--- a/src/cmd-kola
+++ b/src/cmd-kola
@@ -11,10 +11,7 @@ import yaml
 # Just test these boot to start with.  In the future we should at least
 # do ostree upgrades with uefi etc.  But we don't really need the *full*
 # suite...if podman somehow broke with nvme or uefi I'd be amazed and impressed.
-# XXX: nvme=true is is currently disabled due to a regression. See:
-# https://github.com/coreos/coreos-assembler/issues/2184
-# BASIC_SCENARIOS = ["nvme=true", "firmware=uefi", "firmware=uefi-secure"]
-BASIC_SCENARIOS = ["firmware=uefi", "firmware=uefi-secure"]
+BASIC_SCENARIOS = ["nvme=true", "firmware=uefi", "firmware=uefi-secure"]
 arch = platform.machine()
 
 cosa_dir = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
This reverts commit d64c16fae0250140e8dddab8b85ba3f562a63391.

This is fixed now in the latest seabios build:
https://bodhi.fedoraproject.org/updates/FEDORA-2021-2904475482

Closes: #2184