### PR TITLE
Mantle: refactor devshell to be event based

### DIFF
--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -1254,7 +1254,7 @@ func (builder *QemuBuilder) VirtioJournal(config *conf.Conf, queryArguments stri
 	# https://bugzilla.redhat.com/show_bug.cgi?id=1942198
 	ExecStart=/usr/bin/bash -c "journalctl -q -b -f -o json --no-tail %s"
 	[Install]
-	RequiredBy=multi-user.target
+	RequiredBy=basic.target
 	`, queryArguments)
 
 	config.AddSystemdUnit("mantle-virtio-journal-stream.service", streamJournalUnit, conf.Enable)


### PR DESCRIPTION
Instead of using timers to decided when to connect over SSH, this uses
console events to determine when to connect to SSH. Rather than parsing
the virtio-console for ready-status, this uses the console for
determining state.

Signed-off-by: Ben Howard <ben.howard@redhat.com>