### PR TITLE
gangplank: Add coreos-assembler-config-git.json as default

### DIFF
--- a/gangplank/internal/ocp/return.go
+++ b/gangplank/internal/ocp/return.go
@@ -154,7 +154,8 @@ func isKnownBuildMeta(n string) bool {
 	// check for specially named files
 	if strings.HasPrefix(n, "manifest-lock.generated") ||
 		n == "ostree-commit-object" ||
-		n == "commitmeta.json" {
+		n == "commitmeta.json" ||
+		n == "coreos-assembler-config-git.json" {
 		return true
 	}
 	// check for meta*json files


### PR DESCRIPTION
 - Return the config-git file as default to minio.
 - In situations like koji-update the coreos-assembler-config-git.json is
required. Since it is a really small file, let's make it default as well.

Signed-off-by: Renata Ravanelli <rravanel@redhat.com>