### PR TITLE
mantle: pass in the kola arch for GetCosaBuildURL

### DIFF
--- a/mantle/cmd/kola/kola.go
+++ b/mantle/cmd/kola/kola.go
@@ -605,7 +605,7 @@ func getParentFcosBuildBase(stream string) (string, error) {
 		parentVersion = index.Releases[n-1].Version
 	}
 
-	return fcos.GetCosaBuildURL(stream, parentVersion), nil
+	return fcos.GetCosaBuildURL(stream, parentVersion, kola.Options.CosaBuildArch), nil
 }
 
 func runRunUpgrade(cmd *cobra.Command, args []string) error {

--- a/mantle/fcos/metadata.go
+++ b/mantle/fcos/metadata.go
@@ -96,7 +96,7 @@ func FetchStreamThisArchitecture(stream string) (*stream.Arch, error) {
 }
 
 // GetCosaBuildURL returns a URL prefix for the coreos-assembler build.
-func GetCosaBuildURL(stream, buildid string) string {
-	u := fcosinternals.GetCosaBuild(stream, buildid, system.RpmArch())
+func GetCosaBuildURL(stream, buildid, arch string) string {
+	u := fcosinternals.GetCosaBuild(stream, buildid, arch)
 	return u.String()
 }


### PR DESCRIPTION
This allows us to get the build URL based on the passed in
architecture to `kola --arch=$arch`. It will allow us to run
upgrade tests for aws even from an x86_64 cosa.