### PR TITLE
kola/tests/misc/network: Add dhcp test with veth

### DIFF
--- a/mantle/kola/tests/misc/network.go
+++ b/mantle/kola/tests/misc/network.go
@@ -194,11 +194,6 @@ func NetworkInitramfsSecondBoot(c cluster.TestCluster) {
 }
 
 var (
-	defaultLinkConfig = `[Link]
-          NamePolicy=mac
-          MACAddressPolicy=persistent
-`
-
 	dhcpClientConfig = `[main]
           dhcp=dhclient
 `
@@ -410,11 +405,6 @@ func setupBondWithDhcpTest(c cluster.TestCluster, primaryMac, secondaryMac, prim
 		"storage": {
 			"files": [
 				{
-					"path": "/etc/systemd/network/99-default.link",
-					"contents": { "source": "data:text/plain;base64,%s" },
-					"mode": 420
-				},
-				{
 					"path": "/etc/NetworkManager/conf.d/10-dhcp-config.conf",
 					"contents": { "source": "data:text/plain;base64,%s" },
 					"mode": 420
@@ -455,7 +445,6 @@ func setupBondWithDhcpTest(c cluster.TestCluster, primaryMac, secondaryMac, prim
 			]
 		}
 	}`,
-		base64.StdEncoding.EncodeToString([]byte(defaultLinkConfig)),
 		base64.StdEncoding.EncodeToString([]byte(dhcpClientConfig)),
 		base64.StdEncoding.EncodeToString([]byte(captureMacsScript)),
 		base64.StdEncoding.EncodeToString([]byte(setupVethPairs)),
@@ -571,16 +560,6 @@ func setupMultipleNetworkTest(c cluster.TestCluster, primaryMac, secondaryMac st
 		"storage": {
 			"files": [
 				{
-					"path": "/etc/systemd/network/99-default.link",
-					"contents": { "source": "data:text/plain;base64,%s" },
-					"mode": 420
-				},
-				{
-					"path": "/etc/NetworkManager/conf.d/10-dhcp-config.conf",
-					"contents": { "source": "data:text/plain;base64,%s" },
-					"mode": 420
-				},
-				{
 					"path": "/usr/local/bin/capture-macs",
 					"contents": { "source": "data:text/plain;base64,%s" },
 					"mode": 755
@@ -612,8 +591,6 @@ func setupMultipleNetworkTest(c cluster.TestCluster, primaryMac, secondaryMac st
 			]
 		}
 	}`,
-		base64.StdEncoding.EncodeToString([]byte(defaultLinkConfig)),
-		base64.StdEncoding.EncodeToString([]byte(dhcpClientConfig)),
 		base64.StdEncoding.EncodeToString([]byte(captureMacsScript)),
 		base64.StdEncoding.EncodeToString([]byte(setupOvsScript))))
 

--- a/mantle/kola/tests/misc/network.go
+++ b/mantle/kola/tests/misc/network.go
@@ -52,7 +52,7 @@ func init() {
 	register.RegisterTest(&register.Test{
 		Run:         NetworkSecondaryNics,
 		ClusterSize: 0,
-		Name:        "rhcos.network.multipleNics",
+		Name:        "rhcos.network.multiple-nics",
 		Distros:     []string{"rhcos"},
 		Platforms:   []string{"qemu-unpriv"},
 	})
@@ -62,7 +62,7 @@ func init() {
 	register.RegisterTest(&register.Test{
 		Run:         NetworkBondWithDhcp,
 		ClusterSize: 0,
-		Name:        "rhcos.network.bondWithDhcp",
+		Name:        "rhcos.network.bond-with-dhcp",
 		Distros:     []string{"rhcos"},
 		Platforms:   []string{"qemu-unpriv"},
 	})

--- a/mantle/kola/tests/misc/network.go
+++ b/mantle/kola/tests/misc/network.go
@@ -189,7 +189,7 @@ var (
           MACAddressPolicy=persistent
 `
 
-	dhcpConfig = `[main]
+	dhcpClientConfig = `[main]
           dhcp=dhclient
 `
 
@@ -407,7 +407,11 @@ func setupMultipleNetworkTest(c cluster.TestCluster, primaryMac, secondaryMac st
 
 			]
 		}
-	}`, base64.StdEncoding.EncodeToString([]byte(defaultLinkConfig)), base64.StdEncoding.EncodeToString([]byte(dhcpConfig)), base64.StdEncoding.EncodeToString([]byte(captureMacsScript)), base64.StdEncoding.EncodeToString([]byte(setupOvsScript))))
+	}`,
+	base64.StdEncoding.EncodeToString([]byte(defaultLinkConfig)),
+	base64.StdEncoding.EncodeToString([]byte(dhcpClientConfig)),
+	base64.StdEncoding.EncodeToString([]byte(captureMacsScript)),
+	base64.StdEncoding.EncodeToString([]byte(setupOvsScript))))
 
 	switch pc := c.Cluster.(type) {
 	// These cases have to be separated because when put together to the same case statement

--- a/mantle/kola/tests/misc/network.go
+++ b/mantle/kola/tests/misc/network.go
@@ -56,6 +56,16 @@ func init() {
 		Distros:     []string{"rhcos"},
 		Platforms:   []string{"qemu-unpriv"},
 	})
+	// This test follows the same network configuration used on https://github.com/RHsyseng/rhcos-slb
+	// with a slight change, where the MCO script is run from ignition: https://github.com/RHsyseng/rhcos-slb/blob/main/setup-ovs.sh.
+	// and we're using veth pairs instead of real nic when setting the bond
+	register.RegisterTest(&register.Test{
+		Run:         NetworkBondWithDhcp,
+		ClusterSize: 0,
+		Name:        "rhcos.network.bondWithDhcp",
+		Distros:     []string{"rhcos"},
+		Platforms:   []string{"qemu-unpriv"},
+	})
 }
 
 type listener struct {
@@ -219,6 +229,81 @@ var (
           umount /var/mnt
 	`
 
+	setupVethPairsTemplate = `#!/usr/bin/env bash
+          set -ex
+
+          create_veth_pair() {
+            veth_host_side_end_name=$1
+            veth_netns_side_end_name=$2
+            host_side_mac_address=$3
+            netns_side_ip=$4
+            network_namespace=$5
+
+            # Create veth pair and assign a namespace to veth-netns
+            ip link add ${veth_host_side_end_name} type veth peer name ${veth_netns_side_end_name}
+            ip link set ${veth_netns_side_end_name} netns ${network_namespace}
+
+            # Assign an MAC address to the host-side veth end
+            ip link set dev ${veth_host_side_end_name} address ${host_side_mac_address}
+
+            # Assign an IP address to netns-side veth end and bring it up
+            ip netns exec ${network_namespace} ip address add ${netns_side_ip} dev ${veth_netns_side_end_name}
+            ip netns exec ${network_namespace} ip link set ${veth_netns_side_end_name} up
+          }
+
+          activate_veth_end() {
+            veth_end_name=$1
+
+            nmcli dev set ${veth_end_name} managed yes
+            ip link set ${veth_end_name} up
+
+            poll_dhcp_success ${veth_end_name}
+          }
+
+          poll_dhcp_success() {
+            veth_end_name=$1
+            for attempt in {1..5}; do
+              cidr=$(nmcli -g IP4.ADDRESS dev show ${veth_end_name})
+              if [[ ! -z "${cidr}" ]]; then
+                return
+              fi
+              sleep 1
+            done
+
+            echo "failed to get ip for ${veth_end_name}"
+            exit 1
+          }
+
+          primary_mac=%s
+          secondary_mac=%s
+          primary_ip=%s
+          secondary_ip=%s
+
+          network_namespace=test-netns
+          # Create a network namespace
+          ip netns add ${network_namespace}
+
+          # create 2 veth pairs between host side and network_namespace
+          veth1_host_side_end_name=veth1-host
+          veth1_netns_side_end_name=veth1-netns
+          create_veth_pair ${veth1_host_side_end_name} ${veth1_netns_side_end_name} ${primary_mac} 192.168.0.100 ${network_namespace}
+          veth2_host_side_end_name=veth2-host
+          veth2_netns_side_end_name=veth2-netns
+          create_veth_pair ${veth2_host_side_end_name} ${veth2_netns_side_end_name} ${secondary_mac} 192.168.0.101 ${network_namespace}
+
+          # Run a dnsmasq service on the network_namespace, to set the host-side veth ends a ip via their MAC addresses
+          echo -e "dhcp-range=192.168.0.50,192.168.0.60,255.255.255.0,12h\ndhcp-host=${primary_mac},${primary_ip}\ndhcp-host=${secondary_mac},${secondary_ip}" > /etc/dnsmasq.d/dhcp
+          ip netns exec ${network_namespace} dnsmasq &
+
+          # Tell NM to manage the "veth-host" interface and bring it up (will attempt DHCP).
+          # Do this after we start dnsmasq so we don't have to deal with DHCP timeouts.
+          activate_veth_end ${veth1_host_side_end_name}
+          activate_veth_end ${veth2_host_side_end_name}
+
+          # Run setup Ovs script to create the ovs bridge over the bond, using the 2 host-side veth ends.
+          /usr/local/bin/setup-ovs
+`
+
 	setupOvsScript = `#!/usr/bin/env bash
           set -ex
           if [[ ! -f /boot/mac_addresses ]] ; then
@@ -292,6 +377,107 @@ var (
           fi
 `
 )
+
+func NetworkBondWithDhcp(c cluster.TestCluster) {
+	primaryMac := "52:55:00:d1:56:00"
+	secondaryMac := "52:55:00:d1:56:01"
+	primaryIp := "192.168.0.55"
+	secondaryIp := "192.168.0.56"
+	ovsBridgeInterface := "brcnv-iface"
+
+	setupBondWithDhcpTest(c, primaryMac, secondaryMac, primaryIp, secondaryIp)
+
+	m := c.Machines()[0]
+	checkExpectedMAC(c, m, ovsBridgeInterface, primaryMac)
+	checkExpectedIP(c, m, ovsBridgeInterface, primaryIp)
+}
+
+func initSetupVethPairsScript(primaryMac, secondaryMac, primaryIp, secondaryIp string) string {
+	return fmt.Sprintf(setupVethPairsTemplate, primaryMac, secondaryMac, primaryIp, secondaryIp)
+}
+
+func setupBondWithDhcpTest(c cluster.TestCluster, primaryMac, secondaryMac, primaryIp, secondaryIp string) {
+	var m platform.Machine
+	var err error
+	options := platform.QemuMachineOptions{}
+
+	setupVethPairs := initSetupVethPairsScript(primaryMac, secondaryMac, primaryIp, secondaryIp)
+
+	var userdata *conf.UserData = conf.Ignition(fmt.Sprintf(`{
+		"ignition": {
+			"version": "3.2.0"
+		},
+		"storage": {
+			"files": [
+				{
+					"path": "/etc/systemd/network/99-default.link",
+					"contents": { "source": "data:text/plain;base64,%s" },
+					"mode": 420
+				},
+				{
+					"path": "/etc/NetworkManager/conf.d/10-dhcp-config.conf",
+					"contents": { "source": "data:text/plain;base64,%s" },
+					"mode": 420
+				},
+				{
+					"path": "/usr/local/bin/capture-macs",
+					"contents": { "source": "data:text/plain;base64,%s" },
+					"mode": 755
+				},
+				{
+					"path": "/usr/local/bin/create-veth-pairs",
+					"contents": { "source": "data:text/plain;base64,%s" },
+					"mode": 755
+				},
+				{
+					"path": "/usr/local/bin/setup-ovs",
+					"contents": { "source": "data:text/plain;base64,%s" },
+					"mode": 755
+				}
+			]
+		},
+		"systemd": {
+			"units": [
+				{
+					"enabled": true,
+					"name": "openvswitch.service"
+				},
+				{
+					"contents": "[Unit]\nDescription=Capture MAC address from kargs\nAfter=network-online.target\nAfter=openvswitch.service\nConditionKernelCommandLine=macAddressList\n\n[Service]\nType=oneshot\nExecStart=/usr/local/bin/capture-macs\n\n[Install]\nRequiredBy=multi-user.target\n",
+					"enabled": true,
+					"name": "capture-macs.service"
+				},
+				{
+					"contents": "[Unit]\nDescription=Create VETH Pairs and Configue OVS interface over bond\nAfter=network-online.target\nAfter=capture-macs.service\nAfter=openvswitch.service\n\n[Service]\nType=oneshot\nExecStart=/usr/local/bin/create-veth-pairs\n\n[Install]\nRequiredBy=multi-user.target\n",
+					"enabled": true,
+					"name": "create-veth-pairs.service"
+				}
+			]
+		}
+	}`,
+		base64.StdEncoding.EncodeToString([]byte(defaultLinkConfig)),
+		base64.StdEncoding.EncodeToString([]byte(dhcpClientConfig)),
+		base64.StdEncoding.EncodeToString([]byte(captureMacsScript)),
+		base64.StdEncoding.EncodeToString([]byte(setupVethPairs)),
+		base64.StdEncoding.EncodeToString([]byte(setupOvsScript))))
+
+	switch pc := c.Cluster.(type) {
+	// These cases have to be separated because when put together to the same case statement
+	// the golang compiler no longer checks that the individual types in the case have the
+	// NewMachineWithQemuOptions function, but rather whether platform.Cluster
+	// does which fails
+	case *unprivqemu.Cluster:
+		m, err = pc.NewMachineWithQemuOptions(userdata, options)
+	default:
+		panic("unreachable")
+	}
+	if err != nil {
+		c.Fatal(err)
+	}
+
+	// Add karg needed for the ignition to configure the network properly.
+	addKernelArgs(c, m, []string{fmt.Sprintf("macAddressList=%s,%s", primaryMac, secondaryMac)})
+}
 
 // NetworkSecondaryNics verifies that secondary NICs are created on the node
 func NetworkSecondaryNics(c cluster.TestCluster) {


### PR DESCRIPTION
This PR is adding a test that will check DHCP propagation over a bond of two veth pairs.

test network chart attached 
![test-dhcp-netns](https://user-images.githubusercontent.com/48101085/122675497-5b545680-d1e2-11eb-819b-05e0ef503027.png)
