### PR TITLE
kola: Add an AssertCmdOutputContains

### DIFF
--- a/mantle/kola/cluster/cluster.go
+++ b/mantle/kola/cluster/cluster.go
@@ -197,6 +197,16 @@ func (t *TestCluster) RunCmdSyncf(m platform.Machine, f string, args ...interfac
 	t.RunCmdSync(m, fmt.Sprintf(f, args...))
 }
 
+// AssertCmdOutputContains runs cmd via SSH and panics if stdout does not contain expected
+func (t *TestCluster) AssertCmdOutputContains(m platform.Machine, cmd string, expected string) {
+	t.LogJournal(m, "+ "+cmd)
+	outputBuf := t.MustSSH(m, cmd)
+	output := string(outputBuf)
+	if !strings.Contains(output, expected) {
+		t.Fatalf("cmd %s did not output %s", cmd, expected)
+	}
+}
+
 // Synchronously write a log message from the syslog identifier `kola` into the target
 // machine's journal (via ssh) as well as at a debug log level to the current process.
 // This is useful for debugging test failures, as we always capture the target

--- a/mantle/kola/tests/fips/fips.go
+++ b/mantle/kola/tests/fips/fips.go
@@ -132,12 +132,6 @@ func init() {
 // Test: Run basic FIPS test
 func fipsEnableTest(c cluster.TestCluster) {
 	m := c.Machines()[0]
-	status := c.MustSSH(m, `cat /proc/sys/crypto/fips_enabled`)
-	if string(status) != "1" {
-		c.Fatal("/proc/sys/crypto/fips_enabled is not set to 1")
-	}
-	policy := c.MustSSH(m, `update-crypto-policies --show`)
-	if string(policy) != "FIPS" {
-		c.Fatal("update-crypto-policies is not in FIPS mode")
-	}
+	c.AssertCmdOutputContains(m, `cat /proc/sys/crypto/fips_enabled`, "1")
+	c.AssertCmdOutputContains(m, `update-crypto-policies --show`, "FIPS")
 }

--- a/mantle/kola/tests/ignition/mount.go
+++ b/mantle/kola/tests/ignition/mount.go
@@ -229,8 +229,5 @@ func mountValidate(c cluster.TestCluster, m platform.Machine, mountContents, pat
 	}
 
 	fPath := filepath.Join(path, "/hello.txt")
-	fileContents := c.MustSSH(m, "cat "+fPath)
-	if string(fileContents) != "hello world" {
-		c.Fatalf("Failed to write content to %s", fPath)
-	}
+	c.AssertCmdOutputContains(m, "cat "+fPath, "hello world")
 }

--- a/mantle/kola/tests/ignition/sethostname.go
+++ b/mantle/kola/tests/ignition/sethostname.go
@@ -15,8 +15,6 @@
 package ignition
 
 import (
-	"strings"
-
 	"github.com/coreos/mantle/kola/cluster"
 	"github.com/coreos/mantle/kola/register"
 	"github.com/coreos/mantle/platform/conf"
@@ -57,10 +55,5 @@ func init() {
 
 func setHostname(c cluster.TestCluster) {
 	m := c.Machines()[0]
-
-	out := c.MustSSH(m, "hostnamectl")
-
-	if !strings.Contains(string(out), "Static hostname: core1") {
-		c.Fatalf("hostname wasn't set correctly:\n%s", out)
-	}
+	c.AssertCmdOutputContains(m, "hostnamectl", "Static hostname: core1")
 }

--- a/mantle/kola/tests/ignition/symlink.go
+++ b/mantle/kola/tests/ignition/symlink.go
@@ -15,8 +15,6 @@
 package ignition
 
 import (
-	"strings"
-
 	"github.com/coreos/mantle/kola/cluster"
 	"github.com/coreos/mantle/kola/register"
 	"github.com/coreos/mantle/platform/conf"
@@ -56,9 +54,5 @@ func init() {
 func writeAbsoluteSymlink(c cluster.TestCluster) {
 	m := c.Machines()[0]
 
-	out := c.MustSSH(m, "readlink /etc/localtime")
-
-	if strings.Compare(string(out), "/usr/share/zoneinfo/Europe/Zurich") != 0 {
-		c.Fatalf("write absolute symlink failed:\n%s", out)
-	}
+	c.AssertCmdOutputContains(m, "readlink /etc/localtime", "/usr/share/zoneinfo/Europe/Zurich")
 }

--- a/mantle/kola/tests/ignition/systemd.go
+++ b/mantle/kola/tests/ignition/systemd.go
@@ -15,8 +15,6 @@
 package ignition
 
 import (
-	"strings"
-
 	"github.com/coreos/mantle/kola/cluster"
 	"github.com/coreos/mantle/kola/register"
 	"github.com/coreos/mantle/platform/conf"
@@ -58,8 +56,5 @@ func init() {
 func enableSystemdService(c cluster.TestCluster) {
 	m := c.Machines()[0]
 
-	out := c.MustSSH(m, "systemctl status nfs-server.service")
-	if strings.Contains(string(out), "inactive") {
-		c.Fatalf("service was not enabled or systemd-presets did not run")
-	}
+	c.AssertCmdOutputContains(m, "systemctl status nfs-server.service", "inactive")
 }


### PR DESCRIPTION
Followup to previous work on `RunCmdSync` which is aiming
to clean up how we run processes.

The rationale for this helper is much the same as APIs like
https://pkg.go.dev/github.com/stretchr/testify@v1.7.0/assert#Contains

It encapsulates this common pattern in a single line.

Also unlike `MustSSH`, we log the command to the systemd journal
too.