### PR TITLE
RFC: Remove shim `fallback.efi`; chain directly to grub

### DIFF
--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -506,6 +506,13 @@ configfile $prefix/grub.cfg
 boot
 ''')
 
+            # Disable shim fallback; install grub as second-stage bootloader
+            # for fallback path
+            for fbpath in glob.glob(os.path.join(tmpimageefidir, "BOOT", "fb*.efi")):
+                os.unlink(fbpath)
+            for grubpath in glob.glob(os.path.join(tmpimageefidir, vendor_ids[0], "grub*.efi")):
+                shutil.copy(grubpath, os.path.join(tmpimageefidir, "BOOT"))
+
             # Install binaries from boot partition
             # Manually construct the tarball to ensure proper permissions and ownership
             efitarfile = tempfile.NamedTemporaryFile(suffix=".tar")

--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -313,6 +313,10 @@ set prefix=($prefix)/grub2
 configfile $prefix/grub.cfg
 boot
 EOF
+    # Disable shim fallback; install grub as second-stage bootloader for
+    # fallback path instead
+    rm "${target_efi}"/EFI/BOOT/fb*.efi
+    cp "${target_efi}/EFI/${vendor_id}"/grub*.efi "${target_efi}"/EFI/BOOT/
     install_grub_cfg
 }
 


### PR DESCRIPTION
CoreOS makes two assumptions unusual for a Linux distro: that it is the only OS on the machine, and that it is installed by `dd`'ing a disk image onto a disk that's booted on interchangeable hardware.  As such, we've generally assumed that we do not configure UEFI boot variables, and instead rely on UEFI's fallback boot mechanism to boot the OS.  But in fact, shim chains to `fallback.efi` when booted via the fallback mechanism, and the latter sets up UEFI boot variables for us.  If the machine is subsequently reprovisioned from a newer metal image (with a different ESP GUID), this will happen again, leaving a stale boot variable behind.  Some firmware gets confused by this and refuses to boot, and in any case, doing this enough times could eventually fill up EFI variable storage.

The ISO image also creates boot variables via the same mechanism, which is even worse because the ISO media will probably be removed from the machine after one boot.

Delete `fallback.efi`.  In its place, copy `grub.efi` into the `EFI/BOOT` directory, where the fallback shim can find it and chain to it.  Leave the existing copy of grub in place, for existing systems booting via boot variables.

This can be tested by running `sudo efibootmgr` on an EFI system and confirming that there is no entry for the booted OS.

Probably cosa is not the right place for this, and bootupd should handle it instead.  bootupd does at least need to know about it; `bootupctl validate` currently says `Removed: BOOT/fbx64.efi`.