### PR TITLE
gangplank: fixup building of live artifacts

### DIFF
--- a/gangplank/cosa/build.go
+++ b/gangplank/cosa/build.go
@@ -218,7 +218,7 @@ func GetCommandBuildableArtifacts() []string {
 			continue
 		case "iso", "live-iso", "live-kernel", "live-initramfs", "live-rootfs":
 			if !liveAdded {
-				ret = append(ret, "live-iso")
+				ret = append(ret, "live")
 				liveAdded = true
 			}
 		default:

--- a/gangplank/spec/stages.go
+++ b/gangplank/spec/stages.go
@@ -121,6 +121,8 @@ func cosaBuildCmd(b string, js *JobSpec) ([]string, error) {
 		return []string{defaultBaseCommand}, nil
 	case "finalize":
 		return []string{defaultFinalizeCommand}, nil
+	case "live":
+		return []string{fmt.Sprintf("cosa buildextend-%s", b)}, nil
 	}
 
 	if cosa.CanArtifact(b) {
@@ -329,7 +331,7 @@ func (s *Stage) Execute(ctx context.Context, rd *RenderData, envVars []string) e
 
 var (
 	// pseudoStages are special setup and tear down phases.
-	pseudoStages = []string{"base", "finalize"}
+	pseudoStages = []string{"base", "finalize", "live"}
 	// buildableArtifacts are known artifacts types from the schema.
 	buildableArtifacts = append(pseudoStages, cosa.GetCommandBuildableArtifacts()...)
 
@@ -386,11 +388,11 @@ func addShorthandToStage(artifact string, stage *Stage) {
 				BuildArtifacts: []string{"finalize"},
 				ExecutionOrder: 999,
 			}
-		case "live-iso":
+		case "live":
 			return &Stage{
 				ExecutionOrder:   2,
-				BuildArtifacts:   []string{"live-iso"},
-				RequireArtifacts: []string{"qemu", "metal", "metal4k"},
+				BuildArtifacts:   []string{"live"},
+				RequireArtifacts: []string{"ostree", "metal", "metal4k"},
 			}
 		case "metal":
 			return &Stage{


### PR DESCRIPTION
This was previously not working because `cosa buildextend-live-iso`
isn't a valid command. `cosa buildextend-live` is and produces multiple
artifacts (kernel, initramfs, rootfs, iso).

The error I was seeing was:

```
INFO[0219] Executing rendered script  cmd=/bin/bashrendered=/tmp/rendered030160414
+ cosa buildextend-live-iso
Unknown command: buildextend-live-iso
```