### PR TITLE
qemu: Bump timeout for qmp connection

### DIFF
--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -1560,8 +1560,10 @@ func (builder *QemuBuilder) Exec() (*QemuInstance, error) {
 	builder.tempdir = ""
 	cleanupInst = false
 
-	// create the qmp.SocketMonitor
-	if err := util.Retry(10, 1*time.Second,
+	// Connect to the QMP socket which allows us to control qemu.  We wait up to 30s
+	// to avoid flakes on loaded CI systems.  But, probably rather than bumping this
+	// any higher it'd be better to try to reduce parallelism.
+	if err := util.Retry(30, 1*time.Second,
 		func() error {
 			sockMonitor, err := qmp.NewSocketMonitor("unix", inst.qmpSocketPath, 2*time.Second)
 			if err != nil {


### PR DESCRIPTION
On a loaded CI system, there can be latency spikes due to
contention on I/O for example.

Since the kola tests already have overall timeouts, bump this timeout
much higher to reduce the flake rate.

If we start going past 30s, it seems likely that instead of bumping
this timeout we need to reduce parallelism on the CI system.