### PR TITLE
mantle/platform: handle the x86_64 uefi case for PXE

### DIFF
--- a/mantle/platform/metal.go
+++ b/mantle/platform/metal.go
@@ -273,9 +273,18 @@ func (inst *Install) setup(kern *kernelSetup) (*installerRun, error) {
 	pxe.tftpipaddr = "192.168.76.2"
 	switch system.RpmArch() {
 	case "x86_64":
-		pxe.boottype = "pxe"
 		pxe.networkdevice = "e1000"
-		pxe.pxeimagepath = "/usr/share/syslinux/"
+		if builder.Firmware == "uefi" {
+			pxe.boottype = "grub"
+			pxe.bootfile = "/boot/grub2/grubx64.efi"
+			pxe.pxeimagepath = "/boot/efi/EFI/fedora/grubx64.efi"
+			// Choose bootindex=2. First boot the hard drive won't
+			// have an OS and will fall through to bootindex 2 (net)
+			pxe.bootindex = "2"
+		} else {
+			pxe.boottype = "pxe"
+			pxe.pxeimagepath = "/usr/share/syslinux/"
+		}
 	case "aarch64":
 		pxe.boottype = "grub"
 		pxe.networkdevice = "virtio-net-pci"

--- a/src/vmdeps-x86_64.txt
+++ b/src/vmdeps-x86_64.txt
@@ -4,3 +4,6 @@ bootupd
 
 # For creating bootable UEFI media on x86_64
 shim-x64 grub2-efi-x64
+
+# For pxe install kola testing (uses grub2-mknetdir)
+grub2-tools-extra


### PR DESCRIPTION
Needed to add some conditional logic that would set up PXE correctly
for UEFI. Also chose to use `bootindex=2` for the NIC. The first boot
will fallthrough from the hard drive (`bootindex=1`) to the second entry
(NIC/PXE). The second boot will have an OS because the install was done.