### PR TITLE
cmd-build-fast: fix output to $workdir/tmp

### DIFF
--- a/src/cmd-build-fast
+++ b/src/cmd-build-fast
@@ -65,7 +65,7 @@ if [ -n "${projectdir}" ]; then
 else
     fastref=fastbuild
     version="$(date +"%s")"
-    outdir=tmp
+    outdir="${workdir}/tmp"
     rootfsoverrides="${workdir}/overrides/rootfs"
 fi
 if test "$(find "${rootfsoverrides}" -maxdepth 1 | wc -l)" == 0; then
@@ -106,7 +106,7 @@ if [ -z "${projectdir}" ]; then
 fi
 imgname="${fastref}-${version}-qemu.qcow2"
 # Prune previous images
-rm -vf ${outdir}/*.qcow2
+rm -vf "${outdir}"/*.qcow2
 qemu-img create -f qcow2 -o backing_fmt=qcow2,backing_file="${previous_builddir}/${previous_qemu}" "${imgname}.tmp" 20G
 RUNVM_NONET=1 runvm -drive if=virtio,id=target,format=qcow2,file="${imgname}.tmp",cache=unsafe -- \
     /usr/lib/coreos-assembler/offline-update-impl "${workdir}/tmp/repo" "${commit}"


### PR DESCRIPTION
In the case we're running this in the cosa dir and not a project dir, we
want to output to `$workdir/tmp`. If we just use `tmp`, it'll output to
the temporary build dir, which is nuked on exit.