### PR TITLE
ci/prow-rhcos.sh: Also map `master` → `master`

### DIFF
--- a/ci/prow-rhcos.sh
+++ b/ci/prow-rhcos.sh
@@ -6,7 +6,7 @@ set -xeuo pipefail
 BRANCH=${PULL_BASE_REF:-main}
 case ${BRANCH} in
     # For now; OpenShift hasn't done the master->main transition
-    main) RHCOS_BRANCH=master;;
+    main|master) RHCOS_BRANCH=master;;
     rhcos-*) RHCOS_BRANCH=release-${BRANCH#rhcos-};;
     *) echo "Unhandled base ref: ${BRANCH}" 1>&2 && exit 1;;
 esac


### PR DESCRIPTION
In rehearsal I'm seeing
`Unhandled base ref: master` which I *think* may be
due to the fact rehearsal is a very special case that is
simulating a PR, and it doesn't know the default branch is `main`.

Let's just pass through `master` as the identity even though
we shouldn't need it later.