### PR TITLE
[4.8] mantle/platform: Ignore some non-fatal unit failures in RHCOS

### DIFF
--- a/mantle/platform/platform.go
+++ b/mantle/platform/platform.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -396,6 +397,39 @@ func NewMachines(c Cluster, userdata *conf.UserData, n int, options MachineOptio
 	return machs, nil
 }
 
+// checkSystemdUnitFailures make sure no system unit is in failed state.
+func checkSystemdUnitFailures(output string, distribution string) error {
+	var ignoredUnits []string
+
+	// Temporarily ignore some non-fatal flakes on RHCOS. See:
+	// https://bugzilla.redhat.com/show_bug.cgi?id=1914362
+	if distribution == "rhcos" {
+		ignoredUnits = append(ignoredUnits, "user@1000.service")
+		ignoredUnits = append(ignoredUnits, "user-runtime-dir@1000.service")
+	}
+
+	var failedUnits []string
+	for _, unit := range strings.Split(output, "\n") {
+		u := strings.Fields(unit)[0]
+		ignore := false
+		for _, i := range ignoredUnits {
+			if u == i {
+				// Ignoring this unit
+				ignore = true
+				break
+			}
+		}
+		if !ignore {
+			failedUnits = append(failedUnits, u)
+		}
+	}
+	if len(failedUnits) > 0 {
+		return fmt.Errorf("some systemd units failed:\n%s", output)
+	}
+
+	return nil
+}
+
 // CheckMachine tests a machine for various error conditions such as ssh
 // being available and no systemd units failing at the time ssh is reachable.
 // It also ensures the remote system is running Container Linux by CoreOS or
@@ -428,8 +462,13 @@ func CheckMachine(ctx context.Context, m Machine) error {
 	}
 
 	// ensure we're talking to a supported system
+	var distribution string
 	switch string(out) {
-	case `coreos-`, `rhcos-`, `fedora-coreos`:
+	case `fedora-coreos`:
+		distribution = "fcos"
+		break
+	case `rhcos-`:
+		distribution = "rhcos"
 		break
 	default:
 		return fmt.Errorf("not a supported instance: %v", string(out))
@@ -442,7 +481,7 @@ func CheckMachine(ctx context.Context, m Machine) error {
 			return fmt.Errorf("systemctl: %s: %v: %s", out, err, stderr)
 		}
 		if len(out) > 0 {
-			return fmt.Errorf("some systemd units failed:\n%s", out)
+			return checkSystemdUnitFailures(string(out), distribution)
 		}
 	}
 

--- a/mantle/platform/platform_test.go
+++ b/mantle/platform/platform_test.go
@@ -1,0 +1,57 @@
+// Copyright 2021 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package platform
+
+import "testing"
+
+func TestSystemUnitFiltering(t *testing.T) {
+	// Output from: `systemctl --no-legend --state failed list-units`
+	var output string
+
+	output = `● abrt-oops.service         loaded failed failed ABRT kernel log watcher
+● systemd-timesyncd.service loaded failed failed Network Time Synchronization`
+	if checkSystemdUnitFailures(output, "fcos") == nil {
+		t.Errorf("Should have failed")
+	}
+	output = `abrt-oops.service         loaded failed failed ABRT kernel log watcher
+systemd-timesyncd.service loaded failed failed Network Time Synchronization`
+	if checkSystemdUnitFailures(output, "rhcos") == nil {
+		t.Errorf("Should have failed")
+	}
+
+	output = `● user@1000.service             loaded failed failed Foo
+● user-runtime-dir@1000.service loaded failed failed Bar`
+	if checkSystemdUnitFailures(output, "fcos") == nil {
+		t.Errorf("Should have failed")
+	}
+	output = `user@1000.service             loaded failed failed Foo
+user-runtime-dir@1000.service loaded failed failed Bar`
+	if checkSystemdUnitFailures(output, "rhcos") != nil {
+		t.Errorf("Should have passed")
+	}
+
+	output = `● abrt-oops.service         loaded failed failed ABRT kernel log watcher
+● user@1000.service             loaded failed failed Foo
+● user-runtime-dir@1000.service loaded failed failed Bar`
+	if checkSystemdUnitFailures(output, "fcos") == nil {
+		t.Errorf("Should have failed")
+	}
+	output = `abrt-oops.service         loaded failed failed ABRT kernel log watcher
+user@1000.service             loaded failed failed Foo
+user-runtime-dir@1000.service loaded failed failed Bar`
+	if checkSystemdUnitFailures(output, "rhcos") == nil {
+		t.Errorf("Should have failed")
+	}
+}


### PR DESCRIPTION
Special case to ignore some non-fatal unit failures frequently seen in
flakes. This is for RHEL 8 only as this has been fixed upstream in
systemd but not fixed in RHEL 8.

Tracked in https://bugzilla.redhat.com/show_bug.cgi?id=1914362

Cherry-picked from: a542f266 mantle/platform: Ignore some non-fatal unit failures in RHCOS