### PR TITLE
mantle/plume/cosa2stream: set metadata.generator field

### DIFF
--- a/mantle/cmd/plume/cosa2stream.go
+++ b/mantle/cmd/plume/cosa2stream.go
@@ -28,6 +28,8 @@ import (
 	"github.com/coreos/stream-metadata-go/release"
 	"github.com/coreos/stream-metadata-go/stream"
 	"github.com/spf13/cobra"
+
+	"github.com/coreos/mantle/version"
 )
 
 const (
@@ -83,7 +85,10 @@ func runCosaBuildToStream(cmd *cobra.Command, args []string) error {
 	}
 	streamArches := outStream.Architectures
 
-	outStream.Metadata = stream.Metadata{LastModified: time.Now().UTC().Format(time.RFC3339)}
+	outStream.Metadata = stream.Metadata{
+		LastModified: time.Now().UTC().Format(time.RFC3339),
+		Generator:    "plume cosa2stream " + version.Version,
+	}
 
 	childArgs := []string{"generate-release-meta"}
 	if distro != "" {

--- a/mantle/go.mod
+++ b/mantle/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/coreos/ignition/v2 v2.12.0
 	github.com/coreos/ioprogress v0.0.0-20151023204047-4637e494fd9b
 	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
-	github.com/coreos/stream-metadata-go v0.1.2-0.20210805210749-ef7e9dabff95
+	github.com/coreos/stream-metadata-go v0.1.3
 	github.com/digitalocean/go-libvirt v0.0.0-20200810224808-b9c702499bf7 // indirect
 	github.com/digitalocean/go-qemu v0.0.0-20200529005954-1b453d036a9c
 	github.com/digitalocean/godo v1.33.0

--- a/mantle/go.sum
+++ b/mantle/go.sum
@@ -95,6 +95,8 @@ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f h1:lBNOc5arjvs8E5mO2tbp
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/stream-metadata-go v0.1.2-0.20210805210749-ef7e9dabff95 h1:mFmE40SpA//BRV/zotY2XJ8cV+7EdIjiVpu9nuSBiyA=
 github.com/coreos/stream-metadata-go v0.1.2-0.20210805210749-ef7e9dabff95/go.mod h1:zxVoWUDB0H8+tZRhTs0LeLeR/QdmBsuo7FN1oOBrWTE=
+github.com/coreos/stream-metadata-go v0.1.3 h1:i/mUQBANlYirNAU4ybH6x/SCuc/Rh6uiopph6XZhROk=
+github.com/coreos/stream-metadata-go v0.1.3/go.mod h1:zxVoWUDB0H8+tZRhTs0LeLeR/QdmBsuo7FN1oOBrWTE=
 github.com/coreos/vcontext v0.0.0-20210407161507-4ee6c745c8bd h1:iHdPNrKIKSSlAy6nCmBliwn7xFTDu+OoFkArqMTr6Zc=
 github.com/coreos/vcontext v0.0.0-20210407161507-4ee6c745c8bd/go.mod h1:z4pMVvaUrxs98RROlIYdAQCKhEicjnTirOaVyDRH5h8=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=

--- a/mantle/vendor/github.com/coreos/stream-metadata-go/stream/stream.go
+++ b/mantle/vendor/github.com/coreos/stream-metadata-go/stream/stream.go
@@ -17,6 +17,7 @@ type Stream struct {
 // Metadata for a release or stream
 type Metadata struct {
 	LastModified string `json:"last-modified"`
+	Generator    string `json:"generator,omitempty"`
 }
 
 // Arch contains release details for a particular hardware architecture

--- a/mantle/vendor/modules.txt
+++ b/mantle/vendor/modules.txt
@@ -222,7 +222,7 @@ github.com/coreos/ioprogress
 # github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
 github.com/coreos/pkg/capnslog
 github.com/coreos/pkg/multierror
-# github.com/coreos/stream-metadata-go v0.1.2-0.20210805210749-ef7e9dabff95
+# github.com/coreos/stream-metadata-go v0.1.3
 github.com/coreos/stream-metadata-go/arch
 github.com/coreos/stream-metadata-go/fedoracoreos
 github.com/coreos/stream-metadata-go/fedoracoreos/internals


### PR DESCRIPTION
For the same reason as in fedora-coreos-stream-generator, it's useful to record the cosa version that was used to generate RHCOS stream metadata.

xref coreos/fedora-coreos-stream-generator#32