### PR TITLE
Fix CI for rhcos-4.8 branch

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -11,7 +11,7 @@ pod(image: imageName + ":latest", kvm: true, memory: "10Gi") {
     archiveArtifacts artifacts: 'rpmdb.txt'
 
     // Run stage Build FCOS (init, fetch and build)
-    fcosBuild(skipKola: 1, cosaDir: "/srv", noForce: true)
+    fcosBuild(skipKola: 1, cosaDir: "/srv", noForce: true, gitBranch: env.CHANGE_TARGET)
 
     // Run stage Kola QEMU (basic-qemu-scenarios, upgrade and self tests)
     fcosKola(basicScenarios: true, cosaDir: "/srv", addExtTests: ["${env.WORKSPACE}/ci/run-kola-self-tests"])


### PR DESCRIPTION
- We need to match the fedora-coreos-config
branch with the CI branch running.
- For PRs running against this branch the env.CHANGE_TARGET
in Jenkins is used to store the name of the target branch which
is a match with the fedora-coreos-config branch.

Signed-off-by: Renata Ravanelli <rravanel@redhat.com>