### PR TITLE
mantle: bump coreos/stream-metadata-go

### DIFF
--- a/mantle/go.mod
+++ b/mantle/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/coreos/ignition/v2 v2.11.0
 	github.com/coreos/ioprogress v0.0.0-20151023204047-4637e494fd9b
 	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
-	github.com/coreos/stream-metadata-go v0.1.1
+	github.com/coreos/stream-metadata-go v0.1.2-0.20210805210749-ef7e9dabff95
 	github.com/digitalocean/go-libvirt v0.0.0-20200810224808-b9c702499bf7 // indirect
 	github.com/digitalocean/go-qemu v0.0.0-20200529005954-1b453d036a9c
 	github.com/digitalocean/godo v1.33.0

--- a/mantle/go.sum
+++ b/mantle/go.sum
@@ -91,8 +91,8 @@ github.com/coreos/ioprogress v0.0.0-20151023204047-4637e494fd9b h1:mpeSDqY0vMUyJ
 github.com/coreos/ioprogress v0.0.0-20151023204047-4637e494fd9b/go.mod h1:JIWRG8HSwVYUrjdR/JsFg7DEby0nhQcWFPIQvXJyih8=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f h1:lBNOc5arjvs8E5mO2tbpBpLoyyu8B6e44T7hJy6potg=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
-github.com/coreos/stream-metadata-go v0.1.1 h1:97r4UsLPjx6rwavgcoho5sd4N4+Dtgc81h8xCGE3bkY=
-github.com/coreos/stream-metadata-go v0.1.1/go.mod h1:zxVoWUDB0H8+tZRhTs0LeLeR/QdmBsuo7FN1oOBrWTE=
+github.com/coreos/stream-metadata-go v0.1.2-0.20210805210749-ef7e9dabff95 h1:mFmE40SpA//BRV/zotY2XJ8cV+7EdIjiVpu9nuSBiyA=
+github.com/coreos/stream-metadata-go v0.1.2-0.20210805210749-ef7e9dabff95/go.mod h1:zxVoWUDB0H8+tZRhTs0LeLeR/QdmBsuo7FN1oOBrWTE=
 github.com/coreos/vcontext v0.0.0-20210407161507-4ee6c745c8bd h1:iHdPNrKIKSSlAy6nCmBliwn7xFTDu+OoFkArqMTr6Zc=
 github.com/coreos/vcontext v0.0.0-20210407161507-4ee6c745c8bd/go.mod h1:z4pMVvaUrxs98RROlIYdAQCKhEicjnTirOaVyDRH5h8=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=

--- a/mantle/vendor/github.com/coreos/stream-metadata-go/release/release.go
+++ b/mantle/vendor/github.com/coreos/stream-metadata-go/release/release.go
@@ -52,24 +52,30 @@ type Arch struct {
 
 // Media contains release details for various platforms
 type Media struct {
-	Aliyun       *PlatformBase `json:"aliyun"`
-	Aws          *PlatformAws  `json:"aws"`
-	Azure        *PlatformBase `json:"azure"`
-	AzureStack   *PlatformBase `json:"azurestack"`
-	Digitalocean *PlatformBase `json:"digitalocean"`
-	Exoscale     *PlatformBase `json:"exoscale"`
-	Gcp          *PlatformGcp  `json:"gcp"`
-	Ibmcloud     *PlatformBase `json:"ibmcloud"`
-	Metal        *PlatformBase `json:"metal"`
-	Openstack    *PlatformBase `json:"openstack"`
-	Qemu         *PlatformBase `json:"qemu"`
-	Vmware       *PlatformBase `json:"vmware"`
-	Vultr        *PlatformBase `json:"vultr"`
+	Aliyun       *PlatformAliyun `json:"aliyun"`
+	Aws          *PlatformAws    `json:"aws"`
+	Azure        *PlatformBase   `json:"azure"`
+	AzureStack   *PlatformBase   `json:"azurestack"`
+	Digitalocean *PlatformBase   `json:"digitalocean"`
+	Exoscale     *PlatformBase   `json:"exoscale"`
+	Gcp          *PlatformGcp    `json:"gcp"`
+	Ibmcloud     *PlatformBase   `json:"ibmcloud"`
+	Metal        *PlatformBase   `json:"metal"`
+	Openstack    *PlatformBase   `json:"openstack"`
+	Qemu         *PlatformBase   `json:"qemu"`
+	Vmware       *PlatformBase   `json:"vmware"`
+	Vultr        *PlatformBase   `json:"vultr"`
 }
 
 // PlatformBase with no cloud images
 type PlatformBase struct {
 	Artifacts map[string]ImageFormat `json:"artifacts"`
+}
+
+// PlatformAliyun contains Aliyun image information
+type PlatformAliyun struct {
+	PlatformBase
+	Images map[string]CloudImage `json:"images"`
 }
 
 // PlatformAws contains AWS image information

--- a/mantle/vendor/github.com/coreos/stream-metadata-go/release/translate.go
+++ b/mantle/vendor/github.com/coreos/stream-metadata-go/release/translate.go
@@ -39,6 +39,25 @@ func (releaseArch *Arch) toStreamArch(rel *Release) stream.Arch {
 	if relRHCOSExt != nil {
 		rhcosExt = &rhcos.Extensions{}
 	}
+
+	if releaseArch.Media.Aliyun != nil {
+		artifacts["aliyun"] = stream.PlatformArtifacts{
+			Release: rel.Release,
+			Formats: mapFormats(releaseArch.Media.Aliyun.Artifacts),
+		}
+		aliyunImages := stream.ReplicatedImage{
+			Regions: make(map[string]stream.RegionImage),
+		}
+		if releaseArch.Media.Aliyun.Images != nil {
+			for region, image := range releaseArch.Media.Aliyun.Images {
+				ri := stream.RegionImage{Release: rel.Release, Image: image.Image}
+				aliyunImages.Regions[region] = ri
+
+			}
+			cloudImages.Aliyun = &aliyunImages
+		}
+	}
+
 	if releaseArch.Media.Aws != nil {
 		artifacts["aws"] = stream.PlatformArtifacts{
 			Release: rel.Release,
@@ -80,13 +99,6 @@ func (releaseArch *Arch) toStreamArch(rel *Release) stream.Arch {
 		artifacts["azurestack"] = stream.PlatformArtifacts{
 			Release: rel.Release,
 			Formats: mapFormats(releaseArch.Media.AzureStack.Artifacts),
-		}
-	}
-
-	if releaseArch.Media.Aliyun != nil {
-		artifacts["aliyun"] = stream.PlatformArtifacts{
-			Release: rel.Release,
-			Formats: mapFormats(releaseArch.Media.Aliyun.Artifacts),
 		}
 	}
 

--- a/mantle/vendor/github.com/coreos/stream-metadata-go/stream/stream.go
+++ b/mantle/vendor/github.com/coreos/stream-metadata-go/stream/stream.go
@@ -51,20 +51,27 @@ type Artifact struct {
 
 // Images contains images available in cloud providers
 type Images struct {
-	Aws *AwsImage `json:"aws,omitempty"`
-	Gcp *GcpImage `json:"gcp,omitempty"`
+	Aliyun *ReplicatedImage `json:"aliyun,omitempty"`
+	Aws    *AwsImage        `json:"aws,omitempty"`
+	Gcp    *GcpImage        `json:"gcp,omitempty"`
 }
 
-// AwsImage represents an image across all AWS regions
-type AwsImage struct {
-	Regions map[string]AwsRegionImage `json:"regions,omitempty"`
+// ReplicatedImage represents an image in all regions of an AWS-like cloud
+type ReplicatedImage struct {
+	Regions map[string]RegionImage `json:"regions,omitempty"`
 }
 
-// AwsRegionImage represents an image in one AWS region
-type AwsRegionImage struct {
+// RegionImage represents an image in a single region of an AWS-like cloud
+type RegionImage struct {
 	Release string `json:"release"`
 	Image   string `json:"image"`
 }
+
+// AwsImage is a typedef for backwards compatibility.
+type AwsImage = ReplicatedImage
+
+// AwsRegionImage is a typedef for backwards compatibility.
+type AwsRegionImage = RegionImage
 
 // GcpImage represents a GCP cloud image
 type GcpImage struct {

--- a/mantle/vendor/github.com/coreos/stream-metadata-go/stream/stream_utils.go
+++ b/mantle/vendor/github.com/coreos/stream-metadata-go/stream/stream_utils.go
@@ -17,6 +17,35 @@ func (st *Stream) GetArchitecture(archname string) (*Arch, error) {
 	return &archdata, nil
 }
 
+// GetAliyunRegionImage returns the release data (Image ID and release ID) for a particular
+// architecture and region.
+func (st *Stream) GetAliyunRegionImage(archname, region string) (*RegionImage, error) {
+	starch, err := st.GetArchitecture(archname)
+	if err != nil {
+		return nil, err
+	}
+	aliyunimages := starch.Images.Aliyun
+	if aliyunimages == nil {
+		return nil, fmt.Errorf("%s: No Aliyun images", st.FormatPrefix(archname))
+	}
+	var regionVal RegionImage
+	var ok bool
+	if regionVal, ok = aliyunimages.Regions[region]; !ok {
+		return nil, fmt.Errorf("%s: No Aliyun images in region %s", st.FormatPrefix(archname), region)
+	}
+
+	return &regionVal, nil
+}
+
+// GetAliyunImage returns the Aliyun image for a particular architecture and region.
+func (st *Stream) GetAliyunImage(archname, region string) (string, error) {
+	regionVal, err := st.GetAliyunRegionImage(archname, region)
+	if err != nil {
+		return "", err
+	}
+	return regionVal.Image, nil
+}
+
 // GetAwsRegionImage returns the release data (AMI and release ID) for a particular
 // architecture and region.
 func (st *Stream) GetAwsRegionImage(archname, region string) (*AwsRegionImage, error) {

--- a/mantle/vendor/modules.txt
+++ b/mantle/vendor/modules.txt
@@ -222,7 +222,7 @@ github.com/coreos/ioprogress
 # github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
 github.com/coreos/pkg/capnslog
 github.com/coreos/pkg/multierror
-# github.com/coreos/stream-metadata-go v0.1.1
+# github.com/coreos/stream-metadata-go v0.1.2-0.20210805210749-ef7e9dabff95
 github.com/coreos/stream-metadata-go/arch
 github.com/coreos/stream-metadata-go/fedoracoreos
 github.com/coreos/stream-metadata-go/fedoracoreos/internals


### PR DESCRIPTION
This gets us support for Aliyun images that have been uploaded to the
cloud and replicated across regions.