### PR TITLE
[rhcos-4.9] build.sh: pin to kernel < 5.14 to unblock s390x builds

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -32,10 +32,21 @@ configure_yum_repos() {
 }
 
 install_rpms() {
+    local builddeps
+    local frozendeps
+
+    # Pin to 5.13 until https://github.com/openshift/os/issues/646 is root caused
+    # (May be related to https://bugzilla.redhat.com/show_bug.cgi?id=2008401)
+    frozendeps=$(echo kernel{,-core,-modules}-5.13.19-200.fc34)
+
     # First, a general update; this is best practice.  We also hit an issue recently
     # where qemu implicitly depended on an updated libusbx but didn't have a versioned
     # requires https://bugzilla.redhat.com/show_bug.cgi?id=1625641
-    yum -y distro-sync
+    #
+    # In order to prevent the `distro-sync` operation from installing a newer
+    # version of the kernel in addition to what we want to freeze, exclude the
+    # kernel packages from the operation.
+    yum -y distro-sync -x kernel -x kernel-core -x kernel-modules
 
     # xargs is part of findutils, which may not be installed
     yum -y install /usr/bin/xargs
@@ -48,7 +59,7 @@ install_rpms() {
     builddeps=$(grep -v '^#' "${srcdir}"/src/build-deps.txt)
 
     # Process our base dependencies + build dependencies and install
-    (echo "${builddeps}" && "${srcdir}"/src/print-dependencies.sh) | xargs yum -y install
+    (echo "${frozendeps}" && echo "${builddeps}" && "${srcdir}"/src/print-dependencies.sh) | xargs yum -y install
 
     # Commented out for now, see above
     #dnf remove -y ${builddeps}


### PR DESCRIPTION
In openshift/os#646 it was reported that the s390x downstream builds
were failing to build the 4K metal image. This seems to be a
regression in the 5.14 version of the kernel.

This changes forces the use of the last successful 5.13 kernel. Of
note, the kernel packages have to be excluded from the `distro-sync`
operation or we end up with two versions of the the kernel installed
in the image.

(cherry picked from commit b3373de2a07c9037eb4a88bf0963a01036553b55)