### PR TITLE
cmd-init,gangplank: allow for specifying git commit on branch

### DIFF
--- a/gangplank/internal/ocp/worker.go
+++ b/gangplank/internal/ocp/worker.go
@@ -128,7 +128,7 @@ func (ws *workSpec) Exec(ctx ClusterContext) error {
 		bc := apiBuild.Annotations[buildapiv1.BuildConfigAnnotation]
 		bn := apiBuild.Annotations[buildapiv1.BuildNumberAnnotation]
 		log.Infof("Worker is part of buildconfig.openshift.io/%s-%s", bc, bn)
-		if err := cosaInit(); err != nil && err != ErrNoSourceInput {
+		if err := cosaInit(ws.JobSpec); err != nil && err != ErrNoSourceInput {
 			return fmt.Errorf("failed to clone recipe: %w", err)
 		}
 	} else {

--- a/gangplank/internal/spec/cli.go
+++ b/gangplank/internal/spec/cli.go
@@ -68,6 +68,7 @@ func (js *JobSpec) AddCliFlags(cmd *pflag.FlagSet) {
 	// Define the recipe
 	cmd.StringVar(&js.Recipe.GitRef, "git-ref", js.Recipe.GitRef, "Git ref for recipe")
 	cmd.StringVar(&js.Recipe.GitURL, "git-url", js.Recipe.GitURL, "Git URL for recipe")
+	cmd.StringVar(&js.Recipe.GitCommit, "git-commit", "", "Optional Git commit to reset repo to for recipe")
 }
 
 // AddRepos adds an repositories from the CLI

--- a/gangplank/internal/spec/jobspec.go
+++ b/gangplank/internal/spec/jobspec.go
@@ -140,10 +140,12 @@ type Minio struct {
 // Recipe describes where to get the build recipe/config, i.e fedora-coreos-config
 //   GitRef: branch/ref to fetch from
 //   GitUrl: url of the repo
+//   GitCommit: a specific commit in the branch to build from
 type Recipe struct {
-	GitRef string  `yaml:"git_ref,omitempty" json:"git_ref,omitempty"`
-	GitURL string  `yaml:"git_url,omitempty" json:"git_url,omitempty"`
-	Repos  []*Repo `yaml:"repos,omitempty" json:"repos,omitempty"`
+	GitRef    string  `yaml:"git_ref,omitempty" json:"git_ref,omitempty"`
+	GitURL    string  `yaml:"git_url,omitempty" json:"git_url,omitempty"`
+	GitCommit string  `yaml:"git_commit,omitempty" json:"git_commit,omitempty"`
+	Repos     []*Repo `yaml:"repos,omitempty" json:"repos,omitempty"`
 }
 
 // Repo is a yum/dnf repositories to use as an installation source.

--- a/src/cmd-init
+++ b/src/cmd-init
@@ -5,7 +5,7 @@ dn=$(dirname "$0")
 # shellcheck source=src/cmdlib.sh
 . "${dn}"/cmdlib.sh
 
-# Initialize FORCE to 0 and BRANCH/INSTALLER_DIR to an empty string
+# Initialize FORCE to 0 and BRANCH to an empty string
 FORCE=0
 BRANCH=""
 
@@ -27,7 +27,7 @@ EOF
 
 # Call getopt to validate the provided input.
 rc=0
-options=$(getopt --options hfb:i: --longoptions help,force,branch: -- "$@") || rc=$?
+options=$(getopt --options hfb: --longoptions help,force,branch: -- "$@") || rc=$?
 [ $rc -eq 0 ] || {
     print_help
     exit 1

--- a/src/cmd-init
+++ b/src/cmd-init
@@ -5,14 +5,16 @@ dn=$(dirname "$0")
 # shellcheck source=src/cmdlib.sh
 . "${dn}"/cmdlib.sh
 
-# Initialize FORCE to 0 and BRANCH to an empty string
+# Initialize FORCE to 0 and BRANCH/COMMIT to an empty string
 FORCE=0
 BRANCH=""
+COMMIT=""
 
 print_help() {
     cat 1>&2 <<'EOF'
 Usage: coreos-assembler init --help
-       coreos-assembler init [--force] [--branch BRANCH] GITCONFIG [SUBDIR]
+       coreos-assembler init [--force] [--branch BRANCH] 
+                             [--commit COMMIT] GITCONFIG [SUBDIR]
 
   For example, you can use https://github.com/coreos/fedora-coreos-config
   as GITCONFIG, or fork it.  Another option useful for local development
@@ -27,7 +29,7 @@ EOF
 
 # Call getopt to validate the provided input.
 rc=0
-options=$(getopt --options hfb: --longoptions help,force,branch: -- "$@") || rc=$?
+options=$(getopt --options hfb:c: --longoptions help,force,branch:,commit: -- "$@") || rc=$?
 [ $rc -eq 0 ] || {
     print_help
     exit 1
@@ -48,6 +50,15 @@ while true; do
                 shift ;;
             *)
                 BRANCH="$2"
+                shift ;;
+        esac
+        ;;
+    -c | --commit)
+        case "$2" in
+            "")
+                shift ;;
+            *)
+                COMMIT="$2"
                 shift ;;
         esac
         ;;
@@ -96,6 +107,16 @@ mkdir -p src
      case "${source}" in
          /*) ln -s "${source}/${subdir}" config;;
          *) git clone ${BRANCH:+--branch=${BRANCH}} --depth=1 --shallow-submodules --recurse-submodules "${source}" config
+            # If a commit was specified then we'll fetch and reset
+            # the specified branch to that commit. This is useful when
+            # doing pipeline builds and targetting a specific commit
+            # (i.e.) subordinate multi-arch build pipelines running
+            # cosa init later in time than the x86_64 pipeline; new
+            # commits could have come in.
+            if [ -n "${COMMIT}" ]; then
+                git -C ./config fetch origin "$COMMIT"
+                git -C ./config reset --hard "$COMMIT"
+            fi
             if [ -n "${subdir}" ]; then
                 mv config config-git
                 ln -sr config-git/"${subdir}" config


### PR DESCRIPTION
```
commit 8220836713617ef039b2c82887fe0b6728364678
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Fri Aug 27 22:02:27 2021 -0400

    gangplank: allow for specifying configs git commit
    
    This exposes the `cosa init --commit` flag into the jobspec, which
    allows one to force a commit on the specified branch to be used. This
    is useful in pipeline builds when later subordinate (multi-arch)
    pipelines run and we want them to target the same git commit as the
    earlier x86_64 pipeline run.

commit a5f2d12cd04aec5f5c237a2c0f26b58e111c1d32
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Fri Aug 27 16:21:32 2021 -0400

    cmd-init: support --commit
    
    Useful for reseting the local branch of the recently cloned config
    git repo to a specific commit (full SHA-1).
    
    This is most useful in a automated environment where we're doing a
    `cosa init` and we might not always want the latest config repo, but
    rather a specific commit (which could be latest, or not). One example
    of this being useful is when doing pipeline builds and targetting a
    specific commit from subordinate multi-arch build pipelines that run
    later in time than the x86_64 pipeline. For our devel branches new
    commits could have easily been commited in the amount of time between
    the x86_64 pipeline ran and the multi-arch pipelines run.

commit 3fb07496bf4f9d28a04e377e1e5f121304f28828
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Fri Aug 27 16:11:47 2021 -0400

    cmd-init: remove -i short option and INSTALLER_DIR comment
    
    --installer-dir was removed back in accb688. This should have been
    removed with it.
```
