### PR TITLE
buildextend-live: drop shim fallback.efi from ISO; simplify EFI image

### DIFF
--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -480,6 +480,34 @@ def generate_iso():
             tmpimageefidir = os.path.join(tmpdir, "efi")
             ostree_extract_efi(repo, buildmeta_commit, tmpimageefidir)
 
+            # Find name of vendor directory
+            vendor_ids = [n for n in os.listdir(tmpimageefidir) if n != "BOOT"]
+            if len(vendor_ids) != 1:
+                raise Exception(f"did not find exactly one EFI vendor ID: {vendor_ids}")
+
+            # Delete fallback and its CSV file.  Its purpose is to create
+            # EFI boot variables, which we don't want when booting from
+            # removable media.
+            #
+            # A future shim release will merge fallback.efi into the main
+            # shim binary and enable the fallback behavior when the CSV
+            # exists.  But for now, fail if fallback.efi is missing.
+            for path in ensure_glob(os.path.join(tmpimageefidir, "BOOT", "fb*.efi")):
+                os.unlink(path)
+            for path in ensure_glob(os.path.join(tmpimageefidir, vendor_ids[0], "BOOT*.CSV")):
+                os.unlink(path)
+
+            # Drop vendor copies of shim; we already have it in BOOT*.EFI in
+            # BOOT
+            for path in ensure_glob(os.path.join(tmpimageefidir, vendor_ids[0], "shim*.efi")):
+                os.unlink(path)
+
+            # Consolidate remaining files into BOOT.  shim needs GRUB to be
+            # there, and the rest doesn't hurt.
+            for path in ensure_glob(os.path.join(tmpimageefidir, vendor_ids[0], "*")):
+                shutil.move(path, os.path.join(tmpimageefidir, "BOOT"))
+            os.rmdir(os.path.join(tmpimageefidir, vendor_ids[0]))
+
             # Inject a stub grub.cfg pointing to the one in the main ISO image.
             #
             # When booting via El Torito, this stub is not used; GRUB reads
@@ -494,10 +522,7 @@ def generate_iso():
             # Torito at all.  In that case, GRUB thinks it booted from a
             # partition of the disk (a fake ESP created by isohybrid,
             # pointing to efiboot.img) and needs a grub.cfg there.
-            vendor_ids = [n for n in os.listdir(tmpimageefidir) if n != "BOOT"]
-            if len(vendor_ids) != 1:
-                raise Exception(f"did not find exactly one EFI vendor ID: {vendor_ids}")
-            with open(os.path.join(tmpimageefidir, vendor_ids[0], "grub.cfg"), "w") as fh:
+            with open(os.path.join(tmpimageefidir, "BOOT", "grub.cfg"), "w") as fh:
                 fh.write(f'''search --label "{volid}" --set root --no-floppy
 set prefix=($root)/EFI/{vendor_ids[0]}
 echo "Booting via ESP..."

--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -14,12 +14,11 @@ import sys
 import tarfile
 import tempfile
 import time
-import glob
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from cosalib.builds import Builds
 from cosalib.cmdlib import run_verbose, sha256sum_file, flatten_image_yaml
-from cosalib.cmdlib import import_ostree_commit, get_basearch
+from cosalib.cmdlib import import_ostree_commit, get_basearch, ensure_glob
 from cosalib.meta import GenericBuildMeta
 
 
@@ -405,7 +404,7 @@ def generate_iso():
     elif basearch == "ppc64le":
         os.makedirs(os.path.join(tmpisoroot, 'boot/grub'))
         # can be EFI/fedora or EFI/redhat
-        grubpath = glob.glob(os.path.join(tmpisoroot, 'EFI/*/grub.cfg'))
+        grubpath = ensure_glob(os.path.join(tmpisoroot, 'EFI/*/grub.cfg'))
         shutil.move(grubpath[0], os.path.join(tmpisoroot, 'boot/grub/grub.cfg'))
 
         # safely remove things we don't need in the final ISO tree

--- a/src/cmd-generate-hashlist
+++ b/src/cmd-generate-hashlist
@@ -7,7 +7,6 @@ See: https://keylime.dev/
 
 import argparse
 import datetime
-import glob
 import json
 import os
 import subprocess
@@ -19,6 +18,7 @@ sys.path.insert(0, cosa_dir)
 
 from cosalib import meta
 from cosalib.cmdlib import (
+    ensure_glob,
     get_basearch,
     sha256sum_file,
     import_ostree_commit)
@@ -91,7 +91,7 @@ class HashListV1(dict):
         self.hash_from_path(checkout)
 
         # Extract initramfs contents
-        initramfs_path = glob.glob(
+        initramfs_path = ensure_glob(
             os.path.join(
                 checkout, 'usr/lib/modules/*/initramfs.img'))[0]
         initramfs_path = os.path.realpath(initramfs_path)

--- a/src/cosalib/cmdlib.py
+++ b/src/cosalib/cmdlib.py
@@ -2,6 +2,7 @@
 """
 Houses helper code for python based coreos-assembler commands.
 """
+import glob
 import hashlib
 import json
 import os
@@ -378,3 +379,11 @@ def flatten_image_yaml(srcfile, base=None):
     fn = os.path.join(os.path.dirname(srcfile), srcyaml['include'])
     del base['include']
     return flatten_image_yaml(fn, base)
+
+
+def ensure_glob(pathname, **kwargs):
+    '''Call glob.glob(), and fail if there are no results.'''
+    ret = glob.glob(pathname, **kwargs)
+    if not ret:
+        raise Exception(f'No matches for {pathname}')
+    return ret


### PR DESCRIPTION
UEFI boots from removable media via the arch-specific default EFI application in `/EFI/BOOT`.  When booted that way, shim chains to fallback.efi if it exists, and fallback.efi creates an EFI boot entry.  That's not appropriate for removable media boot, since the media will probably never be present again.  If a TPM is present, fallback.efi will additionally reboot the machine, and on some machines this leads to boot loops.  Instead of all this, we just want shim to chain directly to GRUB.

The EFI boot image currently looks like this:

    EFI/BOOT/BOOTX64.EFI
    EFI/BOOT/fbx64.efi
    EFI/fedora/BOOTX64.CSV
    EFI/fedora/fonts/
    EFI/fedora/grub.cfg
    EFI/fedora/grubx64.efi
    EFI/fedora/mmx64.efi
    EFI/fedora/shim.efi
    EFI/fedora/shimx64.efi

Refactor the EFI boot image under the expectation that we never want to create or boot from an EFI boot entry.  Consolidate `/EFI/<vendor-id>` into `/EFI/BOOT` and delete things we don't need: `fallback.efi`, its associated CSV, and extra copies of shim.  The result is this:

    EFI/BOOT/BOOTX64.EFI
    EFI/BOOT/fonts/
    EFI/BOOT/grub.cfg
    EFI/BOOT/grubx64.efi
    EFI/BOOT/mmx64.efi

This also saves a couple MB of space.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2004449