### PR TITLE
kola: alias `iso` to `qemu-iso`

### DIFF
--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -175,6 +175,8 @@ func syncOptionsImpl(useCosa bool) error {
 	// Alias qemu to qemu-unpriv.
 	if kolaPlatform == "qemu" {
 		kolaPlatform = "qemu-unpriv"
+	} else if kolaPlatform == "iso" {
+		kolaPlatform = "qemu-iso"
 	}
 
 	// native 4k requires a UEFI bootloader


### PR DESCRIPTION
That way one can just type `-p iso`.