### PR TITLE
create_disk: add spacing in bootargs

### DIFF
--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -170,7 +170,7 @@ case "${bootfs}" in
     ext4verity)
         # Need blocks to match host page size; TODO
         # really mkfs.ext4 should know this.
-        bootargs="-b $(getconf PAGE_SIZE) -O verity"
+        bootargs+=" -b $(getconf PAGE_SIZE) -O verity"
         ;;
     ext4) ;;
     *) echo "Unhandled bootfs: ${bootfs}" 1>&2; exit 1 ;;


### PR DESCRIPTION
This is a follow up to dd3225f. The addition of a non empty string
value for bootargs before this point means we need to add to the
existing value.