### PR TITLE
[rhcos-4.9] ci/Dockerfile: tickle Quay cache 2021-Oct-01

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /root/containerbuild
 COPY ./src/print-dependencies.sh ./src/deps*.txt ./src/vmdeps*.txt ./src/build-deps.txt /root/containerbuild/src/
 COPY ./build.sh /root/containerbuild/
 RUN ./build.sh configure_yum_repos
-RUN ./build.sh install_rpms  # nocache 20210827
+RUN ./build.sh install_rpms  # nocache 20211001
 
 # Allow Prow to work
 RUN mkdir -p /go && chown 0777 /go


### PR DESCRIPTION
Blow out the Quay cache to pick up `rpm-ostree-2021.11-3.fc34`

(cherry picked from commit f4981a44079854c52f5a24f0dc51a419c79d33b2)