### PR TITLE
Gangplank: use bucket and path prefix for remote objects

### DIFF
--- a/gangplank/cmd/gangplank/pod.go
+++ b/gangplank/cmd/gangplank/pod.go
@@ -108,8 +108,8 @@ func runPod(c *cobra.Command, args []string) {
 					minioSshRemoteKey = cosaPodmanRemoteSshKey
 				}
 				log.WithFields(log.Fields{
-					"remote user":    minioSshRemoteUser,
-					"remote key":     cosaPodmanRemoteSshKey,
+					"remote user": minioSshRemoteUser,
+					"remote key":  cosaPodmanRemoteSshKey,
 					"remote host": minioSshRemoteHost,
 				}).Info("Minio will be forwarded to remote host")
 			}

--- a/gangplank/cosa/build.go
+++ b/gangplank/cosa/build.go
@@ -91,7 +91,7 @@ func ReadBuild(dir, buildID, arch string) (*Build, string, error) {
 		return nil, "", fmt.Errorf("build is undefined")
 	}
 
-	p := filepath.Join(dir, "builds", buildID, arch)
+	p := filepath.Join(dir, buildID, arch)
 	f, err := Open(filepath.Join(p, CosaMetaJSON))
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to open %s to read meta.json: %w", p, err)

--- a/gangplank/cosa/builds.go
+++ b/gangplank/cosa/builds.go
@@ -34,7 +34,7 @@ type buildsJSON struct {
 }
 
 func getBuilds(dir string) (*buildsJSON, error) {
-	path := filepath.Join(dir, "builds", CosaBuildsJSON)
+	path := filepath.Join(dir, CosaBuildsJSON)
 	f, err := Open(path)
 	if err != nil {
 		return nil, ErrNoBuildsFound

--- a/gangplank/cosa/builds_test.go
+++ b/gangplank/cosa/builds_test.go
@@ -27,7 +27,7 @@ func TestBuildsMeta(t *testing.T) {
 	defer os.RemoveAll(tmpd)
 	_ = os.MkdirAll(filepath.Join(tmpd, "builds"), 0755)
 
-	bjson := filepath.Join(tmpd, "builds", CosaBuildsJSON)
+	bjson := filepath.Join(tmpd, CosaBuildsJSON)
 	if err := ioutil.WriteFile(bjson, []byte(testData), 0666); err != nil {
 		t.Fatalf("failed to write the test data %v", err)
 	}

--- a/gangplank/cosa/schema_test.go
+++ b/gangplank/cosa/schema_test.go
@@ -205,7 +205,7 @@ func TestMergeMeta(t *testing.T) {
 	// m represents the merger of b and c
 	// where b is the starting meta.json
 	// m.BuildID should be c.Build
-	m, _, err := ReadBuild(tmpd, "", BuilderArch())
+	m, _, err := ReadBuild(filepath.Join(tmpd, "builds"), "", BuilderArch())
 	if err != nil {
 		t.Fatal("failed to find build")
 	}

--- a/gangplank/go.mod
+++ b/gangplank/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/opencontainers/runtime-spec v1.0.3-0.20200929063507-e6143ca7d51d
 	github.com/openshift/api v0.0.0-20201119214056-f1dea5ee7f60
 	github.com/pkg/errors v0.9.1
+	github.com/prometheus/common v0.10.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5

--- a/gangplank/ocp/ssh.go
+++ b/gangplank/ocp/ssh.go
@@ -27,13 +27,13 @@ type SSHForwardPort struct {
 // definition for forwarding a minio server, or nil if forwarding is
 // not enabled.
 func getSshMinioForwarder(j *spec.JobSpec) *SSHForwardPort {
-	if j.Job.MinioSSHForward == "" {
+	if j.Minio.SSHForward == "" {
 		return nil
 	}
 	return &SSHForwardPort{
-		Host: j.Job.MinioSSHForward,
-		User: j.Job.MinioSSHUser,
-		Key:  j.Job.MinioSSHKey,
+		Host: j.Minio.SSHForward,
+		User: j.Minio.SSHUser,
+		Key:  j.Minio.SSHKey,
 	}
 }
 

--- a/gangplank/ocp/worker.go
+++ b/gangplank/ocp/worker.go
@@ -22,6 +22,10 @@ import (
 // workSpec is a Builder.
 var _ Builder = &workSpec{}
 
+// workerBuild Dir is hard coded. Workers always read builds relative to their
+// local paths and assume the build location is on /srv
+var workerBuildDir string = filepath.Join("/srv", "builds")
+
 // workSpec define job for remote worker to do
 // A workSpec is dispatched by a builder and is tightly coupled to
 // to the dispatching pod.
@@ -171,7 +175,7 @@ func (ws *workSpec) Exec(ctx ClusterContext) error {
 			log.WithError(err).Info("Processed Uploads")
 		}
 
-		b, _, err := cosa.ReadBuild(cosaSrvDir, "", cosa.BuilderArch())
+		b, _, err := cosa.ReadBuild(workerBuildDir, "", cosa.BuilderArch())
 		if err != nil && b != nil {
 			_ = b.WriteMeta(os.Stdout.Name(), false)
 
@@ -185,7 +189,7 @@ func (ws *workSpec) Exec(ctx ClusterContext) error {
 	}()
 
 	// Expose the jobspec and meta.json (if its available) for templating.
-	mBuild, _, _ := cosa.ReadBuild(cosaSrvDir, "", cosa.BuilderArch())
+	mBuild, _, _ := cosa.ReadBuild(workerBuildDir, "", cosa.BuilderArch())
 	if mBuild == nil {
 		mBuild = new(cosa.Build)
 	}
@@ -240,7 +244,7 @@ func (ws *workSpec) Exec(ctx ClusterContext) error {
 			return err
 		}
 
-		next, _, _ := cosa.ReadBuild(cosaSrvDir, "", cosa.BuilderArch())
+		next, _, _ := cosa.ReadBuild(workerBuildDir, "", cosa.BuilderArch())
 		if next != nil && next.BuildArtifacts != nil && (mBuild.BuildArtifacts == nil || mBuild.BuildArtifacts.Ostree.Sha256 != next.BuildArtifacts.Ostree.Sha256) {
 			log.Debug("Stage produced a new OStree")
 

--- a/gangplank/spec/jobspec.go
+++ b/gangplank/spec/jobspec.go
@@ -35,6 +35,9 @@ type JobSpec struct {
 	Recipe     Recipe     `yaml:"recipe,omitempty" json:"recipe,omitempty"`
 	Spec       Spec       `yaml:"spec,omitempty" json:"spec,omitempty"`
 
+	// Minio describes the configuration for corrdinating objects for builds
+	Minio Minio `yaml:"minio,omitempty" json:"minio,omitempty"`
+
 	// PublishOscontainer is a list of push locations for the oscontainer
 	PublishOscontainer PublishOscontainer `yaml:"publish_oscontainer,omitempty" json:"publish_oscontainer,omitempty"`
 
@@ -118,11 +121,19 @@ type Job struct {
 	ForceArch string `yaml:"force_arch,omitempty" json:"force_arch,omitempty"`
 	// Unexported minio valued (run-time options)
 	MinioCfgFile string // not exported
+}
 
-	// Runtime config options for SSH. Not exported for safety.
-	MinioSSHForward string
-	MinioSSHUser    string
-	MinioSSHKey     string
+type Minio struct {
+	// Bucket is the bucket to put all the bits
+	Bucket string `yaml:"bucket,omitempty" json:"bucket,omitempty"`
+	// MinioKeyPrefix is the root path in the bucket to start looking for paths.
+	// The prefix is treated as a path prefix
+	KeyPrefix string `yaml:"key_prefix,omitempty" json:"key_prefix,omitempty"`
+	// Unexported minio valued (run-time options)
+	ConfigFile string `yaml:",omitempty" json:",omitempty"`
+	SSHForward string `yaml:",omitempty" json:",omitempty"`
+	SSHUser    string `yaml:",omitempty" json:",omitempty"`
+	SSHKey     string `yaml:",omitempty" json:",omitempty"`
 }
 
 // Recipe describes where to get the build recipe/config, i.e fedora-coreos-config


### PR DESCRIPTION
Prior to this Gangplank supports S3 in theory -- that is if S3 region
was empty, or in the extremely unlikely event that the caller has the
buckets 'builds' and 'cache.' The reason it worked with Minio is that
the Minio instance was neither shared nor did it remain after the build.

This change allows for Ganplank to use S3 or shared Minio backends by:
- Moving all minio specific information into its own struct
- Requires a bucket, and supports a path prefix for using sub-paths
  inside a bucket.
- Supports S3 secure connections.