### PR TITLE
Gangplank: use pure-Go SSH forwarding

### DIFF
--- a/gangplank/go.mod
+++ b/gangplank/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5
 	github.com/xeipuuv/gojsonschema v1.2.0
+	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.20.1
 	k8s.io/apimachinery v0.20.5

--- a/gangplank/ocp/bc.go
+++ b/gangplank/ocp/bc.go
@@ -388,6 +388,12 @@ binary build interface.`)
 	// Terminate is used to tell all go-routines to end
 	terminate := make(chan bool)
 
+	// If defined, startup SSH before any work begins
+	if m.overSSH != nil {
+		if err := m.fowardOverSSH(terminate, errorCh); err != nil {
+			return err
+		}
+	}
 	// Watch the channels for signals to terminate
 	errored := false
 	go func() {

--- a/gangplank/ocp/filer.go
+++ b/gangplank/ocp/filer.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net"
+	"net/http"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -139,6 +140,11 @@ func (m *minioServer) client() (*minio.Client, error) {
 	}
 	return minio.New(fmt.Sprintf("%s:%d", m.Host, m.Port),
 		&minio.Options{
+			Transport: &http.Transport{
+				MaxIdleConns:       10,
+				IdleConnTimeout:    0,
+				DisableCompression: false, // force compression
+			},
 			Creds:  credentials.NewStaticV4(m.AccessKey, m.SecretKey, ""),
 			Secure: secure,
 			Region: region,


### PR DESCRIPTION
Hack-day project: the use of shell-SSH has bothered me -- it was a hack.
For hack-day, I figured de-hacking the SSH to use pure-Go SSH would be a
fitting project.

This borrows from the libpod GoLang implement of SSH code. Since our
needs a different (they use an http client over ssh to a socket) and we
need to proxy, the sshClient function was modified to return an
ssh.Client.

This ensures that similar code paths are used between remote podman _and_ the minio forwarding.

Oh, this also makes Minio faster by enabling compression. 