### PR TITLE
Gangplank: support opaque secrets for push secrets

### DIFF
--- a/gangplank/internal/ocp/worker.go
+++ b/gangplank/internal/ocp/worker.go
@@ -444,6 +444,12 @@ func writeDockerSecret(ctx ClusterContext, clusterSecretName, authPath string) e
 		key = v1.DockerConfigJsonKey
 	case v1.SecretTypeDockercfg:
 		key = v1.DockerConfigKey
+	case v1.SecretTypeOpaque:
+		if _, ok := secret.Data["docker.json"]; ok {
+			key = v1.DockerConfigJsonKey
+		} else if _, ok := secret.Data["docker.cfg"]; ok {
+			key = v1.DockerConfigKey
+		}
 	default:
 		return fmt.Errorf("writeDockerSecret is not supported for secret type %s", secret.Type)
 	}


### PR DESCRIPTION
ART and RHCOS-devel use opaque secrets for push registries. 

Signed-off-by: Ben Howard <ben.howard@redhat.com>