### PR TITLE
ci/Dockerfile: bump Quay.io nocache hack 20210819

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /root/containerbuild
 COPY ./src/print-dependencies.sh ./src/deps*.txt ./src/vmdeps*.txt ./src/build-deps.txt /root/containerbuild/src/
 COPY ./build.sh /root/containerbuild/
 RUN ./build.sh configure_yum_repos
-RUN ./build.sh install_rpms  # nocache 20210719
+RUN ./build.sh install_rpms  # nocache 20210819
 
 # Allow Prow to work
 RUN mkdir -p /go && chown 0777 /go


### PR DESCRIPTION
To pick up coreos-installer-0.10.0-2.fc34 from the continuous tag.
For https://github.com/coreos/coreos-installer/pull/599