### PR TITLE
cosalib: Add compress option for qemuvariants, ibmcloudvariants

### DIFF
--- a/src/cosalib/ibmcloud.py
+++ b/src/cosalib/ibmcloud.py
@@ -190,4 +190,5 @@ def get_ibmcloud_variant(variant, parser, kwargs={}):
         schema=parser.schema,
         variant=variant,
         force=parser.force,
+        compress=parser.compress,
         **kwargs)

--- a/src/cosalib/qemuvariants.py
+++ b/src/cosalib/qemuvariants.py
@@ -133,6 +133,7 @@ def get_qemu_variant(variant, parser, kwargs={}):
         variant=variant,
         force=parser.force,
         arch=parser.arch,
+        compress=parser.compress,
         **kwargs)
 
 


### PR DESCRIPTION
This is a followup to 835cd92. I couldn't get
`cosa buildextend-* --compress` to work without it.