### PR TITLE
create_disk.sh: remove `options` from s390x parmfile

### DIFF
--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -356,7 +356,7 @@ s390x)
     # stage on s390x, either through zipl->grub2-emu or zipl standalone.
     # See https://github.com/coreos/ignition-dracut/issues/84
     # A similar hack is present in https://github.com/coreos/coreos-assembler/blob/main/src/gf-platformid#L55
-    echo "$(grep options $blsfile) ignition.firstboot" > $tmpfile
+    echo "$(grep options $blsfile | cut -d' ' -f2-) ignition.firstboot" > $tmpfile
 
     # ideally we want to invoke zipl with bls and zipl.conf but we might need
     # to chroot to $rootfs/ to do so. We would also do that when FCOS boot on its own.


### PR DESCRIPTION
We should pass a file containing the kargs here, but not the `options`
key we grepped out of the BLS. Otherwise, I think we'll literally end up
with an `options` karg (which thankfully should have been harmless).
Filter through `cut` to remove that.

We regressed on this at some point. The original commit which added
s390x support didn't do this:

https://github.com/coreos/coreos-assembler/commit/100c2e512ecb89786a53bfb1c81abc003776090d