### PR TITLE
kola: fix panic running fcos.ignition.misc.empty

### DIFF
--- a/mantle/kola/tests/ignition/empty.go
+++ b/mantle/kola/tests/ignition/empty.go
@@ -45,5 +45,9 @@ func init() {
 	})
 }
 
-func empty(_ cluster.TestCluster) {
+func empty(c cluster.TestCluster) {
+	m := c.Machines()[0]
+	// check that the test harness correctly skipped passing SSH keys
+	// via Ignition
+	c.MustSSH(m, "[ ! -e ~/.ssh/authorized_keys.d/ignition ]")
 }

--- a/mantle/kola/tests/ignition/empty.go
+++ b/mantle/kola/tests/ignition/empty.go
@@ -28,7 +28,7 @@ func init() {
 		Name:             "fcos.ignition.misc.empty",
 		Run:              empty,
 		ClusterSize:      1,
-		ExcludePlatforms: []string{"qemu", "esx"},
+		ExcludePlatforms: []string{"qemu", "esx", "aws"},
 		Distros:          []string{"fcos"},
 		UserData:         conf.Empty(),
 		Tags:             []string{"ignition"},

--- a/mantle/platform/conf/conf.go
+++ b/mantle/platform/conf/conf.go
@@ -73,7 +73,7 @@ type Conf struct {
 }
 
 // Empty creates a completely empty configuration. Any configuration addition
-// applied to an empty config triggers a panic.
+// applied to an empty config is ignored.
 func Empty() *UserData {
 	return &UserData{
 		kind: kindEmpty,
@@ -387,8 +387,6 @@ func (c *Conf) AddFile(path, filesystem, contents string, mode int) {
 		c.addFileV32(path, filesystem, contents, mode)
 	} else if c.ignitionV33exp != nil {
 		c.addFileV33exp(path, filesystem, contents, mode)
-	} else {
-		panic("Could not find a supported Ignition config version")
 	}
 }
 
@@ -484,8 +482,6 @@ func (c *Conf) AddSystemdUnit(name, contents string, state systemdUnitState) {
 		c.addSystemdUnitV32(name, contents, enable, mask)
 	} else if c.ignitionV33exp != nil {
 		c.addSystemdUnitV33exp(name, contents, enable, mask)
-	} else {
-		panic("Could not find a supported Ignition config version")
 	}
 }
 
@@ -586,8 +582,6 @@ func (c *Conf) AddSystemdUnitDropin(service, name, contents string) {
 		c.addSystemdDropinV32(service, name, contents)
 	} else if c.ignitionV33exp != nil {
 		c.addSystemdDropinV33exp(service, name, contents)
-	} else {
-		panic("Could not find a supported Ignition config version")
 	}
 }
 
@@ -686,8 +680,6 @@ func (c *Conf) AddAuthorizedKeys(user string, keys []string) {
 		c.addAuthorizedKeysV32(user, keys)
 	} else if c.ignitionV33exp != nil {
 		c.addAuthorizedKeysV33exp(user, keys)
-	} else {
-		panic("Could not find a supported Ignition config version")
 	}
 }
 
@@ -794,8 +786,6 @@ func (c *Conf) AddConfigSource(source string) {
 		c.addConfigSourceV32(source)
 	} else if c.ignitionV33exp != nil {
 		c.addConfigSourceV33exp(source)
-	} else {
-		panic("Could not find a supported Ignition config version")
 	}
 }
 

--- a/mantle/platform/machine/aws/flight.go
+++ b/mantle/platform/machine/aws/flight.go
@@ -63,7 +63,7 @@ func NewFlight(opts *aws.Options) (platform.Flight, error) {
 	// network/ssh.go. However, AWS requires an rsa key. For now
 	// (until we get an updated golang library) we'll just satisfy
 	// the requirement by using a fake key and disabling the
-	// fcos.ignition.v3.noop test on AWS.
+	// fcos.ignition.misc.empty and fcos.ignition.v3.noop tests on AWS.
 	// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html#how-to-generate-your-own-key-and-import-it-to-aws
 	key, err := platform.GenerateFakeKey()
 	if err != nil {


### PR DESCRIPTION
If a test specifies the userdata as `Empty()`, it wants to ensure that there is no Ignition config at all, and all of the additions made to the config by `BaseCluster.RenderUserData()` should be ignored.  The panics added in 22f725a interfere with that, so remove them again.

Currently, the only test that uses `Empty()` is `fcos.ignition.misc.empty`, which relies on Afterburn SSH key injection.  When that test was ported from CL in 6e9e49b, the `UserData` field wasn't renamed to `UserDataV3`, and the nil `UserDataV3` caused the test to start running with a default non-empty Ignition config.  The SSH key was thus injected twice (in the Ignition config and via Afterburn), but the test didn't check for that, so it continued to pass.  Thus, when 22f725a broke `Empty()`, the test continued to work until 1952a49 dropped the separate `UserDataV3` field and the test started invoking `Empty()` again.  (Even then, the test passed cosa CI because it's skipped on qemu, which doesn't have a separate mechanism for injecting SSH keys.)  Extend `fcos.ignition.misc.empty` and `fcos.ignition.v3.noop`, which both rely on Afterburn SSH key injection, to check that Ignition has not written any SSH keys to the node.

Fixes panic in `fcos.ignition.misc.empty`:

    panic: Could not find a supported Ignition config version
    goroutine 5056 [running]:
    github.com/coreos/mantle/platform/conf.(*Conf).AddAuthorizedKeys(0xc000125200, 0x20e06cb, 0x4, 0xc00086ab50, 0x1, 0x1)
    	/root/containerbuild/mantle/platform/conf/conf.go:690 +0x16b
    github.com/coreos/mantle/platform/conf.(*Conf).CopyKeys(0xc000125200, 0xc000010a10, 0x1, 0x1)
    	/root/containerbuild/mantle/platform/conf/conf.go:701 +0x165
    github.com/coreos/mantle/platform.(*BaseCluster).RenderUserData(0xc000735900, 0xc000110f30, 0xc000923d58, 0xd, 0xc001435e20, 0x40)
    	/root/containerbuild/mantle/platform/cluster.go:207 +0x6c5
    github.com/coreos/mantle/platform/machine/aws.(*cluster).NewMachine(0xc00086ab10, 0xc000110f30, 0x0, 0x0, 0x0, 0xc001435ef8)
    	/root/containerbuild/mantle/platform/machine/aws/cluster.go:32 +0x16d
    github.com/coreos/mantle/platform/machine/aws.(*cluster).NewMachineWithOptions(0xc00086ab10, 0xc000110f30, 0x0, 0x0, 0x0, 0x0, 0x1debd01, 0xc001435fa8, 0x30000000056545a, 0xc000ce9740)
    	/root/containerbuild/mantle/platform/machine/aws/cluster.go:85 +0x93
    github.com/coreos/mantle/platform.NewMachines.func1(0xc0015ad1b0, 0x244ea68, 0xc00086ab10, 0xc000110f30, 0x0, 0x0, 0x0, 0x0, 0xc001b40d80, 0xc001b40d20)
    	/root/containerbuild/mantle/platform/platform.go:364 +0xcb
    created by github.com/coreos/mantle/platform.NewMachines
    	/root/containerbuild/mantle/platform/platform.go:362 +0x165

On AWS we can't pass ECDSA keys outside of Ignition configs, and mantle's SSH client doesn't support RSA keys under the Fedora crypto policy (https://github.com/golang/go/issues/37278).  Disable `fcos.ignition.misc.empty` on AWS.  See ac54a8a for details.

cc @travier