### PR TITLE
build: Clean up internal import_ostree_commit helper function

### DIFF
--- a/src/cmd-buildextend-extensions
+++ b/src/cmd-buildextend-extensions
@@ -34,8 +34,7 @@ def main():
         raise Exception(f"Missing {extensions_src}")
 
     commit = buildmeta['ostree-commit']
-    ostree_tarball = os.path.join(builddir, buildmeta['images']['ostree']['path'])
-    cmdlib.import_ostree_commit('tmp/repo', commit, ostree_tarball)
+    cmdlib.import_ostree_commit('tmp/repo', builddir, buildmeta)
 
     tmpworkdir = prepare_tmpworkdir()
     changed = run_rpmostree(tmpworkdir, commit, treefile_src, extensions_src)

--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -614,9 +614,7 @@ def generate_iso():
     print(f"Updated: {buildmeta_path}")
 
 
-commit_tar_name = buildmeta['images']['ostree']['path']
-commit_tar = os.path.join(builddir, commit_tar_name)
-import_ostree_commit(repo, buildmeta_commit, commit_tar)
+import_ostree_commit(repo, builddir, buildmeta)
 
 # lock and build
 with open(build_semaphore, 'w') as f:

--- a/src/cmd-generate-hashlist
+++ b/src/cmd-generate-hashlist
@@ -72,8 +72,6 @@ class HashListV1(dict):
         :type checksum: str
         :param commit: The ostree commit
         :type commit: str
-        :param commit_tar: Path to the ostree tar from the metadata
-        :type commit_tar: str
         :param hashlist: Initialized hash list instance
         :type hashlist: HashListV1
         :returns: Nothing
@@ -81,14 +79,11 @@ class HashListV1(dict):
         :raises: IndexError
         """
         checkout = 'tmp/repo/tmp/keylime-checkout'
-        commit_tar = os.path.join(
-            self._metadata.build_dir,
-            self._metadata['images']['ostree']['path'])
 
         import_ostree_commit(
             'tmp/repo',
-            self._metadata['ostree-commit'],
-            commit_tar,
+            self._metadata.build_dir,
+            self._metadata,
             force=True)
         subprocess.check_call([
             'ostree', 'checkout',

--- a/src/cmd-sign
+++ b/src/cmd-sign
@@ -195,7 +195,7 @@ def robosign_ostree(args, s3, build, gpgkey):
     # and finally add it to the tmprepo too so that buildextend-(qemu|metal)
     # will pull it: we could just nuke the repo to force a re-untar, but it
     # might nuke a more recent commit if we're not operating on the latest
-    import_ostree_commit('tmp/repo', checksum, commit_tarfile, force=True)
+    import_ostree_commit('tmp/repo', builddir, build, force=True)
 
 
 def robosign_images(args, s3, build, gpgkey):

--- a/src/cosalib/cmdlib.py
+++ b/src/cosalib/cmdlib.py
@@ -232,7 +232,9 @@ def rm_allow_noent(path):
         pass
 
 
-def import_ostree_commit(repo, commit, tarfile, force=False):
+def import_ostree_commit(repo, buildpath, buildmeta, force=False):
+    commit = buildmeta['ostree-commit']
+    tarfile = os.path.join(buildpath, buildmeta['images']['ostree']['path'])
     # create repo in case e.g. tmp/ was cleared out; idempotent
     subprocess.check_call(['ostree', 'init', '--repo', repo, '--mode=archive'])
 

--- a/tests/test_cosalib_cmdlib.py
+++ b/tests/test_cosalib_cmdlib.py
@@ -122,7 +122,7 @@ def test_import_ostree_commit(monkeypatch, tmpdir):
                     'ostree', 'init', '--repo', tmpdir, '--mode=archive']
             if self.check_call_count == 1:
                 assert args[0][0:2] == ['tar', '-C']
-                assert args[0][3:5] == ['-xf', 'tarfile']
+                assert args[0][3:5] == ['-xf', './tarfile']
             if self.check_call_count == 2:
                 assert args[0][0:4] == [
                     'ostree', 'pull-local', '--repo', tmpdir]
@@ -138,8 +138,15 @@ def test_import_ostree_commit(monkeypatch, tmpdir):
     # Monkey patch the subprocess function
     monkeypatch.setattr(subprocess, 'check_call', monkeyspcheck_call())
     monkeypatch.setattr(subprocess, 'call', monkeyspcall)
-    # Test
-    cmdlib.import_ostree_commit(tmpdir, 'commit', 'tarfile')
+    build = {
+        'ostree-commit': 'commit',
+        'images': {
+            'ostree': {
+                'path': 'tarfile'
+            }
+        }
+    }
+    cmdlib.import_ostree_commit(tmpdir, './', build)
 
 
 def test_image_info(tmpdir):


### PR DESCRIPTION
I'm going to be reworking this to use `rpm-ostree ex-container`
and it's easier if the callers pass the build metadata directly,
rather than each one parsing it separately.