### PR TITLE
kola/options: don't derive GCP options if build has no GCP image

### DIFF
--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -330,7 +330,7 @@ func syncCosaOptions() error {
 		}
 	case "gce":
 		// Pick up the GCP image from the build metadata
-		if kola.GCEOptions.Image == "" {
+		if kola.GCEOptions.Image == "" && kola.CosaBuild.Meta.Gcp != nil {
 			kola.GCEOptions.Image =
 				fmt.Sprintf("projects/%s/global/images/%s",
 					kola.CosaBuild.Meta.Gcp.ImageProject,


### PR DESCRIPTION
Otherwise, we get a classic NULL pointer dereference. This isn't an
issue for AMIs because the default value is an empty list, so `range`
handles it fine.