### PR TITLE
Gangplank CI fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ endif
 .%.shellchecked: %
 	./tests/check_one.sh $< $@
 
-check: ${src_checked} ${tests_checked} ${cwd_checked} flake8 pycheck mantle-check
+check: ${src_checked} ${tests_checked} ${cwd_checked} flake8 pycheck mantle-check gangplank-check
 	echo OK
 
 pycheck:

--- a/gangplank/internal/cosa/schema_test.go
+++ b/gangplank/internal/cosa/schema_test.go
@@ -15,9 +15,9 @@ import (
 )
 
 const (
-	fcosJSON   = "../../fixtures/fcos.json"
-	rhcosJSON  = "../../fixtures/rhcos.json"
-	cosaSchema = "../../src/schema/v1.json"
+	fcosJSON   = "../../../fixtures/fcos.json"
+	rhcosJSON  = "../../../fixtures/rhcos.json"
+	cosaSchema = "../../../src/schema/v1.json"
 )
 
 var testMeta = []string{fcosJSON, rhcosJSON}

--- a/gangplank/internal/spec/jobspec.go
+++ b/gangplank/internal/spec/jobspec.go
@@ -202,7 +202,7 @@ func (r *Repo) Writer(path string) (string, error) {
 		case code == 204:
 			return f, fmt.Errorf("http response code 204: repo content is empty")
 		case code == 206:
-			return f, errors.New("http response code 206: repo context was truncated")
+			return f, errors.New("http response code 206: repo content was truncated")
 		case code > 400:
 			return f, fmt.Errorf("server responded with %d", code)
 		}

--- a/tools/generate-schema.sh
+++ b/tools/generate-schema.sh
@@ -39,6 +39,6 @@ var generatedSchemaJSON = \`$(< ${schema_json})
 \`
 EOM
 
-cp -av ${out} ${pdir}/gangplank/cosa/
+cp -av ${out} ${pdir}/gangplank/internal/cosa/
 cp -av ${tdir}/*go ${pdir}/mantle/cosa/
 


### PR DESCRIPTION
Three fixes to Gangplank failing in CI:

```
commit d346a21b7f1088698bd0f37854edf1e159c858e9 (HEAD -> pr/minio-ci-fix, me/pr/minio-ci-fix)
Author: Ben Howard <ben.howard@redhat.com>
Date:   Thu Jul 8 16:41:30 2021 -0600

    Gangplank: fix broken URL tests

    The prior URL testing relied on actual HTTP servers which is flawed. In
    some CI cases, this test fails. This makes Gangplank a much better
    netizen by mocking the response instead.

commit aa5e17f086cdf2a13f9666e0f11d88254ce217be
Author: Ben Howard <ben.howard@redhat.com>
Date:   Thu Jul 8 14:49:04 2021 -0600

    Gangplank: fix schema location

    Signed-off-by: Ben Howard <ben.howard@redhat.com>

commit 58af0be4409f8cf247dc2755bbd5973103c5c16c
Author: Ben Howard <ben.howard@redhat.com>
Date:   Thu Jul 8 13:44:30 2021 -0600

    Gangplank: fix minio startup problems in CI

    Minio is taking a bit to come up in CI enviroments. The prior fix which
    pooled on the port does not work in the case "server not ready".

    Changes:
    - Update the startup options to prevent console port collisions
    - Start up quiet, but emit stdOut and stdErr to logging
    - Use the client to connect instead of raw port and use the error
      response to check for "server not ready."
```