### PR TITLE
Dockerfile: tickle Quay.io's cache for new grub2 package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /root/containerbuild
 COPY ./src/print-dependencies.sh ./src/deps*.txt ./src/vmdeps*.txt ./src/build-deps.txt /root/containerbuild/src/
 COPY ./build.sh /root/containerbuild/
 RUN ./build.sh configure_yum_repos
-RUN ./build.sh install_rpms  # nocache 20210603
+RUN ./build.sh install_rpms  # nocache 20210701
 
 # Ok copy in the rest of them for the next few steps
 COPY ./ /root/containerbuild/


### PR DESCRIPTION
Now that https://github.com/coreos/fedora-coreos-config/pull/1063
has landed we need the new grub2 so that our image builds don't fail.