### PR TITLE
Dockerfile: Invalidate quay.io cache for new rpm-ostree

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /root/containerbuild
 COPY ./src/print-dependencies.sh ./src/deps*.txt ./src/vmdeps*.txt ./src/build-deps.txt /root/containerbuild/src/
 COPY ./build.sh /root/containerbuild/
 RUN ./build.sh configure_yum_repos
-RUN ./build.sh install_rpms  # nocache 20210701
+RUN ./build.sh install_rpms  # nocache 20210702
 
 # Ok copy in the rest of them for the next few steps
 COPY ./ /root/containerbuild/


### PR DESCRIPTION
And here we are, again.  Changing a comment string as
an important part of our release pipeline.

This is to pick up https://bodhi.fedoraproject.org/updates/FEDORA-2021-c761456766