### PR TITLE
kola: Replace all non-capturing MustSSH with RunCmdSync

### DIFF
--- a/mantle/kola/tests/crio/crio.go
+++ b/mantle/kola/tests/crio/crio.go
@@ -447,9 +447,9 @@ func crioPodContinuesDuringServiceRestart(c cluster.TestCluster) {
 		podID, crioConfigContainer, crioConfigPod))
 
 	cmd := fmt.Sprintf("sudo crictl exec %s bash -c \"sleep 25 && echo PASS > /tmp/test/restart-test\"", containerID)
-	c.MustSSH(m, cmd)
+	c.RunCmdSync(m, cmd)
 	time.Sleep(3 * time.Second)
-	c.MustSSH(m, "sudo systemctl restart crio")
+	c.RunCmdSync(m, "sudo systemctl restart crio")
 	time.Sleep(25 * time.Second)
 	output := strings.TrimSuffix(string(c.MustSSH(m, "cat /tmp/test/restart-test")), "\n")
 

--- a/mantle/kola/tests/ignition/empty.go
+++ b/mantle/kola/tests/ignition/empty.go
@@ -49,5 +49,5 @@ func noIgnitionSSHKey(c cluster.TestCluster) {
 	m := c.Machines()[0]
 	// check that the test harness correctly skipped passing SSH keys
 	// via Ignition
-	c.MustSSH(m, "[ ! -e ~/.ssh/authorized_keys.d/ignition ]")
+	c.RunCmdSync(m, "[ ! -e ~/.ssh/authorized_keys.d/ignition ]")
 }

--- a/mantle/kola/tests/ignition/execution.go
+++ b/mantle/kola/tests/ignition/execution.go
@@ -47,7 +47,7 @@ func runsOnce(c cluster.TestCluster) {
 	m := c.Machines()[0]
 
 	// remove file created by Ignition; fail if it doesn't exist
-	c.MustSSH(m, "sudo rm /etc/ignition-ran")
+	c.RunCmdSync(m, "sudo rm /etc/ignition-ran")
 
 	err := m.Reboot()
 	if err != nil {
@@ -55,5 +55,5 @@ func runsOnce(c cluster.TestCluster) {
 	}
 
 	// make sure file hasn't been recreated
-	c.MustSSH(m, "test ! -e /etc/ignition-ran")
+	c.RunCmdSync(m, "test ! -e /etc/ignition-ran")
 }

--- a/mantle/kola/tests/ignition/resource.go
+++ b/mantle/kola/tests/ignition/resource.go
@@ -182,7 +182,7 @@ func init() {
 func resourceLocal(c cluster.TestCluster) {
 	server := c.Machines()[0]
 
-	c.MustSSH(server, fmt.Sprintf("sudo systemd-run --quiet ./kolet run %s Serve", c.H.Name()))
+	c.RunCmdSync(server, fmt.Sprintf("sudo systemd-run --quiet ./kolet run %s Serve", c.H.Name()))
 
 	ip := server.PrivateIP()
 	if c.Platform() == packet.Platform {
@@ -234,7 +234,7 @@ func resourceS3(c cluster.TestCluster) {
 	}
 
 	// ...but that the anonymous object is accessible
-	c.MustSSH(m, "curl -sf https://rh-kola-fixtures.s3.amazonaws.com/resources/anonymous")
+	c.RunCmdSync(m, "curl -sf https://rh-kola-fixtures.s3.amazonaws.com/resources/anonymous")
 }
 
 func resourceS3Versioned(c cluster.TestCluster) {

--- a/mantle/kola/tests/ignition/security.go
+++ b/mantle/kola/tests/ignition/security.go
@@ -75,9 +75,9 @@ func securityTLS(c cluster.TestCluster) {
 		ip = server.IP()
 	}
 
-	c.MustSSH(server, "sudo mkdir /var/tls")
-	c.MustSSH(server, "sudo openssl ecparam -genkey -name secp384r1 -out /var/tls/server.key")
-	c.MustSSH(server, strings.Replace(`sudo bash -c 'openssl req -new -x509 -sha256 -key /var/tls/server.key -out /var/tls/server.crt -days 3650 -subj "/CN=$IP" -config <(cat <<-EOF
+	c.RunCmdSync(server, "sudo mkdir /var/tls")
+	c.RunCmdSync(server, "sudo openssl ecparam -genkey -name secp384r1 -out /var/tls/server.key")
+	c.RunCmdSync(server, strings.Replace(`sudo bash -c 'openssl req -new -x509 -sha256 -key /var/tls/server.key -out /var/tls/server.crt -days 3650 -subj "/CN=$IP" -config <(cat <<-EOF
 [req]
 default_bits = 2048
 default_md = sha256
@@ -93,7 +93,7 @@ EOF
 	publicKey := c.MustSSH(server, "sudo cat /var/tls/server.crt")
 
 	var conf *conf.UserData = localSecurityClient
-	c.MustSSH(server, fmt.Sprintf("sudo systemd-run --quiet ./kolet run %s TLSServe", c.H.Name()))
+	c.RunCmdSync(server, fmt.Sprintf("sudo systemd-run --quiet ./kolet run %s TLSServe", c.H.Name()))
 
 	client, err := c.NewMachine(conf.Subst("$IP", ip).Subst("$KEY", dataurl.EncodeBytes(publicKey)))
 	if err != nil {

--- a/mantle/kola/tests/ignition/ssh.go
+++ b/mantle/kola/tests/ignition/ssh.go
@@ -38,5 +38,5 @@ func noAfterburnSSHKey(c cluster.TestCluster) {
 	m := c.Machines()[0]
 	// check that the test harness correctly skipped passing SSH keys
 	// via Afterburn
-	c.MustSSH(m, "[ ! -e ~/.ssh/authorized_keys.d/afterburn ]")
+	c.RunCmdSync(m, "[ ! -e ~/.ssh/authorized_keys.d/afterburn ]")
 }

--- a/mantle/kola/tests/ignition/units.go
+++ b/mantle/kola/tests/ignition/units.go
@@ -63,10 +63,10 @@ func enableSystemdInstantiatedService(c cluster.TestCluster) {
 	m := c.Machines()[0]
 	// MustSSH function will throw an error if the exit code
 	// of the command is anything other than 0.
-	c.MustSSH(m, "systemctl -q is-active echo@foo.service")
-	c.MustSSH(m, "systemctl -q is-active echo@bar.service")
-	c.MustSSH(m, "systemctl -q is-enabled echo@foo.service")
-	c.MustSSH(m, "systemctl -q is-enabled echo@bar.service")
-	c.MustSSH(m, "systemctl -q is-active echo@foo.timer")
-	c.MustSSH(m, "systemctl -q is-enabled echo@foo.timer")
+	c.RunCmdSync(m, "systemctl -q is-active echo@foo.service")
+	c.RunCmdSync(m, "systemctl -q is-active echo@bar.service")
+	c.RunCmdSync(m, "systemctl -q is-enabled echo@foo.service")
+	c.RunCmdSync(m, "systemctl -q is-enabled echo@bar.service")
+	c.RunCmdSync(m, "systemctl -q is-active echo@foo.timer")
+	c.RunCmdSync(m, "systemctl -q is-enabled echo@foo.timer")
 }

--- a/mantle/kola/tests/misc/aws.go
+++ b/mantle/kola/tests/misc/aws.go
@@ -35,5 +35,5 @@ func init() {
 
 func awsVerifyDiskFriendlyName(c cluster.TestCluster) {
 	friendlyName := "/dev/xvda"
-	c.MustSSH(c.Machines()[0], fmt.Sprintf("stat %s", friendlyName))
+	c.RunCmdSync(c.Machines()[0], fmt.Sprintf("stat %s", friendlyName))
 }

--- a/mantle/kola/tests/misc/boot-mirror.go
+++ b/mantle/kola/tests/misc/boot-mirror.go
@@ -196,7 +196,7 @@ func bootMirrorSanityTest(c cluster.TestCluster, m platform.Machine) {
 			c.Fatalf("didn't match fstype for boot")
 		}
 		// Check that growpart didn't run
-		c.MustSSH(m, "if [ -e /run/coreos-growpart.stamp ]; then exit 1; fi")
+		c.RunCmdSync(m, "if [ -e /run/coreos-growpart.stamp ]; then exit 1; fi")
 	})
 }
 
@@ -224,8 +224,8 @@ func verifyBootMirrorAfterReboot(c cluster.TestCluster, m platform.Machine) {
 		if !strings.Contains(string(bootOutput), "degraded") {
 			c.Fatalf("didn't match the state of boot raid device; expected degraded, found: %v", string(bootOutput))
 		}
-		c.MustSSH(m, "grep root=UUID= /proc/cmdline")
-		c.MustSSH(m, "grep rd.md.uuid= /proc/cmdline")
+		c.RunCmdSync(m, "grep root=UUID= /proc/cmdline")
+		c.RunCmdSync(m, "grep rd.md.uuid= /proc/cmdline")
 	})
 }
 

--- a/mantle/kola/tests/misc/multipath.go
+++ b/mantle/kola/tests/misc/multipath.go
@@ -137,7 +137,7 @@ func runMultipathDay1(c cluster.TestCluster) {
 
 func runMultipathDay2(c cluster.TestCluster) {
 	m := c.Machines()[0]
-	c.MustSSH(m, "sudo rpm-ostree kargs --append rd.multipath=default --append root=/dev/disk/by-label/dm-mpath-root")
+	c.RunCmdSync(m, "sudo rpm-ostree kargs --append rd.multipath=default --append root=/dev/disk/by-label/dm-mpath-root")
 	if err := m.Reboot(); err != nil {
 		c.Fatalf("Failed to reboot the machine: %v", err)
 	}

--- a/mantle/kola/tests/misc/network.go
+++ b/mantle/kola/tests/misc/network.go
@@ -536,7 +536,7 @@ func addKernelArgs(c cluster.TestCluster, m platform.Machine, args []string) {
 		rpmOstreeCommand = fmt.Sprintf("%s --append %s", rpmOstreeCommand, arg)
 	}
 
-	c.MustSSH(m, rpmOstreeCommand)
+	c.RunCmdSync(m, rpmOstreeCommand)
 
 	err := m.Reboot()
 	if err != nil {

--- a/mantle/kola/tests/misc/nfs.go
+++ b/mantle/kola/tests/misc/nfs.go
@@ -141,7 +141,7 @@ systemd:
 		c.Fatal(err)
 	}
 
-	c.MustSSH(m2, fmt.Sprintf("stat /var/mnt/%s", path.Base(string(tmp))))
+	c.RunCmdSync(m2, fmt.Sprintf("stat /var/mnt/%s", path.Base(string(tmp))))
 }
 
 // Test that NFSv4 without security works.

--- a/mantle/kola/tests/misc/tls.go
+++ b/mantle/kola/tests/misc/tls.go
@@ -42,6 +42,6 @@ func TestTLSFetchURLs(c cluster.TestCluster) {
 	m := c.Machines()[0]
 
 	for _, url := range urlsToFetch {
-		c.MustSSH(m, fmt.Sprintf("curl -s -S -m 30 --retry 2 %s", url))
+		c.RunCmdSync(m, fmt.Sprintf("curl -s -S -m 30 --retry 2 %s", url))
 	}
 }

--- a/mantle/kola/tests/ostree/basic.go
+++ b/mantle/kola/tests/ostree/basic.go
@@ -204,7 +204,7 @@ func ostreeRemoteTest(c cluster.TestCluster) {
 	// verify `ostree remote add` is successful
 	c.Run("add", func(c cluster.TestCluster) {
 		osRemoteAddCmd := "sudo ostree remote add --no-gpg-verify " + remoteName + " " + remoteUrl
-		c.MustSSH(m, osRemoteAddCmd)
+		c.RunCmdSync(m, osRemoteAddCmd)
 	})
 
 	// verify `ostree remote list`
@@ -300,7 +300,7 @@ func ostreeRemoteTest(c cluster.TestCluster) {
 			c.Fatalf(`No remotes configured on host: %q`, string(preRemotesOut))
 		}
 
-		c.MustSSH(m, ("sudo ostree remote delete " + remoteName))
+		c.RunCmdSync(m, ("sudo ostree remote delete " + remoteName))
 
 		delNumRemotes, delRemoteListOut := getOstreeRemotes(c, m)
 		if delNumRemotes >= preNumRemotes {

--- a/mantle/kola/tests/ostree/unlock.go
+++ b/mantle/kola/tests/ostree/unlock.go
@@ -155,7 +155,7 @@ func ostreeUnlockTest(c cluster.TestCluster) {
 	// re-install the RPM and verify the unlocked deployment is discarded
 	// after reboot
 	c.Run("discard", func(c cluster.TestCluster) {
-		c.MustSSH(m, ("sudo rpm -i " + rpmUrl))
+		c.RunCmdSync(m, ("sudo rpm -i " + rpmUrl))
 
 		unlockRebootErr := m.Reboot()
 		if unlockRebootErr != nil {
@@ -215,7 +215,7 @@ func ostreeHotfixTest(c cluster.TestCluster) {
 	// install the RPM again, reboot, verify it the "hotfix" deployment
 	// and RPM have persisted
 	c.Run("persist", func(c cluster.TestCluster) {
-		c.MustSSH(m, ("sudo rpm -i " + rpmUrl))
+		c.RunCmdSync(m, ("sudo rpm -i " + rpmUrl))
 
 		unlockRebootErr := m.Reboot()
 		if unlockRebootErr != nil {
@@ -231,14 +231,14 @@ func ostreeHotfixTest(c cluster.TestCluster) {
 			c.Fatalf(`Hotfix mode was not detected; got: %q`, ros.Deployments[0].Unlocked)
 		}
 
-		c.MustSSH(m, ("command -v " + rpmName))
+		c.RunCmdSync(m, ("command -v " + rpmName))
 
-		c.MustSSH(m, ("rpm -q " + rpmName))
+		c.RunCmdSync(m, ("rpm -q " + rpmName))
 	})
 
 	// roll back the deployment and verify the "hotfix" is no longer present
 	c.Run("rollback", func(c cluster.TestCluster) {
-		c.MustSSH(m, "sudo rpm-ostree rollback")
+		c.RunCmdSync(m, "sudo rpm-ostree rollback")
 
 		rollbackRebootErr := m.Reboot()
 		if rollbackRebootErr != nil {

--- a/mantle/kola/tests/podman/podman.go
+++ b/mantle/kola/tests/podman/podman.go
@@ -132,7 +132,7 @@ func podmanWorkflow(c cluster.TestCluster) {
 	c.Run("run", func(c cluster.TestCluster) {
 		dir := c.MustSSH(m, `mktemp -d`)
 		cmd := fmt.Sprintf("echo TEST PAGE > %s/index.html", string(dir))
-		c.MustSSH(m, cmd)
+		c.RunCmdSync(m, cmd)
 
 		cmd = fmt.Sprintf("sudo podman run -d -p 80:80 -v %s/index.html:%s/index.html:z %s", string(dir), wwwRoot, image)
 		out := c.MustSSH(m, cmd)
@@ -167,7 +167,7 @@ func podmanWorkflow(c cluster.TestCluster) {
 	// Test: Stop container
 	c.Run("stop", func(c cluster.TestCluster) {
 		cmd := fmt.Sprintf("sudo podman stop %s", id)
-		c.MustSSH(m, cmd)
+		c.RunCmdSync(m, cmd)
 		psInfo, err := getSimplifiedPsInfo(c, m)
 		if err != nil {
 			c.Fatal(err)
@@ -194,7 +194,7 @@ func podmanWorkflow(c cluster.TestCluster) {
 	// Test: Remove container
 	c.Run("remove", func(c cluster.TestCluster) {
 		cmd := fmt.Sprintf("sudo podman rm %s", id)
-		c.MustSSH(m, cmd)
+		c.RunCmdSync(m, cmd)
 		psInfo, err := getSimplifiedPsInfo(c, m)
 		if err != nil {
 			c.Fatal(err)

--- a/mantle/kola/tests/rhcos/sssd.go
+++ b/mantle/kola/tests/rhcos/sssd.go
@@ -44,14 +44,14 @@ func init() {
 func verifyNssAltfiles(c cluster.TestCluster, m platform.Machine) {
 	// MustSSH will panic if exit status is non-zero
 	// Use -q option to indicate that we only care about the exit status
-	c.MustSSH(m, "grep -q altfiles /etc/nsswitch.conf")
+	c.RunCmdSync(m, "grep -q altfiles /etc/nsswitch.conf")
 }
 
 func verifyPamConfigs(c cluster.TestCluster, m platform.Machine) {
 	// MustSSH will panic if exit status is non-zero
 	// Use -q option to indicate that we only care about the exit status
-	c.MustSSH(m, "grep -q pam_sss.so /etc/pam.d/password-auth")
-	c.MustSSH(m, "grep -q pam_sss.so /etc/pam.d/system-auth")
+	c.RunCmdSync(m, "grep -q pam_sss.so /etc/pam.d/password-auth")
+	c.RunCmdSync(m, "grep -q pam_sss.so /etc/pam.d/system-auth")
 }
 
 func verifySSSD(c cluster.TestCluster) {

--- a/mantle/kola/tests/rhcos/upgrade.go
+++ b/mantle/kola/tests/rhcos/upgrade.go
@@ -89,12 +89,12 @@ func rhcosUpgrade(c cluster.TestCluster) {
 		// Should drop this once we fix it more properly in {rpm-,}ostree.
 		// https://github.com/coreos/coreos-assembler/issues/1301
 		// Also we should really add a streaming import for this
-		c.MustSSHf(m, "sudo tar -xf %s -C /var/srv && sudo rm %s", ostreeTarName, ostreeTarName)
-		c.MustSSHf(m, "sudo ostree --repo=/sysroot/ostree/repo pull-local /var/srv %s && sudo rm -rf /var/srv/* && sudo sync", ostreeCommit)
+		c.RunCmdSyncf(m, "sudo tar -xf %s -C /var/srv && sudo rm %s", ostreeTarName, ostreeTarName)
+		c.RunCmdSyncf(m, "sudo ostree --repo=/sysroot/ostree/repo pull-local /var/srv %s && sudo rm -rf /var/srv/* && sudo sync", ostreeCommit)
 	})
 
 	c.Run("upgrade-from-previous", func(c cluster.TestCluster) {
-		c.MustSSHf(m, "sudo rpm-ostree rebase :%s", ostreeCommit)
+		c.RunCmdSyncf(m, "sudo rpm-ostree rebase :%s", ostreeCommit)
 		err := m.Reboot()
 		if err != nil {
 			c.Fatalf("Failed to reboot machine: %v", err)
@@ -125,6 +125,6 @@ func rhcosUpgradeBasic(c cluster.TestCluster) {
 	})
 
 	c.Run("verify-rootfs-migration", func(c cluster.TestCluster) {
-		c.MustSSH(m, "ls /dev/disk/by-label/root")
+		c.RunCmdSync(m, "ls /dev/disk/by-label/root")
 	})
 }

--- a/mantle/kola/tests/rpmostree/deployments.go
+++ b/mantle/kola/tests/rpmostree/deployments.go
@@ -99,14 +99,14 @@ func rpmOstreeUpgradeRollback(c cluster.TestCluster) {
 		// create a local branch to act as our upgrade target
 		originalCsum := originalStatus.Deployments[0].Checksum
 		createBranch := "sudo ostree refs --create " + newBranch + " " + originalCsum
-		c.MustSSH(m, createBranch)
+		c.RunCmdSync(m, createBranch)
 
 		// make a commit to the new branch
 		createCommit := "sudo ostree commit -b " + newBranch + " --tree ref=" + originalCsum + " --add-metadata-string version=" + newVersion
 		newCommit := c.MustSSH(m, createCommit)
 
 		// use "rpm-ostree rebase" to get to the "new" commit
-		c.MustSSH(m, "sudo rpm-ostree rebase :"+newBranch)
+		c.RunCmdSync(m, "sudo rpm-ostree rebase :"+newBranch)
 
 		// get latest rpm-ostree status output to check validity
 		postUpgradeStatus, err := util.GetRpmOstreeStatusJSON(c, m)
@@ -159,7 +159,7 @@ func rpmOstreeUpgradeRollback(c cluster.TestCluster) {
 
 	c.Run("rollback", func(c cluster.TestCluster) {
 		// rollback to original deployment
-		c.MustSSH(m, "sudo rpm-ostree rollback")
+		c.RunCmdSync(m, "sudo rpm-ostree rollback")
 
 		newRebootErr := m.Reboot()
 		if newRebootErr != nil {
@@ -225,7 +225,7 @@ func rpmOstreeInstallUninstall(c cluster.TestCluster) {
 
 	c.Run("install", func(c cluster.TestCluster) {
 		// install package and reboot
-		c.MustSSH(m, "sudo rpm-ostree install "+installPkgName)
+		c.RunCmdSync(m, "sudo rpm-ostree install "+installPkgName)
 
 		installRebootErr := m.Reboot()
 		if installRebootErr != nil {
@@ -285,7 +285,7 @@ func rpmOstreeInstallUninstall(c cluster.TestCluster) {
 
 	// uninstall the package
 	c.Run("uninstall", func(c cluster.TestCluster) {
-		c.MustSSH(m, "sudo rpm-ostree uninstall "+installPkgName)
+		c.RunCmdSync(m, "sudo rpm-ostree uninstall "+installPkgName)
 
 		uninstallRebootErr := m.Reboot()
 		if uninstallRebootErr != nil {

--- a/mantle/kola/tests/rpmostree/status.go
+++ b/mantle/kola/tests/rpmostree/status.go
@@ -42,7 +42,7 @@ var (
 // rpmOstreeCleanup calls 'rpm-ostree cleanup -rpmb' on a host and verifies
 // that only one deployment remains
 func rpmOstreeCleanup(c cluster.TestCluster, m platform.Machine) error {
-	c.MustSSH(m, "sudo rpm-ostree cleanup -rpmb")
+	c.RunCmdSync(m, "sudo rpm-ostree cleanup -rpmb")
 
 	// one last check to make sure we are back to the original state
 	cleanupStatus, err := util.GetRpmOstreeStatusJSON(c, m)

--- a/mantle/kola/tests/upgrade/basic.go
+++ b/mantle/kola/tests/upgrade/basic.go
@@ -288,11 +288,11 @@ func undoZincatiDisablement(c cluster.TestCluster, m platform.Machine) {
 	}
 
 	if !onProdStream(c, d) {
-		c.MustSSH(m, "sudo rm -f /etc/zincati/config.d/90-disable-on-non-production-stream.toml")
+		c.RunCmdSync(m, "sudo rm -f /etc/zincati/config.d/90-disable-on-non-production-stream.toml")
 	}
 
 	if isDevBuild(c, d) {
-		c.MustSSH(m, "sudo rm -f /etc/zincati/config.d/95-disable-on-dev.toml")
+		c.RunCmdSync(m, "sudo rm -f /etc/zincati/config.d/95-disable-on-dev.toml")
 	}
 }
 
@@ -357,7 +357,7 @@ func waitForUpgradeToVersion(c cluster.TestCluster, m platform.Machine, version 
 
 	runFnAndWaitForRebootIntoVersion(c, m, version, func() {
 		// XXX: update to use https://github.com/coreos/zincati/issues/203
-		c.MustSSH(m, "sudo systemctl start zincati.service")
+		c.RunCmdSync(m, "sudo systemctl start zincati.service")
 
 		// sanity-check that Zincati has updates enabled
 		if err := ensureZincatiUpdatesEnabled(c, m); err != nil {
@@ -368,10 +368,10 @@ func waitForUpgradeToVersion(c cluster.TestCluster, m platform.Machine, version 
 
 func rebaseToStream(c cluster.TestCluster, m platform.Machine, ref, version string) {
 	runFnAndWaitForRebootIntoVersion(c, m, version, func() {
-		c.MustSSHf(m, "sudo systemctl stop zincati")
+		c.RunCmdSyncf(m, "sudo systemctl stop zincati")
 		// we use systemd-run here so that we can test the --reboot path
 		// without having SSH not exit cleanly, which would cause an error
-		c.MustSSHf(m, "sudo systemd-run rpm-ostree rebase --reboot %s", ref)
+		c.RunCmdSyncf(m, "sudo systemd-run rpm-ostree rebase --reboot %s", ref)
 	})
 }
 

--- a/mantle/kola/tests/util/containers.go
+++ b/mantle/kola/tests/util/containers.go
@@ -28,5 +28,5 @@ func GenPodmanScratchContainer(c cluster.TestCluster, m platform.Machine, name s
 	        b=$(which %s); libs=$(sudo ldd $b | grep -o /lib'[^ ]*' | sort -u);
 			sudo rsync -av --relative --copy-links $b $libs ./;
 			sudo podman build --network host --layers=false -t localhost/%s .`
-	c.MustSSH(m, fmt.Sprintf(cmd, strings.Join(binnames, " "), name))
+	c.RunCmdSync(m, fmt.Sprintf(cmd, strings.Join(binnames, " "), name))
 }


### PR DESCRIPTION
Probably 70% of the invocations of `MustSSH` weren't actually
capturing stdout, so it would just get lost.  Instead, use
`RunCmdSync` for this which keeps everything consistently in
the systemd journal in order.

This will help debugging because often one needs to consult
the journal, and having log messages there will help.