### PR TITLE
kola/harness.go: fix panic on non-exclusive test fail

### DIFF
--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -1056,7 +1056,11 @@ func makeNonExclusiveTest(tests []*register.Test, flight platform.Flight) regist
 						defer collectLogsExternalTest(h, t, tcluster)
 					}
 
-					t.Run(tcluster)
+					newTC := cluster.TestCluster{
+						H:       h,
+						Cluster: tcluster.Cluster,
+					}
+					t.Run(newTC)
 				}
 				// Each non-exclusive test is run as a subtest of this wrapper test
 				tcluster.H.Run(t.Name, run)


### PR DESCRIPTION
fixes: https://github.com/coreos/coreos-assembler/issues/2407 

Failure of a non-exclusive test would result in a golang panic. We were
using a TestCluster object that references the parent's harness.H. Thus, on
error, the parent's goroutine would incorrectly be terminated.

To fix the problem we create a new TestCluster for each test. This will
reference the correct harness.H object for its corresponding test.