### PR TITLE
cosa2stream: adapt to leading version strings > 2 chars

### DIFF
--- a/mantle/cmd/plume/cosa2stream.go
+++ b/mantle/cmd/plume/cosa2stream.go
@@ -118,7 +118,8 @@ func runCosaBuildToStream(cmd *cobra.Command, args []string) error {
 			arch := parts[0]
 			ver := parts[1]
 			// Convert e.g. 48.82.<timestamp> to rhcos-4.8
-			archStreamName = fmt.Sprintf("rhcos-%s.%s", ver[0:1], ver[1:2])
+			verSplit := strings.Split(ver, ".")
+			archStreamName = fmt.Sprintf("rhcos-%s.%s", verSplit[0][0:1], verSplit[0][1:])
 			if arch != "x86_64" {
 				archStreamName += "-" + arch
 			}


### PR DESCRIPTION
RHCOS version strings have thusfar lead with a 2 digit identifier that
signifies the OCP version. As we roll into 4.10 time frame, the
handling around that leading version identifier is no longer
sufficient.

This changes the code to split the larger version string by the dots
and then manipulates the leading version so that building the stream
name matches.

For example:

49.84.202110071540-0 -> rhcos-4.9
410.84.202110071540-0 -> rhcos-4.10

Closes: #2479