### PR TITLE
src/cmd-upload-oscontainer: use arch in the push tag

### DIFF
--- a/src/cmd-upload-oscontainer
+++ b/src/cmd-upload-oscontainer
@@ -19,6 +19,8 @@ sys.path.insert(0, cosa_dir)
 from cosalib import cmdlib
 
 parser = argparse.ArgumentParser()
+parser.add_argument("--arch-tag", help="append arch name to push tag",
+                    action='store_true')
 parser.add_argument("--name", help="oscontainer name",
                     action='store', required=True)
 parser.add_argument("--from", help="Base image", default='scratch',
@@ -91,8 +93,10 @@ if display_name == "":
     raise SystemExit(f"Failed to find NAME= in /usr/lib/os-release in commit {ostree_commit}")
 shutil.rmtree(tmp_osreleasedir)
 
-# The build ID is the container tag
-osc_name_and_tag = "{}:{}".format(args.name, latest_build)
+osc_name_and_tag = f"{args.name}:{latest_build}"
+if args.arch_tag:
+    arch = meta.get("coreos-assembler.basearch", cmdlib.get_basearch)
+    osc_name_and_tag = f"{args.name}:{latest_build}-{arch}"
 
 # TODO: Use labels for the build hash and avoid pulling the oscontainer
 # every time we want to poll.


### PR DESCRIPTION
Add the architecture to the default push tag for two reasons:
- The release team for RHCOS has requested that the image tag include
  the architecture.
- `aarch64` builds are planned to share the build id. Unless the images
  are pushed to separate tags, one build could step on another.

The better solution would be to use "fat manifests", however, they
are not universally supported yet. Quay plans on providing this in the
4.8 time-frame. Until such time, this is the cleanest path.

Signed-off-by: Ben Howard <ben.howard@redhat.com>
(cherry picked from commit 44999096d5e22623356e2d0c50e39f31c8a63390)