### PR TITLE
mantle/kola: add back in cross building of kolet

### DIFF
--- a/mantle/Makefile
+++ b/mantle/Makefile
@@ -11,9 +11,11 @@ schema-update:
 	$(MAKE) -C ../tools schema
 
 .PHONY: install
-install: bin/ore bin/kola bin/plume bin/kolet
+install: build
 	install -D -t $(DESTDIR)$(PREFIX)/bin bin/{ore,kola,plume}
-	install -D -m 0755 -t $(DESTDIR)$(PREFIX)/lib/kola/$(ARCH) bin/kolet
+	for arch in s390x x86_64 aarch64 ppc64le; do \
+		install -D -m 0755 -t $(DESTDIR)$(PREFIX)/lib/kola/$${arch} bin/$${arch}/kolet; \
+	done
 
 test:
 	./test

--- a/mantle/build
+++ b/mantle/build
@@ -31,36 +31,30 @@ host_build() {
         "$@" "${REPO_PATH}/cmd/$cmd"
 }
 
-host_static_build() {
+cross_static_build() {
     local cmd=$1; shift
-    echo "Building $cmd (static)"
-    go build \
-        -ldflags "${ldflags} -extldflags=-static" \
-        -mod vendor \
-        -o "bin/$cmd" \
-        -tags osusergo,netgo \
-        ${race} \
-        "${REPO_PATH}/cmd/$cmd"
-}
-
-# Unused now, but kept in case we want it in the future
-cross_build() {
     local a
     local r
-    for a in amd64 arm64 s390x ppc64le; do
-        ( [[ "${a}" =~ s390x ]] || [ -z "${ENABLE_GO_RACE_DETECTOR:-}" ] ) && r= || r="-race"
-        echo "Building $a/$1"
+	declare -A arches=([s390x]=s390x [x86_64]=amd64 [aarch64]=arm64 [ppc64le]=ppc64le)
+	for a in "${!arches[@]}"; do \
+        [[ "${a}" =~ s390x ]] && r= || r=$race
         mkdir -p "bin/$a"
-        CGO_ENABLED=0 GOARCH=$a \
-            go build -mod=vendor -ldflags "${ldflags}" ${r} \
-            -o "bin/$a/$1" "${REPO_PATH}/cmd/$1"
+        echo "Building $a/$cmd (static)"
+        GOARCH=${arches[$a]} \
+        go build \
+            -ldflags "${ldflags} -extldflags=-static" \
+            -mod vendor \
+            -o "bin/$a/$cmd" \
+            -tags osusergo,netgo \
+            ${r} \
+            "${REPO_PATH}/cmd/$cmd"
     done
 }
 
 for arg in "$@"; do
     cmd=$(basename "${arg}")
     if [ "${cmd}" = "kolet" ]; then
-        host_static_build kolet
+        cross_static_build kolet
     else
         host_build "${cmd}"
     fi

--- a/mantle/build
+++ b/mantle/build
@@ -7,7 +7,7 @@ cd $(dirname $0)
 source ./env
 
 if [[ $# -eq 0 ]]; then
-	set -- cmd/* schema
+    set -- cmd/* schema
 fi
 
 race=
@@ -21,40 +21,40 @@ version="${version/-/+}"
 ldflags="-X ${REPO_PATH}/version.Version=${version}"
 
 host_build() {
-	local cmd=$1; shift
-	echo "Building $cmd"
-	go build \
-		-ldflags "${ldflags}" \
-		-mod vendor \
-		-o "bin/$cmd" \
-		${race} \
-		"$@" "${REPO_PATH}/cmd/$cmd"
+    local cmd=$1; shift
+    echo "Building $cmd"
+    go build \
+        -ldflags "${ldflags}" \
+        -mod vendor \
+        -o "bin/$cmd" \
+        ${race} \
+        "$@" "${REPO_PATH}/cmd/$cmd"
 }
 
 host_static_build() {
-	local cmd=$1; shift
-	echo "Building $cmd (static)"
-	go build \
-		-ldflags "${ldflags} -extldflags=-static" \
-		-mod vendor \
-		-o "bin/$cmd" \
-		-tags osusergo,netgo \
-		${race} \
-		"${REPO_PATH}/cmd/$cmd"
+    local cmd=$1; shift
+    echo "Building $cmd (static)"
+    go build \
+        -ldflags "${ldflags} -extldflags=-static" \
+        -mod vendor \
+        -o "bin/$cmd" \
+        -tags osusergo,netgo \
+        ${race} \
+        "${REPO_PATH}/cmd/$cmd"
 }
 
 # Unused now, but kept in case we want it in the future
 cross_build() {
-	local a
-	local r
-	for a in amd64 arm64 s390x ppc64le; do
-		( [[ "${a}" =~ s390x ]] || [ -z "${ENABLE_GO_RACE_DETECTOR:-}" ] ) && r= || r="-race"
-		echo "Building $a/$1"
-		mkdir -p "bin/$a"
-		CGO_ENABLED=0 GOARCH=$a \
-			go build -mod=vendor -ldflags "${ldflags}" ${r} \
-			-o "bin/$a/$1" "${REPO_PATH}/cmd/$1"
-	done
+    local a
+    local r
+    for a in amd64 arm64 s390x ppc64le; do
+        ( [[ "${a}" =~ s390x ]] || [ -z "${ENABLE_GO_RACE_DETECTOR:-}" ] ) && r= || r="-race"
+        echo "Building $a/$1"
+        mkdir -p "bin/$a"
+        CGO_ENABLED=0 GOARCH=$a \
+            go build -mod=vendor -ldflags "${ldflags}" ${r} \
+            -o "bin/$a/$1" "${REPO_PATH}/cmd/$1"
+    done
 }
 
 for arg in "$@"; do

--- a/mantle/build
+++ b/mantle/build
@@ -34,19 +34,16 @@ host_build() {
 cross_static_build() {
     local cmd=$1; shift
     local a
-    local r
 	declare -A arches=([s390x]=s390x [x86_64]=amd64 [aarch64]=arm64 [ppc64le]=ppc64le)
 	for a in "${!arches[@]}"; do \
-        [[ "${a}" =~ s390x ]] && r= || r=$race
         mkdir -p "bin/$a"
         echo "Building $a/$cmd (static)"
-        GOARCH=${arches[$a]} \
+        CGO_ENABLED=0 GOARCH=${arches[$a]} \
         go build \
             -ldflags "${ldflags} -extldflags=-static" \
             -mod vendor \
             -o "bin/$a/$cmd" \
             -tags osusergo,netgo \
-            ${r} \
             "${REPO_PATH}/cmd/$cmd"
     done
 }

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -1048,7 +1048,7 @@ func runTest(h *harness.H, t *register.Test, pltfrm string, flight platform.Flig
 
 // scpKolet searches for a kolet binary and copies it to the machine.
 func scpKolet(machines []platform.Machine) error {
-	mArch := system.RpmArch()
+	mArch := Options.CosaBuildArch
 	exePath, err := os.Executable()
 	if err != nil {
 		return errors.Wrapf(err, "finding path of executable")

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -1049,10 +1049,14 @@ func runTest(h *harness.H, t *register.Test, pltfrm string, flight platform.Flig
 // scpKolet searches for a kolet binary and copies it to the machine.
 func scpKolet(machines []platform.Machine) error {
 	mArch := system.RpmArch()
+	exePath, err := os.Executable()
+	if err != nil {
+		return errors.Wrapf(err, "finding path of executable")
+	}
 	for _, d := range []string{
 		".",
-		filepath.Dir(os.Args[0]),
-		filepath.Join(filepath.Dir(os.Args[0]), mArch),
+		filepath.Dir(exePath),
+		filepath.Join(filepath.Dir(exePath), mArch),
 		filepath.Join("/usr/lib/kola", mArch),
 	} {
 		kolet := filepath.Join(d, "kolet")


### PR DESCRIPTION
```
commit 2286ef173bbfa2fb43c844b7e17dd5f4ff503ffe (HEAD -> dusty-kolet-multi-arch, origin/dusty-kolet-multi-arch)
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Wed Aug 11 16:09:27 2021 -0400

    mantle: cross build kolet
    
    This will enable us to run tests on our aarch64 AWS instances from
    COSA running in our main openshift/jenkins pipeline (x86_64).

commit 6843431ba1429de56914ee82c30449bc9abfab06
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Wed Aug 11 16:08:12 2021 -0400

    mantle/kola: pick up arch from kola options
    
    `kola --arch` was added in 6796eeb and we can use it now if the user
    is targeting an alternative architecture to the one they are
    currently running on.

commit 4020ce20728dab9d8493074e6edd371350b340bc
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Wed Aug 11 16:05:32 2021 -0400

    mantle/kola: use os.Executable() when trying to find kolet
    
    `os.Executable()` gives us the path to the executable we were called
    from (i.e. `/usr/bin/kola`) which is probably what the original author
    wanted when they were trying to use `os.Args[0]`, which will just be
    `kola`.

```