### PR TITLE
platform/qemu: switch boot order for multipath disks

### DIFF
--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -282,8 +282,7 @@ func (inst *QemuInstance) SwitchBootOrder() (err2 error) {
 		return errors.Wrapf(err, "Could not list blk devices through qmp")
 	}
 
-	var blkdev string
-	var bootdev string
+	var bootdev, primarydev, secondarydev string
 	// Get bootdevice for pxe boot
 	for _, dev := range devs.Return {
 		switch dev.Type {
@@ -299,8 +298,10 @@ func (inst *QemuInstance) SwitchBootOrder() (err2 error) {
 		switch dev.Device {
 		case "installiso":
 			bootdev = devpath
-		case "d1":
-			blkdev = devpath
+		case "d1", "mpath10":
+			primarydev = devpath
+		case "mpath11":
+			secondarydev = devpath
 		default:
 			break
 		}
@@ -311,8 +312,14 @@ func (inst *QemuInstance) SwitchBootOrder() (err2 error) {
 		return errors.Wrapf(err, "Could not set bootindex for bootdev")
 	}
 	// set bootindex to 1 to boot from disk
-	if err := setBootIndexForDevice(monitor, blkdev, 1); err != nil {
-		return errors.Wrapf(err, "Could not set bootindex for blkdev")
+	if err := setBootIndexForDevice(monitor, primarydev, 1); err != nil {
+		return errors.Wrapf(err, "Could not set bootindex for primarydev")
+	}
+	// set bootindex to 2 for secondary multipath disk
+	if secondarydev != "" {
+		if err := setBootIndexForDevice(monitor, secondarydev, 2); err != nil {
+			return errors.Wrapf(err, "Could not set bootindex for secondarydev")
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
switch boot order for multipath disks when running testiso with `qemu-multipath`. there was a regression in the arm64 rhcos pipeline with testiso failing with:

```
+ kola testiso -S --qemu-native-4k --qemu-multipath --scenarios iso-install --output-dir tmp/kola-metal4k
Testing scenarios: [iso-install]
Error: scenario iso-install: switching boot order failed: Could not set bootindex for blkdev: Running QMP command: Device '' not found; <nil>
2021-06-03T08:32:21Z cli: scenario iso-install: switching boot order failed: Could not set bootindex for blkdev: Running QMP command: Device '' not found; <nil>
```

the disk device for multipath was not recognized when switching bootorder causing this to fail.