### PR TITLE
cosalib, ore: add ability to cross upload aarch64 AMIs

### DIFF
--- a/mantle/cmd/plume/prerelease.go
+++ b/mantle/cmd/plume/prerelease.go
@@ -462,7 +462,7 @@ func awsUploadToPartition(spec *channelSpec, part *awsPartitionSpec, imagePath s
 
 	plog.Printf("Creating AMIs from %v...", snapshot.SnapshotID)
 
-	imageID, err := api.CreateHVMImage(snapshot.SnapshotID, aws.ContainerLinuxDiskSizeGiB, imageName, imageDescription)
+	imageID, err := api.CreateHVMImage(snapshot.SnapshotID, aws.ContainerLinuxDiskSizeGiB, imageName, imageDescription, "x86_64")
 	if err != nil {
 		return nil, fmt.Errorf("unable to create image: %v", err)
 	}

--- a/src/cmd-ore-wrapper
+++ b/src/cmd-ore-wrapper
@@ -88,6 +88,7 @@ Each target has its own sub options. To access them us:
                         help="Upload/replicate to specific regions",
                         nargs='+')
     parser.add_argument("--source-region", help="Region to copy AMI from")
+    parser.add_argument("--arch", dest="arch", help="Architecture to target")
 
     parser.description = (
         f"'ore' interface for running ore commands for {target.upper()}"

--- a/src/cosalib/aws.py
+++ b/src/cosalib/aws.py
@@ -139,6 +139,9 @@ def aws_run_ore(build, args):
     # This matches the Container Linux schema:
     # https://stable.release.core-os.net/amd64-usr/current/coreos_production_ami_all.json
     ami_data = build.meta.get("amis", [])
+    # filter out (remove) existing entries (can happen if --force is used) from the
+    # ami list that match this region.
+    ami_data = [ami for ami in ami_data if ami.get('name') != region]
     ami_data.append({
         'name': region,
         'hvm': ore_data.get('HVM'),

--- a/src/cosalib/aws.py
+++ b/src/cosalib/aws.py
@@ -125,6 +125,8 @@ def aws_run_ore(build, args):
         '--disk-size-inspect',
         '--delete-object'
     ])
+    if args.arch:
+        ore_args.extend(['--arch', f"{args.arch}"])
     for user in args.grant_user:
         ore_args.extend(['--grant-user', user])
     for user in args.grant_user_snapshot:

--- a/src/cosalib/aws.py
+++ b/src/cosalib/aws.py
@@ -103,7 +103,9 @@ def aws_run_ore_replicate(build, args):
 
 @retry(reraise=True, stop=stop_after_attempt(3))
 def aws_run_ore(build, args):
-    ore_args = ['ore']
+    # First add the ore command to run before any options
+    ore_args = ['ore', 'aws', 'upload']
+
     if args.log_level:
         ore_args.extend(['--log-level', args.log_level])
 
@@ -115,7 +117,6 @@ def aws_run_ore(build, args):
         region = args.region[0]
 
     ore_args.extend([
-        'aws', 'upload',
         '--region', f"{region}",
         '--bucket', f"{args.bucket}",
         '--ami-name', f"{build.build_name}-{build.build_id}",

--- a/src/cosalib/build.py
+++ b/src/cosalib/build.py
@@ -88,10 +88,12 @@ class _Build:
         else:
             build = builds.get_latest()
 
+        self._basearch = kwargs.get("arch", None) or BASEARCH
+        log.info("Targeting architecture: %s", self.basearch)
         log.info("Targeting build: %s", build)
         self._build_dir = builds.get_build_dir(
             build,
-            basearch=kwargs.get("arch", BASEARCH)
+            basearch=self.basearch
         )
 
         # This is a bit subtle; but essentially, we want to verify that the
@@ -115,7 +117,8 @@ class _Build:
             "commit": None,
             "config": None,
             "image": None,
-            "meta": Meta(self.workdir, build, schema=schema)
+            "meta": Meta(self.workdir, build,
+                         basearch=self.basearch, schema=schema)
         }
 
         os.environ['workdir'] = self._workdir
@@ -252,7 +255,8 @@ class _Build:
 
     @property
     def basearch(self):
-        return self.meta.get("coreos-assembler.basearch", BASEARCH)
+        """ get the target architecture """
+        return self._basearch
 
     def ensure_built(self):
         if not self.have_artifact:

--- a/src/cosalib/meta.py
+++ b/src/cosalib/meta.py
@@ -260,7 +260,7 @@ class GenericBuildMeta(GenericMeta):
     """
 
     def __init__(self, workdir=None, build='latest',
-                 schema=SCHEMA_PATH):
+                 basearch=None, schema=SCHEMA_PATH):
         builds = Builds(workdir)
         if build != "latest":
             if not builds.has(build):
@@ -268,7 +268,9 @@ class GenericBuildMeta(GenericMeta):
         else:
             build = builds.get_latest()
 
-        self._build_dir = builds.get_build_dir(build)
+        self._build_dir = \
+            builds.get_build_dir(build,
+                                 basearch=basearch)
         path = os.path.join(self._build_dir, 'meta.json')
         super().__init__(schema=schema, path=path)
 

--- a/src/cosalib/qemuvariants.py
+++ b/src/cosalib/qemuvariants.py
@@ -132,6 +132,7 @@ def get_qemu_variant(variant, parser, kwargs={}):
         schema=parser.schema,
         variant=variant,
         force=parser.force,
+        arch=parser.arch,
         **kwargs)
 
 


### PR DESCRIPTION
This adds the ability to specify an architecture to buildextend-aws
so that we can upload an aarch64 AMI even if we're on x86_64.
