### PR TITLE
gangplank: allow for specifying extra build meta to copy

### DIFF
--- a/gangplank/cmd/gangplank/generate.go
+++ b/gangplank/cmd/gangplank/generate.go
@@ -85,6 +85,8 @@ func setCliSpec() {
 		if spec.Recipe.Repos == nil {
 			spec.AddRepos()
 		}
+		// Override CopyBuild from the CLI
+		spec.AddCopyBuild()
 		if minioSshRemoteHost != "" && minioCfgFile == "" {
 			spec.Minio.SSHForward = minioSshRemoteHost
 			spec.Minio.SSHUser = minioSshRemoteUser

--- a/gangplank/internal/spec/cli.go
+++ b/gangplank/internal/spec/cli.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"strings"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 )
 
@@ -26,6 +27,9 @@ var (
 
 	// repos is a list a URLs that is added to the Repos.
 	repos []string
+
+	// copy-build is an extra build to copy build metadata for
+	copyBuild string
 )
 
 func init() {
@@ -69,6 +73,9 @@ func (js *JobSpec) AddCliFlags(cmd *pflag.FlagSet) {
 	cmd.StringVar(&js.Recipe.GitRef, "git-ref", js.Recipe.GitRef, "Git ref for recipe")
 	cmd.StringVar(&js.Recipe.GitURL, "git-url", js.Recipe.GitURL, "Git URL for recipe")
 	cmd.StringVar(&js.Recipe.GitCommit, "git-commit", "", "Optional Git commit to reset repo to for recipe")
+
+	// Define any extra builds that we want to copy build metadata for
+	cmd.StringVar(&copyBuild, "copy-build", "", "Optional: extra build to copy build metadata for")
 }
 
 // AddRepos adds an repositories from the CLI
@@ -82,6 +89,14 @@ func (js *JobSpec) AddRepos() {
 					URL: &r,
 				})
 		}
+	}
+}
+
+// AddCopyBuild adds --copy-build from the CLI
+func (js *JobSpec) AddCopyBuild() {
+	if copyBuild != "" {
+		log.Infof("Adding copy build meta for %s from the CLI", copyBuild)
+		js.CopyBuild = copyBuild
 	}
 }
 

--- a/gangplank/internal/spec/jobspec.go
+++ b/gangplank/internal/spec/jobspec.go
@@ -49,6 +49,9 @@ type JobSpec struct {
 	// DelayedMetaMerge ensures that 'cosa build' is called with
 	// --delayed-meta-merge
 	DelayedMetaMerge bool `yaml:"delay_meta_merge" json:"delay_meta_meta,omitempty"`
+
+	// CopyBuild defines an extra build to copy the build metadata for
+	CopyBuild string `yaml:"copy-build,omitempty" json:"copy-build",omitempty"`
 }
 
 // Artifacts describe the expect build outputs.


### PR DESCRIPTION
There can be cases where we want to copy over a specific build's
metadata and not just the latest build's metadata. For example,
when we encode information about a parent build that might not be
the latest in the build history. This commit adds another parameter
to the job spec and CLI for copying over an extra set of build
metadata to the target.

This is part of a fix for https://github.com/coreos/coreos-assembler/issues/2380