### PR TITLE
rhcos/upgrade: Fix regression in previous commit

### DIFF
--- a/mantle/kola/tests/rhcos/upgrade.go
+++ b/mantle/kola/tests/rhcos/upgrade.go
@@ -119,7 +119,7 @@ func setup(c cluster.TestCluster) {
 			outputname="%s"
 			commit="%s"
 			ostree --repo=tmp/repo-cache init --mode=bare-user
-			rpm-ostree ex-container import --repo=tmp/repo oci-archive:$tarname:latest
+			rpm-ostree ex-container import --repo=tmp/repo ostree-unverified-image:oci-archive:$tarname:latest
 			ostree --repo=tmp/repo pull-local tmp/repo-cache "$commit"
 			tar -cf "$outputname" -C tmp/repo .
 			rm tmp/repo-cache -rf


### PR DESCRIPTION
Looks like https://github.com/coreos/coreos-assembler/commit/dd63990f38e389e38cae769a2ebd16ccea6125b2
had a merge conflict that accidentally reverted
https://github.com/coreos/coreos-assembler/commit/8f189dea965aceb8af55710b8c22643f546ea3c7#diff-c5df1f8a6c1a7123836929c6273f851d696767a674a22bd1df712f5e2b920ce0

Closes: https://github.com/openshift/os/issues/656