### PR TITLE
Enhance multipath support and add more multipath tests

### DIFF
--- a/mantle/cmd/kola/qemuexec.go
+++ b/mantle/cmd/kola/qemuexec.go
@@ -295,14 +295,7 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 	if memory != 0 {
 		builder.Memory = memory
 	}
-	for _, size := range addDisks {
-		if err := builder.AddDisk(&platform.Disk{
-			Size:          size,
-			MultiPathDisk: kola.QEMUOptions.MultiPathDisk,
-		}); err != nil {
-			return errors.Wrapf(err, "adding additional disk")
-		}
-	}
+	builder.AddDisksFromSpecs(addDisks)
 	if cpuCountHost {
 		builder.Processors = -1
 	}

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -969,6 +969,7 @@ func runTest(h *harness.H, t *register.Test, pltfrm string, flight platform.Flig
 		var userdata *conf.UserData = t.UserData
 
 		options := platform.MachineOptions{
+			MultiPathDisk:   t.MultiPathDisk,
 			AdditionalDisks: t.AdditionalDisks,
 			MinMemory:       t.MinMemory,
 		}

--- a/mantle/kola/register/register.go
+++ b/mantle/kola/register/register.go
@@ -67,8 +67,9 @@ type Test struct {
 	// Whether the primary disk is multipathed.
 	MultiPathDisk bool
 
-	// Sizes of additional empty disks to attach to the node (e.g. ["1G",
-	// "5G"]) -- defaults to none.
+	// Sizes of additional empty disks to attach to the node, followed by
+	// comma-separated list of optional options (e.g. ["1G",
+	// "5G:foo,bar"]) -- defaults to none.
 	AdditionalDisks []string
 
 	// Minimum amount of memory required for test.

--- a/mantle/kola/register/register.go
+++ b/mantle/kola/register/register.go
@@ -69,7 +69,7 @@ type Test struct {
 
 	// Sizes of additional empty disks to attach to the node, followed by
 	// comma-separated list of optional options (e.g. ["1G",
-	// "5G:foo,bar"]) -- defaults to none.
+	// "5G:mpath,foo,bar"]) -- defaults to none.
 	AdditionalDisks []string
 
 	// Minimum amount of memory required for test.

--- a/mantle/kola/register/register.go
+++ b/mantle/kola/register/register.go
@@ -64,6 +64,9 @@ type Test struct {
 	Flags                []Flag   // special-case options for this test
 	Tags                 []string // list of tags that can be matched against -- defaults to none
 
+	// Whether the primary disk is multipathed.
+	MultiPathDisk bool
+
 	// Sizes of additional empty disks to attach to the node (e.g. ["1G",
 	// "5G"]) -- defaults to none.
 	AdditionalDisks []string

--- a/mantle/platform/machine/aws/cluster.go
+++ b/mantle/platform/machine/aws/cluster.go
@@ -82,6 +82,9 @@ func (ac *cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 	if len(options.AdditionalDisks) > 0 {
 		return nil, errors.New("platform aws does not yet support additional disks")
 	}
+	if options.MultiPathDisk {
+		return nil, errors.New("platform aws does not support multipathed disks")
+	}
 	return ac.NewMachine(userdata)
 }
 

--- a/mantle/platform/machine/azure/cluster.go
+++ b/mantle/platform/machine/azure/cluster.go
@@ -88,6 +88,9 @@ func (ac *cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 	if len(options.AdditionalDisks) > 0 {
 		return nil, errors.New("platform azure does not yet support additional disks")
 	}
+	if options.MultiPathDisk {
+		return nil, errors.New("platform azure does not support multipathed disks")
+	}
 	return ac.NewMachine(userdata)
 }
 

--- a/mantle/platform/machine/do/cluster.go
+++ b/mantle/platform/machine/do/cluster.go
@@ -92,6 +92,9 @@ func (dc *cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 	if len(options.AdditionalDisks) > 0 {
 		return nil, errors.New("platform do does not yet support additional disks")
 	}
+	if options.MultiPathDisk {
+		return nil, errors.New("platform do does not support multipathed disks")
+	}
 	return dc.NewMachine(userdata)
 }
 

--- a/mantle/platform/machine/esx/cluster.go
+++ b/mantle/platform/machine/esx/cluster.go
@@ -95,6 +95,9 @@ func (ec *cluster) NewMachineWithOptions(userdata *platformConf.UserData, option
 	if len(options.AdditionalDisks) > 0 {
 		return nil, errors.New("platform esx does not yet support additional disks")
 	}
+	if options.MultiPathDisk {
+		return nil, errors.New("platform esx does not support multipathed disks")
+	}
 	return ec.NewMachine(userdata)
 }
 

--- a/mantle/platform/machine/gcloud/cluster.go
+++ b/mantle/platform/machine/gcloud/cluster.go
@@ -95,6 +95,9 @@ func (gc *cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 	if len(options.AdditionalDisks) > 0 {
 		return nil, errors.New("platform gce does not yet support additional disks")
 	}
+	if options.MultiPathDisk {
+		return nil, errors.New("platform gce does not support multipathed disks")
+	}
 	return gc.NewMachine(userdata)
 }
 

--- a/mantle/platform/machine/openstack/cluster.go
+++ b/mantle/platform/machine/openstack/cluster.go
@@ -84,6 +84,9 @@ func (oc *cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 	if len(options.AdditionalDisks) > 0 {
 		return nil, errors.New("platform openstack does not yet support additional disks")
 	}
+	if options.MultiPathDisk {
+		return nil, errors.New("platform openstack does not support multipathed disks")
+	}
 	return oc.NewMachine(userdata)
 }
 

--- a/mantle/platform/machine/packet/cluster.go
+++ b/mantle/platform/machine/packet/cluster.go
@@ -116,6 +116,9 @@ func (pc *cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 	if len(options.AdditionalDisks) > 0 {
 		return nil, errors.New("platform packet does not yet support additional disks")
 	}
+	if options.MultiPathDisk {
+		return nil, errors.New("platform packet does not support multipathed disks")
+	}
 	return pc.NewMachine(userdata)
 }
 

--- a/mantle/platform/machine/qemuiso/cluster.go
+++ b/mantle/platform/machine/qemuiso/cluster.go
@@ -53,6 +53,9 @@ func (qc *Cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 }
 
 func (qc *Cluster) NewMachineWithQemuOptions(userdata *conf.UserData, options platform.QemuMachineOptions) (platform.Machine, error) {
+	if options.MultiPathDisk {
+		return nil, errors.New("platform qemu-iso does not support multipathed primary disks")
+	}
 	id := uuid.New()
 
 	dir := filepath.Join(qc.RuntimeConf().OutputDir, id)

--- a/mantle/platform/machine/qemuiso/cluster.go
+++ b/mantle/platform/machine/qemuiso/cluster.go
@@ -116,13 +116,7 @@ func (qc *Cluster) NewMachineWithQemuOptions(userdata *conf.UserData, options pl
 		return nil, errors.Wrapf(err, "adding ISO image")
 	}
 
-	for _, disk := range options.AdditionalDisks {
-		if err = builder.AddDisk(&platform.Disk{
-			Size: disk,
-		}); err != nil {
-			return nil, errors.Wrapf(err, "adding additional disk")
-		}
-	}
+	builder.AddDisksFromSpecs(options.AdditionalDisks)
 
 	if len(options.HostForwardPorts) > 0 {
 		builder.EnableUsermodeNetworking(options.HostForwardPorts)

--- a/mantle/platform/machine/unprivqemu/cluster.go
+++ b/mantle/platform/machine/unprivqemu/cluster.go
@@ -137,13 +137,7 @@ func (qc *Cluster) NewMachineWithQemuOptions(userdata *conf.UserData, options pl
 	if err != nil {
 		return nil, err
 	}
-	for _, disk := range options.AdditionalDisks {
-		if err = builder.AddDisk(&platform.Disk{
-			Size: disk,
-		}); err != nil {
-			return nil, errors.Wrapf(err, "adding additional disk")
-		}
-	}
+	builder.AddDisksFromSpecs(options.AdditionalDisks)
 
 	if len(options.HostForwardPorts) > 0 {
 		builder.EnableUsermodeNetworking(options.HostForwardPorts)

--- a/mantle/platform/metal.go
+++ b/mantle/platform/metal.go
@@ -553,7 +553,7 @@ func (inst *Install) InstallViaISOEmbed(kargs []string, liveIgnition, targetIgni
 	if inst.MultiPathDisk {
 		// we only have one multipath device so it has to be that
 		targetDevice = "/dev/mapper/mpatha"
-		appendMultipathKargs = "--append-karg rd.multipath=default --append-karg root=/dev/disk/by-label/dm-mpath-root"
+		appendMultipathKargs = "--append-karg rd.multipath=default --append-karg root=/dev/disk/by-label/dm-mpath-root --append-karg rw"
 	}
 
 	inst.kargs = kargs

--- a/mantle/platform/platform.go
+++ b/mantle/platform/platform.go
@@ -152,6 +152,7 @@ type Flight interface {
 }
 
 type MachineOptions struct {
+	MultiPathDisk   bool
 	AdditionalDisks []string
 	MinMemory       int
 }

--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -98,10 +98,25 @@ type Disk struct {
 	nbdServCmd     exec.Cmd // command to serve the disk
 }
 
-// ParseDiskSpec converts a disk specification into a Disk. The format is: <size>
+// ParseDiskSpec converts a disk specification into a Disk. The format is:
+// <size>[:<opt1>,<opt2>,...].
 func ParseDiskSpec(spec string) (*Disk, error) {
+	split := strings.Split(spec, ":")
+	var size string
+	if len(split) == 1 {
+		size = split[0]
+	} else if len(split) == 2 {
+		size = split[0]
+		for _, opt := range strings.Split(split[1], ",") {
+			if true { // no supported options yet
+				return nil, fmt.Errorf("unknown disk option %s", opt)
+			}
+		}
+	} else {
+		return nil, fmt.Errorf("invalid disk spec %s", spec)
+	}
 	return &Disk{
-		Size:          spec,
+		Size:          size,
 	}, nil
 }
 

--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -69,7 +69,6 @@ type QemuMachineOptions struct {
 	MachineOptions
 	HostForwardPorts []HostForwardPort
 	DisablePDeathSig bool
-	MultiPathDisk    bool
 	SecondaryNics    int
 }
 

--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -393,8 +393,6 @@ type QemuBuilder struct {
 	// primaryIsBoot is true if the only boot media should be the primary disk
 	primaryIsBoot bool
 
-	MultiPathDisk bool
-
 	// tempdir holds our temporary files
 	tempdir string
 
@@ -422,11 +420,10 @@ type QemuBuilder struct {
 // NewQemuBuilder creates a new build for QEMU with default settings.
 func NewQemuBuilder() *QemuBuilder {
 	ret := QemuBuilder{
-		Firmware:      "bios",
-		Swtpm:         true,
-		Pdeathsig:     true,
-		MultiPathDisk: false,
-		Argv:          []string{},
+		Firmware:  "bios",
+		Swtpm:     true,
+		Pdeathsig: true,
+		Argv:      []string{},
 	}
 	return &ret
 }

--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -99,6 +99,13 @@ type Disk struct {
 	nbdServCmd     exec.Cmd // command to serve the disk
 }
 
+// ParseDiskSpec converts a disk specification into a Disk. The format is: <size>
+func ParseDiskSpec(spec string) (*Disk, error) {
+	return &Disk{
+		Size:          spec,
+	}, nil
+}
+
 // bootIso is an internal struct used by AddIso() and setupIso()
 type bootIso struct {
 	path      string
@@ -974,6 +981,18 @@ func (builder *QemuBuilder) AddBootDisk(disk *Disk) error {
 // AddDisk adds a secondary disk for the instance.
 func (builder *QemuBuilder) AddDisk(disk *Disk) error {
 	return builder.addDiskImpl(disk, false)
+}
+
+// AddDisksFromSpecs adds multiple secondary disks from their specs.
+func (builder *QemuBuilder) AddDisksFromSpecs(specs []string) error {
+	for _, spec := range specs {
+		if disk, err := ParseDiskSpec(spec); err != nil {
+			return errors.Wrapf(err, "parsing additional disk spec '%s'", spec)
+		} else if err = builder.AddDisk(disk); err != nil {
+			return errors.Wrapf(err, "adding additional disk '%s'", spec)
+		}
+	}
+	return nil
 }
 
 // AddIso adds an ISO image, optionally configuring its boot index

--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -103,12 +103,15 @@ type Disk struct {
 func ParseDiskSpec(spec string) (*Disk, error) {
 	split := strings.Split(spec, ":")
 	var size string
+	multipathed := false
 	if len(split) == 1 {
 		size = split[0]
 	} else if len(split) == 2 {
 		size = split[0]
 		for _, opt := range strings.Split(split[1], ",") {
-			if true { // no supported options yet
+			if opt == "mpath" {
+				multipathed = true
+			} else {
 				return nil, fmt.Errorf("unknown disk option %s", opt)
 			}
 		}
@@ -117,6 +120,7 @@ func ParseDiskSpec(spec string) (*Disk, error) {
 	}
 	return &Disk{
 		Size:          size,
+		MultiPathDisk: multipathed,
 	}, nil
 }
 


### PR DESCRIPTION
The two key commits are:

```
tests/multipath: add multipath.day1 test

Rename the existing test to `multipath.day2` and add a new
`multipath.day1` test which leverages the new `MultiPathed` test knob to
tell kola to provision a multipathed boot disk.
```
---
```
tests/multipath: add multipath.partition test

There have been requests to support multipath on specific partitions
instead of the whole disk. There are some caveats, but this should work.
Add a test for this which verifies that `/var/lib/containers` can be on
multipath.

The huge annoyance here is that we can't use Ignition to format the
disk. I'm hoping we can clean this up eventually, but it's intimately
tied to how multipath itself works and how FCOS/RHCOS integrates it.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=1981973
```

See individual commit messages for more details.