### PR TITLE
mantle/kola: a few additions for --arch

### DIFF
--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -62,6 +62,7 @@ func init() {
 	sv(&kola.Options.Stream, "stream", "", "CoreOS stream ID (e.g. for Fedora CoreOS: stable, testing, next)")
 	sv(&kola.Options.CosaWorkdir, "workdir", "", "coreos-assembler working directory")
 	sv(&kola.Options.CosaBuildId, "build", "", "coreos-assembler build ID")
+	sv(&kola.Options.CosaBuildArch, "arch", system.RpmArch(), "The target architecture of the build")
 	// rhcos-specific options
 	sv(&kola.Options.OSContainer, "oscontainer", "", "oscontainer image pullspec for pivot (RHCOS only)")
 
@@ -182,9 +183,9 @@ func syncOptionsImpl(useCosa bool) error {
 	}
 	// default to BIOS, UEFI for aarch64 and x86(only for 4k)
 	if kola.QEMUOptions.Firmware == "" {
-		if system.RpmArch() == "aarch64" {
+		if kola.Options.CosaBuildArch == "aarch64" {
 			kola.QEMUOptions.Firmware = "uefi"
-		} else if system.RpmArch() == "x86_64" && kola.QEMUOptions.Native4k {
+		} else if kola.Options.CosaBuildArch == "x86_64" && kola.QEMUOptions.Native4k {
 			kola.QEMUOptions.Firmware = "uefi"
 		} else {
 			kola.QEMUOptions.Firmware = "bios"
@@ -210,7 +211,9 @@ func syncOptionsImpl(useCosa bool) error {
 			kola.Options.CosaWorkdir = "."
 		}
 
-		localbuild, err := sdk.GetLocalBuild(kola.Options.CosaWorkdir, kola.Options.CosaBuildId)
+		localbuild, err := sdk.GetLocalBuild(kola.Options.CosaWorkdir,
+			kola.Options.CosaBuildId,
+			kola.Options.CosaBuildArch)
 		if err != nil {
 			return err
 		}
@@ -234,7 +237,8 @@ func syncOptionsImpl(useCosa bool) error {
 		}
 
 		if kola.Options.CosaWorkdir != "" && kola.Options.CosaWorkdir != "none" {
-			localbuild, err := sdk.GetLatestLocalBuild(kola.Options.CosaWorkdir)
+			localbuild, err := sdk.GetLatestLocalBuild(kola.Options.CosaWorkdir,
+				kola.Options.CosaBuildArch)
 			if err != nil {
 				if !os.IsNotExist(errors.Cause(err)) {
 					return err

--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -77,7 +77,7 @@ func init() {
 	sv(&kola.AWSOptions.Profile, "aws-profile", "default", "AWS profile name")
 	sv(&kola.AWSOptions.AMI, "aws-ami", "alpha", `AWS AMI ID, or (alpha|beta|stable) to use the latest image`)
 	// See https://github.com/openshift/installer/issues/2919 for example
-	sv(&kola.AWSOptions.InstanceType, "aws-type", "m5.large", "AWS instance type")
+	sv(&kola.AWSOptions.InstanceType, "aws-type", "", "AWS instance type")
 	sv(&kola.AWSOptions.SecurityGroup, "aws-sg", "kola", "AWS security group name")
 	sv(&kola.AWSOptions.IAMInstanceProfile, "aws-iam-profile", "kola", "AWS IAM instance profile name")
 
@@ -175,6 +175,16 @@ func syncOptionsImpl(useCosa bool) error {
 	// Alias qemu to qemu-unpriv.
 	if kolaPlatform == "qemu" {
 		kolaPlatform = "qemu-unpriv"
+	}
+
+	// Choose an appropriate AWS instance type for the target architecture
+	if kola.AWSOptions.InstanceType == "" {
+		switch kola.Options.CosaBuildArch {
+		case "x86_64":
+			kola.AWSOptions.InstanceType = "m5.large"
+		case "aarch64":
+			kola.AWSOptions.InstanceType = "a1.metal"
+		}
 	}
 
 	// native 4k requires a UEFI bootloader

--- a/mantle/platform/platform.go
+++ b/mantle/platform/platform.go
@@ -170,8 +170,9 @@ type Options struct {
 	SystemdDropins []SystemdDropin
 	Stream         string
 
-	CosaWorkdir string
-	CosaBuildId string
+	CosaWorkdir   string
+	CosaBuildId   string
+	CosaBuildArch string
 
 	NoTestExitError bool
 

--- a/mantle/sdk/repo.go
+++ b/mantle/sdk/repo.go
@@ -24,7 +24,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/coreos/coreos-assembler-schema/cosa"
-	"github.com/coreos/mantle/system"
 )
 
 const (
@@ -80,16 +79,15 @@ func GetLocalFastBuildQemu() (string, error) {
 	return "", nil
 }
 
-func GetLatestLocalBuild(root string) (*LocalBuild, error) {
-	return GetLocalBuild(root, "latest")
+func GetLatestLocalBuild(root, arch string) (*LocalBuild, error) {
+	return GetLocalBuild(root, "latest", arch)
 }
 
-func GetLocalBuild(root, buildid string) (*LocalBuild, error) {
+func GetLocalBuild(root, buildid, arch string) (*LocalBuild, error) {
 	if err := RequireCosaRoot(root); err != nil {
 		return nil, err
 	}
 
-	arch := system.RpmArch()
 	builddir := filepath.Join(root, "builds", buildid, arch)
 	metapath := filepath.Join(builddir, "meta.json")
 	cosameta, err := cosa.ParseBuild(metapath)


### PR DESCRIPTION
```
commit d0aad530476227f69c8993f7bb55573bfb6b3f02
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Tue Aug 10 12:26:01 2021 -0400

    mantle/kola: pick up AMI from the build meta
    
    Right now we have to specify --aws-ami even if we have build metadata.
    This doesn't make a lot of sense since it's in the build metadata and
    we shouldn't have to fish for it twice. Let's pull it from there
    if the user didn't specify it.

commit bf459a30df40746cbbab80297a980dc9b0e06cb7
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Tue Aug 10 10:44:38 2021 -0400

    mantle/kola: switch AWS instance type based on arch
    
    This will allow us to run against aarch64 without having to
    specify the instance type each time.

commit a09a22e5fbfeb5fc37be95479b8e2aeaae56a766
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Tue Aug 10 10:43:51 2021 -0400

    mantle/kola: add --arch argument to specify target architecture
    
    Will allow us to target architectures that aren't the same as the
    currently running COSA. For example, there is nothing architecture
    specific about making API calls to bring up a cloud instance so we
    should be able to target any architecture even if we're running on
    x86_64.
```
