### PR TITLE
[rhcos-4.9] buildextend-live: fix `/run/media/iso` mount flake booting from disk

### DIFF
--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -538,8 +538,15 @@ boot
             # Note: virt-make-fs lets us do this as non-root
             efibootfile = os.path.join(tmpisoimages, 'efiboot.img')
             os.environ["LIBGUESTFS_BACKEND"] = "direct"
-            run_verbose(['virt-make-fs', '--type=vfat', efitarfile.name,
-                         efibootfile])
+            # On RHEL 8, when booting from a disk device (rather than a CD),
+            # https://github.com/systemd/systemd/issues/14408 causes the
+            # hybrid ESP to race with the ISO9660 filesystem for the
+            # /dev/disk/by-label symlink unless the ESP has its own label,
+            # so set EFI-SYSTEM for consistency with the metal image.
+            # This should not be needed on Fedora or RHEL 9, but seems like
+            # a good thing to do anyway.
+            run_verbose(['virt-make-fs', '--type=vfat', '--label=EFI-SYSTEM',
+                         efitarfile.name, efibootfile])
 
         genisoargs += ['-eltorito-alt-boot',
                        '-efi-boot', 'images/efiboot.img',


### PR DESCRIPTION
When booting the RHCOS live ISO image from a USB stick or other disk device, boot sometimes fails with the following error:

```
[    9.410095] systemd[1]: Reached target Initrd Root Device.
[    9.415226] systemd[1]: Mounting /run/media/iso...
[    9.498191] ISOFS: Unable to identify CD-ROM format.
[    9.499552] mount[722]: mount: /run/media/iso: wrong fs type, bad option, bad superblock on /dev/sda2, missing codepage or helper program, or other error.
Failed to mount /run/media/iso.
See 'systemctl status run-media-iso.mount' for details.
```

`35coreos-live/live-generator` creates `run-media-iso.mount`, which mounts the ISO from `/dev/disk/by-label/rhcos-<version>`.  The latter should point to `/dev/sda1`, but in this case it's pointing to `/dev/sda2`, which is `efiboot.img`.  `/dev/sda2` does not have a filesystem label, but because of https://github.com/systemd/systemd/issues/14408, `60-persistent-storage.rules` falls back to using the filesystem label from `/dev/sda` (the whole-disk device) when evaluating symlinks for `/dev/sda2`.  As a result, `/dev/sda1` and `/dev/sda2` race to own the `/dev/disk/by-label` symlink, and if `sda2` wins, the mount fails.

CD and virtual CD boot are not affected because CD-ROM devices are not partitionable.  FCOS is not affected because the udev rules on FCOS include https://github.com/systemd/systemd/pull/14485.

Fix the race by giving `efiboot.img` its own filesystem label, preventing the buggy udev rules from reusing the label from the ISO 9660 filesystem.  This seems like a reasonable thing to do anyway (the non-live images label the ESP as `EFI-SYSTEM`) and it's free.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2007089.  Backports #2458.