### PR TITLE
[rhcos-4.7] buildextend-live: drop shim fallback.efi from ISO

### DIFF
--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -38,6 +38,14 @@ def ostree_extract_efi(repo, commit, destdir):
                  commit, destdir])
 
 
+def ensure_glob(pathname, **kwargs):
+    '''Call glob.glob(), and fail if there are no results.'''
+    ret = glob.glob(pathname, **kwargs)
+    if not ret:
+        raise Exception(f'No matches for {pathname}')
+    return ret
+
+
 live_exclude_kargs = set([
     '$ignition_firstboot',   # unsubstituted variable in grub config
     'console',               # no serial console by default on ISO
@@ -507,6 +515,20 @@ echo "Booting via ESP..."
 configfile $prefix/grub.cfg
 boot
 ''')
+
+            # Delete fallback and its CSV file.  Its purpose is to create
+            # EFI boot variables, which we don't want when booting from
+            # removable media.  Replace it with a copy of GRUB.
+            #
+            # A future shim release will merge fallback.efi into the main
+            # shim binary and enable the fallback behavior when the CSV
+            # exists.  But for now, fail if fallback.efi is missing.
+            for path in ensure_glob(os.path.join(tmpimageefidir, "BOOT", "fb*.efi")):
+                os.unlink(path)
+            for path in ensure_glob(os.path.join(tmpimageefidir, vendor_ids[0], "BOOT*.CSV")):
+                os.unlink(path)
+            for path in ensure_glob(os.path.join(tmpimageefidir, vendor_ids[0], "grub*.efi")):
+                shutil.copy(path, os.path.join(tmpimageefidir, "BOOT"))
 
             # Install binaries from boot partition
             # Manually construct the tarball to ensure proper permissions and ownership


### PR DESCRIPTION
UEFI boots from removable media via the arch-specific default EFI application in `/EFI/BOOT`.  When booted that way, shim chains to fallback.efi if it exists, and fallback.efi creates an EFI boot entry.  That's not appropriate for removable media boot, since the media will probably never be present again.  If a TPM is present, fallback.efi will additionally reboot the machine, and on some machines this leads to boot loops.  Instead of all this, we just want shim to chain directly to GRUB.

Drop fallback.efi and its associated CSV from the EFI image.  Replace it with a copy of GRUB in the right place for shim to chain to it.

This is a lightweight backport of https://github.com/coreos/coreos-assembler/pull/2435.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2004449