### PR TITLE
Use `ostree-unverified-image:` with `rpm-ostree import`

### DIFF
--- a/mantle/kola/tests/rhcos/upgrade.go
+++ b/mantle/kola/tests/rhcos/upgrade.go
@@ -101,7 +101,7 @@ func rhcosUpgrade(c cluster.TestCluster) {
 				outputname="%s"
 				commit="%s"
 				ostree --repo=tmp/repo-cache init --mode=bare-user
-				rpm-ostree ex-container import --repo=tmp/repo oci-archive:$tarname:latest
+				rpm-ostree ex-container import --repo=tmp/repo ostree-unverified-image:oci-archive:$tarname:latest
 				ostree --repo=tmp/repo pull-local tmp/repo-cache "$commit"
 				tar -cf "$outputname" -C tmp/repo .
 				rm tmp/repo-cache -rf

--- a/mantle/kola/tests/upgrade/basic.go
+++ b/mantle/kola/tests/upgrade/basic.go
@@ -152,7 +152,7 @@ func fcosUpgradeBasic(c cluster.TestCluster) {
 			tmprepo := workdir + "/repo-bare"
 			// TODO: https://github.com/ostreedev/ostree-rs-ext/issues/34
 			c.RunCmdSyncf(m, "ostree --repo=%s init --mode=bare-user", tmprepo)
-			c.RunCmdSyncf(m, "rpm-ostree ex-container import --repo=%s --write-ref %s oci-archive:%s:latest", tmprepo, ostreeref, ostreeblob)
+			c.RunCmdSyncf(m, "rpm-ostree ex-container import --repo=%s --write-ref %s ostree-unverified-image:oci-archive:%s:latest", tmprepo, ostreeref, ostreeblob)
 			c.RunCmdSyncf(m, "ostree --repo=%s init --mode=archive", ostreeRepo)
 			c.RunCmdSyncf(m, "ostree --repo=%s pull-local %s %s", ostreeRepo, tmprepo, ostreeref)
 		} else {

--- a/src/cosalib/cmdlib.py
+++ b/src/cosalib/cmdlib.py
@@ -262,7 +262,7 @@ def import_ostree_commit(repo, buildpath, buildmeta, force=False):
         if os.environ.get('COSA_PRIVILEGED', '') == '1':
             build_repo = os.path.join(repo, '../../cache/repo-build')
             subprocess.check_call(['sudo', 'rpm-ostree', 'ex-container', 'import', '--repo', build_repo,
-                                   '--write-ref', buildmeta['buildid'], 'oci-archive:' + tarfile])
+                                   '--write-ref', buildmeta['buildid'], 'ostree-unverified-image:oci-archive:' + tarfile])
             subprocess.check_call(['sudo', 'ostree', f'--repo={repo}', 'pull-local', build_repo, buildmeta['buildid']])
             uid = os.getuid()
             gid = os.getgid()
@@ -271,7 +271,7 @@ def import_ostree_commit(repo, buildpath, buildmeta, force=False):
             with tempfile.TemporaryDirectory() as tmpd:
                 subprocess.check_call(['ostree', 'init', '--repo', tmpd, '--mode=bare-user'])
                 subprocess.check_call(['rpm-ostree', 'ex-container', 'import', '--repo', tmpd,
-                                       '--write-ref', buildmeta['buildid'], 'oci-archive:' + tarfile])
+                                       '--write-ref', buildmeta['buildid'], 'ostree-unverified-image:oci-archive:' + tarfile])
                 subprocess.check_call(['ostree', f'--repo={repo}', 'pull-local', tmpd, buildmeta['buildid']])
 
 


### PR DESCRIPTION
https://github.com/coreos/rpm-ostree/pull/3129 redid the container
image handling in the experimental API we're using.

Closes: https://github.com/openshift/os/issues/645