### PR TITLE
gangplank: add a ReturnFiles stage

### DIFF
--- a/gangplank/cmd/gangplank/commonflags.go
+++ b/gangplank/cmd/gangplank/commonflags.go
@@ -35,6 +35,7 @@ func init() {
 	specCommonFlags.StringSliceVar(&generateCommands, "singleCmd", []string{}, "commands to run in stage")
 	specCommonFlags.StringSliceVar(&generateSingleRequires, "singleReq", []string{}, "artifacts to require")
 	specCommonFlags.StringVarP(&cosaSrvDir, "srvDir", "S", "", "directory for /srv; in pod mount this will be bind mounted")
+	specCommonFlags.StringSliceVar(&generateReturnFiles, "returnFiles", []string{}, "Extra files to upload to the minio server")
 	jobspec.AddKolaTestFlags(&cosaKolaTests, specCommonFlags)
 
 	username := ""

--- a/gangplank/cmd/gangplank/generate.go
+++ b/gangplank/cmd/gangplank/generate.go
@@ -18,6 +18,9 @@ var (
 	// generateSingleCommands is a list of command that will be run in the stage
 	generateCommands []string
 
+	// generateReturnFiles defines a list of extra files to upload to minio server
+	generateReturnFiles []string
+
 	// generateSingleStage indicates that all commands/artfiacts should be in the same stage
 	generateSingleStage bool
 
@@ -71,6 +74,7 @@ func init() {
 	cmdGenerateSingle.Flags().StringVar(&generateFileName, "yaml-out", "", "write YAML to file")
 	cmdGenerateSingle.Flags().StringSliceVar(&generateCommands, "cmd", []string{}, "commands to run in stage")
 	cmdGenerateSingle.Flags().StringSliceVar(&generateSingleRequires, "req", []string{}, "artifacts to require")
+	cmdGenerateSingle.Flags().StringSliceVar(&generateReturnFiles, "returnFiles", []string{}, "Extra files to upload to the minio server")
 	jobspec.AddKolaTestFlags(&cosaKolaTests, cmdGenerateSingle.Flags())
 }
 
@@ -135,6 +139,7 @@ func setCliSpec() {
 
 	spec.Stages[0].AddCommands(generateCommands)
 	spec.Stages[0].AddRequires(generateSingleRequires)
+	spec.Stages[0].AddReturnFiles(generateReturnFiles)
 }
 
 // generateCLICommand is the full spec generator command

--- a/gangplank/internal/ocp/cosa-podman.go
+++ b/gangplank/internal/ocp/cosa-podman.go
@@ -76,12 +76,10 @@ func podmanRunner(term termChan, cp CosaPodder, envVars []v1.EnvVar) error {
 
 	// If a URI for the container API server has been specified
 	// by the user then let's honor that. Else construct one.
-	podmanRemote := false
 	socket := os.Getenv(podmanContainerHostEnvVar)
 	if strings.HasPrefix(socket, "ssh://") {
 		l = l.WithField("podman socket", socket)
 		l.Info("Lauching remote pod")
-		podmanRemote = true
 	} else {
 		// Once podman 3.2.0 is released use this instead:
 		//      import "github.com/containers/podman/v3/pkg/util"
@@ -161,7 +159,7 @@ func podmanRunner(term termChan, cp CosaPodder, envVars []v1.EnvVar) error {
 	}
 
 	var srvVol *entities.VolumeConfigResponse = nil
-	if podmanRemote || clusterCtx.podmanSrvDir == "" {
+	if clusterCtx.podmanSrvDir == "" {
 		// If running podman remotely or the srvDir is undefined, create and use an ephemeral
 		// volume. The volume will be removed via ender()
 		srvVol, err = podVolumes.Create(connText, entities.VolumeCreateOptions{Name: podSpec.Name}, nil)

--- a/gangplank/internal/ocp/return.go
+++ b/gangplank/internal/ocp/return.go
@@ -43,7 +43,10 @@ func (r *Return) Run(ctx context.Context, ws *workSpec) error {
 	}
 	baseBuildDir := filepath.Join(cosaSrvDir, "builds")
 	b, path, err := cosa.ReadBuild(baseBuildDir, "", cosa.BuilderArch())
-	if err != nil {
+	if err == cosa.ErrNoBuildsFound {
+		// If there are no builds, ignore
+		return nil
+	} else if err != nil {
 		return err
 	}
 	if b == nil {

--- a/gangplank/internal/ocp/worker.go
+++ b/gangplank/internal/ocp/worker.go
@@ -231,6 +231,7 @@ func (ws *workSpec) Exec(ctx ClusterContext) error {
 			"required artifacts": stage.RequireArtifacts,
 			"optional artifacts": stage.RequestArtifacts,
 			"commands":           stage.Commands,
+			"return files":       stage.ReturnFiles,
 		})
 		l.Info("Executing Stage")
 
@@ -273,6 +274,12 @@ func (ws *workSpec) Exec(ctx ClusterContext) error {
 		if stage.ReturnCacheRepo {
 			l.WithField("tarball", cacheRepoTarballName).Infof("Sending %s back as a tarball", cosaSrvTmpRepo)
 			if err := uploadPathAsTarBall(ctx, cacheBucket, cacheRepoTarballName, cosaSrvTmpRepo, "", true, ws.Return); err != nil {
+				return err
+			}
+		}
+		if len(stage.ReturnFiles) != 0 {
+			l.WithField("files", stage.ReturnFiles).Infof("Sending requested files back to remote")
+			if err := uploadReturnFiles(ctx, cacheBucket, stage.ReturnFiles, ws.Return); err != nil {
 				return err
 			}
 		}

--- a/gangplank/internal/spec/cli.go
+++ b/gangplank/internal/spec/cli.go
@@ -89,6 +89,11 @@ func (s *Stage) AddCommands(args []string) {
 	s.Commands = append(s.Commands, args...)
 }
 
+// AddReturnFiles adds return files to a stage
+func (s *Stage) AddReturnFiles(args []string) {
+	s.ReturnFiles = append(s.ReturnFiles, args...)
+}
+
 // AddRequires adds in requires based on the arifacts that a stage requires
 // inconsideration of what the stage builds
 func (s *Stage) AddRequires(args []string) {

--- a/gangplank/internal/spec/stages.go
+++ b/gangplank/internal/spec/stages.go
@@ -90,6 +90,9 @@ type Stage struct {
 	RequireCacheRepo bool `yaml:"require_cache_repo,omitempty" json:"require_cache_repo_repo,omitempty"`
 	RequestCacheRepo bool `yaml:"request_cache_repo,omitempty" json:"request_cache_repo_repo,omitempty"`
 
+	// ReturnFiles returns a list of files that were requested to be returned.
+	ReturnFiles []string `yaml:"return_files,omitempty" json:"return_files,omitempty"`
+
 	// KolaTests are shorthands for testing.
 	KolaTests []string `yaml:"kola_tests,omitempty" json:"kola_tests,omitempty"`
 


### PR DESCRIPTION
```
commit 320e4bef1406441db9aaa19d3a40ca35f60ee8b6
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon Jul 26 14:33:07 2021 -0400

    gangplank: add a ReturnFiles stage
    
    Allows for users to request files to be returned back to the minio
    server. One case where this is useful is in our lockfile bumper
    where we run `cosa fetch --update-lockfile` and want to get just the
    json file copied back. Example usage:
    
    ```
    gangplank pod --podman --singleCmd "cosa fetch --update-lockfile --dry-run" --returnFiles src/config/manifest-lock.aarch64.json
    ```
    
    or as part of a spec:
    
    ```
    job:
      strict: true
      miniocfgfile: ""
    recipe:
      git_ref: testing-devel
      git_url: https://github.com/coreos/fedora-coreos-config
    stages:
    - id: ExecOrder 1 Stage
      execution_order: 1
      description: Stage 1 execution base
      post_commands:
        - cosa fetch --update-lockfile --dry-run
      return_files:
        - src/config/manifest-lock.aarch64.json
    delay_meta_merge: false
    ```

commit f8a4a151018501b89f6c52c970e623229f689d5e
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon Jul 26 14:29:41 2021 -0400

    gangplank: allow for the case where no builds were created
    
    This will skip the attempt at uploading artifacts if no builds
    exist. This happens in cases like `cosa fetch --update-lockfile`,
    which is what we use for our lockfile bumper.

commit 63f39973824e7f246b76a776be2f576d6361291d
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Fri Jul 23 13:29:05 2021 -0400

    gangplank: allow for use of a srvDir even for podman remote
    
    If the remote directory exists and the user wants it to persist then
    maybe we should allow it.
```
