### PR TITLE
pkcs7encrypt: Added a command for encrypting files using openssl

### DIFF
--- a/src/deps.txt
+++ b/src/deps.txt
@@ -62,6 +62,9 @@ python3-flake8 python3-pytest python3-pytest-cov pylint
 # For cmd-virt-install
 python3-libvirt
 
+# For pkcs7encrypt
+openssl
+
 # Support for Koji uploads.
 krb5-libs krb5-workstation koji-utils python3-koji python3-koji-cli-plugins
 

--- a/src/pkcs7encrypt
+++ b/src/pkcs7encrypt
@@ -1,0 +1,22 @@
+#!/usr/bin/python3
+
+# Used to encrypt files before upload (such as build.log)
+
+import subprocess
+import argparse
+import os
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument("cert", help="X.509 Certificate")
+parser.add_argument("input", help="Path to file to encrypt into PKCS7 structure")
+parser.add_argument("output", help="Path to encrypted PKCS7 structure")
+args = parser.parse_args()
+
+files = [args.cert, args.input]
+for path in files:
+    if not os.path.exists(path):
+        raise FileNotFoundError(path)
+
+subprocess.check_call(["openssl", "smime", "-encrypt", "-aes-256-cbc", "-in", args.input,
+                     "-out", args.output, "-outform", "PEM", args.cert])


### PR DESCRIPTION
This will be used in the RHCOS pipeline to encrypt build logs before they are uploaded to S3.