### PR TITLE
cmdlib: Bump ppc64le memory to 4G, due to page faults on Power 8

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -500,6 +500,9 @@ runvm() {
     # then add all the base deps
     # for syntax see: https://github.com/koalaman/shellcheck/wiki/SC2031
     rpms=$(grep -v '^#' < "${DIR}"/vmdeps.txt)
+    # There seems to be some false positives in shellcheck
+    # https://github.com/koalaman/shellcheck/issues/2217
+    # shellcheck disable=2031
     archrpms=$(grep -v '^#' < "${DIR}/vmdeps-${arch}.txt")
 
     # shellcheck disable=SC2086
@@ -552,6 +555,9 @@ EOF
 
     touch "${runvm_console}"
 
+    # There seems to be some false positives in shellcheck
+    # https://github.com/koalaman/shellcheck/issues/2217
+    # shellcheck disable=2031
     case $arch in
     "x86_64")  memory=2048 ;;
     # Power 8 page faults with 2G of memory in rpm-ostree


### PR DESCRIPTION
Around start of the June, builds of FCOS on Power 8 host started to fail due to the kernel page allocation failures. I haven't noticed any obvious issues so I assume that some combination of overhead of radix mode, 64k pages and possibly in connection to some changes in Fedora, rpm-ostree causing this. Power 9 is unaffected.  Bumping the memory resolves this issue.
CC'ing @Prashanth684 