### PR TITLE
mantle/kola: set c6g.xlarge default aarch64 aws instance type

### DIFF
--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -204,7 +204,7 @@ func syncOptionsImpl(useCosa bool) error {
 		case "x86_64":
 			kola.AWSOptions.InstanceType = "m5.large"
 		case "aarch64":
-			kola.AWSOptions.InstanceType = "a1.metal"
+			kola.AWSOptions.InstanceType = "c6g.xlarge"
 		}
 		fmt.Printf("Using %s instance type\n", kola.AWSOptions.InstanceType)
 	}


### PR DESCRIPTION
Now that we've got console=ttyS0 in the aarch64 images they can boot
on all aarch64 instance types (see [1]). The c6g.xlarge is not a bare
metal instance type and thus will boot much faster so let's go with
that.

[1] https://github.com/coreos/fedora-coreos-tracker/issues/920)