### PR TITLE
More assert output

### DIFF
--- a/mantle/kola/cluster/cluster.go
+++ b/mantle/kola/cluster/cluster.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/kballard/go-shellquote"
@@ -204,6 +205,15 @@ func (t *TestCluster) AssertCmdOutputContains(m platform.Machine, cmd string, ex
 	output := string(outputBuf)
 	if !strings.Contains(output, expected) {
 		t.Fatalf("cmd %s did not output %s", cmd, expected)
+	}
+}
+
+// AssertCmdOutputContains runs cmd via SSH and panics if stdout does not contain expected
+func (t *TestCluster) AssertCmdOutputMatches(m platform.Machine, cmd string, expected *regexp.Regexp) {
+	t.LogJournal(m, "+ "+cmd)
+	output := t.MustSSH(m, cmd)
+	if !expected.Match(output) {
+		t.Fatalf("cmd %s output did not match regexp %s: %s", cmd, expected, string(output))
 	}
 }
 

--- a/mantle/kola/tests/misc/selinux.go
+++ b/mantle/kola/tests/misc/selinux.go
@@ -135,11 +135,7 @@ func SelinuxEnforce(c cluster.TestCluster) {
 
 	testSelinuxCmds(c, m, cmdList)
 
-	output := c.MustSSH(m, "getenforce")
-
-	if string(output) != "Enforcing" {
-		c.Fatalf(`command "getenforce" has unexpected output: want %q, got %q`, "Enforcing", string(output))
-	}
+	c.AssertCmdOutputMatches(m, "getenforce", regexp.MustCompile("^Enforcing$"))
 }
 
 // SelinuxBoolean checks that you can tweak a boolean in the current session
@@ -216,11 +212,5 @@ func SelinuxManage(c cluster.TestCluster) {
 	testSelinuxCmds(c, m, cmdList)
 
 	// the change should be persisted after a reboot
-	output := c.MustSSH(m, "sudo semanage fcontext -l | grep vasd")
-
-	s := ".*system_u:object_r:httpd_log_t:s0"
-	match := regexp.MustCompile(s).MatchString(string(output))
-	if !match {
-		c.Fatalf(`The SELinux file context "/var/opt/quest/vas/vasd(/.*)?" is incorrectly configured.  Tried to match regexp %q, output was %q`, s, string(output))
-	}
+	c.AssertCmdOutputMatches(m, "sudo semanage fcontext -l | grep vasd", regexp.MustCompile(".*system_u:object_r:httpd_log_t:s0"))
 }

--- a/mantle/kola/tests/ostree/basic.go
+++ b/mantle/kola/tests/ostree/basic.go
@@ -149,11 +149,7 @@ func ostreeBasicTest(c cluster.TestCluster) {
 	// the checksum now
 	c.Run("rev-parse", func(c cluster.TestCluster) {
 		// check the output of `ostree rev-parse`
-		oRevParseOut := c.MustSSH(m, ("ostree rev-parse " + oas.Origin))
-
-		if string(oRevParseOut) != oas.Checksum {
-			c.Fatalf(`Checksum from "ostree rev-parse" does not match; expected %q, got %q`, oas.Checksum, string(oRevParseOut))
-		}
+		c.AssertCmdOutputContains(m, ("ostree rev-parse " + oas.Origin), oas.Checksum)
 	})
 
 	// verify the output of 'ostree show'
@@ -234,10 +230,7 @@ func ostreeRemoteTest(c cluster.TestCluster) {
 
 	// verify `ostree remote show-url`
 	c.Run("show-url", func(c cluster.TestCluster) {
-		osRemoteShowUrlOut := c.MustSSH(m, ("ostree remote show-url " + remoteName))
-		if string(osRemoteShowUrlOut) != remoteUrl {
-			c.Fatalf(`URLs don't match; expected %q, got %q`, remoteName, string(osRemoteShowUrlOut))
-		}
+		c.AssertCmdOutputContains(m, ("ostree remote show-url " + remoteName), remoteUrl)
 	})
 
 	// verify `ostree remote refs`

--- a/mantle/kola/tests/podman/podman.go
+++ b/mantle/kola/tests/podman/podman.go
@@ -157,11 +157,7 @@ func podmanWorkflow(c cluster.TestCluster) {
 	// Test: Execute command in container
 	c.Run("exec", func(c cluster.TestCluster) {
 		cmd := fmt.Sprintf("sudo podman exec %s echo hello", id)
-		out := c.MustSSH(m, cmd)
-
-		if string(out) != "hello" {
-			c.Fatal("Could not exec command in container")
-		}
+		c.AssertCmdOutputContains(m, cmd, "hello")
 	})
 
 	// Test: Stop container

--- a/mantle/kola/tests/rpmostree/deployments.go
+++ b/mantle/kola/tests/rpmostree/deployments.go
@@ -242,10 +242,7 @@ func rpmOstreeInstallUninstall(c cluster.TestCluster) {
 		}
 
 		// check the command is present, in the rpmdb, and usable
-		cmdOut := c.MustSSH(m, "command -v "+installPkgName)
-		if string(cmdOut) != installPkgBin {
-			c.Fatalf(`%q binary in unexpected location. expectd %q, got %q`, installPkgName, installPkgBin, string(cmdOut))
-		}
+		c.AssertCmdOutputContains(m, "command -v "+installPkgName, installPkgBin)
 
 		rpmOut := c.MustSSH(m, "rpm -q "+installPkgName)
 		rpmRegex := "^" + installPkgName

--- a/mantle/kola/tests/rpmostree/deployments.go
+++ b/mantle/kola/tests/rpmostree/deployments.go
@@ -243,13 +243,7 @@ func rpmOstreeInstallUninstall(c cluster.TestCluster) {
 
 		// check the command is present, in the rpmdb, and usable
 		c.AssertCmdOutputContains(m, "command -v "+installPkgName, installPkgBin)
-
-		rpmOut := c.MustSSH(m, "rpm -q "+installPkgName)
-		rpmRegex := "^" + installPkgName
-		rpmMatch := regexp.MustCompile(rpmRegex).MatchString(string(rpmOut))
-		if !rpmMatch {
-			c.Fatalf(`Output from "rpm -q" was unexpected: %q`, string(rpmOut))
-		}
+		c.AssertCmdOutputMatches(m, "rpm -q "+installPkgName, regexp.MustCompile("^"+installPkgName))
 
 		// package should be in the metadata
 		var reqPkg bool = false

--- a/mantle/kola/tests/rpmostree/status.go
+++ b/mantle/kola/tests/rpmostree/status.go
@@ -62,10 +62,7 @@ func rpmOstreeStatus(c cluster.TestCluster) {
 	m := c.Machines()[0]
 
 	// check that rpm-ostreed is static?
-	enabledOut := c.MustSSH(m, "systemctl is-enabled rpm-ostreed")
-	if string(enabledOut) != "static" {
-		c.Fatalf(`The "rpm-ostreed" service is not "static": got %v`, string(enabledOut))
-	}
+	c.AssertCmdOutputContains(m, "systemctl is-enabled rpm-ostreed", "static")
 
 	status, err := util.GetRpmOstreeStatusJSON(c, m)
 	if err != nil {
@@ -73,10 +70,7 @@ func rpmOstreeStatus(c cluster.TestCluster) {
 	}
 
 	// after running an 'rpm-ostree' command the daemon should be active
-	statusOut := c.MustSSH(m, "systemctl is-active rpm-ostreed")
-	if string(statusOut) != "active" {
-		c.Fatalf(`The "rpm-ostreed" service is not active: got %v`, string(statusOut))
-	}
+	c.AssertCmdOutputContains(m, "systemctl is-active rpm-ostreed", "active")
 
 	// a deployment should be booted (duh!)
 	if _, err := util.GetBootedDeployment(c, m); err != nil {


### PR DESCRIPTION
kola: Port more tests to AssertCmdOutputContains

In some cases this slightly weakens the assertion, but this
time I did look more carefully around substring matching.  Motivated
mainly by removing code.

---

kola: Add AssertCmdOutputMatches

This regexp based version can be more precise than just `Contains`,
and we had other tests that were doing this manually.

---

