### PR TITLE
kola: Add support for .ociarchive to RHCOS upgrade test

### DIFF
--- a/mantle/kola/tests/upgrade/basic.go
+++ b/mantle/kola/tests/upgrade/basic.go
@@ -145,12 +145,14 @@ func fcosUpgradeBasic(c cluster.TestCluster) {
 			c.Fatal(err)
 		}
 
+		// Keep any changes around here in sync with tests/rhcos/upgrade.go too!
+
 		// See https://github.com/coreos/fedora-coreos-tracker/issues/812
 		if strings.HasSuffix(ostreeblob, ".ociarchive") {
 			tmprepo := workdir + "/repo-bare"
 			// TODO: https://github.com/ostreedev/ostree-rs-ext/issues/34
 			c.RunCmdSyncf(m, "ostree --repo=%s init --mode=bare-user", tmprepo)
-			c.RunCmdSyncf(m, "rpm-ostree ex-container import --repo=%s --write-ref %s oci-archive:%s", tmprepo, ostreeref, ostreeblob)
+			c.RunCmdSyncf(m, "rpm-ostree ex-container import --repo=%s --write-ref %s oci-archive:%s:latest", tmprepo, ostreeref, ostreeblob)
 			c.RunCmdSyncf(m, "ostree --repo=%s init --mode=archive", ostreeRepo)
 			c.RunCmdSyncf(m, "ostree --repo=%s pull-local %s %s", ostreeRepo, tmprepo, ostreeref)
 		} else {


### PR DESCRIPTION
I forgot that we forked the upgrade tests between FCOS/RHCOS
when doing https://github.com/coreos/coreos-assembler/pull/2300

The ugly hack here is to downconvert the oci image on the kola
container side to the old tar format, because the rpm-ostree
in RHEL8 is too old to natively accept the ociarchive.

Once that is fixed, (which will be helped by us testing
this end-to-end) then this code will get nicer.