### PR TITLE
mantle/kola: detect kernel circular locking dep warning

### DIFF
--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -131,6 +131,10 @@ var (
 			match: regexp.MustCompile(`WARNING: CPU: \d+ PID: \d+ at (.+)`),
 		},
 		{
+			desc:  "kernel circular locking dependency warning",
+			match: regexp.MustCompile("WARNING: possible circular locking dependency detected"),
+		},
+		{
 			desc:  "failure of disk under I/O",
 			match: regexp.MustCompile("rejecting I/O to offline device"),
 		},


### PR DESCRIPTION
We'd like to know when these pop up.