### PR TITLE
buildextend-*: Add `--compress`

### DIFF
--- a/src/cmd-artifact-disk
+++ b/src/cmd-artifact-disk
@@ -13,11 +13,12 @@ import cosalib.qemuvariants as QVariants
 import cosalib.vmware as VmwareOVA
 
 
-def get_builder(imgtype, build_root, build="latest", force=False, schema=None):
+def get_builder(imgtype, build_root, build="latest", force=False, compress=False, schema=None):
     kargs = {
         "build": build,
         "buildroot": build_root,
         "force": force,
+        "compress": compress,
         "schema": schema,
         "variant": imgtype
     }
@@ -48,6 +49,8 @@ def artifact_cli():
     # Options for finding the build.
     parser.add_argument("--force", action='store_true',
                         help="Force rebuild of existing disk")
+    parser.add_argument("--compress", action='store_true',
+                        help="Compress generated image")
 
     # Support for legacy cmd-buildextend-* targets
     symlink = None
@@ -90,7 +93,7 @@ def artifact_cli():
 
     if build_target:
         builder = get_builder(build_target, args.buildroot, args.build,
-                              force=args.force, schema=args.schema)
+                              force=args.force, compress=args.compress, schema=args.schema)
     elif args.command == "manual":
         kwargs = {
             'force': args.force,

--- a/src/cmd-ore-wrapper
+++ b/src/cmd-ore-wrapper
@@ -74,6 +74,8 @@ Each target has its own sub options. To access them us:
                         help="ore configuration")
     parser.add_argument("--force", action='store_true',
                         help="Force the operation if it has already happened")
+    parser.add_argument("--compress", action='store_true',
+                        help="Compress generated image")
     parser.add_argument("--help", action='store_true',
                         help="Print this message")
     parser.add_argument("--upload", action='store_true',

--- a/src/cosalib/qemuvariants.py
+++ b/src/cosalib/qemuvariants.py
@@ -4,6 +4,7 @@ Provides a base abstration for building images.
 
 import logging as log
 import os.path
+import subprocess
 import shutil
 import sys
 
@@ -163,6 +164,7 @@ class QemuVariantImage(_Build):
         self.mutate_callback = kwargs.pop("mutate-callback", None)
         self.platform = kwargs.pop("platform", "qemu")
         self.force = kwargs.get("force", False)
+        self.compress = kwargs.get("compress", False)
         self.tar_members = kwargs.pop("tar_members", None)
         self.tar_flags = kwargs.pop("tar_flags", [DEFAULT_TAR_FLAGS])
         self.gzip = kwargs.pop("gzip", False)
@@ -314,3 +316,5 @@ class QemuVariantImage(_Build):
         self._found_files[self.image_name] = img_meta
         imgs[self.platform] = img_meta
         self.meta_write(artifact_name=self.platform_image_name)
+        if self.compress:
+            subprocess.check_call(['cosa', 'compress', '--artifact=' + self.platform])


### PR DESCRIPTION
The RHCOS pipeline is trying to add an `azurestack` artifact and
that's blowing transient disk usage past the the 50Gi PVC.

There's no real reason not to compress right after building
artifacts that we're not going to immediately test locally (e.g.
like we do with `qemu`) so add an option to compress directly.