### PR TITLE
buildextend-live: log a message when booting via the stub grub.cfg

### DIFF
--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -501,6 +501,7 @@ def generate_iso():
             with open(os.path.join(tmpimageefidir, vendor_ids[0], "grub.cfg"), "w") as fh:
                 fh.write(f'''search --label "{volid}" --set root --no-floppy
 set prefix=($root)/EFI/{vendor_ids[0]}
+echo "Booting via ESP..."
 configfile $prefix/grub.cfg
 boot
 ''')


### PR DESCRIPTION
At runtime it's immediately overwritten by the GRUB menu, but it shows up in console logs.  This will help validate automated tests.