### PR TITLE
build: Keep Dockerfile + ci/Dockerfile in sync, require rpm-ostree v2021.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,11 @@
 FROM quay.io/coreos-assembler/cosa-buildroot:latest
 WORKDIR /root/containerbuild
 
-# Only need a few of our scripts for the first few steps
+# We semi-support skipping the buildroot and just using e.g. `FROM fedora:34` as a base image,
+# so keep this in sync with `ci/Dockerfile`.
 COPY ./src/print-dependencies.sh ./src/deps*.txt ./src/vmdeps*.txt ./src/build-deps.txt /root/containerbuild/src/
 COPY ./build.sh /root/containerbuild/
+RUN ./build.sh configure_yum_repos
 RUN ./build.sh install_rpms
 
 COPY ./ /root/containerbuild/

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -7,6 +7,7 @@
 FROM registry.fedoraproject.org/fedora:34
 WORKDIR /root/containerbuild
 
+# Keep this section in sync with `Dockerfile.
 # Only need a few of our scripts for the first few steps
 COPY ./src/print-dependencies.sh ./src/deps*.txt ./src/vmdeps*.txt ./src/build-deps.txt /root/containerbuild/src/
 COPY ./build.sh /root/containerbuild/


### PR DESCRIPTION

The internal RHCOS pipeline is rebuilding cosa due to multiarch, and
there was a subtle difference that crept in between the two `Dockerfile`s;
notably the main one wasn't configuring the `-continuous` repo
where we'd bypassed the manual Bodhi stuff to fast track
a new `rpm-ostree`.

We need that for https://github.com/openshift/os/pull/603

Sync the two `Dockerfile`s and also require the updated version.