### PR TITLE
kola: set KOLA_TEST and KOLA_TEST_EXE in external tests

### DIFF
--- a/docs/kola/external-tests.md
+++ b/docs/kola/external-tests.md
@@ -68,6 +68,14 @@ example, one can have the binary drive a container runtime.
 A test is considered failed if the unit exits with any non-zero exit status or
 dies from any signal other than `SIGTERM`.
 
+## Environment variables
+
+The following environment variables are accessible to the test:
+- `KOLA_EXT_DATA`: path to test data; see above
+- `KOLA_UNIT`: name of systemd unit running the test itself
+- `KOLA_TEST`: name of the kola test
+- `KOLA_TEST_EXE`: basename of the test executable as found by kola
+
 ## Support for rebooting
 
 An important feature of exttests is support for rebooting the host system.

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -800,7 +800,8 @@ func registerExternalTest(testname, executable, dependencydir string, userdata *
 		unitName = fmt.Sprintf("%s-%d.service", KoletExtTestUnit, num)
 	}
 
-	remotepath := fmt.Sprintf("/usr/local/bin/kola-runext-%s", filepath.Base(executable))
+	base := filepath.Base(executable)
+	remotepath := fmt.Sprintf("/usr/local/bin/kola-runext-%s", base)
 
 	// Note this isn't Type=oneshot because it's cleaner to support self-SIGTERM that way
 	unit := fmt.Sprintf(`[Unit]
@@ -808,9 +809,11 @@ func registerExternalTest(testname, executable, dependencydir string, userdata *
 RemainAfterExit=yes
 EnvironmentFile=-/run/kola-runext-env
 Environment=KOLA_UNIT=%s
+Environment=KOLA_TEST=%s
+Environment=KOLA_TEST_EXE=%s
 Environment=%s=%s
 ExecStart=%s
-`, unitName, kolaExtBinDataEnv, kolaExtBinDataDir, remotepath)
+`, unitName, testname, base, kolaExtBinDataEnv, kolaExtBinDataDir, remotepath)
 	config.AddSystemdUnit(unitName, unit, conf.NoState)
 
 	// Architectures using 64k pages use slightly more memory, ask for more than requested


### PR DESCRIPTION
That way the test can know its own name, which can be useful if e.g.
sharing test implementations across multiple separate tests. Planning to
use this for https://github.com/coreos/fedora-coreos-tracker/issues/990.