### PR TITLE
[rhcos-4.6] buildextend-live: drop shim fallback.efi from ISO

### DIFF
--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -491,9 +491,10 @@ def generate_iso():
 
     run_verbose(genisoargs)
 
-    # Add MBR for x86_64 legacy (BIOS) boot when ISO is copied to a USB stick
+    # Add MBR, and GPT with ESP, for x86_64 BIOS/UEFI boot when ISO is
+    # copied to a USB stick
     if basearch == "x86_64":
-        run_verbose(['/usr/bin/isohybrid', tmpisofile])
+        run_verbose(['/usr/bin/isohybrid', '--uefi', tmpisofile])
 
     isoinfo = run_verbose(['isoinfo', '-lR', '-i', tmpisofile],
                           stdout=subprocess.PIPE, text=True).stdout

--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -38,6 +38,14 @@ def ostree_extract_efi(repo, commit, destdir):
                  commit, destdir])
 
 
+def ensure_glob(pathname, **kwargs):
+    '''Call glob.glob(), and fail if there are no results.'''
+    ret = glob.glob(pathname, **kwargs)
+    if not ret:
+        raise Exception(f'No matches for {pathname}')
+    return ret
+
+
 live_exclude_kargs = set([
     '$ignition_firstboot',   # unsubstituted variable in grub config
     'console',               # no serial console by default on ISO
@@ -493,6 +501,20 @@ echo "Booting via ESP..."
 configfile $prefix/grub.cfg
 boot
 ''')
+
+            # Delete fallback and its CSV file.  Its purpose is to create
+            # EFI boot variables, which we don't want when booting from
+            # removable media.  Replace it with a copy of GRUB.
+            #
+            # A future shim release will merge fallback.efi into the main
+            # shim binary and enable the fallback behavior when the CSV
+            # exists.  But for now, fail if fallback.efi is missing.
+            for path in ensure_glob(os.path.join(tmpimageefidir, "BOOT", "fb*.efi")):
+                os.unlink(path)
+            for path in ensure_glob(os.path.join(tmpimageefidir, vendor_ids[0], "BOOT*.CSV")):
+                os.unlink(path)
+            for path in ensure_glob(os.path.join(tmpimageefidir, vendor_ids[0], "grub*.efi")):
+                shutil.copy(path, os.path.join(tmpimageefidir, "BOOT"))
 
             # Install binaries from boot partition
             # Manually construct the tarball to ensure proper permissions and ownership

--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -489,6 +489,7 @@ def generate_iso():
             with open(os.path.join(tmpimageefidir, vendor_ids[0], "grub.cfg"), "w") as fh:
                 fh.write(f'''search --label "{volid}" --set root --no-floppy
 set prefix=($root)/EFI/{vendor_ids[0]}
+echo "Booting via ESP..."
 configfile $prefix/grub.cfg
 boot
 ''')

--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -469,6 +469,30 @@ def generate_iso():
             tmpimageefidir = os.path.join(tmpdir, "efi")
             ostree_extract_efi(repo, buildmeta_commit, tmpimageefidir)
 
+            # Inject a stub grub.cfg pointing to the one in the main ISO image.
+            #
+            # When booting via El Torito, this stub is not used; GRUB reads
+            # the ISO image directly using its own ISO support.  This
+            # happens when booting from a CD device, or when the ISO is
+            # copied to a USB stick and booted on EFI firmware which prefers
+            # to boot a hard disk from an El Torito image if it has one.
+            # EDK II in QEMU behaves this way.
+            #
+            # This stub is used with EFI firmware which prefers to boot a
+            # hard disk from an ESP, or which cannot boot a hard disk via El
+            # Torito at all.  In that case, GRUB thinks it booted from a
+            # partition of the disk (a fake ESP created by isohybrid,
+            # pointing to efiboot.img) and needs a grub.cfg there.
+            vendor_ids = [n for n in os.listdir(tmpimageefidir) if n != "BOOT"]
+            if len(vendor_ids) != 1:
+                raise Exception(f"did not find exactly one EFI vendor ID: {vendor_ids}")
+            with open(os.path.join(tmpimageefidir, vendor_ids[0], "grub.cfg"), "w") as fh:
+                fh.write(f'''search --label "{volid}" --set root --no-floppy
+set prefix=($root)/EFI/{vendor_ids[0]}
+configfile $prefix/grub.cfg
+boot
+''')
+
             # Install binaries from boot partition
             # Manually construct the tarball to ensure proper permissions and ownership
             efitarfile = tempfile.NamedTemporaryFile(suffix=".tar")


### PR DESCRIPTION
UEFI boots from removable media via the arch-specific default EFI application in `/EFI/BOOT`.  When booted that way, shim chains to fallback.efi if it exists, and fallback.efi creates an EFI boot entry.  That's not appropriate for removable media boot, since the media will probably never be present again.  If a TPM is present, fallback.efi will additionally reboot the machine, and on some machines this leads to boot loops.  Instead of all this, we just want shim to chain directly to GRUB.

Drop fallback.efi and its associated CSV from the EFI image.  Replace it with a copy of GRUB in the right place for shim to chain to it.

Unlike 4.7+, the 4.6 live ISO doesn't attempt to support UEFI booting when copied to a USB stick (except for firmware that can do so via El Torito).  Fixing this is a small change, so for consistency with newer releases, backport the commits to do so.  Then apply a lightweight backport of https://github.com/coreos/coreos-assembler/pull/2435.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2004449