### PR TITLE
cmd-compress,cmd-buildupload: return early if meta.json missing for arch

### DIFF
--- a/src/cmd-buildupload
+++ b/src/cmd-buildupload
@@ -89,6 +89,12 @@ def cmd_upload_s3(args):
 
 
 def s3_upload_build(args, builddir, bucket, prefix):
+    # In the case where we are doing builds for different architectures
+    # it's likely not all builds for this arch are local. If the meta.json
+    # doesn't exist then return early.
+    if not os.path.exists(f'{builddir}/meta.json'):
+        print(f"No meta.json exists for {builddir}.. Skipping")
+        return
     build = load_json(f'{builddir}/meta.json')
 
     # Upload images with special handling for gzipped data.

--- a/src/cmd-compress
+++ b/src/cmd-compress
@@ -80,6 +80,12 @@ def xz_threads():
 def compress_one_builddir(builddir):
     print(f"Compressing: {builddir}")
     buildmeta_path = os.path.join(builddir, 'meta.json')
+    # In the case where we are doing builds for different architectures
+    # it's likely not all builds for this arch are local. If the meta.json
+    # doesn't exist then return early.
+    if not os.path.exists(buildmeta_path):
+        print(f"No meta.json exists for {builddir}.. Skipping")
+        return False
     with open(buildmeta_path) as f:
         buildmeta = json.load(f)
 


### PR DESCRIPTION
When we're operating on separate builders for different architectures
it's valid that build directories for the other architectures won't
exist locally on the machine. In that case let's have
`compress_one_builddir()` and `s3_upload_build()` return early.