### PR TITLE
cmd-sign: update to accept architecture as an argument

### DIFF
--- a/src/cmd-sign
+++ b/src/cmd-sign
@@ -65,6 +65,8 @@ def parse_args():
     robosig.add_argument("--gpgkeypath", help="path to directory containing "
                          "public keys to use for signature verification",
                          default="/etc/pki/rpm-gpg")
+    robosig.add_argument("--arch", default=get_basearch(),
+                         help="the target architecture")
     robosig.set_defaults(func=cmd_robosignatory)
 
     return parser.parse_args()
@@ -102,7 +104,7 @@ def cmd_robosignatory(args):
 
 def robosign_ostree(args, s3, build, gpgkey):
     builds = Builds()
-    builddir = builds.get_build_dir(args.build)
+    builddir = builds.get_build_dir(args.build, args.arch)
     checksum = build['ostree-commit']
 
     # Copy commit object to a temporary location. A preferred approach here is
@@ -112,8 +114,8 @@ def robosign_ostree(args, s3, build, gpgkey):
     # so we at least GC on failure. For now, just use a stable path so we
     # clobber previous runs.
     build_dir_commit_obj = os.path.join(builddir, 'ostree-commit-object')
-    commit_key = f'{args.prefix}/tmp/ostree-commit-object'
-    commitmeta_key = f'{args.prefix}/tmp/ostree-commitmeta-object'
+    commit_key = f'{args.prefix}/tmp-{args.arch}/ostree-commit-object'
+    commitmeta_key = f'{args.prefix}/tmp-{args.arch}/ostree-commitmeta-object'
     print(f"Uploading s3://{args.bucket}/{commit_key}")
     s3.upload_file(build_dir_commit_obj, args.bucket, commit_key)
     s3.delete_object(Bucket=args.bucket, Key=commitmeta_key)
@@ -125,7 +127,7 @@ def robosign_ostree(args, s3, build, gpgkey):
         environment=fedenv,
         body={
             'build_id': args.build,
-            'basearch': get_basearch(),
+            'basearch': args.arch,
             'commit_object': f's3://{args.bucket}/{commit_key}',
             'checksum': f'sha256:{checksum}',
             **args.extra_keys
@@ -200,10 +202,9 @@ def robosign_ostree(args, s3, build, gpgkey):
 
 def robosign_images(args, s3, build, gpgkey):
     builds = Builds()
-    builddir = builds.get_build_dir(args.build)
+    builddir = builds.get_build_dir(args.build, args.arch)
 
-    # NB: we just handle the current basearch for now
-    full_prefix = f'{args.prefix}/{args.build}/{get_basearch()}'
+    full_prefix = f'{args.prefix}/{args.build}/{args.arch}'
 
     # collect all the image paths to sign
     artifacts = [{
@@ -218,7 +219,7 @@ def robosign_images(args, s3, build, gpgkey):
         environment=fedenv,
         body={
             'build_id': args.build,
-            'basearch': get_basearch(),
+            'basearch': args.arch,
             'artifacts': artifacts,
             **args.extra_keys
         }

--- a/src/cmd-sign
+++ b/src/cmd-sign
@@ -197,7 +197,8 @@ def robosign_ostree(args, s3, build, gpgkey):
     # and finally add it to the tmprepo too so that buildextend-(qemu|metal)
     # will pull it: we could just nuke the repo to force a re-untar, but it
     # might nuke a more recent commit if we're not operating on the latest
-    import_ostree_commit('tmp/repo', builddir, build, force=True)
+    if os.path.exists('tmp/repo'):
+        import_ostree_commit('tmp/repo', builddir, build, force=True)
 
 
 def robosign_images(args, s3, build, gpgkey):


### PR DESCRIPTION
```
commit e8bc539458b2a310fa699ab64d181f36a913fa6a
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Fri Jul 30 15:07:21 2021 -0400

    cmd-sign: conditionalize ostree commit import
    
    Let's only re-import back into tmp ostree repo if it exists. In some
    cases the build may have happened remotely and the tmp repo won't exist.

commit 8a98016066c112bea705bb9233b8d615a0fe1fe1
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Fri Jul 30 15:05:53 2021 -0400

    cmd-sign: update to accept architecture as an argument
    
    Also update the locations in s3 for temporary file passing
    to be architecture specific so we don't stomp on each other
    if multiple runs are going at the same time.
```
