### PR TITLE
kola: Change RunCmdSync to log command output to journal too

### DIFF
--- a/mantle/kola/tests/ostree/unlock.go
+++ b/mantle/kola/tests/ostree/unlock.go
@@ -55,10 +55,7 @@ func ostreeAdminUnlock(c cluster.TestCluster, m platform.Machine, hotfix bool) e
 		unlockCmd = "sudo ostree admin unlock --hotfix"
 	}
 
-	_, unlockCmdErr := c.SSH(m, unlockCmd)
-	if unlockCmdErr != nil {
-		return fmt.Errorf(`Failed to unlock deployment: %v`, unlockCmdErr)
-	}
+	c.RunCmdSync(m, unlockCmd)
 
 	status, err := util.GetRpmOstreeStatusJSON(c, m)
 	if err != nil {


### PR DESCRIPTION
The original goal of this new API was just to log the command invocation
to the journal, but looking at things further here, the common path
is to *not* capture the output.

Fix things here so that we log both the command stdout+stderr
as a unified stream into the journal, and then capture the last 20
lines from the journal for `kola` as a Go error message.

(In practice, we should probably not capture the journal text into
 `t.Fatalf()` but just say "see the journal" and then have a higher
 level pass which gathers relevant failures from the journal
 from all machines)

My immediate motivation is improved debugging for hotfix
failures: https://github.com/coreos/fedora-coreos-tracker/issues/942