### PR TITLE
mantle/platform/conf: support wrapping the next stable spec

### DIFF
--- a/mantle/platform/conf/conf_test.go
+++ b/mantle/platform/conf/conf_test.go
@@ -41,7 +41,6 @@ func TestConfCopyKey(t *testing.T) {
 		Ignition(`{ "ignition": { "version": "2.2.0" } }`),
 		Ignition(`{ "ignition": { "version": "2.3.0" } }`),
 		Ignition(`{ "ignition": { "version": "2.4.0" } }`),
-		Ignition(`{ "ignition": { "version": "3.4.0" } }`),
 		Ignition(`{ "ignition": { "version": "3.5.0" } }`),
 	}
 
@@ -60,6 +59,8 @@ func TestConfCopyKey(t *testing.T) {
 		Ignition(`{ "ignition": { "version": "3.2.0" } }`),
 		Ignition(`{ "ignition": { "version": "3.3.0" } }`),
 		Ignition(`{ "ignition": { "version": "3.4.0-experimental" } }`),
+		// special-case handling of next stable spec
+		Ignition(`{ "ignition": { "version": "3.4.0" } }`),
 	}
 
 	for i, tt := range tests {

--- a/mantle/platform/conf/conf_test.go
+++ b/mantle/platform/conf/conf_test.go
@@ -41,6 +41,8 @@ func TestConfCopyKey(t *testing.T) {
 		Ignition(`{ "ignition": { "version": "2.2.0" } }`),
 		Ignition(`{ "ignition": { "version": "2.3.0" } }`),
 		Ignition(`{ "ignition": { "version": "2.4.0" } }`),
+		Ignition(`{ "ignition": { "version": "3.4.0" } }`),
+		Ignition(`{ "ignition": { "version": "3.5.0" } }`),
 	}
 
 	for _, tt := range tests {
@@ -56,6 +58,8 @@ func TestConfCopyKey(t *testing.T) {
 		Ignition(`{ "ignition": { "version": "3.0.0" } }`),
 		Ignition(`{ "ignition": { "version": "3.1.0" } }`),
 		Ignition(`{ "ignition": { "version": "3.2.0" } }`),
+		Ignition(`{ "ignition": { "version": "3.3.0" } }`),
+		Ignition(`{ "ignition": { "version": "3.4.0-experimental" } }`),
 	}
 
 	for i, tt := range tests {


### PR DESCRIPTION
When stabilizing an Ignition spec in the presence of external kola tests using the experimental spec, three things must be stabilized in lockstep for CI to stay green: Ignition, mantle, and the external tests.  CI can add workarounds for the external tests (by running `sed` over the configs) but stabilizing mantle is harder, especially since vendoring the new Ignition into mantle also requires stabilizing the Ignition spec inside the vendored Butane.

Teach `platform/conf` to handle the next stable spec via a trick: create an empty config using the current stable spec and add the provided config to it as a merged child via a `data:` URL.  That way we can still add our config fragments without understanding the provided config.

This allows stabilization to proceed without immediately updating mantle.  After Ignition, Butane, and the external tests have been stabilized, mantle should still be updated to the new spec when convenient.

In the process, switch to the new Ignition `GetConfigVersion()` so we don't have to chain config parsing anymore.

Fixes https://github.com/coreos/coreos-assembler/issues/2249.