### PR TITLE
mantle/kola: grab AWS images for aarch64 from stream metadata

### DIFF
--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -366,12 +366,12 @@ func syncStreamOptions() error {
 	case "":
 		return fmt.Errorf("Must specify -b/--distro with --stream")
 	case "fcos":
-		artifacts, err = fcos.FetchStreamThisArchitecture(kola.Options.Stream)
+		artifacts, err = fcos.FetchCanonicalStreamArtifacts(kola.Options.Stream, kola.Options.CosaBuildArch)
 		if err != nil {
 			return errors.Wrapf(err, "failed to fetch stream")
 		}
 	case "rhcos":
-		artifacts, err = rhcos.FetchStreamThisArchitecture(kola.Options.Stream)
+		artifacts, err = rhcos.FetchStreamArtifacts(kola.Options.Stream, kola.Options.CosaBuildArch)
 		if err != nil {
 			return errors.Wrapf(err, "failed to fetch stream")
 		}
@@ -393,7 +393,9 @@ func syncStreamOptions() error {
 		return fmt.Errorf("Unhandled platform %s for stream", kolaPlatform)
 	}
 
-	fmt.Printf("Resolved distro=%s stream=%s platform=%s to release=%s %s\n", kola.Options.Distribution, kola.Options.Stream, kolaPlatform, release, extra)
+	fmt.Printf("Resolved distro=%s stream=%s platform=%s arch=%s to release=%s %s\n",
+		kola.Options.Distribution, kola.Options.Stream,
+		kolaPlatform, kola.Options.CosaBuildArch, release, extra)
 
 	return nil
 }


### PR DESCRIPTION
Now that our stream metadata has mutli-arch images let's be able to
switch on that now as well. For example now we can pick up the aarch64
AMI with something like:

```
cosa kola spawn -b fcos --stream stable --arch=aarch64 -p aws --aws-credentials-file /srv/creds
```