### PR TITLE
Makefile: disable Gangplank, again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ endif
 .%.shellchecked: %
 	./tests/check_one.sh $< $@
 
-check: ${src_checked} ${tests_checked} ${cwd_checked} flake8 pycheck mantle-check gangplank-check
+check: ${src_checked} ${tests_checked} ${cwd_checked} flake8 pycheck mantle-check
 	echo OK
 
 pycheck:


### PR DESCRIPTION
 Gangplank checks are broken on Prow. Since Ganplank is not a full-production tool, let's disable for now.
