### PR TITLE
Configure the console by default only on particular platforms

### DIFF
--- a/mantle/cmd/kola/switchkernel.go
+++ b/mantle/cmd/kola/switchkernel.go
@@ -60,7 +60,7 @@ var (
 	
 	if [[ $FROM_KERNEL == "default" && $TO_KERNEL == "rt-kernel" ]]; then
 		# Switch from default to RT Kernel
-		# https://github.com/openshift/machine-config-operator/blob/master/pkg/daemon/update.go#L711
+		# https://github.com/openshift/machine-config-operator/blob/e246be62e7839a086bc4494203472349c406dcae/pkg/daemon/update.go#L711
 		RT_KERNEL_REPO=$3
 		if [[ -z $(ls ${RT_KERNEL_REPO}) ]]; then
 			echo "No kernel-rt package available in the repo: ${RT_KERNEL_REPO}"

--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -182,15 +182,7 @@ fi
 
 set -x
 kargs="$(python3 -c 'import sys, json; args = json.load(sys.stdin)["extra-kargs"]; print(" ".join(args))' < "${image_json}")"
-tty="console=tty0 console=${DEFAULT_TERMINAL},115200n8"
-# On each s390x hypervisor, a tty would be automatically detected by the kernel
-# and systemd, there is no need to specify one. However, we keep DEFAULT_TERMINAL
-# as ttysclp0, which is helpful for building/testing with KVM+virtio (cmd-run).
-# For aarch64, ttyAMA0 is used as the default console
-case "$basearch" in
-    "aarch64"|"s390x") tty= ;;
-esac
-kargs="$kargs $tty ignition.platform.id=$ignition_platform_id"
+kargs="$kargs ignition.platform.id=$ignition_platform_id"
 
 qemu-img create -f ${image_format} "${path}.tmp" "${image_size}"
 
@@ -217,10 +209,17 @@ cat >image-dynamic.json << EOF
 }
 EOF
 cat "${image_json}" image-dynamic.json | jq -s add > image-for-disk.json
+platforms_json=
+if [ -e "${configdir}/platforms.yaml" ]; then
+    platforms_json="${workdir}/tmp/platforms.json"
+    yaml2json "${configdir}/platforms.yaml" "${platforms_json}"
+fi
 runvm "${target_drive[@]}" -- \
         /usr/lib/coreos-assembler/create_disk.sh \
             --config "$(pwd)"/image-for-disk.json \
             --kargs "\"${kargs}\"" \
+            --platform "${ignition_platform_id}" \
+            ${platforms_json:+--platforms-json "${platforms_json}"} \
             "${disk_args[@]}"
 /usr/lib/coreos-assembler/finalize-artifact "${path}.tmp" "${path}"
 

--- a/src/cosalib/qemuvariants.py
+++ b/src/cosalib/qemuvariants.py
@@ -221,7 +221,7 @@ class QemuVariantImage(_Build):
             return None
 
     def set_platform(self):
-        run_verbose(['/usr/lib/coreos-assembler/gf-platformid',
+        run_verbose(['/usr/lib/coreos-assembler/gf-set-platform',
                      self.image_qemu, self.tmp_image, self.platform])
 
     def mutate_image(self):

--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -364,7 +364,7 @@ install_grub_cfg() {
     # 0700 to match the RPM permissions which I think are mainly in case someone has
     # manually set a grub password
     mkdir -p -m 0700 $rootfs/boot/grub2
-    printf "%s" "$grub_script" > $rootfs/boot/grub2/grub.cfg
+    printf "%s\n" "$grub_script" > $rootfs/boot/grub2/grub.cfg
 }
 
 # Other arch-specific bootloader changes

--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -406,7 +406,7 @@ s390x)
     # this is only a temporary solution until we are able to do firstboot check at bootloader
     # stage on s390x, either through zipl->grub2-emu or zipl standalone.
     # See https://github.com/coreos/ignition-dracut/issues/84
-    # A similar hack is present in https://github.com/coreos/coreos-assembler/blob/main/src/gf-set-platform#L55
+    # There's a similar hack in gf-set-platform
     echo "$(grep options $blsfile | cut -d' ' -f2-) ignition.firstboot" > $tmpfile
 
     # ideally we want to invoke zipl with bls and zipl.conf but we might need

--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -406,7 +406,7 @@ s390x)
     # this is only a temporary solution until we are able to do firstboot check at bootloader
     # stage on s390x, either through zipl->grub2-emu or zipl standalone.
     # See https://github.com/coreos/ignition-dracut/issues/84
-    # A similar hack is present in https://github.com/coreos/coreos-assembler/blob/main/src/gf-platformid#L55
+    # A similar hack is present in https://github.com/coreos/coreos-assembler/blob/main/src/gf-set-platform#L55
     echo "$(grep options $blsfile | cut -d' ' -f2-) ignition.firstboot" > $tmpfile
 
     # ideally we want to invoke zipl with bls and zipl.conf but we might need

--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -29,6 +29,8 @@ Options:
     --disk: disk device to use
     --help: show this help
     --kargs: kernel CLI args
+    --platform: Ignition platform ID
+    --platforms-json: platforms.yaml in JSON format
     --no-x86-bios-bootloader: don't install BIOS bootloader on x86_64
 
 You probably don't want to run this script by hand. This script is
@@ -38,6 +40,8 @@ EOC
 
 config=
 disk=
+platform=metal
+platforms_json=
 x86_bios_bootloader=1
 extrakargs=""
 
@@ -50,6 +54,8 @@ do
         --help)                  usage; exit;;
         --kargs)                 extrakargs="${extrakargs} ${1}"; shift;;
         --no-x86-bios-bootloader) x86_bios_bootloader=0;;
+        --platform)              platform="${1}"; shift;;
+        --platforms-json)        platforms_json="${1}"; shift;;
          *) echo "${flag} is not understood."; usage; exit 10;;
      esac;
 done
@@ -61,6 +67,27 @@ udevtrig() {
 
 export PATH=$PATH:/sbin:/usr/sbin
 arch="$(uname -m)"
+
+if [ -n "$platforms_json" ]; then
+    platform_grub_cmds=$(jq -r ".${arch}.${platform}.grub_commands // [] | join(\"\\\\n\")" < "${platforms_json}")
+    platform_kargs=$(jq -r ".${arch}.${platform}.kernel_arguments // [] | join(\" \")" < "${platforms_json}")
+else
+    # Add legacy kargs and console settings
+    platform_grub_cmds='serial --speed=115200\nterminal_input serial console\nterminal_output serial console'
+    DEFAULT_TERMINAL=$(. $(dirname "$0")/cmdlib.sh; echo $DEFAULT_TERMINAL)
+    # On each s390x hypervisor, a tty would be automatically detected by the
+    # kernel and systemd, there is no need to specify one.  However, we keep
+    # DEFAULT_TERMINAL as ttysclp0, which is helpful for building/testing
+    # with KVM+virtio (cmd-run).  For aarch64, ttyAMA0 is used as the
+    # default console
+    case "$arch" in
+        "aarch64"|"s390x") platform_kargs= ;;
+        *) platform_kargs="console=tty0 console=${DEFAULT_TERMINAL},115200n8" ;;
+    esac
+fi
+if [ -n "${platform_kargs}" ]; then
+    extrakargs="${extrakargs} ${platform_kargs}"
+fi
 
 disk=$(realpath /dev/disk/by-id/virtio-target)
 
@@ -364,7 +391,16 @@ install_grub_cfg() {
     # 0700 to match the RPM permissions which I think are mainly in case someone has
     # manually set a grub password
     mkdir -p -m 0700 $rootfs/boot/grub2
-    printf "%s\n" "$grub_script" > $rootfs/boot/grub2/grub.cfg
+    printf "%s\n" "$grub_script" | \
+        sed -E 's@(^# CONSOLE-SETTINGS-START$)@\1'"${platform_grub_cmds:+\\n${platform_grub_cmds}}"'@' \
+        > $rootfs/boot/grub2/grub.cfg
+    if [ -n "$platforms_json" ]; then
+        # Copy platforms table if it's non-empty for this arch
+        if jq -e ".$arch" < "$platforms_json" > /dev/null; then
+            mkdir -p "$rootfs/boot/coreos"
+            jq ".$arch" < "$platforms_json" > "$rootfs/boot/coreos/platforms.json"
+        fi
+    fi
 }
 
 # Other arch-specific bootloader changes

--- a/src/gf-set-platform
+++ b/src/gf-set-platform
@@ -7,8 +7,8 @@ dn=$(dirname "$0")
 # shellcheck source=src/libguestfish.sh
 . "${dn}"/libguestfish.sh
 
-# Usage: gf-platformid <input image> <output image> PLATFORMID
-# Example: gf-platformid fedora-coreos.qcow2 fedora-coreos-aws.qcow2 aws
+# Usage: gf-set-platform <input image> <output image> PLATFORMID
+# Example: gf-set-platform fedora-coreos.qcow2 fedora-coreos-aws.qcow2 aws
 #
 # This will add ignition.platform.id=aws to the bootloader arguments. Intended to
 # be used for Ignition. It's much faster to do this than generate a fresh image
@@ -30,7 +30,7 @@ set -x
 # See also:
 # https://github.com/coreos/coreos-assembler/issues/292
 # https://github.com/coreos/coreos-assembler/pull/394
-tmpd=$(mktemp -tdp "$(dirname "${dest}")" gf-platformid.XXXXXX)
+tmpd=$(mktemp -tdp "$(dirname "${dest}")" gf-set-platform.XXXXXX)
 tmp_dest=${tmpd}/box.img
 
 /usr/lib/coreos-assembler/cp-reflink "${src}" "${tmp_dest}"

--- a/src/gf-set-platform
+++ b/src/gf-set-platform
@@ -51,7 +51,7 @@ coreos_gf upload "${tmpd}"/bls.conf "${blscfg_path}"
 
 if [ "$basearch" = "s390x" ] ; then
     # Before we re-run zipl make sure we have the firstboot options
-    # A hack similar to https://github.com/coreos/coreos-assembler/blob/main/src/create_disk.sh#L381
+    # There's a similar hack in create_disk.sh
     sed -i -e 's|^\(options .*\)|\1 ignition.firstboot|' "${tmpd}"/bls.conf
     coreos_gf rename "${blscfg_path}" "${blscfg_path}.orig"
     coreos_gf upload "${tmpd}"/bls.conf "${blscfg_path}"

--- a/src/gf-set-platform
+++ b/src/gf-set-platform
@@ -41,13 +41,42 @@ coreos_gf_run_mount ro "${tmp_dest}"
 # We just mount the boot partition writable
 coreos_gf remount /boot rw:true
 
+# Look up platform-specific configuration
+rewrite_grub_cmds=
+extra_grub_cmds=
+extra_kargs=
+remove_kargs=
+if [ "$(coreos_gf exists /boot/coreos/platforms.json)" = "true" ]; then
+    coreos_gf download /boot/coreos/platforms.json "${tmpd}"/platforms.json
+    rewrite_grub_cmds=1
+    extra_grub_cmds=$(jq -r ".${platformid}.grub_commands // [] | join(\"\\\\n\")" < "${tmpd}/platforms.json")
+    extra_kargs=$(jq -r ".${platformid}.kernel_arguments // [] | join(\" \")" < "${tmpd}/platforms.json")
+    remove_kargs=$(jq -r ".qemu.kernel_arguments // [] | join(\" \")" < "${tmpd}/platforms.json")
+fi
+
 # Inject PLATFORM label in BLS config (for subsequent config regeneration)
 blscfg_path=$(coreos_gf glob-expand /boot/loader/entries/ostree-*.conf)
 coreos_gf download "${blscfg_path}" "${tmpd}"/bls.conf
 # Remove any platformid currently there
 sed -i -e 's, ignition.platform.id=[a-zA-Z0-9]*,,g' "${tmpd}"/bls.conf
 sed -i -e '/^options / s,$, ignition.platform.id='"${platformid}"',' "${tmpd}"/bls.conf
+if [ -n "$remove_kargs" ]; then
+    # Remove existing qemu-specific kargs
+    sed -i -e '/^options / s@ '"${remove_kargs}"'@@' "${tmpd}"/bls.conf
+fi
+if [ -n "$extra_kargs" ]; then
+    sed -i -e '/^options / s@$@ '"${extra_kargs}"'@' "${tmpd}"/bls.conf
+fi
 coreos_gf upload "${tmpd}"/bls.conf "${blscfg_path}"
+
+if [ -n "$rewrite_grub_cmds" ]; then
+    # Remove qemu-specific grub.cfg commands and inject any new ones
+    coreos_gf download /boot/grub2/grub.cfg "${tmpd}"/grub-orig.cfg
+    awk '/^# CONSOLE-SETTINGS-START$/ {suspend=1; print} {if (!suspend) print} /^# CONSOLE-SETTINGS-END$/ {suspend=0; print}' "${tmpd}"/grub-orig.cfg | \
+        sed -E 's@(^# CONSOLE-SETTINGS-START$)@\1'"${extra_grub_cmds:+\\n${extra_grub_cmds}}"'@' \
+        > "${tmpd}"/grub.cfg
+    coreos_gf upload "${tmpd}"/grub.cfg /boot/grub2/grub.cfg
+fi
 
 if [ "$basearch" = "s390x" ] ; then
     # Before we re-run zipl make sure we have the firstboot options

--- a/src/grub.cfg
+++ b/src/grub.cfg
@@ -56,9 +56,10 @@ function load_video {
   fi
 }
 
-serial --speed=115200
-terminal_input serial console
-terminal_output serial console
+# Any non-default console settings will be inserted here.
+# CONSOLE-SETTINGS-START
+# CONSOLE-SETTINGS-END
+
 if [ x$feature_timeout_style = xy ] ; then
   set timeout_style=menu
   set timeout=1


### PR DESCRIPTION
Stop specifying `console=` kernel arguments by default, except on specific arch/platform pairs where we know we need them.  Do the same with console configuration in `grub.cfg`.  More info in coreos/fedora-coreos-tracker#567.

Read `platforms.yaml` from the config repo (https://github.com/coreos/fedora-coreos-config/pull/1181) to determine what console settings should be applied for each arch/platform.  Convert the table for the current arch to JSON and copy it to `/boot/coreos/platforms.json` in the image, since coreos-installer needs the same data when overriding the platform ID at install time (https://github.com/coreos/coreos-installer/pull/605).  If `platforms.yaml` is missing, continue applying the previous defaults.

We do this in two places: `create_disk.sh` configures console settings for `metal` and `qemu` images from `platforms.yaml`.  For other platforms, `gf-set-platform` (previously `gf-platformid`) reads `platforms.json` from the image, undoes any `qemu`-specific settings, and applies settings for the target platform.

cc @coreos/multi-arch