### PR TITLE
support replication of images across regions for IBMCloud and PowerVS

### DIFF
--- a/gangplank/vendor/github.com/coreos/coreos-assembler-schema/cosa/cosa_v1.go
+++ b/gangplank/vendor/github.com/coreos/coreos-assembler-schema/cosa/cosa_v1.go
@@ -50,7 +50,7 @@ type Build struct {
 	FedoraCoreOsParentVersion string                `json:"fedora-coreos.parent-version,omitempty"`
 	Gcp                       *Gcp                  `json:"gcp,omitempty"`
 	GitDirty                  string                `json:"coreos-assembler.config-dirty,omitempty"`
-	IbmCloud                  *Cloudartifact        `json:"ibmcloud,omitempty"`
+	IbmCloud                  []Cloudartifact       `json:"ibmcloud,omitempty"`
 	ImageInputChecksum        string                `json:"coreos-assembler.image-input-checksum,omitempty"`
 	InputHasOfTheRpmOstree    string                `json:"rpm-ostree-inputhash"`
 	Koji                      *Koji                 `json:"koji,omitempty"`
@@ -70,7 +70,7 @@ type Build struct {
 	OverridesActive           bool                  `json:"coreos-assembler.overrides-active,omitempty"`
 	PkgdiffAgainstParent      PackageSetDifferences `json:"parent-pkgdiff,omitempty"`
 	PkgdiffBetweenBuilds      PackageSetDifferences `json:"pkgdiff,omitempty"`
-	PowerVirtualServer        *Cloudartifact        `json:"powervs,omitempty"`
+	PowerVirtualServer        []Cloudartifact       `json:"powervs,omitempty"`
 	ReleasePayload            *Image                `json:"release-payload,omitempty"`
 }
 
@@ -103,7 +103,8 @@ type BuildArtifacts struct {
 
 type Cloudartifact struct {
 	Bucket string `json:"bucket,omitempty"`
-	Image  string `json:"image"`
+	Image  string `json:"image,omitempty"`
+	Object string `json:"object,omitempty"`
 	Region string `json:"region,omitempty"`
 	URL    string `json:"url"`
 }

--- a/gangplank/vendor/github.com/coreos/coreos-assembler-schema/cosa/schema_doc.go
+++ b/gangplank/vendor/github.com/coreos/coreos-assembler-schema/cosa/schema_doc.go
@@ -74,10 +74,11 @@ var generatedSchemaJSON = `{
       "cloudartifact": {
          "type": "object",
          "required": [
-             "image",
              "url"
          ],
          "optional": [
+             "image",
+             "object",
              "bucket",
              "region"
          ],
@@ -101,6 +102,11 @@ var generatedSchemaJSON = `{
              "$id":"#/cloudartifact/region",
              "type":"string",
              "title":"Region"
+            },
+            "object": {
+             "$id":"#/cloudartifact/object",
+             "type":"string",
+             "title":"Object"
             }
           }
      },
@@ -178,7 +184,7 @@ var generatedSchemaJSON = `{
       }
  },
  "$schema":"http://json-schema.org/draft-07/schema#",
- "$id":"http://github.com/coreos/coreos-assembler/blob/main/schema/v1.json",
+ "$id":"http://github.com/coreos/coreos-assembler/blob/main/v1.json.json",
  "type":"object",
  "title":"CoreOS Assember v1 meta.json schema",
  "required": [
@@ -820,16 +826,22 @@ var generatedSchemaJSON = `{
       }
     },
    "ibmcloud": {
-      "$id":"#/properties/ibmcloud",
-      "type":"object",
-      "title":"IBM Cloud",
-      "$ref": "#/definitions/cloudartifact"
+     "$id":"#/properties/ibmcloud",
+     "type":"array",
+     "title":"IBM Cloud",
+     "items": {
+       "type":"object",
+       "$ref": "#/definitions/cloudartifact"
+      }
     },
    "powervs": {
-      "$id":"#/properties/powervs",
-      "type":"object",
-      "title":"Power Virtual Server",
-      "$ref": "#/definitions/cloudartifact"
+     "$id":"#/properties/powervs",
+     "type":"array",
+     "title":"Power Virtual Server",
+     "items": {
+       "type":"object",
+       "$ref": "#/definitions/cloudartifact"
+      }
     },
     "release-payload": {
       "$id":"#/properties/release-payload",

--- a/mantle/cmd/ore/ibmcloud/copy-object.go
+++ b/mantle/cmd/ore/ibmcloud/copy-object.go
@@ -1,0 +1,78 @@
+// Copyright 2021 RedHat.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ibmcloud
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	cmdCopyObject = &cobra.Command{
+		Use:   "copy-object",
+		Short: "Copy IBMCloud object to a bucket",
+		Long:  "Copy an IBMCloud object from a bucket in a region to another bucket in a specified region",
+		Example: `  ore ibmcloud copy-object --source-name=image.qcow2 \
+		--destination-region=us-south \
+		--destination-bucket=coreos-dev-image-ibmcloud-us-south`,
+		RunE: runCopyObject,
+
+		SilenceUsage: true,
+	}
+
+	copyCloudObjectStorage string
+	sourceBucket           string
+	sourceName             string
+	destRegion             string
+	destBucket             string
+)
+
+func init() {
+	IbmCloud.AddCommand(cmdCopyObject)
+	cmdCopyObject.Flags().StringVar(&copyCloudObjectStorage, "cloud-object-storage", "coreos-dev-image-ibmcloud", "cloud object storage to be used")
+	cmdCopyObject.Flags().StringVar(&sourceBucket, "source-bucket", "coreos-dev-image-ibmcloud-us-east", "bucket where object needs to be copied from")
+	cmdCopyObject.Flags().StringVar(&sourceName, "source-name", "", "name of object to be copied")
+	cmdCopyObject.MarkFlagRequired("source-name")
+	cmdCopyObject.Flags().StringVar(&destRegion, "destination-region", "", "region to be copied to")
+	cmdCopyObject.MarkFlagRequired("destination-region")
+	cmdCopyObject.Flags().StringVar(&destBucket, "destination-bucket", "", "destination bucket to copy to")
+	cmdCopyObject.MarkFlagRequired("destination-bucket")
+}
+
+func runCopyObject(cmd *cobra.Command, args []string) error {
+	if err := API.NewS3Client(copyCloudObjectStorage, destRegion); err != nil {
+		return err
+	}
+
+	bucketExists, err := API.CheckBucketExists(destBucket)
+	if err != nil {
+		return err
+	}
+
+	if !bucketExists {
+		if err = API.CreateBucket(destBucket); err != nil {
+			return err
+		}
+	}
+
+	if err = API.CopyObject(sourceBucket, sourceName, destBucket); err != nil {
+		fmt.Fprintf(os.Stderr, "Couldn't copy objects: %v\n", err)
+		os.Exit(1)
+	}
+
+	return nil
+}

--- a/mantle/vendor/github.com/coreos/coreos-assembler-schema/cosa/cosa_v1.go
+++ b/mantle/vendor/github.com/coreos/coreos-assembler-schema/cosa/cosa_v1.go
@@ -50,7 +50,7 @@ type Build struct {
 	FedoraCoreOsParentVersion string                `json:"fedora-coreos.parent-version,omitempty"`
 	Gcp                       *Gcp                  `json:"gcp,omitempty"`
 	GitDirty                  string                `json:"coreos-assembler.config-dirty,omitempty"`
-	IbmCloud                  *Cloudartifact        `json:"ibmcloud,omitempty"`
+	IbmCloud                  []Cloudartifact       `json:"ibmcloud,omitempty"`
 	ImageInputChecksum        string                `json:"coreos-assembler.image-input-checksum,omitempty"`
 	InputHasOfTheRpmOstree    string                `json:"rpm-ostree-inputhash"`
 	Koji                      *Koji                 `json:"koji,omitempty"`
@@ -70,7 +70,7 @@ type Build struct {
 	OverridesActive           bool                  `json:"coreos-assembler.overrides-active,omitempty"`
 	PkgdiffAgainstParent      PackageSetDifferences `json:"parent-pkgdiff,omitempty"`
 	PkgdiffBetweenBuilds      PackageSetDifferences `json:"pkgdiff,omitempty"`
-	PowerVirtualServer        *Cloudartifact        `json:"powervs,omitempty"`
+	PowerVirtualServer        []Cloudartifact       `json:"powervs,omitempty"`
 	ReleasePayload            *Image                `json:"release-payload,omitempty"`
 }
 
@@ -103,7 +103,8 @@ type BuildArtifacts struct {
 
 type Cloudartifact struct {
 	Bucket string `json:"bucket,omitempty"`
-	Image  string `json:"image"`
+	Image  string `json:"image,omitempty"`
+	Object string `json:"object,omitempty"`
 	Region string `json:"region,omitempty"`
 	URL    string `json:"url"`
 }

--- a/mantle/vendor/github.com/coreos/coreos-assembler-schema/cosa/schema_doc.go
+++ b/mantle/vendor/github.com/coreos/coreos-assembler-schema/cosa/schema_doc.go
@@ -74,10 +74,11 @@ var generatedSchemaJSON = `{
       "cloudartifact": {
          "type": "object",
          "required": [
-             "image",
              "url"
          ],
          "optional": [
+             "image",
+             "object",
              "bucket",
              "region"
          ],
@@ -101,6 +102,11 @@ var generatedSchemaJSON = `{
              "$id":"#/cloudartifact/region",
              "type":"string",
              "title":"Region"
+            },
+            "object": {
+             "$id":"#/cloudartifact/object",
+             "type":"string",
+             "title":"Object"
             }
           }
      },
@@ -178,7 +184,7 @@ var generatedSchemaJSON = `{
       }
  },
  "$schema":"http://json-schema.org/draft-07/schema#",
- "$id":"http://github.com/coreos/coreos-assembler/blob/main/schema/v1.json",
+ "$id":"http://github.com/coreos/coreos-assembler/blob/main/v1.json.json",
  "type":"object",
  "title":"CoreOS Assember v1 meta.json schema",
  "required": [
@@ -820,16 +826,22 @@ var generatedSchemaJSON = `{
       }
     },
    "ibmcloud": {
-      "$id":"#/properties/ibmcloud",
-      "type":"object",
-      "title":"IBM Cloud",
-      "$ref": "#/definitions/cloudartifact"
+     "$id":"#/properties/ibmcloud",
+     "type":"array",
+     "title":"IBM Cloud",
+     "items": {
+       "type":"object",
+       "$ref": "#/definitions/cloudartifact"
+      }
     },
    "powervs": {
-      "$id":"#/properties/powervs",
-      "type":"object",
-      "title":"Power Virtual Server",
-      "$ref": "#/definitions/cloudartifact"
+     "$id":"#/properties/powervs",
+     "type":"array",
+     "title":"Power Virtual Server",
+     "items": {
+       "type":"object",
+       "$ref": "#/definitions/cloudartifact"
+      }
     },
     "release-payload": {
       "$id":"#/properties/release-payload",

--- a/schema/cosa/cosa_v1.go
+++ b/schema/cosa/cosa_v1.go
@@ -50,7 +50,7 @@ type Build struct {
 	FedoraCoreOsParentVersion string                `json:"fedora-coreos.parent-version,omitempty"`
 	Gcp                       *Gcp                  `json:"gcp,omitempty"`
 	GitDirty                  string                `json:"coreos-assembler.config-dirty,omitempty"`
-	IbmCloud                  *Cloudartifact        `json:"ibmcloud,omitempty"`
+	IbmCloud                  []Cloudartifact       `json:"ibmcloud,omitempty"`
 	ImageInputChecksum        string                `json:"coreos-assembler.image-input-checksum,omitempty"`
 	InputHasOfTheRpmOstree    string                `json:"rpm-ostree-inputhash"`
 	Koji                      *Koji                 `json:"koji,omitempty"`
@@ -70,7 +70,7 @@ type Build struct {
 	OverridesActive           bool                  `json:"coreos-assembler.overrides-active,omitempty"`
 	PkgdiffAgainstParent      PackageSetDifferences `json:"parent-pkgdiff,omitempty"`
 	PkgdiffBetweenBuilds      PackageSetDifferences `json:"pkgdiff,omitempty"`
-	PowerVirtualServer        *Cloudartifact        `json:"powervs,omitempty"`
+	PowerVirtualServer        []Cloudartifact       `json:"powervs,omitempty"`
 	ReleasePayload            *Image                `json:"release-payload,omitempty"`
 }
 
@@ -103,7 +103,8 @@ type BuildArtifacts struct {
 
 type Cloudartifact struct {
 	Bucket string `json:"bucket,omitempty"`
-	Image  string `json:"image"`
+	Image  string `json:"image,omitempty"`
+	Object string `json:"object,omitempty"`
 	Region string `json:"region,omitempty"`
 	URL    string `json:"url"`
 }

--- a/schema/cosa/schema_doc.go
+++ b/schema/cosa/schema_doc.go
@@ -74,10 +74,11 @@ var generatedSchemaJSON = `{
       "cloudartifact": {
          "type": "object",
          "required": [
-             "image",
              "url"
          ],
          "optional": [
+             "image",
+             "object",
              "bucket",
              "region"
          ],
@@ -101,6 +102,11 @@ var generatedSchemaJSON = `{
              "$id":"#/cloudartifact/region",
              "type":"string",
              "title":"Region"
+            },
+            "object": {
+             "$id":"#/cloudartifact/object",
+             "type":"string",
+             "title":"Object"
             }
           }
      },
@@ -178,7 +184,7 @@ var generatedSchemaJSON = `{
       }
  },
  "$schema":"http://json-schema.org/draft-07/schema#",
- "$id":"http://github.com/coreos/coreos-assembler/blob/main/schema/v1.json",
+ "$id":"http://github.com/coreos/coreos-assembler/blob/main/v1.json.json",
  "type":"object",
  "title":"CoreOS Assember v1 meta.json schema",
  "required": [
@@ -820,16 +826,22 @@ var generatedSchemaJSON = `{
       }
     },
    "ibmcloud": {
-      "$id":"#/properties/ibmcloud",
-      "type":"object",
-      "title":"IBM Cloud",
-      "$ref": "#/definitions/cloudartifact"
+     "$id":"#/properties/ibmcloud",
+     "type":"array",
+     "title":"IBM Cloud",
+     "items": {
+       "type":"object",
+       "$ref": "#/definitions/cloudartifact"
+      }
     },
    "powervs": {
-      "$id":"#/properties/powervs",
-      "type":"object",
-      "title":"Power Virtual Server",
-      "$ref": "#/definitions/cloudartifact"
+     "$id":"#/properties/powervs",
+     "type":"array",
+     "title":"Power Virtual Server",
+     "items": {
+       "type":"object",
+       "$ref": "#/definitions/cloudartifact"
+      }
     },
     "release-payload": {
       "$id":"#/properties/release-payload",

--- a/schema/generate-schema.sh
+++ b/schema/generate-schema.sh
@@ -10,7 +10,7 @@ if [ ! -x "${GOBIN}/schematyper" ]; then
 fi
 
 schema_version="v1"
-schema_json="../src/schema/${schema_version}.json"
+schema_json="../schema/${schema_version}.json"
 echo "Generating COSA Schema ${schema_version}"
 
 out="${tdir}/cosa_${schema_version}.go"

--- a/schema/v1.json
+++ b/schema/v1.json
@@ -69,10 +69,11 @@
       "cloudartifact": {
          "type": "object",
          "required": [
-             "image",
              "url"
          ],
          "optional": [
+             "image",
+             "object",
              "bucket",
              "region"
          ],
@@ -96,6 +97,11 @@
              "$id":"#/cloudartifact/region",
              "type":"string",
              "title":"Region"
+            },
+            "object": {
+             "$id":"#/cloudartifact/object",
+             "type":"string",
+             "title":"Object"
             }
           }
      },
@@ -815,16 +821,22 @@
       }
     },
    "ibmcloud": {
-      "$id":"#/properties/ibmcloud",
-      "type":"object",
-      "title":"IBM Cloud",
-      "$ref": "#/definitions/cloudartifact"
+     "$id":"#/properties/ibmcloud",
+     "type":"array",
+     "title":"IBM Cloud",
+     "items": {
+       "type":"object",
+       "$ref": "#/definitions/cloudartifact"
+      }
     },
    "powervs": {
-      "$id":"#/properties/powervs",
-      "type":"object",
-      "title":"Power Virtual Server",
-      "$ref": "#/definitions/cloudartifact"
+     "$id":"#/properties/powervs",
+     "type":"array",
+     "title":"Power Virtual Server",
+     "items": {
+       "type":"object",
+       "$ref": "#/definitions/cloudartifact"
+      }
     },
     "release-payload": {
       "$id":"#/properties/release-payload",

--- a/src/cmd-generate-release-meta
+++ b/src/cmd-generate-release-meta
@@ -124,7 +124,7 @@ def append_build(out, input_):
     # build the architectures dict
     arch_dict = {"media": {}}
     ensure_dup(input_, arch_dict, "ostree-commit", "commit")
-    platforms = ["aliyun", "aws", "azure", "azurestack", "digitalocean", "exoscale", "gcp", "ibmcloud", "metal", "openstack", "qemu", "vmware", "vultr"]
+    platforms = ["aliyun", "aws", "azure", "azurestack", "digitalocean", "exoscale", "gcp", "ibmcloud", "metal", "openstack", "powervs", "qemu", "vmware", "vultr"]
     for platform in platforms:
         if input_.get("images", {}).get(platform, None) is not None:
             print(f"   - {platform}")
@@ -144,6 +144,19 @@ def append_build(out, input_):
             for cloud_dict in input_.get(meta_key):
                 arch_dict["media"][cloud]["images"][cloud_dict["name"]] = {
                     "image": cloud_dict[image_field]
+                }
+
+    # IBMCloud/PowerVS specific additions
+    for meta_key, cloud, object_field, bucket_field, url_field in \
+        ("ibmcloud", "ibmcloud", "object", "bucket", "url"), \
+            ("powervs", "powervs", "object", "bucket", "url"):
+        if input_.get(meta_key, None) is not None:
+            arch_dict["media"].setdefault(cloud, {}).setdefault("images", {})
+            for cloud_dict in input_.get(meta_key):
+                arch_dict["media"][cloud]["images"][cloud_dict["region"]] = {
+                    "object": cloud_dict[object_field],
+                    "bucket": cloud_dict[bucket_field],
+                    "url": cloud_dict[url_field]
                 }
 
     # GCP specific additions

--- a/src/v1.json
+++ b/src/v1.json
@@ -69,10 +69,11 @@
       "cloudartifact": {
          "type": "object",
          "required": [
-             "image",
              "url"
          ],
          "optional": [
+             "image",
+             "object",
              "bucket",
              "region"
          ],
@@ -96,6 +97,11 @@
              "$id":"#/cloudartifact/region",
              "type":"string",
              "title":"Region"
+            },
+            "object": {
+             "$id":"#/cloudartifact/object",
+             "type":"string",
+             "title":"Object"
             }
           }
      },
@@ -815,16 +821,22 @@
       }
     },
    "ibmcloud": {
-      "$id":"#/properties/ibmcloud",
-      "type":"object",
-      "title":"IBM Cloud",
-      "$ref": "#/definitions/cloudartifact"
+     "$id":"#/properties/ibmcloud",
+     "type":"array",
+     "title":"IBM Cloud",
+     "items": {
+       "type":"object",
+       "$ref": "#/definitions/cloudartifact"
+      }
     },
    "powervs": {
-      "$id":"#/properties/powervs",
-      "type":"object",
-      "title":"Power Virtual Server",
-      "$ref": "#/definitions/cloudartifact"
+     "$id":"#/properties/powervs",
+     "type":"array",
+     "title":"Power Virtual Server",
+     "items": {
+       "type":"object",
+       "$ref": "#/definitions/cloudartifact"
+      }
     },
     "release-payload": {
       "$id":"#/properties/release-payload",


### PR DESCRIPTION
This PR includes the following changes to support replication of IBMCloud images across regions:

- Add a `copy-object` command to `ore/ibmcloud` to copy an image from a bucket in one region to a bucket in another region
- Change schema of IBMCloud/PowerVS to an array rather than object to support multiple entries for the different buckets and regions
- Add replication functionality to `cosalib/ibmcloud.py` which can be leveraged in the pipeline.
- Add IBMCloud/PowerVS uploaded images to release.json