### PR TITLE
gangplank: use dynamically selected port for ssh port forwarding

### DIFF
--- a/gangplank/cmd/gangplank/pod.go
+++ b/gangplank/cmd/gangplank/pod.go
@@ -108,7 +108,7 @@ func runPod(c *cobra.Command, args []string) {
 						hostparts := strings.Split(parts[1], ":")
 						port, err := strconv.Atoi(hostparts[1])
 						if err != nil {
-							log.WithError(err).Fatalf("failed to define minio port %s", hostparts[1])
+							log.WithError(err).Fatalf("failed to define minio ssh port %s", hostparts[1])
 						}
 						parts[1] = hostparts[0]
 						minioSshRemotePort = port

--- a/gangplank/internal/ocp/bc.go
+++ b/gangplank/internal/ocp/bc.go
@@ -395,7 +395,7 @@ binary build interface.`)
 
 	// If defined, startup SSH before any work begins
 	if m.overSSH != nil {
-		if err := m.fowardOverSSH(terminate, errorCh); err != nil {
+		if err := m.forwardOverSSH(terminate, errorCh); err != nil {
 			return err
 		}
 	}

--- a/gangplank/internal/ocp/filer.go
+++ b/gangplank/internal/ocp/filer.go
@@ -76,7 +76,7 @@ func StartStandaloneMinioServer(ctx context.Context, srvDir, cfgFile string, ove
 	if m.overSSH != nil {
 		m.sshStopCh = make(chan bool, 1)
 		m.sshErrCh = make(chan error, 256)
-		if err := m.fowardOverSSH(m.sshStopCh, m.sshErrCh); err != nil {
+		if err := m.forwardOverSSH(m.sshStopCh, m.sshErrCh); err != nil {
 			return nil, err
 		}
 	}

--- a/gangplank/internal/ocp/ssh.go
+++ b/gangplank/internal/ocp/ssh.go
@@ -119,8 +119,8 @@ func sshClient(user, host, port string, secure bool, identity string) (*ssh.Clie
 	)
 }
 
-// fowardOverSSH forwards the minio connection over SSH.
-func (m *minioServer) fowardOverSSH(termCh termChan, errCh chan<- error) error {
+// forwardOverSSH forwards the minio connection over SSH.
+func (m *minioServer) forwardOverSSH(termCh termChan, errCh chan<- error) error {
 	sshPort := 22
 	if m.overSSH.SSHPort != 0 {
 		sshPort = m.overSSH.SSHPort

--- a/gangplank/internal/ocp/ssh.go
+++ b/gangplank/internal/ocp/ssh.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/containers/podman/v3/pkg/terminal"
@@ -131,6 +132,12 @@ func (m *minioServer) fowardOverSSH(termCh termChan, errCh chan<- error) error {
 		"remote user": m.overSSH.User,
 		"port":        sshport,
 	})
+	// Set the port to use for the proxied connection *once* here so
+	// it won't change during the course of the run. This is because
+	// below we change the m.Port to match the dynamically chosen
+	// remote port for the ssh forward but the server listening port
+	// will remain whatever the original value of m.Port is.
+	minioServerPort := m.Port
 
 	l.Info("Forwarding local port over SSH to remote host")
 
@@ -139,12 +146,26 @@ func (m *minioServer) fowardOverSSH(termCh termChan, errCh chan<- error) error {
 		return err
 	}
 
-	// Open the remote port over SSH
-	remotePort, err := client.Listen("tcp4", fmt.Sprintf("127.0.0.1:%d", m.Port))
+	// Open the remote port over SSH, use empty port definition to have it
+	// dynamically chosen based on port availabilty on the remote. If
+	// we don't do this then multiple concurrent gangplank runs will fail
+	// because they'll try to use the same port.
+	remoteConn, err := client.Listen("tcp4", "127.0.0.1:")
 	if err != nil {
-		err = fmt.Errorf("%w: failed to open remote port over sshfor proxy", err)
+		err = fmt.Errorf("%w: failed to open remote port over ssh for proxy", err)
 		return err
 	}
+	remoteSSHport, err := strconv.Atoi(strings.Split(remoteConn.Addr().String(), ":")[1])
+	if err != nil {
+		err = fmt.Errorf("%w: failed to parse remote ssh port from connection", err)
+		return err
+	}
+	log.Infof("The SSH forwarding chose port %v on the remote host", remoteSSHport)
+	// Update m.Port in the minioServer definition so the miniocfg
+	// that gets passed to the remote specifies the correct port for
+	// the local connection there.
+	log.Infof("Changing remote local port (forward) from %v to %v", m.Port, remoteSSHport)
+	m.Port = remoteSSHport
 
 	// copyIO is a blind copier that copies between source and destination
 	copyIO := func(src, dest net.Conn) {
@@ -155,7 +176,7 @@ func (m *minioServer) fowardOverSSH(termCh termChan, errCh chan<- error) error {
 
 	// proxy is a helper function that connects the local port to the remoteClient
 	proxy := func(conn net.Conn) {
-		proxy, err := net.Dial("tcp4", fmt.Sprintf("127.0.0.1:%d", m.Port))
+		proxy, err := net.Dial("tcp4", fmt.Sprintf("127.0.0.1:%d", minioServerPort))
 		if err != nil {
 			err = fmt.Errorf("%w: failed to open local port for proxy", err)
 			errCh <- err
@@ -170,7 +191,7 @@ func (m *minioServer) fowardOverSSH(termCh termChan, errCh chan<- error) error {
 		// resulting in the go-routines exiting.
 		<-termCh
 		l.Info("Shutting down ssh forwarding")
-		errCh <- remotePort.Close()
+		errCh <- remoteConn.Close()
 		errCh <- client.Close()
 	}()
 
@@ -178,7 +199,7 @@ func (m *minioServer) fowardOverSSH(termCh termChan, errCh chan<- error) error {
 		// Loop checking for connections or termination.
 		for {
 			// For each connection, create a proxy from the remote port to the local port
-			remoteClient, err := remotePort.Accept()
+			remoteClient, err := remoteConn.Accept()
 			if err != nil {
 				if err == io.EOF {
 					return


### PR DESCRIPTION
If we try to use port 9000 for every ssh forwarded minio then we
can only run one gangplank at a time because the remote host only
has one port 9000. Let's have SSH dynamically choose the port and
then update our configs based on that.
