### PR TITLE
deps: add fedora-repos-ostree

### DIFF
--- a/src/deps.txt
+++ b/src/deps.txt
@@ -93,3 +93,6 @@ python3-flufl-lock
 
 # entrypoint uses bsdtar for automatic compression detection
 bsdtar
+
+# For pulling from the prod OSTree repo, e.g. during release jobs
+fedora-repos-ostree


### PR DESCRIPTION
I'd like to use the official Fedora prod OSTree repo config shipped in
FCOS to pull down commits in the release pipeline. But it's obviously
useful to have it available too for manual testing.