### PR TITLE
Dockerfile: tickle Quay.io's cache for new seabios package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /root/containerbuild
 COPY ./src/print-dependencies.sh ./src/deps*.txt ./src/vmdeps*.txt ./src/build-deps.txt /root/containerbuild/src/
 COPY ./build.sh /root/containerbuild/
 RUN ./build.sh configure_yum_repos
-RUN ./build.sh install_rpms  # nocache 20210521
+RUN ./build.sh install_rpms  # nocache 20210603
 
 # Ok copy in the rest of them for the next few steps
 COPY ./ /root/containerbuild/


### PR DESCRIPTION
Follow-up to https://github.com/coreos/coreos-assembler/pull/2208.
Otherwise Quay.io probably won't pick up the new seabios package with
the fix.