### PR TITLE
fastbuild: Better namespace for refs

### DIFF
--- a/src/cmd-build-fast
+++ b/src/cmd-build-fast
@@ -94,7 +94,7 @@ if [ -n "${projectdir}" ]; then
     rm _install -rf
     make
     make install DESTDIR="$(pwd)/_install"
-    fastref="$(basename "${projectdir}")"
+    fastref=cosa/fastbuild/"$(basename "${projectdir}")"
     version="$(git describe --tags --abbrev=10)"
     if ! git diff --quiet; then
         version="${version}+dirty"
@@ -102,7 +102,7 @@ if [ -n "${projectdir}" ]; then
     outdir=${projectdir}/.cosa
     rootfsoverrides="${projectdir}/_install"
 else
-    fastref=fastbuild
+    fastref=cosa/fastbuild/${name}
     version="$(date +"%s")"
     outdir="${workdir}/tmp"
     rootfsoverrides="${workdir}/overrides/rootfs"
@@ -143,7 +143,7 @@ commit=$(ostree --repo="${tmprepo}" rev-parse "${fastref}")
 if [ -z "${projectdir}" ]; then
     restore_etc
 fi
-imgname="${fastref}-${version}-qemu.qcow2"
+imgname="$(basename "${fastref}")-${version}-qemu.qcow2"
 # Prune previous images
 rm -vf "${outdir}"/*.qcow2
 qemu-img create -f qcow2 -o backing_fmt=qcow2,backing_file="${previous_builddir}/${previous_qemu}" "${imgname}.tmp" 20G


### PR DESCRIPTION
I did a `cosa build-fast` in my ostreedev/ostree git repo, which
failed because I'd also imported a container into `tmp/repo` which
creates a ref like `ostree/container/blob...`, but this code tried
to create a ref just named `ostree` - and that would require `ostree`
to be both a file and directory.

A general best practice for refs is namespacing; here, let's use
`cosa/fastbuild/`.