### PR TITLE
mantle/kola: Update upgrade test to use an Ignition spec 3 image

### DIFF
--- a/mantle/cmd/kola/kola.go
+++ b/mantle/cmd/kola/kola.go
@@ -518,16 +518,16 @@ func syncFindParentImageOptions() error {
 			return err
 		}
 	case "rhcos":
-		// Hardcoded for now based on https://github.com/openshift/installer/blob/release-4.3/data/data/rhcos.json
-		tag := "rhcos-4.3"
-		release := "43.81.202003111353.0"
+		// Hardcoded for now based on https://github.com/openshift/installer/blob/release-4.6/data/data/rhcos.json
+		tag := "rhcos-4.6"
+		release := "46.82.202011260640-0"
 		switch system.RpmArch() {
 		case "s390x":
 			tag += "-" + system.RpmArch()
-			release = "43.81.202003172338.0"
+			release = "46.82.202011261339-0"
 		case "ppc64le":
 			tag += "-" + system.RpmArch()
-			release = "43.81.202003172241.0"
+			release = "46.82.202011260639-0"
 		}
 		parentBaseURL = fmt.Sprintf("https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/%s/%s/%s/", tag, release, system.RpmArch())
 		// sigh...someday we'll get the stuff signed by ART or maybe https://github.com/openshift/enhancements/pull/201 will just happen


### PR DESCRIPTION
This is needed for the rhcos-4.8 branch as RHEL COSA is currently stuck on F33 based COSA.

Cherry-picked from: 1d01a752fa2468ccaf5f1a882f522cad6926ac85