### PR TITLE
gangplank: add support for uploading extra files

### DIFF
--- a/gangplank/internal/ocp/cosa-podman.go
+++ b/gangplank/internal/ocp/cosa-podman.go
@@ -76,12 +76,10 @@ func podmanRunner(term termChan, cp CosaPodder, envVars []v1.EnvVar) error {
 
 	// If a URI for the container API server has been specified
 	// by the user then let's honor that. Else construct one.
-	podmanRemote := false
 	socket := os.Getenv(podmanContainerHostEnvVar)
 	if strings.HasPrefix(socket, "ssh://") {
 		l = l.WithField("podman socket", socket)
 		l.Info("Lauching remote pod")
-		podmanRemote = true
 	} else {
 		// Once podman 3.2.0 is released use this instead:
 		//      import "github.com/containers/podman/v3/pkg/util"
@@ -161,7 +159,7 @@ func podmanRunner(term termChan, cp CosaPodder, envVars []v1.EnvVar) error {
 	}
 
 	var srvVol *entities.VolumeConfigResponse = nil
-	if podmanRemote || clusterCtx.podmanSrvDir == "" {
+	if clusterCtx.podmanSrvDir == "" {
 		// If running podman remotely or the srvDir is undefined, create and use an ephemeral
 		// volume. The volume will be removed via ender()
 		srvVol, err = podVolumes.Create(connText, entities.VolumeCreateOptions{Name: podSpec.Name}, nil)


### PR DESCRIPTION
There are two commits here that are unrelated but both generally useful:

```
commit 58c14dc53d0e515e994c1e74686f088b8467bc2a
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Fri Jul 23 13:29:05 2021 -0400

    gangplank: allow for use of a srvDir even for podman remote
    
    If the remote directory exists and the user wants it to persist then
    maybe we should allow it.

commit 15287f62f99edbad98fd5b12adfe3ef9666c5e66
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Fri Jul 23 13:11:30 2021 -0400

    gangplank: add support for uploading extra files
    
    For bump lockfile we want to be able to just harvest off the updated
    lockfile (no actual builds happen). In that case let's create the file
    under tmp/ with a .minioupload suffix and match on that when we upload
    things.
    
    This also changes the code to opt out of uploading build contents if
    no builds exist.
```
