### PR TITLE
kola/tests: fix `coreos.ignition.ssh.key`

### DIFF
--- a/mantle/kola/tests/ignition/empty.go
+++ b/mantle/kola/tests/ignition/empty.go
@@ -26,7 +26,7 @@ import (
 func init() {
 	register.RegisterTest(&register.Test{
 		Name:             "fcos.ignition.misc.empty",
-		Run:              empty,
+		Run:              noIgnitionSSHKey,
 		ClusterSize:      1,
 		ExcludePlatforms: []string{"qemu", "esx", "aws"},
 		Distros:          []string{"fcos"},
@@ -35,7 +35,7 @@ func init() {
 	})
 	register.RegisterTest(&register.Test{
 		Name:             "fcos.ignition.v3.noop",
-		Run:              empty,
+		Run:              noIgnitionSSHKey,
 		ClusterSize:      1,
 		ExcludePlatforms: []string{"qemu", "esx", "aws"},
 		Distros:          []string{"fcos"},
@@ -45,7 +45,7 @@ func init() {
 	})
 }
 
-func empty(c cluster.TestCluster) {
+func noIgnitionSSHKey(c cluster.TestCluster) {
 	m := c.Machines()[0]
 	// check that the test harness correctly skipped passing SSH keys
 	// via Ignition

--- a/mantle/kola/tests/ignition/ssh.go
+++ b/mantle/kola/tests/ignition/ssh.go
@@ -15,6 +15,7 @@
 package ignition
 
 import (
+	"github.com/coreos/mantle/kola/cluster"
 	"github.com/coreos/mantle/kola/register"
 	"github.com/coreos/mantle/platform/conf"
 )
@@ -24,11 +25,18 @@ func init() {
 	// without injecting via platform metadata
 	register.RegisterTest(&register.Test{
 		Name:             "coreos.ignition.ssh.key",
-		Run:              empty,
+		Run:              noAfterburnSSHKey,
 		ClusterSize:      1,
 		ExcludePlatforms: []string{"qemu", "openstack"}, // redundant on qemu
 		Flags:            []register.Flag{register.NoSSHKeyInMetadata},
 		UserData:         conf.Ignition(`{"ignition":{"version":"3.0.0"}}`),
 		Tags:             []string{"ignition"},
 	})
+}
+
+func noAfterburnSSHKey(c cluster.TestCluster) {
+	m := c.Machines()[0]
+	// check that the test harness correctly skipped passing SSH keys
+	// via Afterburn
+	c.MustSSH(m, "[ ! -e ~/.ssh/authorized_keys.d/afterburn ]")
 }


### PR DESCRIPTION
`coreos.ignition.ssh.key` uses the same test function as the tests in `empty.go` but wants the opposite result: verifying that Afterburn did not inject keys.  Give it its own test function.

Fixes #2238.