### PR TITLE
Artifact kola

### DIFF
--- a/src/cmd-kola
+++ b/src/cmd-kola
@@ -30,12 +30,14 @@ parser.add_argument("subargs", help="Remaining arguments for kola", nargs='*',
                     default=[])
 args, unknown_args = parser.parse_known_args()
 
+default_output_dir_base = os.environ.get('ARTIFACT_DIR', 'tmp')
+
 if args.upgrades:
     default_cmd = 'run-upgrade'
-    default_output_dir = "tmp/kola-upgrade"
+    default_output_dir = os.path.join(default_output_dir_base, "kola-upgrade")
 else:
     default_cmd = 'run'
-    default_output_dir = "tmp/kola"
+    default_output_dir = os.path.join(default_output_dir_base, "kola")
 
 # XXX: teach to kola to auto-detect based on prefix; see discussions in
 # https://github.com/coreos/coreos-assembler/pull/85

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -605,11 +605,11 @@ EOF
 
     rm -rf "${tmp_builddir}/supermin.out" "${vmpreparedir}" "${vmbuilddir}"
 
-    if test -n "${ARTIFACT_DIR:-}"; then
-        cp "${runvm_console}" "${ARTIFACT_DIR}"
-    fi
     if [ ! -f "${rc_file}" ]; then
         cat "${runvm_console}"
+        if test -n "${ARTIFACT_DIR:-}"; then
+            cp "${runvm_console}" "${ARTIFACT_DIR}"
+        fi
         fatal "Couldn't find rc file; failure inside supermin init?"
     fi
     rc="$(cat "${rc_file}")"


### PR DESCRIPTION
build: Only artifact console on failure

No reason to save it on success.

---

kola: Write to ARTIFACT_DIR if set by default

This should get us the kola logs in Prow by default.

---

