### PR TITLE
cmd-sign: fix arch handling in cmd_robosignatory

### DIFF
--- a/src/cmd-sign
+++ b/src/cmd-sign
@@ -17,7 +17,6 @@ import tempfile
 import boto3
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from cosalib.meta import GenericBuildMeta as Meta
 from cosalib.builds import Builds
 from cosalib.cmdlib import (
     get_basearch,
@@ -45,6 +44,8 @@ def main():
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--build", help="Build ID", default='latest')
+    parser.add_argument("--arch", default=get_basearch(),
+                        help="the target architecture")
     subparsers = parser.add_subparsers(dest='cmd', title='subcommands')
     subparsers.required = True
 
@@ -65,8 +66,6 @@ def parse_args():
     robosig.add_argument("--gpgkeypath", help="path to directory containing "
                          "public keys to use for signature verification",
                          default="/etc/pki/rpm-gpg")
-    robosig.add_argument("--arch", default=get_basearch(),
-                         help="the target architecture")
     robosig.set_defaults(func=cmd_robosignatory)
 
     return parser.parse_args()
@@ -85,7 +84,7 @@ def cmd_robosignatory(args):
         key, val = keyval.split('=', 1)  # will throw exception if there's no =
         args.extra_keys[key] = val
 
-    build = Meta(build=args.build)
+    build = builds.get_build_meta(args.build, args.arch)
     version = build['ostree-version']
 
     # 32.20200615.2.0 -> 32

--- a/src/cmd-sign
+++ b/src/cmd-sign
@@ -43,7 +43,7 @@ def main():
 
 def parse_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--build", help="Build ID", default='latest')
+    parser.add_argument("--build", help="Build ID", required=True)
     parser.add_argument("--arch", default=get_basearch(),
                         help="the target architecture")
     subparsers = parser.add_subparsers(dest='cmd', title='subcommands')
@@ -73,8 +73,6 @@ def parse_args():
 
 def cmd_robosignatory(args):
     builds = Builds()
-    if args.build == 'latest':
-        args.build = builds.get_latest()
 
     s3 = boto3.client('s3')
     args.bucket, args.prefix = get_bucket_and_prefix(args.s3)


### PR DESCRIPTION
```
commit c99d7e9e94efbd8868a3ee662ae8cba48d261bbd
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Wed Aug 11 14:06:30 2021 -0400

    cmd-sign: require passing in the build id
    
    Now that we have multipe architectures building let's be very explicit
    what build ostree/artifacts we want signed by requiring the user to
    tell us.

commit b98eb9acbfd905f60d12a00b5bfa06f3b502d82f
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Wed Aug 11 14:04:51 2021 -0400

    cmd-sign: fix arch handling in cmd_robosignatory
    
    I missed this one in 62fae82.

```
