### PR TITLE
tests: squash ro `/var` race in multipath.partition

### DIFF
--- a/mantle/kola/tests/misc/multipath.go
+++ b/mantle/kola/tests/misc/multipath.go
@@ -75,6 +75,8 @@ systemd:
       contents: |
         [Unit]
         Description=Mount /var/lib/containers
+        # See https://github.com/coreos/coreos-assembler/pull/2457
+        After=ostree-remount.service
         After=mpath-var-lib-containers.service
         Before=kubelet.service
 


### PR DESCRIPTION
In the `multipath.partition` test, we mount a multipath device on
`/var/lib/containers`, and rely on systemd to create the mountpoint. But
because we we weren't deterministically ordered against
`ostree-remount.service`, in rare cases we can run approximately at the
same time and systemd will try to create the mountpoint during that
short window of time when `/var` is read-only. So then the test failed
like this:

```
systemd[1]: Found device /dev/disk/by-label/dm-mpath-containers.
systemd[1]: var-lib-containers.mount: Failed to check directory /var/lib/containers: No such file or directory
systemd[1]: Mounting Mount /var/lib/containers...
mount[983]: mount: /var/lib/containers: mount point does not exist.
systemd[1]: var-lib-containers.mount: Mount process exited, code=exited, status=32/n/a
systemd[1]: var-lib-containers.mount: Failed with result 'exit-code'.
systemd[1]: Failed to mount Mount /var/lib/containers.
```

It took me a while to figure out this was the issue, because systemd
ignores errors from `mkdir`:

https://github.com/systemd/systemd/blob/3a18c0e5f2e4d8d46f3fd11cd0e421f52e727b0d/src/core/mount.c#L1023

An `EROFS` here would've made it much more obvious.

Anyway, let's just add an `After=` in the mount unit to fix this. An
alternative would've been to create the directory from Ignition (which
it would've done automatically for us if we used it to set up the
filesystem and mount unit, but we can't do this for non-root multipath,
because $reasons).

Long-term fix for this is https://github.com/ostreedev/ostree/pull/2187.