### PR TITLE
mantle: Add `COSA_IGNITION_DEFAULT_VERSION` envvar mainly for `cosa run`

### DIFF
--- a/mantle/platform/conf/conf.go
+++ b/mantle/platform/conf/conf.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"strings"
 
 	butane "github.com/coreos/butane/config"
@@ -102,7 +103,11 @@ func EmptyIgnition() *UserData {
 // stable supported Ignition spec.
 func Ignition(data string) *UserData {
 	if data == "" {
-		data = `{"ignition": {"version": "3.2.0"}}`
+		ignver, ok := os.LookupEnv("COSA_IGNITION_DEFAULT_VERSION")
+		if !ok {
+			ignver = "3.2.0"
+		}
+		data = fmt.Sprintf(`{"ignition": {"version": "%s"}}`, ignver)
 	}
 	return &UserData{
 		kind: kindIgnition,


### PR DESCRIPTION
Every time I go to `cosa run rhcos-4.6.qcow2` I keep being confused
by the failure in the initramfs, which is just because we inject
a too-new Ignition version.

I am sure we will want this for FCOS too - being able to conveniently
boot older disk images is very useful for bisection for example.

Ideally we make this configurable/autodetected, but for now
this hidden environment variable is enough to unblock me.