### PR TITLE
oscontainer: Only use buildah to work around nested `podman push` bug

### DIFF
--- a/src/oscontainer.py
+++ b/src/oscontainer.py
@@ -113,14 +113,11 @@ def oscontainer_build(containers_storage, tmpdir, src, ref, image_name_and_tag,
     else:
         ostree_version = None
 
-    podman_base_argv = ['podman']
     buildah_base_argv = ['buildah']
     if containers_storage is not None:
-        podman_base_argv.append(f"--root={containers_storage}")
         buildah_base_argv.append(f"--root={containers_storage}")
         if os.environ.get('container') is not None:
             print("Using nested container mode due to container environment variable")
-            podman_base_argv.extend(NESTED_BUILD_ARGS)
             buildah_base_argv.extend(NESTED_BUILD_ARGS)
         else:
             print("Skipping nested container mode")
@@ -223,7 +220,7 @@ def oscontainer_build(containers_storage, tmpdir, src, ref, image_name_and_tag,
 
     if push:
         print("Pushing container")
-        podCmd = podman_base_argv + ['push']
+        podCmd = buildah_base_argv + ['push']
         if not tls_verify:
             tls_arg = '--tls-verify=false'
         else:
@@ -235,14 +232,15 @@ def oscontainer_build(containers_storage, tmpdir, src, ref, image_name_and_tag,
 
         if cert_dir != "":
             podCmd.append("--cert-dir={}".format(cert_dir))
-        podCmd.append(image_name_and_tag)
 
         if digestfile is not None:
             podCmd.append(f'--digestfile={digestfile}')
 
+        podCmd.append(image_name_and_tag)
+
         run_verbose(podCmd)
     elif digestfile is not None:
-        inspect = run_get_json(podman_base_argv + ['inspect', image_name_and_tag])[0]
+        inspect = run_get_json(buildah_base_argv + ['inspect', image_name_and_tag])[0]
         with open(digestfile, 'w') as f:
             f.write(inspect['Digest'])
 


### PR DESCRIPTION
I'm seeing this in my f34 toolbox trying to use `upload-oscontainer`:

```
+ podman --root=./tmp/containers-storage --storage-driver vfs push --tls-verify --authfile=/var/home/walters/.docker/config.json registry.ci.openshift.org/coreos/walters-rhcos-47:47.84.202109021332-0 --digestfile=tmp/oscontainer-digest
Error: failed to open 2048 locks in /libpod_lock: permission denied
```

I didn't dig deep into it; tried adding `--runroot` but that
didn't help.  Anyways, since `buildah` is I think better
tested for this purpose (nested container builds) let's use just
it instead of both `buildah` and `podman`.

This fixes the above bug.