### PR TITLE
qemuexec: support multipath on additional disks

### DIFF
--- a/mantle/cmd/kola/qemuexec.go
+++ b/mantle/cmd/kola/qemuexec.go
@@ -295,10 +295,27 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 	if memory != 0 {
 		builder.Memory = memory
 	}
-	for _, size := range addDisks {
+	for _, spec := range addDisks {
+		split := strings.Split(spec, ":")
+		var size string
+		multipathed := false
+		if len(split) == 1 {
+			size = split[0]
+		} else if len(split) == 2 {
+			size = split[0]
+			for _, opt := range strings.Split(split[1], ",") {
+				if opt == "mpath" {
+					multipathed = true
+				} else {
+					return fmt.Errorf("unknown disk option %s", opt)
+				}
+			}
+		} else {
+			return fmt.Errorf("invalid disk spec %s", spec)
+		}
 		if err := builder.AddDisk(&platform.Disk{
 			Size:          size,
-			MultiPathDisk: kola.QEMUOptions.MultiPathDisk,
+			MultiPathDisk: multipathed,
 		}); err != nil {
 			return errors.Wrapf(err, "adding additional disk")
 		}

--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -393,8 +393,6 @@ type QemuBuilder struct {
 	// primaryIsBoot is true if the only boot media should be the primary disk
 	primaryIsBoot bool
 
-	MultiPathDisk bool
-
 	// tempdir holds our temporary files
 	tempdir string
 
@@ -422,11 +420,10 @@ type QemuBuilder struct {
 // NewQemuBuilder creates a new build for QEMU with default settings.
 func NewQemuBuilder() *QemuBuilder {
 	ret := QemuBuilder{
-		Firmware:      "bios",
-		Swtpm:         true,
-		Pdeathsig:     true,
-		MultiPathDisk: false,
-		Argv:          []string{},
+		Firmware:  "bios",
+		Swtpm:     true,
+		Pdeathsig: true,
+		Argv:      []string{},
 	}
 	return &ret
 }


### PR DESCRIPTION
Right now, `--qemu-multipath` turns on multipathing for the primary disk
and all additional disks. But ideally, we want these to be independent,
so that e.g.  we could turn on multipath just for an additional disk but
not the primary disk (or vice versa).

Change `--qemu-multipath` to make it only apply to the primary disk.
Then, add support for specifying comma-separated options to additional
disks using the format `--add-disk <size>:<opt1>,<opt2>,...`. Add
support for `mpath` as a disk option to mean turning on multipath just
for that disk.

This allows me to easily interactively test how the OS behaves before
writing a test which does the same thing.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=1981973