### PR TITLE
mantle/platform/openstack: wait 10 minutes for instances to come up

### DIFF
--- a/mantle/platform/api/openstack/api.go
+++ b/mantle/platform/api/openstack/api.go
@@ -304,7 +304,7 @@ func (a *API) CreateServer(name, sshKeyID, userdata string) (*Server, error) {
 
 	serverID := server.ID
 
-	err = util.WaitUntilReady(5*time.Minute, 10*time.Second, func() (bool, error) {
+	err = util.WaitUntilReady(10*time.Minute, 10*time.Second, func() (bool, error) {
 		var err error
 		server, err = servers.Get(a.computeClient, serverID).Extract()
 		if err != nil {


### PR DESCRIPTION
For some reason the instances in VexxHost started taking longer than
5 minutes to come up and it's causing test failures. Let's increase
the timeout to 10 minutes to see if that helps.