### PR TITLE
build+metal: Use shared ostree-importing code

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -161,10 +161,7 @@ if [ -n "${previous_commit}" ]; then
     commitpartial=${tmprepo}/state/${previous_commit}.commitpartial
     if [ ! -f "${commitpath}" ] || [ -f "${commitpartial}" ]; then
         if [ -f "${previous_builddir}/${previous_ostree_tarfile_path}" ]; then
-            mkdir tmp/prev_repo
-            tar -C tmp/prev_repo -xf "${previous_builddir}/${previous_ostree_tarfile_path}"
-            ostree pull-local --repo="${tmprepo}" tmp/prev_repo "${previous_commit}"
-            rm -rf tmp/prev_repo
+            import_ostree_commit_for_build "${previous_build}"
         else
             # ok, just fallback to importing the commit object only
             mkdir -p "$(dirname "${commitpath}")"

--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -115,18 +115,8 @@ fi
 commit=$(meta_key ostree-commit)
 
 ostree_repo=${tmprepo}
-rev_parsed=$(ostree rev-parse --repo="${ostree_repo}" "${build}" 2>/dev/null || :)
-if [ "${rev_parsed}" != "${commit}" ]; then
-    # Probably an older commit or tmp/ was wiped. Let's extract it to a separate
-    # temporary repo (not to be confused with ${tmprepo}...) so we can feed it
-    # as a ref (if not temp) to create_disk.
-    echo "Cache for build ${build} is gone"
-    echo "Importing commit ${commit} into temporary OSTree repo"
-    mkdir -p tmp/repo
-    commit_tar_name=$(jq -re .images.ostree.path < "${builddir}/meta.json")
-    tar -C tmp/repo -xf "${builddir}/${commit_tar_name}"
-    ostree_repo=$PWD/tmp/repo
-fi
+# Ensure that we have the cached unpacked commit
+import_ostree_commit_for_build "${build}"
 
 image_format=raw
 if [[ $image_type == qemu ]]; then

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -815,3 +815,18 @@ sys.path.insert(0, '${DIR}')
 from cosalib import cmdlib
 cmdlib.flatten_image_yaml_to_file('${srcfile}', '${outfile}')")
 }
+
+# Shell wrapper for the Python import_ostree_commit
+import_ostree_commit_for_build() {
+    local buildid=$1; shift
+    (python3 -c "
+import sys
+sys.path.insert(0, '${DIR}')
+from cosalib import cmdlib
+from cosalib.builds import Builds
+builds = Builds('${workdir:-$(pwd)}')
+builddir = builds.get_build_dir('${buildid}')
+buildmeta = builds.get_build_meta('${buildid}')
+cmdlib.import_ostree_commit('${workdir:-$(pwd)}/tmp/repo', builddir, buildmeta)
+")
+}

--- a/src/cosalib/cmdlib.py
+++ b/src/cosalib/cmdlib.py
@@ -233,6 +233,14 @@ def rm_allow_noent(path):
         pass
 
 
+# In coreos-assembler, we are strongly oriented towards the concept of a single
+# versioned "build" object that has artifacts.  But rpm-ostree (among other things)
+# really natively wants to operate on unpacked ostree repositories.  So, we maintain
+# a `tmp/repo` (along with `cache/repo-build`) that are treated as caches.
+# In some cases, such as building a qemu image, then later trying to generate
+# a metal image, we may not have preserved that cache.
+#
+# Call this function to ensure that the ostree commit for a given build is in tmp/repo.
 def import_ostree_commit(repo, buildpath, buildmeta, force=False):
     commit = buildmeta['ostree-commit']
     tarfile = os.path.join(buildpath, buildmeta['images']['ostree']['path'])
@@ -249,6 +257,7 @@ def import_ostree_commit(repo, buildpath, buildmeta, force=False):
             and not force):
         return
 
+    print(f"Extracting {commit}")
     # extract in a new tmpdir inside the repo itself so we can still hardlink
     if tarfile.endswith('.tar'):
         with tempfile.TemporaryDirectory(dir=repo) as d:


### PR DESCRIPTION
The metal case broke with gangplank+aarch64, because it is
running separate pods for the build or something.

In the Jenkins (x86_64) flow I think we bypass this because we have a single
pod which already has the cached commit in `tmp/repo`.

Anyways, dedup all this code using a shared helper.