### PR TITLE
ci/Dockerfile: bump Quay.io nocache hack

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /root/containerbuild
 COPY ./src/print-dependencies.sh ./src/deps*.txt ./src/vmdeps*.txt ./src/build-deps.txt /root/containerbuild/src/
 COPY ./build.sh /root/containerbuild/
 RUN ./build.sh configure_yum_repos
-RUN ./build.sh install_rpms  # nocache 20210702
+RUN ./build.sh install_rpms  # nocache 20210719
 
 # Allow Prow to work
 RUN mkdir -p /go && chown 0777 /go


### PR DESCRIPTION
Latest rpm-ostree release with
https://github.com/coreos/rpm-ostree/pull/2990 is in the continuous tag.
Rebuild to get it into cosa.

Closes: https://github.com/openshift/os/issues/552