### PR TITLE
kola/systemd: Fix regression in previous commit

### DIFF
--- a/mantle/kola/tests/ignition/systemd.go
+++ b/mantle/kola/tests/ignition/systemd.go
@@ -56,5 +56,5 @@ func init() {
 func enableSystemdService(c cluster.TestCluster) {
 	m := c.Machines()[0]
 
-	c.AssertCmdOutputContains(m, "systemctl status nfs-server.service", "inactive")
+	c.AssertCmdOutputContains(m, "systemctl show -p ActiveState nfs-server.service", "ActiveState=active")
 }


### PR DESCRIPTION
I missed the inverted logic here.  Strengthen the test
to actively check the service state instead of checking for the
absence of `inactive` in the output text.