### PR TITLE
kola: add new tracker_list field for denylist

### DIFF
--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -277,12 +277,13 @@ func testRequiresInternet(test *register.Test) bool {
 }
 
 type DenyListObj struct {
-	Pattern    string   `yaml:"pattern"`
-	Tracker    string   `yaml:"tracker"`
-	Streams    []string `yaml:"streams"`
-	Arches     []string `yaml:"arches"`
-	Platforms  []string `yaml:"platforms"`
-	SnoozeDate string   `yaml:"snooze"`
+	Pattern     string   `yaml:"pattern"`
+	Tracker     string   `yaml:"tracker"`
+	TrackerList []string `yaml:"tracker_list"`
+	Streams     []string `yaml:"streams"`
+	Arches      []string `yaml:"arches"`
+	Platforms   []string `yaml:"platforms"`
+	SnoozeDate  string   `yaml:"snooze"`
 }
 
 type ManifestData struct {
@@ -358,7 +359,13 @@ func parseDenyListYaml(pltfrm string) error {
 			fmt.Printf("⚠️  Skipping kola test pattern \"%s\":\n", obj.Pattern)
 		}
 
-		fmt.Printf("  👉 %s\n", obj.Tracker)
+		if obj.Tracker != "" {
+			fmt.Printf("  👉 %s\n", obj.Tracker)
+		} else if len(obj.TrackerList) > 0 {
+			for _, tracker := range obj.TrackerList {
+				fmt.Printf("  👉 %s\n", tracker)
+			}
+		}
 		DenylistedTests = append(DenylistedTests, obj.Pattern)
 	}
 


### PR DESCRIPTION
In openshift/os#595 and openshift/os#599, I found myself mixed up with
the support of the `tracker` field.  It's defined as a string, so
magically hoping that a slice of strings would be supported was
misguided.

Decided to try adding support for a new `tracker_list` field for those
times when one issue just doesn't cut it.

This seemed more straight-forward than trying to manually unmarshal
the YAML or trying to find all the denylist documents in use.