### PR TITLE
create_disk: Sprinkle on some `udevadm settle`

### DIFF
--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -66,6 +66,12 @@ disk=$(realpath /dev/disk/by-id/virtio-target)
 
 config="${config:?--config must be defined}"
 
+# https://github.com/coreos/coreos-assembler/pull/2480
+dump_err_info () {
+    lsblk -f || true
+}
+trap dump_err_info ERR
+
 # Parse the passed config JSON and extract a mandatory value
 getconfig() {
     k=$1


### PR DESCRIPTION
Blind attempt to help with
https://github.com/openshift/os/issues/646

Basically, let's ensure we synchronize with udev after each
time we create a filesystem, to avoid any races with re-probing.