### PR TITLE
[rhcos-4.8] Gangplank: Fix jobspec bad repo test for rhcos-4.8

### DIFF
--- a/gangplank/spec/jobspec.go
+++ b/gangplank/spec/jobspec.go
@@ -186,6 +186,7 @@ func (r *Repo) Writer(path string) (string, error) {
 
 	closer := func() error { return nil }
 	var dataR io.Reader
+	var respStatusCode int
 	if r.URL != nil && *r.URL != "" {
 		resp, err := http.Get(*r.URL)
 		if err != nil {
@@ -193,6 +194,7 @@ func (r *Repo) Writer(path string) (string, error) {
 		}
 		dataR = resp.Body
 		closer = resp.Body.Close
+		respStatusCode = resp.StatusCode
 	} else {
 		dataR = strings.NewReader(*r.Inline)
 	}
@@ -200,7 +202,7 @@ func (r *Repo) Writer(path string) (string, error) {
 	defer closer() //nolint
 
 	n, err := io.Copy(out, dataR)
-	if n == 0 {
+	if n == 0 || respStatusCode >= 400 {
 		return f, errors.New("No remote content fetched")
 	}
 	return f, err

--- a/gangplank/spec/jobspec_test.go
+++ b/gangplank/spec/jobspec_test.go
@@ -35,7 +35,7 @@ func TestURL(t *testing.T) {
 		},
 		{
 			desc:    "bad repo",
-			repo:    Repo{URL: strPtr("http://fedora.com/this/will/not/exist/no/really/it/shouldnt")},
+			repo:    Repo{URL: strPtr("http://mirrors.kernel.org/this/will/not/exist/no/really/it/shouldnt")},
 			wantErr: true,
 		},
 		{


### PR DESCRIPTION
Correctly interpret HTTP-Error Codes as errors.
Use mirrors.kernel.org as domain as fedora.com is currently on sale.

Signed-off-by: Jan Schintag <jan.schintag@de.ibm.com>