### PR TITLE
cmdlib: add support for arch to insert_build

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -794,14 +794,15 @@ get_latest_qemu() {
 insert_build() {
     local buildid=$1; shift
     local workdir=$1; shift
+    local arch=${1:-}
     (python3 -c "
 import sys
 sys.path.insert(0, '${DIR}')
 from cosalib.builds import Builds
 builds = Builds('${workdir:-$(pwd)}')
-builds.insert_build('${buildid}')
+builds.insert_build('${buildid}', basearch='${arch:-}')
 builds.bump_timestamp()
-print('Build ${buildid} was inserted')")
+print('Build ${buildid} was inserted ${arch:+for $arch}')")
 }
 
 flatten_image_yaml_to_file() {

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -793,7 +793,7 @@ get_latest_qemu() {
 
 insert_build() {
     local buildid=$1; shift
-    local dir=$1; shift
+    local workdir=$1; shift
     (python3 -c "
 import sys
 sys.path.insert(0, '${DIR}')

--- a/src/cosalib/builds.py
+++ b/src/cosalib/builds.py
@@ -102,7 +102,7 @@ class Builds:  # pragma: nocover
         for build in self._data['builds']:
             if build['id'] == build_id:
                 if basearch in build['arches']:
-                    raise "Build {build_id} for {basearch} already exists"
+                    raise Exception(f"Build {build_id} for {basearch} already exists")
                 build['arches'] += [basearch]
                 break
         else:


### PR DESCRIPTION
```
commit 44a4821ce974de2f3a41b9f98a60557696f0fad6
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Thu Aug 5 12:33:55 2021 -0400

    cmdlib: add support for arch to insert_build
    
    This will allow us to call insert_build with an optional
    target architecture, which is then passed on to insert_build
    from the builds python library.
    
    Also updated an error message in builds.py.

commit a74a4f922796f811fc7c2195bd794c6659305b4d
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Thu Aug 5 11:51:00 2021 -0400

    cmdlib: modify insert_build to use passed in argument for directory
    
    Previously the $dir was not used and we only got lucky because the
    single caller of this function was also using a variable named
    $workdir.
```