### PR TITLE
mantle/harness, mantle/kola: Add test specific timeouts

### DIFF
--- a/docs/kola/external-tests.md
+++ b/docs/kola/external-tests.md
@@ -192,6 +192,7 @@ Here's an example `kola.json`:
     "requiredTag": "special",
     "additionalDisks": [ "5G" ],
     "minMemory": 4096,
+    "timeoutMin": 8,
     "exclusive": true
 }
 ```
@@ -223,6 +224,9 @@ The `minMemory` key takes a size in MB and ensures that an instance type with
 at least the specified amount of memory is used. On QEMU, this is equivalent to
 the `--memory` argument to `qemuexec`. This is currently only enforced on
 `qemu-unpriv`.
+
+The `timeoutMin` key takes a positive integer and specifies a timeout for the test 
+in minutes. After the specified amount of time, the test will be interrupted.
 
 The `exclusive` key takes a boolean value. If `true`, the test will be run by 
 itself in its own VM such that other tests do not conflict with it. If this key 

--- a/mantle/harness/suite.go
+++ b/mantle/harness/suite.go
@@ -283,10 +283,13 @@ func (s *Suite) runTests(out, tap io.Writer) error {
 		tap:       tap,
 		suite:     s,
 		reporters: s.opts.Reporters,
+		// we set an initial non-zero timeout, this will
+		// be overriden since the suite will run tests as subtests
+		timeout: defaultTimeout,
 	}
 	tRunner(t, func(t *H) {
-		for name, test := range s.tests {
-			t.Run(name, test)
+		for name, htest := range s.tests {
+			t.RunTimeout(name, htest.run, htest.timeout)
 		}
 		// Run catching the signal rather than the tRunner as a separate
 		// goroutine to avoid adding a goroutine during the sequential

--- a/mantle/harness/test.go
+++ b/mantle/harness/test.go
@@ -16,6 +16,7 @@ package harness
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/coreos/mantle/lang/maps"
 )
@@ -23,18 +24,24 @@ import (
 // Test is a single test function.
 type Test func(*H)
 
-// Tests is a set of test functions that can be given to a Suite.
-type Tests map[string]Test
+type HarnessTest struct {
+	run Test
+	// time after which test will timeout in minutes
+	timeout time.Duration
+}
+
+// Tests is a set of test functions and timeouts that can be given to a Suite.
+type Tests map[string]*HarnessTest
 
 // Add inserts the given Test into the set, initializing Tests if needed.
 // If a test with the given name already exists Add will panic.
-func (ts *Tests) Add(name string, test Test) {
+func (ts *Tests) Add(name string, test Test, timeout time.Duration) {
 	if *ts == nil {
 		*ts = make(Tests)
 	} else if _, ok := (*ts)[name]; ok {
 		panic(fmt.Errorf("harness: duplicate test %q", name))
 	}
-	(*ts)[name] = test
+	(*ts)[name] = &HarnessTest{run: test, timeout: timeout}
 }
 
 // List returns a sorted list of test names.

--- a/mantle/harness/test_test.go
+++ b/mantle/harness/test_test.go
@@ -21,9 +21,12 @@ import (
 
 func TestTestsAdd(t *testing.T) {
 	var ts Tests
-	ts.Add("test1", nil)
-	ts.Add("test2", nil)
-	expect := Tests(map[string]Test{"test1": nil, "test2": nil})
+
+	ht1 := &HarnessTest{run: nil, timeout: 0}
+	ht2 := &HarnessTest{run: nil, timeout: 2}
+	ts.Add("test1", nil, 0)
+	ts.Add("test2", nil, 2)
+	expect := Tests(map[string]*HarnessTest{"test1": ht1, "test2": ht2})
 	if !reflect.DeepEqual(ts, expect) {
 		t.Errorf("got %v wanted %v", ts, expect)
 	}
@@ -31,17 +34,17 @@ func TestTestsAdd(t *testing.T) {
 
 func TestTestsAddDup(t *testing.T) {
 	var ts Tests
-	ts.Add("test1", nil)
+	ts.Add("test1", nil, 0)
 	defer func() {
 		if recover() == nil {
 			t.Errorf("Add did not panic")
 		}
 	}()
-	ts.Add("test1", nil)
+	ts.Add("test1", nil, 0)
 }
 
 func TestTestsList(t *testing.T) {
-	ts := Tests(map[string]Test{"test01": nil, "test2": nil})
+	ts := Tests(map[string]*HarnessTest{"test01": nil, "test2": nil})
 	list := ts.List()
 	expect := []string{"test01", "test2"}
 	if !reflect.DeepEqual(list, expect) {

--- a/mantle/harness/timeout_test.go
+++ b/mantle/harness/timeout_test.go
@@ -1,0 +1,124 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package harness
+
+import (
+	"bytes"
+	"testing"
+	"time"
+)
+
+const slack = time.Duration(500) * time.Millisecond
+
+func TestTimeoutBasic(t *testing.T) {
+	timeToRun := time.Duration(2) * time.Second
+
+	tests := make(Tests)
+	tests.Add("test-1", func(h *H) {
+		_ = h
+		select {
+		case <-time.After(3 * time.Second):
+			return
+		case <-h.TimeoutContext.Done():
+			return
+		}
+	}, timeToRun)
+
+	suite := NewSuite(Options{Parallel: 1}, tests)
+
+	start := time.Now()
+	buf := &bytes.Buffer{}
+	if err := suite.runTests(buf, nil); err != nil {
+		t.Log("\n" + buf.String())
+	}
+
+	total := time.Since(start)
+	// We will make sure there are no goroutines leftover
+	// In the kola tests, we check for timeouts in the SSH code
+	// to exit running goroutines
+
+	if !(timeToRun-slack < total && total < timeToRun+slack) {
+		t.Errorf("Expected: %v +/- %v, Got: %v", timeToRun, slack, total)
+	}
+
+}
+
+func TestTimeoutNoInterrupt(t *testing.T) {
+	timeToRun := time.Duration(1) * time.Second
+
+	tests := make(Tests)
+	tests.Add("test-1", func(h *H) {
+		_ = h
+		select {
+		case <-time.After(timeToRun):
+			return
+		case <-h.TimeoutContext.Done():
+			return
+		}
+	}, time.Duration(5)*time.Second)
+
+	suite := NewSuite(Options{Parallel: 1}, tests)
+
+	start := time.Now()
+	buf := &bytes.Buffer{}
+	if err := suite.runTests(buf, nil); err != nil {
+		t.Log("\n" + buf.String())
+	}
+	total := time.Since(start)
+
+	if !(timeToRun-slack < total && total < timeToRun+slack) {
+		t.Errorf("Expected: %v +/- %v, Got: %v", timeToRun, slack, total)
+	}
+}
+
+func TestTimeoutMultipleTests(t *testing.T) {
+	totalTime := time.Duration(2) * time.Second
+
+	tests := make(Tests)
+	// Will finish after 1s
+	tests.Add("test-1", func(h *H) {
+		_ = h
+		select {
+		case <-time.After(1 * time.Second):
+			return
+		case <-h.TimeoutContext.Done():
+			return
+		}
+	}, time.Duration(5)*time.Second)
+
+	// Will timeout after 1s
+	tests.Add("test-2", func(h *H) {
+		_ = h
+		select {
+		case <-time.After(2 * time.Second):
+			return
+		case <-h.TimeoutContext.Done():
+			return
+		}
+	}, time.Duration(1)*time.Second)
+
+	suite := NewSuite(Options{Parallel: 2}, tests)
+
+	start := time.Now()
+	buf := &bytes.Buffer{}
+	if err := suite.runTests(buf, nil); err != nil {
+		t.Log("\n" + buf.String())
+	}
+	total := time.Since(start)
+
+	if !(totalTime-slack < total && total < totalTime+slack) {
+		t.Errorf("Expected: %v +/- %v, Got: %v", totalTime, slack, total)
+	}
+}

--- a/mantle/kola/cluster/cluster.go
+++ b/mantle/kola/cluster/cluster.go
@@ -137,14 +137,24 @@ func DropFile(machines []platform.Machine, localPath string) error {
 // This ensures the output will be correctly accumulated under the correct
 // test.
 func (t *TestCluster) SSH(m platform.Machine, cmd string) ([]byte, error) {
-	stdout, stderr, err := m.SSH(cmd)
+	var stdout, stderr []byte
+	var err error
+	sshCompleted := make(chan bool)
+	go func() {
+		stdout, stderr, err = m.SSH(cmd)
+		sshCompleted <- true
+	}()
 
-	if len(stderr) > 0 {
-		for _, line := range strings.Split(string(stderr), "\n") {
-			t.Log(line)
+	select {
+	case <-t.H.TimeoutContext.Done():
+		t.H.FailNow()
+	case <-sshCompleted:
+		if len(stderr) > 0 {
+			for _, line := range strings.Split(string(stderr), "\n") {
+				t.Log(line)
+			}
 		}
 	}
-
 	return stdout, err
 }
 

--- a/mantle/kola/register/register.go
+++ b/mantle/kola/register/register.go
@@ -16,6 +16,7 @@ package register
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/coreos/mantle/kola/cluster"
 	"github.com/coreos/mantle/platform/conf"
@@ -53,17 +54,18 @@ type Test struct {
 	NativeFuncs          map[string]NativeFuncWrap
 	UserData             *conf.UserData
 	ClusterSize          int
-	Platforms            []string // allowlist of platforms to run test against -- defaults to all
-	Firmwares            []string // allowlist of firmwares to run test against -- defaults to all
-	ExcludePlatforms     []string // denylist of platforms to ignore -- defaults to none
-	ExcludeFirmwares     []string // denylist of firmwares to ignore -- defaults to none
-	Distros              []string // allowlist of distributions to run test against -- defaults to all
-	ExcludeDistros       []string // denylist of distributions to ignore -- defaults to none
-	Architectures        []string // allowlist of machine architectures supported -- defaults to all
-	ExcludeArchitectures []string // denylist of architectures to ignore -- defaults to none
-	Flags                []Flag   // special-case options for this test
-	Tags                 []string // list of tags that can be matched against -- defaults to none
-	RequiredTag          string   // if specified, test is filtered by default unless tag is provided -- defaults to none
+	Platforms            []string      // allowlist of platforms to run test against -- defaults to all
+	Firmwares            []string      // allowlist of firmwares to run test against -- defaults to all
+	ExcludePlatforms     []string      // denylist of platforms to ignore -- defaults to none
+	ExcludeFirmwares     []string      // denylist of firmwares to ignore -- defaults to none
+	Distros              []string      // allowlist of distributions to run test against -- defaults to all
+	ExcludeDistros       []string      // denylist of distributions to ignore -- defaults to none
+	Architectures        []string      // allowlist of machine architectures supported -- defaults to all
+	ExcludeArchitectures []string      // denylist of architectures to ignore -- defaults to none
+	Flags                []Flag        // special-case options for this test
+	Tags                 []string      // list of tags that can be matched against -- defaults to none
+	Timeout              time.Duration // the duration for which a test will be allowed to run
+	RequiredTag          string        // if specified, test is filtered by default unless tag is provided -- defaults to none
 
 	// Whether the primary disk is multipathed.
 	MultiPathDisk bool


### PR DESCRIPTION
Each test has an adjustable timeout and by default all tests have a 10 min
timeout. If a test is running a subtest, the timeout is ignored.

As requested here: https://github.com/coreos/coreos-assembler/issues/2350 