### PR TITLE
kola/qemuexec: add --ssh-command

### DIFF
--- a/mantle/cmd/kola/qemuexec.go
+++ b/mantle/cmd/kola/qemuexec.go
@@ -65,6 +65,8 @@ var (
 
 	consoleFile string
 
+	sshCommand string
+
 	secondaryNics int
 )
 
@@ -91,6 +93,7 @@ func init() {
 	cmdQemuExec.Flags().BoolVar(&propagateInitramfsFailure, "propagate-initramfs-failure", false, "Error out if the system fails in the initramfs")
 	cmdQemuExec.Flags().StringVarP(&consoleFile, "console-to-file", "", "", "Filepath in which to save serial console logs")
 	cmdQemuExec.Flags().IntVarP(&secondaryNics, "secondary-nics", "", 0, "Number of secondary NICs to add")
+	cmdQemuExec.Flags().StringVarP(&sshCommand, "ssh-command", "x", "", "Command to execute instead of spawning a shell")
 
 }
 
@@ -320,7 +323,7 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 	builder.Append(args...)
 
 	if devshell && !devshellConsole {
-		return runDevShellSSH(ctx, builder, config)
+		return runDevShellSSH(ctx, builder, config, sshCommand)
 	}
 	if config != nil {
 		if directIgnition {


### PR DESCRIPTION
Add a generic `--ssh-command` switch which overrides the SSH default of
spawning the user's shell. This can be useful for example if you just
want to run a single command and get out, or if you want to line up a
command in the VM so it's already underway by the time you context
switch back to it.

Example usage:

```
$ cosa run -x 'rpm-ostree status'
[QEMU guest is booting] cosa-devsh login: core (automatic login)
State: idle
Deployments:
● ostree://fedora:fedora/x86_64/coreos/testing-devel
                   Version: 34.20210726.dev.0 (2021-07-26T18:15:29Z)
                    Commit: a698c7a3f189c6ccc3cdc5352cf2f06d150eb7412f4bd318e32d400ab0e2658b
              GPGSignature: (unsigned)
[SESSION] Clean exit from SSH, terminating instance
```

Or sounding the bell when a command is done:

```
$ cosa run -x 'some long command; echo -e "\a"; bash'
```