### PR TITLE
Gangplank: disable tests pending Minio fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ endif
 .%.shellchecked: %
 	./tests/check_one.sh $< $@
 
-check: ${src_checked} ${tests_checked} ${cwd_checked} flake8 pycheck mantle-check gangplank-check
+check: ${src_checked} ${tests_checked} ${cwd_checked} flake8 pycheck mantle-check
 	echo OK
 
 pycheck:


### PR DESCRIPTION
Since Gangplank is breaking CI, let's disable it for now.