### PR TITLE
Make cosa alias compatible with ZSH

### DIFF
--- a/docs/building-fcos.md
+++ b/docs/building-fcos.md
@@ -82,6 +82,9 @@ here need to change for that.
 ```sh
 cosa() {
    env | grep COREOS_ASSEMBLER
+   if [ -n "$ZSH_VERSION" ]; then
+      setopt SH_WORD_SPLIT
+   fi
    set -x
    podman run --rm -ti --security-opt label=disable --privileged                                    \
               --uidmap=1000:0:1 --uidmap=0:1:1000 --uidmap 1001:1001:64536                          \


### PR DESCRIPTION
Not sure if there is a better way to do this, but this seemed the least intrusive. Without this, I was enable to use any of the variable overrides:

```
shanemcd@fedora:~/fcos 
 $ export COREOS_ASSEMBLER_GIT=/home/shanemcd/coreos-assembler
shanemcd@fedora:~/fcos 
 $ cosa init https://github.com/coreos/fedora-coreos-config   
COREOS_ASSEMBLER_GIT=/home/shanemcd/coreos-assembler
+cosa:6> podman run --rm -ti --security-opt 'label=disable' --privileged '--uidmap=1000:0:1' '--uidmap=0:1:1000' --uidmap 1001:1001:64536 -v /home/shanemcd/fcos:/srv/ --device /dev/kvm --device /dev/fuse --tmpfs /tmp -v /var/tmp:/var/tmp --name cosa '-v /home/shanemcd/coreos-assembler/src/:/usr/lib/coreos-assembler/:ro' quay.io/coreos-assembler/coreos-assembler:latest init https://github.com/coreos/fedora-coreos-config
Error: error creating named volume " /home/shanemcd/coreos-assembler/src/": error running volume create option: names must match [a-zA-Z0-9][a-zA-Z0-9_.-]*: invalid argument
+cosa:14> rc=125 
+cosa:14> set +x
```