### PR TITLE
buildextend-live: fix `kargs.json` for multi-arch

### DIFF
--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -417,7 +417,12 @@ def generate_iso():
         os.makedirs(os.path.join(tmpisoroot, 'boot/grub'))
         # can be EFI/fedora or EFI/redhat
         grubpath = ensure_glob(os.path.join(tmpisoroot, 'EFI/*/grub.cfg'))
+        if len(grubpath) != 1:
+            raise Exception(f'Found != 1 grub.cfg files: {grubpath}')
         shutil.move(grubpath[0], os.path.join(tmpisoroot, 'boot/grub/grub.cfg'))
+        for f in kargs_json['files']:
+            if re.match('^EFI/.*/grub.cfg$', f['path']):
+                f['path'] = 'boot/grub/grub.cfg'
 
         # safely remove things we don't need in the final ISO tree
         for d in ['EFI', 'isolinux', 'zipl.prm']:

--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -376,14 +376,10 @@ def generate_iso():
             fh.write('#' * karg_embed_area_length)
             fh.seek(0)
             fh.write(cmdline)
-        kargs_json['files'].sort(key=lambda f: f['path'])
         kargs_json.update(
             size=karg_embed_area_length,
             default=cmdline.strip(),
         )
-        with open(os.path.join(tmpisocoreos, kargs_file), 'w') as fh:
-            json.dump(kargs_json, fh, indent=2, sort_keys=True)
-            fh.write('\n')
 
     # These sections are based on lorax templates
     # see https://github.com/weldr/lorax/tree/master/share/templates.d/99-generic
@@ -562,6 +558,16 @@ boot
         genisoargs += ['-eltorito-alt-boot',
                        '-efi-boot', 'images/efiboot.img',
                        '-no-emul-boot']
+
+    # We've done everything that might affect kargs, so filter out any files
+    # that no longer exist and write out the kargs JSON if it lists any files
+    kargs_json['files'] = [f for f in kargs_json['files']
+            if os.path.exists(os.path.join(tmpisoroot, f['path']))]
+    kargs_json['files'].sort(key=lambda f: f['path'])
+    if kargs_json['files']:
+        with open(os.path.join(tmpisocoreos, kargs_file), 'w') as fh:
+            json.dump(kargs_json, fh, indent=2, sort_keys=True)
+            fh.write('\n')
 
     # Define inputs and outputs
     genisoargs += ['-o', tmpisofile, tmpisoroot]


### PR DESCRIPTION
#2429 re-introduced the problem fixed by #1994: some arches remove bootloader configs after the config file list has been generated.  Defer writing out `kargs.json` until later, and filter out files that no longer exist.

Also fix the path to `grub.cfg` on ppc64le.

cc @coreos/multi-arch 