### PR TITLE
cosalib: support parent_build argument to init_build_meta_json

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -358,7 +358,7 @@ fi
 
 image_input_checksum=$( (echo "${commit}" && echo "${image_config_checksum}") | sha256sum_str)
 echo "New image input checksum: ${image_input_checksum}"
-init_build_meta_json "${commit}" tmp/
+init_build_meta_json "${commit}" "${PARENT_BUILD:-}" tmp/
 buildid=$(jq -r '.["buildid"]' < tmp/meta.json)
 echo "New build ID: ${buildid}"
 # Also write out a ref with the build ID

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -773,12 +773,13 @@ print(Builds('${workdir:-$(pwd)}').get_build_dir('${buildid}'))")
 
 init_build_meta_json() {
     local ostree_commit=$1; shift
+    local parent_build=$1; shift
     local dir=$1; shift
     (python3 -c "
 import sys
 sys.path.insert(0, '${DIR}')
 from cosalib.builds import Builds
-print(Builds('${workdir:-$(pwd)}').init_build_meta_json('${ostree_commit}', '${dir}'))")
+print(Builds('${workdir:-$(pwd)}').init_build_meta_json('${ostree_commit}', '${parent_build}', '${dir}'))")
 }
 
 get_latest_qemu() {

--- a/src/cosalib/builds.py
+++ b/src/cosalib/builds.py
@@ -113,7 +113,7 @@ class Builds:  # pragma: nocover
                 ]
             })
 
-    def init_build_meta_json(self, ostree_commit, destdir):
+    def init_build_meta_json(self, ostree_commit, parent_build, destdir):
         """
         Given a new ostree version, initialize a new coreos-assembler
         build by writing a `meta.json` in destdir.
@@ -129,7 +129,7 @@ class Builds:  # pragma: nocover
         buildid = version
         genver_key = 'coreos-assembler.image-genver'
         if not self.is_empty():
-            previous_buildid = self.get_latest()
+            previous_buildid = parent_build or self.get_latest()
             metapath = self.get_build_dir(previous_buildid) + '/meta.json'
             with open(metapath) as f:
                 previous_buildmeta = json.load(f)


### PR DESCRIPTION
If there is ever a case where there are missing architectures for
a given build then the pipeline will buildprep the meta.json from
the last released build for that architecture. Now we need to be
able to tell init_build_meta_json that the parent for the given
architecture might not be the latest build, in which case we'll
specify the parent build ID directly.