### PR TITLE
build: Default to CMD=/usr/bin/bash in our oscontainers

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -405,7 +405,7 @@ else
             ;;
         oci)
             ostree_tarfile_path="${name}-${buildid}-ostree.${basearch}.ociarchive"
-            rpm-ostree ex-container 'export' --repo="${tmprepo}" "${buildid}" oci-archive:"${ostree_tarfile_path}".tmp:latest
+            rpm-ostree ex-container 'export' --cmd /usr/bin/bash --repo="${tmprepo}" "${buildid}" oci-archive:"${ostree_tarfile_path}".tmp:latest
             ;;
         *) fatal "Unknown ostree-format: ${ostree_format}"
     esac


### PR DESCRIPTION
The ostree-container code does not have a default here because
it's a low level API.  Here, let's match the Fedora default so
the resulting containers can be run with a minimum of friction.