### PR TITLE
mantle/platform/conf: bump 9p mount msize to match supermin

### DIFF
--- a/mantle/platform/conf/conf.go
+++ b/mantle/platform/conf/conf.go
@@ -1099,7 +1099,7 @@ Before=basic.target
 What=%s
 Where=%s
 Type=9p
-Options=trans=virtio,version=9p2000.L%s
+Options=trans=virtio,version=9p2000.L%s,msize=10485760
 [Install]
 WantedBy=multi-user.target
 `, dest, dest, readonlyStr)


### PR DESCRIPTION
This squashes the qemu warning about small msize when we run `cosa run`
for example. I.e. this is the same as #2201 but for kola-created 9p
mounts.

Closes: #2171