### PR TITLE
gangplank: fix subtle creation of new remoteSSHport var

### DIFF
--- a/gangplank/internal/ocp/ssh.go
+++ b/gangplank/internal/ocp/ssh.go
@@ -154,7 +154,7 @@ func (m *minioServer) startMinioAndForwardOverSSH(ctx context.Context, termCh te
 			err = fmt.Errorf("%w: failed to open remote port over ssh for proxy", err)
 			return err
 		}
-		remoteSSHport, err := strconv.Atoi(strings.Split(remoteConn.Addr().String(), ":")[1])
+		remoteSSHport, err = strconv.Atoi(strings.Split(remoteConn.Addr().String(), ":")[1])
 		if err != nil {
 			err = fmt.Errorf("%w: failed to parse remote ssh port from connection", err)
 			return err


### PR DESCRIPTION
We need to re-use the one that was created outside of the for loop
not create a newly scoped version of remoteSSHport. This meant the
port got changed to 0:

```
INFO[0000] Changing minio port for local and remote (forward) from 0 to 0
```

and since there was already special handling to assign the port to 9000
if it was 0 then it made it through. Fix this now.