### PR TITLE
cmdlib: support `statoverride` file in root of an `overlay.d` directory

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -273,10 +273,16 @@ commit_overlay() {
     # using ostree's --statoverride when dealing with executable files. See:
     # https://github.com/ostreedev/ostree/issues/2368
     rm -rf "${TMPDIR}/overlay" && (umask 0022 && cp -r "${respath}" "${TMPDIR}/overlay")
+    # Apply statoverrides from a file in the root of the overlay, which may
+    # or may not exist.  ostree doesn't support comments in statoverride
+    # files, but we do.
+    touch "${TMPDIR}/overlay/statoverride"
     echo -n "Committing ${name}: ${path} ... "
     ostree commit --repo="${tmprepo}" --tree=dir="${TMPDIR}/overlay" -b "${name}" \
         --owner-uid 0 --owner-gid 0 --no-xattrs --no-bindings --parent=none \
-        --mode-ro-executables --timestamp "${git_timestamp}"
+        --mode-ro-executables --timestamp "${git_timestamp}" \
+        --statoverride <(sed -e '/^#/d' "${TMPDIR}/overlay/statoverride") \
+        --skip-list <(echo /statoverride)
 }
 
 # Implement support for automatic local overrides:


### PR DESCRIPTION
If an `overlay.d` directory contains a file called `statoverride` at the root, pass it to ostree.  This allows overlay files to have permission bits that aren't tracked by Git.

`statoverride` files don't support comments.  For convenience, filter out lines starting with `#`.