### PR TITLE
Don't enable `go build -race` by default

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -2,7 +2,7 @@
 
 // Build coreos-assembler image and create
 // an imageStream for it
-def imageName = buildImage()
+def imageName = buildImage(env: [ENABLE_GO_RACE_DETECTOR: "1"])
 
 pod(image: imageName + ":latest", kvm: true, memory: "10Gi") {
     checkout scm

--- a/mantle/build
+++ b/mantle/build
@@ -48,7 +48,7 @@ cross_build() {
 	local a
 	local r
 	for a in amd64 arm64 s390x ppc64le; do
-		[[ "${a}" =~ s390x ]] && r= || r="-race"
+		( [[ "${a}" =~ s390x ]] || [ -z "${ENABLE_GO_RACE_DETECTOR:-}" ] ) && r= || r="-race"
 		echo "Building $a/$1"
 		mkdir -p "bin/$a"
 		CGO_ENABLED=0 GOARCH=$a \


### PR DESCRIPTION
This code is new and we're still squashing races. Let's gate it behind
an env var so it's not enabled in production builds since this can cause
failures (see: https://github.com/coreos/coreos-assembler/pull/2219).

This way it's still easy for local devs to enable it and we can still
opt into it for our upstream CI.