### PR TITLE
mantle/kola: fixup comments about architecture assumption

### DIFF
--- a/mantle/kola/tests/misc/boot-mirror.go
+++ b/mantle/kola/tests/misc/boot-mirror.go
@@ -97,8 +97,8 @@ func runBootMirrorTest(c cluster.TestCluster) {
 			MinMemory:       4096,
 		},
 	}
-	// FIXME: kola currently assumes the host CPU architecture matches
-	// the one under test
+	// FIXME: for QEMU tests kola currently assumes the host CPU architecture
+	// matches the one under test
 	userdata := bootmirror.Subst("LAYOUT", system.RpmArch())
 	m, err = c.Cluster.(*unprivqemu.Cluster).NewMachineWithQemuOptions(userdata, options)
 	if err != nil {
@@ -144,8 +144,8 @@ func runBootMirrorLUKSTest(c cluster.TestCluster) {
 			MinMemory:       4096,
 		},
 	}
-	// FIXME: kola currently assumes the host CPU architecture matches
-	// the one under test
+	// FIXME: for QEMU tests kola currently assumes the host CPU architecture
+	// matches the one under test
 	userdata := bootmirrorluks.Subst("LAYOUT", system.RpmArch())
 	m, err = c.Cluster.(*unprivqemu.Cluster).NewMachineWithQemuOptions(userdata, options)
 	if err != nil {


### PR DESCRIPTION
In 6796eeb we added support for kola --arch so the comments
weren't 100% true any longer. Tweak them to be more accurate
because we do still assume the same architecture for QEMU tests.