### PR TITLE
kola/harness: add support for required tags

### DIFF
--- a/docs/kola/external-tests.md
+++ b/docs/kola/external-tests.md
@@ -189,6 +189,7 @@ Here's an example `kola.json`:
     "architectures": "!s390x ppc64le",
     "platforms": "qemu-unpriv",
     "tags": "sometagname needs-internet skip-base-checks othertag",
+    "requiredTag": "special",
     "additionalDisks": [ "5G" ],
     "minMemory": 4096,
     "exclusive": true
@@ -205,12 +206,15 @@ string, the value instead declares exclusions i.e. `ExclusiveArchitectures`
 instead  of `Architectures` in reference to kola internals.
 
 In this example, `sometagname` and `othertag` are arbitrary tags one can use
-with `kola run --tags`, but some tags have semantic meaning.
+with `kola run --tag`, but some tags have semantic meaning.
 
 Tags with semantic meaning:
 
  - `needs-internet`: Taken from the Autopkgtest (linked above).  Currently only the `qemu` platform enforces this restriction.   
  - `skip-base-checks`: Skip built-in checks for e.g. kernel warnings on the console.
+
+If a test has a `requiredTag`, it is run only if the required tag is specified.
+In the example above, the test would only run if `--tag special` was provided.
 
 The `additionalDisks` key has the same semantics as the `--add-disk` argument
 to `qemuexec`. It is currently only supported on `qemu-unpriv`.

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -440,6 +440,10 @@ func filterTests(tests map[string]*register.Test, patterns []string, pltfrm stri
 			}
 		}
 
+		if t.RequiredTag != "" && !hasString(t.RequiredTag, Tags) {
+			continue
+		}
+
 		if (!noPattern && !match && !tagMatch) || (!tagMatch && noPattern && len(Tags) > 0) {
 			continue
 		}
@@ -671,6 +675,7 @@ type externalTestMeta struct {
 	Platforms       string   `json:"platforms,omitempty"`
 	Distros         string   `json:"distros,omitempty"`
 	Tags            string   `json:"tags,omitempty"`
+	RequiredTag     string   `json:"requiredTag,omitempty"`
 	AdditionalDisks []string `json:"additionalDisks,omitempty"`
 	MinMemory       int      `json:"minMemory,omitempty"`
 	Exclusive       bool     `json:"exclusive"`
@@ -883,6 +888,7 @@ ExecStart=%s
 	}
 	t.Tags = append(t.Tags, strings.Fields(targetMeta.Tags)...)
 	// TODO validate tags here
+	t.RequiredTag = targetMeta.RequiredTag
 
 	register.RegisterTest(t)
 

--- a/mantle/kola/register/register.go
+++ b/mantle/kola/register/register.go
@@ -63,6 +63,7 @@ type Test struct {
 	ExcludeArchitectures []string // denylist of architectures to ignore -- defaults to none
 	Flags                []Flag   // special-case options for this test
 	Tags                 []string // list of tags that can be matched against -- defaults to none
+	RequiredTag          string   // if specified, test is filtered by default unless tag is provided -- defaults to none
 
 	// Whether the primary disk is multipathed.
 	MultiPathDisk bool


### PR DESCRIPTION
I'd like to add some tests which shouldn't run by default. Let's
leverage tags for this by having a new special `requiredTag` field which
makes the test be skipped unless the required tag is specified.

