### PR TITLE
build: Honor ARTIFACT_DIR for supermin

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -608,6 +608,9 @@ EOF
 
     rm -rf "${tmp_builddir}/supermin.out" "${vmpreparedir}" "${vmbuilddir}"
 
+    if test -n "${ARTIFACT_DIR:-}"; then
+        cp "${runvm_console}" "${ARTIFACT_DIR}"
+    fi
     if [ ! -f "${rc_file}" ]; then
         cat "${runvm_console}"
         fatal "Couldn't find rc file; failure inside supermin init?"


### PR DESCRIPTION
OpenShift CI sets `ARTIFACT_DIR` as a place to put log files.
Let's always copy the console there if set; this will help
debug things like OOM issues.