### PR TITLE
kola: Add RunCmdSync that logs cmd to target journal, use in upgrade test

### DIFF
--- a/mantle/kola/cluster/cluster.go
+++ b/mantle/kola/cluster/cluster.go
@@ -21,6 +21,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/kballard/go-shellquote"
+
 	"github.com/coreos/mantle/harness"
 	"github.com/coreos/mantle/platform"
 	"github.com/coreos/pkg/capnslog"
@@ -168,4 +170,27 @@ func (t *TestCluster) MustSSH(m platform.Machine, cmd string) []byte {
 
 func (t *TestCluster) MustSSHf(m platform.Machine, f string, args ...interface{}) []byte {
 	return t.MustSSH(m, fmt.Sprintf(f, args...))
+}
+
+// RunCmdSync is like MustSSH, but logs the command to the target journal before executing.
+func (t *TestCluster) RunCmdSync(m platform.Machine, cmd string) []byte {
+	t.LogJournal(m, cmd)
+	return t.MustSSH(m, cmd)
+}
+
+// RunCmdSyncf is like MustSSHf, but logs the command to the target journal before executing.
+func (t *TestCluster) RunCmdSyncf(m platform.Machine, f string, args ...interface{}) []byte {
+	return t.RunCmdSync(m, fmt.Sprintf(f, args...))
+}
+
+// Synchronously write a log message from the syslog identifier `kola` into the target
+// machine's journal (via ssh) as well as at a debug log level to the current process.
+// This is useful for debugging test failures, as we always capture the target
+// system journal.
+func (t *TestCluster) LogJournal(m platform.Machine, msg string) {
+	t.MustSSH(m, fmt.Sprintf("logger -t kola %s", shellquote.Join(msg)))
+}
+
+func (t *TestCluster) LogJournalf(m platform.Machine, f string, args ...interface{}) {
+	t.LogJournal(m, fmt.Sprintf(f, args...))
 }

--- a/mantle/kola/tests/upgrade/basic.go
+++ b/mantle/kola/tests/upgrade/basic.go
@@ -146,14 +146,14 @@ func fcosUpgradeBasic(c cluster.TestCluster) {
 		// remounting in libostree forcing a cache flush and blocking D-Bus.
 		// Should drop this once we fix it more properly in {rpm-,}ostree.
 		// https://github.com/coreos/coreos-assembler/issues/1301
-		c.MustSSHf(m, "tar -xf %s -C %s && sync", kola.CosaBuild.Meta.BuildArtifacts.Ostree.Path, ostreeRepo)
+		c.RunCmdSyncf(m, "tar -xf %s -C %s && sync", kola.CosaBuild.Meta.BuildArtifacts.Ostree.Path, ostreeRepo)
 
 		// disable zincati; from now on, we'll start it manually whenenever we
 		// want to upgrade via Zincati
-		c.MustSSH(m, "sudo systemctl disable --now --quiet zincati.service")
-		c.MustSSH(m, "sudo rm /etc/zincati/config.d/99-updates.toml")
+		c.RunCmdSync(m, "sudo systemctl disable --now --quiet zincati.service")
+		c.RunCmdSync(m, "sudo rm /etc/zincati/config.d/99-updates.toml")
 		// delete what mantle adds (XXX: should just opt out of this upfront)
-		c.MustSSH(m, "sudo rm /etc/zincati/config.d/90-disable-auto-updates.toml")
+		c.RunCmdSync(m, "sudo rm /etc/zincati/config.d/90-disable-auto-updates.toml")
 
 	})
 


### PR DESCRIPTION
I'm trying to debug a failure in the upgrade test and not getting
any logging around the invocations of commands makes it really hard.

Because we always capture the target system journal by default,
add a new wrapper for `MustSSH` that prints the command to the
journal too.

I considered changing `MustSSH` by default but that's used
in a *lot* of places and I'd like to try this out in
just the upgrade test to start.  If this works OK we can
consider a tree-wide change.