### PR TITLE
docs: Add cosa container age check in cosa alias

### DIFF
--- a/docs/building-fcos.md
+++ b/docs/building-fcos.md
@@ -82,6 +82,19 @@ here need to change for that.
 ```sh
 cosa() {
    env | grep COREOS_ASSEMBLER
+   local -r COREOS_ASSEMBLER_CONTAINER_LATEST="quay.io/coreos-assembler/coreos-assembler:latest"
+   if [[ -z ${COREOS_ASSEMBLER_CONTAINER} ]] && $(podman image exists ${COREOS_ASSEMBLER_CONTAINER_LATEST}); then
+       local -r cosa_build_date_str="$(podman inspect -f "{{.Created}}" ${COREOS_ASSEMBLER_CONTAINER_LATEST} | awk '{print $1}')"
+       local -r cosa_build_date="$(date -d ${cosa_build_date_str} +%s)"
+       if [[ $(date +%s) -ge $((cosa_build_date + 60*60*24*7)) ]] ; then
+         echo -e "\e[0;33m----" >&2
+         echo "The COSA container image is more that a week old and likely outdated." >&2
+         echo "You should pull the latest version with:" >&2
+         echo "podman pull ${COREOS_ASSEMBLER_CONTAINER_LATEST}" >&2
+         echo -e "----\e[0m" >&2
+         sleep 10
+       fi
+   fi
    set -x
    podman run --rm -ti --security-opt label=disable --privileged                                    \
               --uidmap=1000:0:1 --uidmap=0:1:1000 --uidmap 1001:1001:64536                          \
@@ -90,7 +103,7 @@ cosa() {
               ${COREOS_ASSEMBLER_CONFIG_GIT:+-v $COREOS_ASSEMBLER_CONFIG_GIT:/srv/src/config/:ro}   \
               ${COREOS_ASSEMBLER_GIT:+-v $COREOS_ASSEMBLER_GIT/src/:/usr/lib/coreos-assembler/:ro}  \
               ${COREOS_ASSEMBLER_CONTAINER_RUNTIME_ARGS}                                            \
-              ${COREOS_ASSEMBLER_CONTAINER:-quay.io/coreos-assembler/coreos-assembler:latest} "$@"
+              ${COREOS_ASSEMBLER_CONTAINER:-$COREOS_ASSEMBLER_CONTAINER_LATEST} "$@"
    rc=$?; set +x; return $rc
 }
 ```


### PR DESCRIPTION
It is easy to miss updating the local COSA container and trigger weird
issues during local development.

Add a check to the cosa shell alias looking at the container creation
time and printing out a warning (with a sleep 10) if it is more than a
week old and thus most probably outdated.

Do this only if no specific container image is set as it is the case
were most changes could be creating issues.

Fixes: https://github.com/coreos/coreos-assembler/issues/2434