### PR TITLE
kola: tests/crio: add namespace_option to container spec

### DIFF
--- a/mantle/kola/tests/crio/crio.go
+++ b/mantle/kola/tests/crio/crio.go
@@ -127,6 +127,9 @@ var crioContainerTemplate = `{
 			"memory_limit_in_bytes": 268435456
 		},
 		"security_context": {
+			"namespace_options": {
+				"pid": 1
+			},
 			"readonly_rootfs": false,
 			"selinux_options": {
 				"user": "system_u",


### PR DESCRIPTION
As mentioned here: https://bugzilla.redhat.com/show_bug.cgi?id=1986239#c3, the pod spec has a namespace option and is requesting a container level pid namespace whereas the container spec is requesting a pod level pid namespace.