### PR TITLE
metal: fix read-race condition when updating metadata

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -431,7 +431,8 @@ cat > tmp/buildmeta.json <<EOF
  "coreos-assembler.code-source": "${src_location}",
  "coreos-assembler.container-config-git": $(jq -M '.git' ${PWD}/coreos-assembler-config-git.json),
  "coreos-assembler.meta-stamp": $(python3 -c 'import time; print(time.time_ns())'),
- "coreos-assembler.delayed-meta-merge": ${DELAY_META_MERGE}
+ "coreos-assembler.delayed-meta-merge": ${DELAY_META_MERGE},
+ "coreos-assembler.meta-stamp": $(date +%s%9N)
 }
 EOF
 

--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -228,8 +228,7 @@ runvm "${target_drive[@]}" -- \
 /usr/lib/coreos-assembler/finalize-artifact "${path}.tmp" "${path}"
 
 sha256=$(sha256sum_str < "${img}")
-# there's probably a jq one-liner for this...
-python3 -c "
+cosa meta --workdir "${workdir}" --build "${build}" --dump | python3 -c "
 import sys, json
 j = json.load(sys.stdin)
 j['images']['${image_type}'] = {
@@ -238,7 +237,7 @@ j['images']['${image_type}'] = {
     'size': $(stat -c '%s' "${img}")
 }
 json.dump(j, sys.stdout, indent=4)
-" < "${builddir}/meta.json" | jq -s add > "meta.json.new"
+" | jq -s add > "meta.json.new"
 
 # and now the crucial bits
 cosa meta --workdir "${workdir}" --build "${build}" --artifact "${image_type}" --artifact-json "$(readlink -f meta.json.new)"

--- a/src/cosalib/meta.py
+++ b/src/cosalib/meta.py
@@ -134,10 +134,6 @@ class GenericMeta(dict):
         """
         # Remove any current data
         self.clear()
-        # Load the file and record the initial timestamp to
-        # detect conflicts
-        with open(self.path) as f:
-            self._initial_timestamp = os.fstat(f.fileno()).st_mtime
         # Read under a lock to prevent race conditions
         self.update(load_json(self.path))
         self.validate()

--- a/src/cosalib/meta.py
+++ b/src/cosalib/meta.py
@@ -138,7 +138,8 @@ class GenericMeta(dict):
         # detect conflicts
         with open(self.path) as f:
             self._initial_timestamp = os.fstat(f.fileno()).st_mtime
-            self.update(json.load(f))
+        # Read under a lock to prevent race conditions
+        self.update(load_json(self.path))
         self.validate()
 
     def write(self, artifact_name=None, merge_func=merge_meta, final=False):


### PR DESCRIPTION
This change uses the meta locking to prevent a RW operation from
happening at exactly the same time. In CI, was observed that another
process could be emitting a new meta.json at the same time a seperate
bash script could be reading from meta.json.

Fixes #2277.

Signed-off-by: Ben Howard <ben.howard@redhat.com>