### PR TITLE
cmd-generate-hashlist: use ostree, not qcow in metadata

### DIFF
--- a/src/cmd-generate-hashlist
+++ b/src/cmd-generate-hashlist
@@ -58,10 +58,8 @@ class HashListV1(dict):
         if timestamp is None:
             timestamp = datetime.datetime.utcnow().isoformat()
         self['meta']['timestamp'] = timestamp
-        self['meta']['image'] = os.path.sep.join([
-            'builds', self._metadata['ostree-version'],
-            self._metadata['coreos-assembler.basearch'],
-            self._metadata['images']['qemu']['path']])
+        self['meta']['ostree'] = self._metadata['images']['ostree']['path']
+        self['meta']['arch'] = self._metadata['coreos-assembler.basearch']
 
         self['hashes'] = {}
 


### PR DESCRIPTION
Since the qemu image isn't used in hashlist generation at all
and the ostree tarball is, let's include the filename of the tarball
in the metadata instead.

Also, there's no need for it being a relative path versus just a
filename so make it just the filename.

Also, add in the architecture into the metadata, because why not?

This yields something like the following at the beginning of the
json output:

```
{
    "release": "34.20210811.dev.0",
    "meta": {
        "generator": "coreos-assembler-64649ca8a328b7599d90207b2ab6406e2a4564d0",
        "timestamp": "2021-08-12T14:15:19.685588",
        "ostree": "fedora-coreos-34.20210811.dev.0-ostree.aarch64.tar",
        "arch": "aarch64"
    },
```