### PR TITLE
create_disk: Add build-kernel

### DIFF
--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -259,12 +259,15 @@ test -d "${deploy_root}"
 #                convenient to have here as a strong cross-reference.
 # imgid:         The full image name, the same as will end up in the
 #                `images` dict in `meta.json`.
+# build-kernel:  The version of the kernel used to generate the filesystems.
+#                This could be useful when trying to diagnose the XFS layout.
 cat > $rootfs/.coreos-aleph-version.json << EOF
 {
 	"build": "${buildid}",
 	"ref": "${ref}",
 	"ostree-commit": "${commit}",
-	"imgid": "${imgid}"
+	"imgid": "${imgid}",
+	"build-kernel": "$(uname -r)"
 }
 EOF
 


### PR DESCRIPTION
I was reading this code for an unrelated reason and thought
about reproducibility of builds, and I think having the kernel
version here will help.  It's the thing that ends up creating
the actual filesystem layout.

Longer term of course we really need to snapshot version the bits
that go into cosa builds and then reference that snapshot here.