### PR TITLE
cmdlib: Fix shellcheck for libguestfish.sh

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -435,8 +435,10 @@ impl_rpmostree_compose() {
         # "cache2" has an explicit label so we can find it in qemu easily
         if [ ! -f "${workdir}"/cache/cache2.qcow2 ]; then
             qemu-img create -f qcow2 cache2.qcow2.tmp 10G
-            (source /usr/lib/coreos-assembler/libguestfish.sh
-            virt-format --filesystem=xfs --label=cosa-cache -a cache2.qcow2.tmp)
+            (
+             # shellcheck source=src/libguestfish.sh
+             source /usr/lib/coreos-assembler/libguestfish.sh
+             virt-format --filesystem=xfs --label=cosa-cache -a cache2.qcow2.tmp)
             mv -T cache2.qcow2.tmp "${workdir}"/cache/cache2.qcow2
         fi
         # And remove the old one


### PR DESCRIPTION
We need to use the same `src=` annotation we use in
other places to work on a pristine build before `make install`
has run.