### PR TITLE
mantle/openstack: various openstack updates

### DIFF
--- a/mantle/cmd/ore/openstack/create.go
+++ b/mantle/cmd/ore/openstack/create.go
@@ -19,6 +19,7 @@ import (
 	"os"
 
 	"github.com/coreos/mantle/sdk"
+	"github.com/coreos/mantle/system"
 	"github.com/spf13/cobra"
 )
 
@@ -37,10 +38,12 @@ After a successful run, the final line of output will be the ID of the image.
 
 	path string
 	name string
+	arch string
 )
 
 func init() {
 	OpenStack.AddCommand(cmdCreate)
+	cmdCreate.Flags().StringVar(&arch, "arch", system.RpmArch(), "The architecture of the image")
 	cmdCreate.Flags().StringVar(&path, "file",
 		sdk.BuildRoot()+"/images/amd64-usr/latest/coreos_production_openstack_image.img",
 		"path to CoreOS image (build with: ./image_to_vm.sh --format=openstack ...)")
@@ -48,7 +51,7 @@ func init() {
 }
 
 func runCreate(cmd *cobra.Command, args []string) error {
-	id, err := API.UploadImage(name, path)
+	id, err := API.UploadImage(name, path, arch)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Couldn't create image: %v\n", err)
 		os.Exit(1)

--- a/mantle/cmd/ore/openstack/create.go
+++ b/mantle/cmd/ore/openstack/create.go
@@ -36,9 +36,10 @@ After a successful run, the final line of output will be the ID of the image.
 		SilenceUsage: true,
 	}
 
-	path string
-	name string
-	arch string
+	path       string
+	name       string
+	arch       string
+	visibility string
 )
 
 func init() {
@@ -48,10 +49,11 @@ func init() {
 		sdk.BuildRoot()+"/images/amd64-usr/latest/coreos_production_openstack_image.img",
 		"path to CoreOS image (build with: ./image_to_vm.sh --format=openstack ...)")
 	cmdCreate.Flags().StringVar(&name, "name", "", "image name")
+	cmdCreate.Flags().StringVar(&visibility, "visibility", "private", "Image visibility within OpenStack")
 }
 
 func runCreate(cmd *cobra.Command, args []string) error {
-	id, err := API.UploadImage(name, path, arch)
+	id, err := API.UploadImage(name, path, arch, visibility)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Couldn't create image: %v\n", err)
 		os.Exit(1)

--- a/mantle/go.mod
+++ b/mantle/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/digitalocean/go-qemu v0.0.0-20200529005954-1b453d036a9c
 	github.com/digitalocean/godo v1.33.0
 	github.com/dimchansky/utfbom v1.1.1 // indirect
-	github.com/golang/protobuf v1.4.2
+	github.com/golang/protobuf v1.4.2 // indirect
 	github.com/google/renameio v1.0.1 // indirect
 	github.com/gophercloud/gophercloud v0.17.0
 	github.com/gophercloud/utils v0.0.0-20210323225332-7b186010c04f

--- a/mantle/kola/tests/ignition/ssh.go
+++ b/mantle/kola/tests/ignition/ssh.go
@@ -27,7 +27,7 @@ func init() {
 		Name:             "coreos.ignition.ssh.key",
 		Run:              noAfterburnSSHKey,
 		ClusterSize:      1,
-		ExcludePlatforms: []string{"qemu", "openstack"}, // redundant on qemu
+		ExcludePlatforms: []string{"qemu"}, // redundant on qemu
 		Flags:            []register.Flag{register.NoSSHKeyInMetadata},
 		UserData:         conf.Ignition(`{"ignition":{"version":"3.0.0"}}`),
 		Tags:             []string{"ignition"},

--- a/mantle/platform/api/openstack/api.go
+++ b/mantle/platform/api/openstack/api.go
@@ -545,12 +545,14 @@ func (a *API) GetConsoleOutput(id string) (string, error) {
 	return servers.ShowConsoleOutput(a.computeClient, id, servers.ShowConsoleOutputOpts{}).Extract()
 }
 
-func (a *API) UploadImage(name, path string) (string, error) {
+func (a *API) UploadImage(name, path, arch string) (string, error) {
 	image, err := images.Create(a.imageClient, images.CreateOpts{
 		Name:            name,
 		ContainerFormat: "bare",
 		DiskFormat:      "qcow2",
 		Tags:            []string{"mantle"},
+		// https://docs.openstack.org/glance/latest/admin/useful-image-properties.html#image-property-keys-and-values
+		Properties: map[string]string{"architecture": arch},
 	}).Extract()
 	if err != nil {
 		return "", fmt.Errorf("creating image: %v", err)

--- a/mantle/platform/api/openstack/api.go
+++ b/mantle/platform/api/openstack/api.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/coreos/pkg/capnslog"
 	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/bootfromvolume"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/floatingips"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/keypairs"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/flavors"
@@ -159,11 +160,11 @@ func New(opts *Options) (*API, error) {
 	}
 
 	if a.opts.Image != "" {
-		tmp, err := a.ResolveImage(a.opts.Image)
+		uuid, err := a.ResolveImage(a.opts.Image)
 		if err != nil {
 			return nil, fmt.Errorf("resolving image: %v", err)
 		}
-		a.opts.Image = tmp
+		a.opts.Image = uuid
 	}
 
 	if a.opts.Network != "" {
@@ -280,11 +281,12 @@ func (a *API) CreateServer(name, sshKeyID, userdata string) (*Server, error) {
 		return nil, fmt.Errorf("retrieving security group: %v", err)
 	}
 
-	server, err := servers.Create(a.computeClient, keypairs.CreateOptsExt{
+	// Define options for the new instance. Use keypairs.CreateOptsExt
+	// to add our SSH key to the instance that way.
+	serverCreateOpts := keypairs.CreateOptsExt{
 		CreateOptsBuilder: servers.CreateOpts{
 			Name:      name,
 			FlavorRef: a.opts.Flavor,
-			ImageRef:  a.opts.Image,
 			Metadata: map[string]string{
 				"CreatedBy": "mantle",
 			},
@@ -297,6 +299,23 @@ func (a *API) CreateServer(name, sshKeyID, userdata string) (*Server, error) {
 			UserData: []byte(userdata),
 		},
 		KeyName: sshKeyID,
+	}
+	// Create a boot device volume and create an instance from that by
+	// using "boot-from-volume". This means the instances boot a bit faster.
+	// Previously we were timing out because it was taking 10+ minutes for
+	// instances to come up in VexxHost. This helps with that.
+	bootVolume := []bootfromvolume.BlockDevice{
+		bootfromvolume.BlockDevice{
+			UUID:                a.opts.Image,
+			VolumeSize:          10,
+			DeleteOnTermination: true,
+			SourceType:          bootfromvolume.SourceImage,
+			DestinationType:     bootfromvolume.DestinationVolume,
+		},
+	}
+	server, err := bootfromvolume.Create(a.computeClient, bootfromvolume.CreateOptsExt{
+		CreateOptsBuilder: serverCreateOpts,
+		BlockDevice:       bootVolume,
 	}).Extract()
 	if err != nil {
 		return nil, fmt.Errorf("creating server: %v", err)

--- a/mantle/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/bootfromvolume/doc.go
+++ b/mantle/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/bootfromvolume/doc.go
@@ -1,0 +1,152 @@
+/*
+Package bootfromvolume extends a server create request with the ability to
+specify block device options. This can be used to boot a server from a block
+storage volume as well as specify multiple ephemeral disks upon creation.
+
+It is recommended to refer to the Block Device Mapping documentation to see
+all possible ways to configure a server's block devices at creation time:
+
+https://docs.openstack.org/nova/latest/user/block-device-mapping.html
+
+Note that this package implements `block_device_mapping_v2`.
+
+Example of Creating a Server From an Image
+
+This example will boot a server from an image and use a standard ephemeral
+disk as the server's root disk. This is virtually no different than creating
+a server without using block device mappings.
+
+	blockDevices := []bootfromvolume.BlockDevice{
+		bootfromvolume.BlockDevice{
+			BootIndex:           0,
+			DeleteOnTermination: true,
+			DestinationType:     bootfromvolume.DestinationLocal,
+			SourceType:          bootfromvolume.SourceImage,
+			UUID:                "image-uuid",
+		},
+	}
+
+	serverCreateOpts := servers.CreateOpts{
+		Name:      "server_name",
+		FlavorRef: "flavor-uuid",
+		ImageRef:  "image-uuid",
+	}
+
+	createOpts := bootfromvolume.CreateOptsExt{
+		CreateOptsBuilder: serverCreateOpts,
+		BlockDevice:       blockDevices,
+	}
+
+	server, err := bootfromvolume.Create(client, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example of Creating a Server From a New Volume
+
+This example will create a block storage volume based on the given Image. The
+server will use this volume as its root disk.
+
+	blockDevices := []bootfromvolume.BlockDevice{
+		bootfromvolume.BlockDevice{
+			DeleteOnTermination: true,
+			DestinationType:     bootfromvolume.DestinationVolume,
+			SourceType:          bootfromvolume.SourceImage,
+			UUID:                "image-uuid",
+			VolumeSize:          2,
+		},
+	}
+
+	serverCreateOpts := servers.CreateOpts{
+		Name:      "server_name",
+		FlavorRef: "flavor-uuid",
+	}
+
+	createOpts := bootfromvolume.CreateOptsExt{
+		CreateOptsBuilder: serverCreateOpts,
+		BlockDevice:       blockDevices,
+	}
+
+	server, err := bootfromvolume.Create(client, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example of Creating a Server From an Existing Volume
+
+This example will create a server with an existing volume as its root disk.
+
+	blockDevices := []bootfromvolume.BlockDevice{
+		bootfromvolume.BlockDevice{
+			DeleteOnTermination: true,
+			DestinationType:     bootfromvolume.DestinationVolume,
+			SourceType:          bootfromvolume.SourceVolume,
+			UUID:                "volume-uuid",
+		},
+	}
+
+	serverCreateOpts := servers.CreateOpts{
+		Name:      "server_name",
+		FlavorRef: "flavor-uuid",
+	}
+
+	createOpts := bootfromvolume.CreateOptsExt{
+		CreateOptsBuilder: serverCreateOpts,
+		BlockDevice:       blockDevices,
+	}
+
+	server, err := bootfromvolume.Create(client, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example of Creating a Server with Multiple Ephemeral Disks
+
+This example will create a server with multiple ephemeral disks. The first
+block device will be based off of an existing Image. Each additional
+ephemeral disks must have an index of -1.
+
+	blockDevices := []bootfromvolume.BlockDevice{
+		bootfromvolume.BlockDevice{
+			BootIndex:           0,
+			DestinationType:     bootfromvolume.DestinationLocal,
+			DeleteOnTermination: true,
+			SourceType:          bootfromvolume.SourceImage,
+			UUID:                "image-uuid",
+			VolumeSize:          5,
+		},
+		bootfromvolume.BlockDevice{
+			BootIndex:           -1,
+			DestinationType:     bootfromvolume.DestinationLocal,
+			DeleteOnTermination: true,
+			GuestFormat:         "ext4",
+			SourceType:          bootfromvolume.SourceBlank,
+			VolumeSize:          1,
+		},
+		bootfromvolume.BlockDevice{
+			BootIndex:           -1,
+			DestinationType:     bootfromvolume.DestinationLocal,
+			DeleteOnTermination: true,
+			GuestFormat:         "ext4",
+			SourceType:          bootfromvolume.SourceBlank,
+			VolumeSize:          1,
+		},
+	}
+
+	serverCreateOpts := servers.CreateOpts{
+		Name:      "server_name",
+		FlavorRef: "flavor-uuid",
+		ImageRef:  "image-uuid",
+	}
+
+	createOpts := bootfromvolume.CreateOptsExt{
+		CreateOptsBuilder: serverCreateOpts,
+		BlockDevice:       blockDevices,
+	}
+
+	server, err := bootfromvolume.Create(client, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+*/
+package bootfromvolume

--- a/mantle/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/bootfromvolume/requests.go
+++ b/mantle/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/bootfromvolume/requests.go
@@ -1,0 +1,133 @@
+package bootfromvolume
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
+)
+
+type (
+	// DestinationType represents the type of medium being used as the
+	// destination of the bootable device.
+	DestinationType string
+
+	// SourceType represents the type of medium being used as the source of the
+	// bootable device.
+	SourceType string
+)
+
+const (
+	// DestinationLocal DestinationType is for using an ephemeral disk as the
+	// destination.
+	DestinationLocal DestinationType = "local"
+
+	// DestinationVolume DestinationType is for using a volume as the destination.
+	DestinationVolume DestinationType = "volume"
+
+	// SourceBlank SourceType is for a "blank" or empty source.
+	SourceBlank SourceType = "blank"
+
+	// SourceImage SourceType is for using images as the source of a block device.
+	SourceImage SourceType = "image"
+
+	// SourceSnapshot SourceType is for using a volume snapshot as the source of
+	// a block device.
+	SourceSnapshot SourceType = "snapshot"
+
+	// SourceVolume SourceType is for using a volume as the source of block
+	// device.
+	SourceVolume SourceType = "volume"
+)
+
+// BlockDevice is a structure with options for creating block devices in a
+// server. The block device may be created from an image, snapshot, new volume,
+// or existing volume. The destination may be a new volume, existing volume
+// which will be attached to the instance, ephemeral disk, or boot device.
+type BlockDevice struct {
+	// SourceType must be one of: "volume", "snapshot", "image", or "blank".
+	SourceType SourceType `json:"source_type" required:"true"`
+
+	// UUID is the unique identifier for the existing volume, snapshot, or
+	// image (see above).
+	UUID string `json:"uuid,omitempty"`
+
+	// BootIndex is the boot index. It defaults to 0.
+	BootIndex int `json:"boot_index"`
+
+	// DeleteOnTermination specifies whether or not to delete the attached volume
+	// when the server is deleted. Defaults to `false`.
+	DeleteOnTermination bool `json:"delete_on_termination"`
+
+	// DestinationType is the type that gets created. Possible values are "volume"
+	// and "local".
+	DestinationType DestinationType `json:"destination_type,omitempty"`
+
+	// GuestFormat specifies the format of the block device.
+	GuestFormat string `json:"guest_format,omitempty"`
+
+	// VolumeSize is the size of the volume to create (in gigabytes). This can be
+	// omitted for existing volumes.
+	VolumeSize int `json:"volume_size,omitempty"`
+
+	// DeviceType specifies the device type of the block devices.
+	// Examples of this are disk, cdrom, floppy, lun, etc.
+	DeviceType string `json:"device_type,omitempty"`
+
+	// DiskBus is the bus type of the block devices.
+	// Examples of this are ide, usb, virtio, scsi, etc.
+	DiskBus string `json:"disk_bus,omitempty"`
+
+	// VolumeType is the volume type of the block device.
+	// This requires Compute API microversion 2.67 or later.
+	VolumeType string `json:"volume_type,omitempty"`
+}
+
+// CreateOptsExt is a structure that extends the server `CreateOpts` structure
+// by allowing for a block device mapping.
+type CreateOptsExt struct {
+	servers.CreateOptsBuilder
+	BlockDevice []BlockDevice `json:"block_device_mapping_v2,omitempty"`
+}
+
+// ToServerCreateMap adds the block device mapping option to the base server
+// creation options.
+func (opts CreateOptsExt) ToServerCreateMap() (map[string]interface{}, error) {
+	base, err := opts.CreateOptsBuilder.ToServerCreateMap()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(opts.BlockDevice) == 0 {
+		err := gophercloud.ErrMissingInput{}
+		err.Argument = "bootfromvolume.CreateOptsExt.BlockDevice"
+		return nil, err
+	}
+
+	serverMap := base["server"].(map[string]interface{})
+
+	blockDevice := make([]map[string]interface{}, len(opts.BlockDevice))
+
+	for i, bd := range opts.BlockDevice {
+		b, err := gophercloud.BuildRequestBody(bd, "")
+		if err != nil {
+			return nil, err
+		}
+		blockDevice[i] = b
+	}
+	serverMap["block_device_mapping_v2"] = blockDevice
+
+	return base, nil
+}
+
+// Create requests the creation of a server from the given block device mapping.
+func Create(client *gophercloud.ServiceClient, opts servers.CreateOptsBuilder) (r servers.CreateResult) {
+	b, err := opts.ToServerCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Post(createURL(client), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200, 202},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/mantle/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/bootfromvolume/results.go
+++ b/mantle/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/bootfromvolume/results.go
@@ -1,0 +1,12 @@
+package bootfromvolume
+
+import (
+	os "github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
+)
+
+// CreateResult temporarily contains the response from a Create call.
+// It embeds the standard servers.CreateResults type and so can be used the
+// same way as a standard server request result.
+type CreateResult struct {
+	os.CreateResult
+}

--- a/mantle/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/bootfromvolume/urls.go
+++ b/mantle/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/bootfromvolume/urls.go
@@ -1,0 +1,7 @@
+package bootfromvolume
+
+import "github.com/gophercloud/gophercloud"
+
+func createURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("servers")
+}

--- a/mantle/vendor/modules.txt
+++ b/mantle/vendor/modules.txt
@@ -274,6 +274,7 @@ github.com/googleapis/gax-go/v2
 # github.com/gophercloud/gophercloud v0.17.0
 github.com/gophercloud/gophercloud
 github.com/gophercloud/gophercloud/openstack
+github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/bootfromvolume
 github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/floatingips
 github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/keypairs
 github.com/gophercloud/gophercloud/openstack/compute/v2/flavors


### PR DESCRIPTION
```
commit fe65d83bb67a89b0a62a4508fa84764917c9c02c
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Thu Sep 16 13:55:11 2021 -0400

    mantle/openstack: add ability to mark visibility for uploaded images
    
    Eventually we want our uploaded images to stay in VexxHost so users
    there can use them. For now we delete them every time. Let's expose
    a flag so that the image visibility can be exposed at image creation
    time.

commit c17deee4181bf357f1cb9e05b508fe4bc4aca82e
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Thu Sep 16 10:27:06 2021 -0400

    mantle/openstack: support specifying image architecture
    
    This adds an --arch argument to `ore openstack create-image`
    and will allow us to create images with the "architecture"
    property. This means we can create "aarch64" images and then
    test them in VexxHost.
    
    For more property keys and descriptions see:
    https://docs.openstack.org/glance/latest/admin/useful-image-properties.html#image-property-keys-and-values

commit f3d737ebde65ca0a0468b9976a2a6197aa011ff3
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Thu Sep 16 09:38:41 2021 -0400

    mantle/openstack: use boot-from-volume when creating instances
    
    Create a boot device volume and create an instance from that by
    using "boot-from-volume", similar to EBS backed EC2 instances.
    This means the instances boot a bit faster. Previously we were
    timing out because it was taking 10+ minutes for instances to come
    up in VexxHost. This helps with that.

commit 0b05dc3812bcf1a8c3d57bcd1873e7a3b239cddb
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Thu Sep 16 07:49:26 2021 -0400

    Revert "mantle: exclude openstack from coreos.ignition.ssh.key test"
    
    This reverts commit 5fe65f0e048552b1fd6679561656150bf7af29af.
    
    https://github.com/coreos/fedora-coreos-tracker/issues/662 was fixed.
```
