### PR TITLE
cmd-build-fast: add --no-undeploy

### DIFF
--- a/src/cmd-build-fast
+++ b/src/cmd-build-fast
@@ -19,13 +19,14 @@ dn=$(dirname "$0")
 
 print_help() {
     cat 1>&2 <<'EOF'
-Usage: coreos-assembler build-fast
+Usage: coreos-assembler build-fast [--undeploy]
 EOF
 }
 
 # Parse options
+NO_UNDEPLOY=0
 rc=0
-options=$(getopt --options h --longoptions help -- "$@") || rc=$?
+options=$(getopt --options h --longoptions help,no-undeploy -- "$@") || rc=$?
 [ $rc -eq 0 ] || {
     print_help
     exit 1
@@ -36,6 +37,9 @@ while true; do
         -h | --help)
             print_help
             exit 0
+            ;;
+        --no-undeploy)
+            NO_UNDEPLOY=1
             ;;
         --)
             shift
@@ -144,7 +148,7 @@ imgname="${fastref}-${version}-qemu.qcow2"
 rm -vf "${outdir}"/*.qcow2
 qemu-img create -f qcow2 -o backing_fmt=qcow2,backing_file="${previous_builddir}/${previous_qemu}" "${imgname}.tmp" 20G
 RUNVM_NONET=1 runvm -drive if=virtio,id=target,format=qcow2,file="${imgname}.tmp",cache=unsafe -- \
-    /usr/lib/coreos-assembler/offline-update-impl "${workdir}/tmp/repo" "${commit}"
+    /usr/lib/coreos-assembler/offline-update-impl "${workdir}/tmp/repo" "${commit}" "${NO_UNDEPLOY}"
 mv "${imgname}.tmp" "${imgname}"
 mv "${imgname}" "${outdir}/${imgname}"
 rm "${tmp_builddir}" -rf

--- a/src/cmd-build-fast
+++ b/src/cmd-build-fast
@@ -17,6 +17,41 @@ dn=$(dirname "$0")
 # shellcheck source=src/cmdlib.sh
 . "${dn}"/cmdlib.sh
 
+print_help() {
+    cat 1>&2 <<'EOF'
+Usage: coreos-assembler build-fast
+EOF
+}
+
+# Parse options
+rc=0
+options=$(getopt --options h --longoptions help -- "$@") || rc=$?
+[ $rc -eq 0 ] || {
+    print_help
+    exit 1
+}
+eval set -- "$options"
+while true; do
+    case "$1" in
+        -h | --help)
+            print_help
+            exit 0
+            ;;
+        --)
+            shift
+            break
+            ;;
+        -*)
+            fatal "$0: unrecognized option: $1"
+            exit 1
+            ;;
+        *)
+            break
+            ;;
+    esac
+    shift
+done
+
 
 # Detect the case that we're in a git repo without COSA_DIR
 # Note we use -e and not -d here so it also works in git worktrees.

--- a/src/cmd-offline-update
+++ b/src/cmd-offline-update
@@ -97,4 +97,4 @@ commit=$(json_key ostree-commit)
 fi
 
 runvm -drive if=virtio,id=target,format=qcow2,file="${disk}" -- \
-    /usr/lib/coreos-assembler/offline-update-impl "${workdir}/tmp/repo" "${commit}"
+    /usr/lib/coreos-assembler/offline-update-impl "${workdir}/tmp/repo" "${commit}" "1"

--- a/src/offline-update-impl
+++ b/src/offline-update-impl
@@ -15,6 +15,8 @@ repo=$1
 shift
 ref=$1
 shift
+no_undeploy=$1
+shift
 
 set -x
 ostree pull-local --repo="${sysroot}"/ostree/repo "${repo}" "${ref}"
@@ -40,6 +42,9 @@ EOF
     chmod a+x /usr/bin/dummy-mkconfig
 fi
 env OSTREE_DEBUG_GRUB2=1 OSTREE_GRUB2_EXEC=/usr/bin/dummy-mkconfig ostree admin --sysroot="${sysroot}" --os="${stateroot}" deploy "${ref}"
+if [ "${no_undeploy}" = 0 ]; then
+    env OSTREE_DEBUG_GRUB2=1 OSTREE_GRUB2_EXEC=/usr/bin/dummy-mkconfig ostree admin --sysroot="${sysroot}" undeploy 1
+fi
 # EVEN MORE tremendous hackery for old systems that use grub2-mkconfig or zipl
 if [ "${bootloader}" != "none" ]; then
     # shellcheck disable=SC2010


### PR DESCRIPTION
In some situations, scripts or tests expect a single deployment to exist
since it's presumably the first boot. Since this is likely the common
case, start undeploying by default, and add an option to skip it if
wanted.