### PR TITLE
Re-enable most of Gangplank CI, disable Minio

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ endif
 .%.shellchecked: %
 	./tests/check_one.sh $< $@
 
-check: ${src_checked} ${tests_checked} ${cwd_checked} flake8 pycheck mantle-check
+check: ${src_checked} ${tests_checked} ${cwd_checked} flake8 pycheck mantle-check gangplank-check
 	echo OK
 
 pycheck:

--- a/gangplank/Makefile
+++ b/gangplank/Makefile
@@ -32,9 +32,13 @@ staticanalysis:
 	env CGO_ENABLED=0 golangci-lint run -v --build-tags ${buildtags},gangway ./...
 
 .PHONY: test
+test: miniotag ?= ",!minio"
 test: fmt
-	go test -mod=vendor -tags ${buildtags},gangway -v ${pkgs} && \
-	env CGO_ENABLED=0 go test -mod=vendor -tags ${buildtags},!gangway -v -cover ${pkgs}
+	go test -mod=vendor -cover=1 -tags ${buildtags},gangway,!minio -v ${pkgs} && \
+	env CGO_ENABLED=0 go test -cover=1 -mod=vendor -tags ${buildtags},!gangway${miniotags} -v -cover ${pkgs}
+.PHONY: test-full
+test-full:
+	$(MAKE) test miniotags=",minio"
 
 .PHONY: clean
 clean:

--- a/gangplank/cmd/gangplank/pod.go
+++ b/gangplank/cmd/gangplank/pod.go
@@ -104,7 +104,7 @@ func runPod(c *cobra.Command, args []string) {
 				minioSshRemoteHost = containerHost()
 				if strings.Contains(minioSshRemoteHost, "@") {
 					parts := strings.Split(minioSshRemoteHost, "@")
-					if strings.Contains(parts[1], ":"){
+					if strings.Contains(parts[1], ":") {
 						hostparts := strings.Split(parts[1], ":")
 						port, err := strconv.Atoi(hostparts[1])
 						if err != nil {

--- a/gangplank/internal/ocp/filer_test.go
+++ b/gangplank/internal/ocp/filer_test.go
@@ -1,3 +1,4 @@
+// +minio
 package ocp
 
 import (

--- a/gangplank/internal/ocp/return_test.go
+++ b/gangplank/internal/ocp/return_test.go
@@ -1,3 +1,4 @@
+// +minio
 package ocp
 
 import (

--- a/gangplank/internal/ocp/ssh.go
+++ b/gangplank/internal/ocp/ssh.go
@@ -30,9 +30,9 @@ func getSshMinioForwarder(j *spec.JobSpec) *SSHForwardPort {
 		return nil
 	}
 	return &SSHForwardPort{
-		Host: j.Minio.SSHForward,
-		User: j.Minio.SSHUser,
-		Key:  j.Minio.SSHKey,
+		Host:    j.Minio.SSHForward,
+		User:    j.Minio.SSHUser,
+		Key:     j.Minio.SSHKey,
 		SSHPort: j.Minio.SSHPort,
 	}
 }


### PR DESCRIPTION
The Minio checks are flaky. Rather than disable all CI on Gangplank, its
cleaner to disable the Minio specific tests using build flags to buy
time for better tests.
