### PR TITLE
mantle/kola: add testiso scenario for ISO copied to USB stick

### DIFF
--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -149,6 +149,7 @@ func init() {
 	bv(&kola.QEMUOptions.Swtpm, "qemu-swtpm", true, "Create temporary software TPM")
 
 	sv(&kola.QEMUIsoOptions.IsoPath, "qemu-iso", "", "path to CoreOS ISO image")
+	bv(&kola.QEMUIsoOptions.AsDisk, "qemu-iso-as-disk", false, "attach ISO image as regular disk")
 }
 
 // Sync up the command line options if there is dependency

--- a/mantle/cmd/kola/qemuexec.go
+++ b/mantle/cmd/kola/qemuexec.go
@@ -286,7 +286,7 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 		}
 	}
 	if kola.QEMUIsoOptions.IsoPath != "" {
-		err := builder.AddIso(kola.QEMUIsoOptions.IsoPath, "")
+		err := builder.AddIso(kola.QEMUIsoOptions.IsoPath, "", kola.QEMUIsoOptions.AsDisk)
 		if err != nil {
 			return err
 		}

--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -367,7 +367,7 @@ func runTestIso(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("build %s has no live ISO", kola.CosaBuild.Meta.Name)
 		}
 		ranTest = true
-		if err := testLiveLogin(ctx, filepath.Join(outputDir, scenarioISOLiveLogin)); err != nil {
+		if err := testLiveLogin(ctx, filepath.Join(outputDir, scenarioISOLiveLogin), false); err != nil {
 			return errors.Wrapf(err, "scenario %s", scenarioISOLiveLogin)
 		}
 		printSuccess(scenarioISOLiveLogin)
@@ -556,7 +556,7 @@ func testLiveIso(ctx context.Context, inst platform.Install, outdir string, offl
 	return awaitCompletion(ctx, mach.QemuInst, outdir, completionChannel, mach.BootStartedErrorChannel, []string{liveOKSignal, signalCompleteString})
 }
 
-func testLiveLogin(ctx context.Context, outdir string) error {
+func testLiveLogin(ctx context.Context, outdir string, asDisk bool) error {
 	if err := os.MkdirAll(outdir, 0755); err != nil {
 		return err
 	}
@@ -565,7 +565,7 @@ func testLiveLogin(ctx context.Context, outdir string) error {
 	builder := newBaseQemuBuilder()
 	defer builder.Close()
 	// Drop the bootindex bit (applicable to all arches except s390x and ppc64le); we want it to be the default
-	if err := builder.AddIso(isopath, ""); err != nil {
+	if err := builder.AddIso(isopath, "", asDisk); err != nil {
 		return err
 	}
 

--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -171,8 +171,7 @@ func init() {
 	cmdTestIso.Flags().BoolVar(&console, "console", false, "Connect qemu console to terminal, turn off automatic initramfs failure checking")
 	cmdTestIso.Flags().BoolVar(&pxeAppendRootfs, "pxe-append-rootfs", false, "Append rootfs to PXE initrd instead of fetching at runtime")
 	cmdTestIso.Flags().StringSliceVar(&pxeKernelArgs, "pxe-kargs", nil, "Additional kernel arguments for PXE")
-	// FIXME move scenarioISOLiveLogin into the defaults once https://github.com/coreos/fedora-coreos-config/pull/339#issuecomment-613000050 is fixed
-	cmdTestIso.Flags().StringSliceVar(&scenarios, "scenarios", []string{scenarioPXEInstall, scenarioISOOfflineInstall, scenarioPXEOfflineInstall}, fmt.Sprintf("Test scenarios (also available: %v)", []string{scenarioISOLiveLogin, scenarioISOInstall}))
+	cmdTestIso.Flags().StringSliceVar(&scenarios, "scenarios", []string{scenarioPXEInstall, scenarioISOOfflineInstall, scenarioPXEOfflineInstall, scenarioISOLiveLogin}, fmt.Sprintf("Test scenarios (also available: %v)", []string{scenarioISOInstall}))
 	cmdTestIso.Args = cobra.ExactArgs(0)
 
 	root.AddCommand(cmdTestIso)

--- a/mantle/platform/machine/qemuiso/cluster.go
+++ b/mantle/platform/machine/qemuiso/cluster.go
@@ -115,7 +115,7 @@ func (qc *Cluster) NewMachineWithQemuOptions(userdata *conf.UserData, options pl
 		builder.Memory = int(memory)
 	}
 
-	if err := builder.AddIso(qc.flight.opts.IsoPath, ""); err != nil {
+	if err := builder.AddIso(qc.flight.opts.IsoPath, "", qc.flight.opts.AsDisk); err != nil {
 		return nil, errors.Wrapf(err, "adding ISO image")
 	}
 

--- a/mantle/platform/machine/qemuiso/flight.go
+++ b/mantle/platform/machine/qemuiso/flight.go
@@ -30,6 +30,7 @@ type Options struct {
 	IsoPath  string
 	Firmware string
 	Memory   string
+	AsDisk   bool
 
 	*platform.Options
 }

--- a/mantle/platform/metal.go
+++ b/mantle/platform/metal.go
@@ -702,7 +702,7 @@ After=dev-mapper-mpatha.device`)
 		return nil, err
 	}
 
-	if err := qemubuilder.AddIso(srcisopath, "bootindex=3"); err != nil {
+	if err := qemubuilder.AddIso(srcisopath, "bootindex=3", false); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
We support writing the live ISO to a USB stick and booting that way, but that path exercises different bootloader code and we should test it explicitly.  Add a flag `--qemu-iso-as-disk` and a testiso scenario `iso-as-disk` that do so.  QEMU's UEFI firmware would still try to boot via El Torito, but some hardware prefers or requires booting via the ESP in the hybrid GPT, so overwrite the El Torito signature in this case to force QEMU to boot via the ESP.

`iso-as-disk` is based on `iso-live-login`, which has been disabled by default for 17 months with a comment saying that it doesn't work.  Re-enable the latter by default; let's see whether that's still true.