### PR TITLE
Dockerfile: Stop running unit tests

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -7,6 +7,11 @@ def imageName = buildImage(env: [ENABLE_GO_RACE_DETECTOR: "1"])
 pod(image: imageName + ":latest", kvm: true, memory: "10Gi") {
     checkout scm
 
+    stage("Unit tests") {
+        shwrap("make check")
+        shwrap("make unittest")
+    }
+
     shwrap("rpm -qa | sort > rpmdb.txt")
     archiveArtifacts artifacts: 'rpmdb.txt'
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,6 @@ RUN ./build.sh write_archive_info
 RUN ./build.sh make_and_makeinstall
 RUN ./build.sh configure_user
 
-RUN make check
-RUN make unittest
-RUN make clean
-
 # clean up scripts (it will get cached in layers, but oh well)
 WORKDIR /srv/
 RUN chown builder: /srv


### PR DESCRIPTION
We support building this image in many places; in OpenShift
clusters, locally via `podman` as well as in the special `quay.io`
build environment.  The gangplank tests are failing in the latter.

In practice, don't need to re-run unit tests in quay.io.  Code
landing via PRs is already tested.