### PR TITLE
Mantle: rename platform.NewBuilder to NewQemuBuilder

### DIFF
--- a/mantle/cmd/kola/qemuexec.go
+++ b/mantle/cmd/kola/qemuexec.go
@@ -196,7 +196,7 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Cannot use --bind-rw with --ignition-direct")
 	}
 
-	builder := platform.NewBuilder()
+	builder := platform.NewQemuBuilder()
 	defer builder.Close()
 
 	if butane != "" {

--- a/mantle/kola/tests/ignition/qemufailure.go
+++ b/mantle/kola/tests/ignition/qemufailure.go
@@ -53,7 +53,7 @@ func ignitionFailure(c cluster.TestCluster) error {
 	}
 	failConfig.AddFile("/notwritable.txt", "/", "Hello world", 0644)
 
-	builder := platform.NewBuilder()
+	builder := platform.NewQemuBuilder()
 	defer builder.Close()
 	builder.SetConfig(failConfig)
 	err = builder.AddBootDisk(&platform.Disk{

--- a/mantle/platform/machine/qemuiso/cluster.go
+++ b/mantle/platform/machine/qemuiso/cluster.go
@@ -94,7 +94,7 @@ func (qc *Cluster) NewMachineWithQemuOptions(userdata *conf.UserData, options pl
 		consolePath: filepath.Join(dir, "console.txt"),
 	}
 
-	builder := platform.NewBuilder()
+	builder := platform.NewQemuBuilder()
 	builder.ConfigFile = confPath
 	defer builder.Close()
 	builder.UUID = qm.id

--- a/mantle/platform/machine/unprivqemu/cluster.go
+++ b/mantle/platform/machine/unprivqemu/cluster.go
@@ -94,7 +94,7 @@ func (qc *Cluster) NewMachineWithQemuOptions(userdata *conf.UserData, options pl
 		consolePath: filepath.Join(dir, "console.txt"),
 	}
 
-	builder := platform.NewBuilder()
+	builder := platform.NewQemuBuilder()
 	if options.DisablePDeathSig {
 		builder.Pdeathsig = false
 	}

--- a/mantle/platform/metal.go
+++ b/mantle/platform/metal.go
@@ -91,7 +91,7 @@ var (
 // NewMetalQemuBuilderDefault returns a QEMU builder instance with some
 // defaults set up for bare metal.
 func NewMetalQemuBuilderDefault() *QemuBuilder {
-	builder := NewBuilder()
+	builder := NewQemuBuilder()
 	// https://github.com/coreos/fedora-coreos-tracker/issues/388
 	// https://github.com/coreos/fedora-coreos-docs/pull/46
 	builder.Memory = 4096

--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -419,8 +419,8 @@ type QemuBuilder struct {
 	fds []*os.File
 }
 
-// NewBuilder creates a new build for QEMU with default settings.
-func NewBuilder() *QemuBuilder {
+// NewQemuBuilder creates a new build for QEMU with default settings.
+func NewQemuBuilder() *QemuBuilder {
 	ret := QemuBuilder{
 		Firmware:      "bios",
 		Swtpm:         true,


### PR DESCRIPTION
The name 'NewBuilder' in the context of platform is vague.