### PR TITLE
mantle/platform/qemu: update deprecated -chardev options

### DIFF
--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -1504,7 +1504,7 @@ func (builder *QemuBuilder) Exec() (*QemuInstance, error) {
 	// The qmp socket path must be unique to the instance.
 	inst.qmpSocketPath = filepath.Join(builder.tempdir, fmt.Sprintf("qmp-%d.sock", time.Now().UnixNano()))
 	qmpID := "qemu-qmp"
-	builder.Append("-chardev", fmt.Sprintf("socket,id=%s,path=%s,server,nowait", qmpID, inst.qmpSocketPath))
+	builder.Append("-chardev", fmt.Sprintf("socket,id=%s,path=%s,server=on,wait=off", qmpID, inst.qmpSocketPath))
 	builder.Append("-mon", fmt.Sprintf("chardev=%s,mode=control", qmpID))
 
 	// Set up the virtio channel to get Ignition failures by default


### PR DESCRIPTION
When using a qemu with commit ccd3b3b8112b ("qemu-option: warn for
short-form boolean options"), "cosa kola run" throws deprecation
warnings:

qemu-system-s390x: -chardev socket,id=qemu-qmp,path=...,server,nowait: warning: short-form boolean option 'server' deprecated
Please use server=on instead
qemu-system-s390x: -chardev socket,id=qemu-qmp,path=...,server,nowait: warning: short-form boolean option 'nowait' deprecated
Please use wait=off instead

Fix up the 'server' and 'nowait' options accordingly.

Signed-off-by: Julian Wiedmann <jwi@linux.ibm.com>