### PR TITLE
build: Add a `:latest` tag to ociarchive export

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -405,7 +405,7 @@ else
             ;;
         oci)
             ostree_tarfile_path="${name}-${buildid}-ostree.${basearch}.ociarchive"
-            rpm-ostree ex-container 'export' --repo="${tmprepo}" "${buildid}" oci-archive:"${ostree_tarfile_path}".tmp
+            rpm-ostree ex-container 'export' --repo="${tmprepo}" "${buildid}" oci-archive:"${ostree_tarfile_path}".tmp:latest
             ;;
         *) fatal "Unknown ostree-format: ${ostree_format}"
     esac


### PR DESCRIPTION
For rpm-ostree, we currently need the two colons `:` in e.g.
`rpm-ostree rebase oci-archive:/path/to/blah:latest` to know
that we're rebasing to a container image (as opposed to just
`rpm-ostree rebase oci-archive:/path/to/blah` which may be
an ostree remote named `oci-archive`.

However, unlike the docker registry transport, by default
no tag `:latest` is emitted into the archive unless specified.