### PR TITLE
qemuexec: also check --qemu-memory for VM memory

### DIFF
--- a/mantle/cmd/kola/qemuexec.go
+++ b/mantle/cmd/kola/qemuexec.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -292,8 +293,15 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 		}
 	}
 	builder.Hostname = hostname
+	// for historical reasons, both --memory and --qemu-memory are supported
 	if memory != 0 {
 		builder.Memory = memory
+	} else if kola.QEMUOptions.Memory != "" {
+		parsedMem, err := strconv.ParseInt(kola.QEMUOptions.Memory, 10, 32)
+		if err != nil {
+			return errors.Wrapf(err, "parsing memory option")
+		}
+		builder.Memory = int(parsedMem)
 	}
 	builder.AddDisksFromSpecs(addDisks)
 	if cpuCountHost {


### PR DESCRIPTION
We have a `--memory` switch scoped to `qemuexec` but the global
`--qemu-memory` is still also scoped in, which is confusing. Probably we
should've just kept the latter one only. But for now at least let's
support both.

Closes: #2502