### PR TITLE
ci/Dockerfile: clear Quay.io cache for rpm-ostree 2021.10

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /root/containerbuild
 COPY ./src/print-dependencies.sh ./src/deps*.txt ./src/vmdeps*.txt ./src/build-deps.txt /root/containerbuild/src/
 COPY ./build.sh /root/containerbuild/
 RUN ./build.sh configure_yum_repos
-RUN ./build.sh install_rpms  # nocache 20210823
+RUN ./build.sh install_rpms  # nocache 20210826
 
 # Allow Prow to work
 RUN mkdir -p /go && chown 0777 /go


### PR DESCRIPTION
I'd like to get https://github.com/openshift/os/pull/603 merged in a
controlled fashion otherwise without it RHCOS builds will just break
whenever rpm-ostree hits Fedora stable.