### PR TITLE
kola: only rerun failed tests if --rerun provided

### DIFF
--- a/mantle/cmd/kola/kola.go
+++ b/mantle/cmd/kola/kola.go
@@ -190,7 +190,7 @@ func runRun(cmd *cobra.Command, args []string) error {
 		patterns = args
 	}
 
-	return kolaRunPatterns(patterns, runRerunFlag, false)
+	return kolaRunPatterns(patterns, runRerunFlag)
 }
 
 func runRerun(cmd *cobra.Command, args []string) error {
@@ -212,10 +212,10 @@ func runRerun(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	return kolaRunPatterns(patterns, false, true)
+	return kolaRunPatterns(patterns, false)
 }
 
-func kolaRunPatterns(patterns []string, rerun bool, disableNonExclusive bool) error {
+func kolaRunPatterns(patterns []string, rerun bool) error {
 	var err error
 	outputDir, err = kola.SetupOutputDir(outputDir, kolaPlatform)
 	if err != nil {
@@ -226,7 +226,7 @@ func kolaRunPatterns(patterns []string, rerun bool, disableNonExclusive bool) er
 		return err
 	}
 
-	runErr := kola.RunTests(patterns, runMultiply, rerun, kolaPlatform, outputDir, !kola.Options.NoTestExitError, disableNonExclusive)
+	runErr := kola.RunTests(patterns, runMultiply, rerun, kolaPlatform, outputDir, !kola.Options.NoTestExitError)
 
 	// needs to be after RunTests() because harness empties the directory
 	if err := writeProps(); err != nil {
@@ -642,7 +642,7 @@ func runRunUpgrade(cmd *cobra.Command, args []string) error {
 		patterns = args
 	}
 
-	runErr := kola.RunUpgradeTests(patterns, runRerunFlag, kolaPlatform, outputDir, !kola.Options.NoTestExitError, false)
+	runErr := kola.RunUpgradeTests(patterns, runRerunFlag, kolaPlatform, outputDir, !kola.Options.NoTestExitError)
 
 	// needs to be after RunTests() because harness empties the directory
 	if err := writeProps(); err != nil {

--- a/mantle/harness/reporters/json.go
+++ b/mantle/harness/reporters/json.go
@@ -16,6 +16,7 @@ package reporters
 
 import (
 	"encoding/json"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -41,6 +42,23 @@ type jsonTest struct {
 	Result   testresult.TestResult `json:"result"`
 	Duration time.Duration         `json:"duration"`
 	Output   string                `json:"output"`
+}
+
+func DeserialiseReport(filename string) (*jsonReporter, error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	bytes, err := ioutil.ReadAll(file)
+	if err != nil {
+		return nil, err
+	}
+	var data jsonReporter
+	if err = json.Unmarshal(bytes, &data); err != nil {
+		return nil, err
+	}
+	return &data, err
 }
 
 func NewJSONReporter(filename, platform, version string) *jsonReporter {

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -512,7 +512,7 @@ func filterTests(tests map[string]*register.Test, patterns []string, pltfrm stri
 // register tests in their init() function.  outputDir is where various test
 // logs and data will be written for analysis after the test run. If it already
 // exists it will be erased!
-func runProvidedTests(tests map[string]*register.Test, patterns []string, multiply int, rerun bool, pltfrm, outputDir string, propagateTestErrors bool) error {
+func runProvidedTests(tests map[string]*register.Test, patterns []string, multiply int, rerun bool, pltfrm, outputDir string, propagateTestErrors bool, disableNonExclusive bool) error {
 	var versionStr string
 
 	// Avoid incurring cost of starting machine in getClusterSemver when
@@ -540,7 +540,7 @@ func runProvidedTests(tests map[string]*register.Test, patterns []string, multip
 	// Generate non-exclusive test wrapper (run multiple tests in one VM)
 	var nonExclusiveTests []*register.Test
 	for _, test := range tests {
-		if test.NonExclusive {
+		if test.NonExclusive && !disableNonExclusive {
 			nonExclusiveTests = append(nonExclusiveTests, test)
 			delete(tests, test.Name)
 		}
@@ -657,12 +657,12 @@ func rerunFailedTests(flight platform.Flight, outputDir string, pltfrm string, v
 	return err
 }
 
-func RunTests(patterns []string, multiply int, rerun bool, pltfrm, outputDir string, propagateTestErrors bool) error {
-	return runProvidedTests(register.Tests, patterns, multiply, rerun, pltfrm, outputDir, propagateTestErrors)
+func RunTests(patterns []string, multiply int, rerun bool, pltfrm, outputDir string, propagateTestErrors bool, disableNonExclusive bool) error {
+	return runProvidedTests(register.Tests, patterns, multiply, rerun, pltfrm, outputDir, propagateTestErrors, disableNonExclusive)
 }
 
-func RunUpgradeTests(patterns []string, rerun bool, pltfrm, outputDir string, propagateTestErrors bool) error {
-	return runProvidedTests(register.UpgradeTests, patterns, 0, rerun, pltfrm, outputDir, propagateTestErrors)
+func RunUpgradeTests(patterns []string, rerun bool, pltfrm, outputDir string, propagateTestErrors bool, disableNonExclusive bool) error {
+	return runProvidedTests(register.UpgradeTests, patterns, 0, rerun, pltfrm, outputDir, propagateTestErrors, disableNonExclusive)
 }
 
 // externalTestMeta is parsed from kola.json in external tests

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -512,7 +512,7 @@ func filterTests(tests map[string]*register.Test, patterns []string, pltfrm stri
 // register tests in their init() function.  outputDir is where various test
 // logs and data will be written for analysis after the test run. If it already
 // exists it will be erased!
-func runProvidedTests(tests map[string]*register.Test, patterns []string, multiply int, pltfrm, outputDir string, propagateTestErrors bool) error {
+func runProvidedTests(tests map[string]*register.Test, patterns []string, multiply int, rerun bool, pltfrm, outputDir string, propagateTestErrors bool) error {
 	var versionStr string
 
 	// Avoid incurring cost of starting machine in getClusterSemver when
@@ -622,7 +622,7 @@ func runProvidedTests(tests map[string]*register.Test, patterns []string, multip
 	firstRunErr := suite.Run()
 	firstRunErr = handleSuiteErrors(outputDir, firstRunErr)
 
-	if len(failedTests) > 0 {
+	if len(failedTests) > 0 && rerun {
 		newOutputDir := filepath.Join(outputDir, "rerun")
 		err = rerunFailedTests(flight, newOutputDir, pltfrm, versionStr)
 		handleSuiteErrors(newOutputDir, err)
@@ -657,12 +657,12 @@ func rerunFailedTests(flight platform.Flight, outputDir string, pltfrm string, v
 	return err
 }
 
-func RunTests(patterns []string, multiply int, pltfrm, outputDir string, propagateTestErrors bool) error {
-	return runProvidedTests(register.Tests, patterns, multiply, pltfrm, outputDir, propagateTestErrors)
+func RunTests(patterns []string, multiply int, rerun bool, pltfrm, outputDir string, propagateTestErrors bool) error {
+	return runProvidedTests(register.Tests, patterns, multiply, rerun, pltfrm, outputDir, propagateTestErrors)
 }
 
-func RunUpgradeTests(patterns []string, pltfrm, outputDir string, propagateTestErrors bool) error {
-	return runProvidedTests(register.UpgradeTests, patterns, 0, pltfrm, outputDir, propagateTestErrors)
+func RunUpgradeTests(patterns []string, rerun bool, pltfrm, outputDir string, propagateTestErrors bool) error {
+	return runProvidedTests(register.UpgradeTests, patterns, 0, rerun, pltfrm, outputDir, propagateTestErrors)
 }
 
 // externalTestMeta is parsed from kola.json in external tests

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -512,7 +512,7 @@ func filterTests(tests map[string]*register.Test, patterns []string, pltfrm stri
 // register tests in their init() function.  outputDir is where various test
 // logs and data will be written for analysis after the test run. If it already
 // exists it will be erased!
-func runProvidedTests(tests map[string]*register.Test, patterns []string, multiply int, rerun bool, pltfrm, outputDir string, propagateTestErrors bool, disableNonExclusive bool) error {
+func runProvidedTests(tests map[string]*register.Test, patterns []string, multiply int, rerun bool, pltfrm, outputDir string, propagateTestErrors bool) error {
 	var versionStr string
 
 	// Avoid incurring cost of starting machine in getClusterSemver when
@@ -540,7 +540,7 @@ func runProvidedTests(tests map[string]*register.Test, patterns []string, multip
 	// Generate non-exclusive test wrapper (run multiple tests in one VM)
 	var nonExclusiveTests []*register.Test
 	for _, test := range tests {
-		if test.NonExclusive && !disableNonExclusive {
+		if test.NonExclusive {
 			nonExclusiveTests = append(nonExclusiveTests, test)
 			delete(tests, test.Name)
 		}
@@ -584,7 +584,7 @@ func runProvidedTests(tests map[string]*register.Test, patterns []string, multip
 				// Keep track of failed tests for a rerun
 				// Non-exclusive test wrapper is not rerun since each non-exclusive
 				// test is run in its own VM during the rerun
-				if h.Failed() && test.Name != "non-exclusive-tests" {
+				if h.Failed() {
 					failedTests = append(failedTests, test)
 				}
 			}()
@@ -657,12 +657,12 @@ func rerunFailedTests(flight platform.Flight, outputDir string, pltfrm string, v
 	return err
 }
 
-func RunTests(patterns []string, multiply int, rerun bool, pltfrm, outputDir string, propagateTestErrors bool, disableNonExclusive bool) error {
-	return runProvidedTests(register.Tests, patterns, multiply, rerun, pltfrm, outputDir, propagateTestErrors, disableNonExclusive)
+func RunTests(patterns []string, multiply int, rerun bool, pltfrm, outputDir string, propagateTestErrors bool) error {
+	return runProvidedTests(register.Tests, patterns, multiply, rerun, pltfrm, outputDir, propagateTestErrors)
 }
 
-func RunUpgradeTests(patterns []string, rerun bool, pltfrm, outputDir string, propagateTestErrors bool, disableNonExclusive bool) error {
-	return runProvidedTests(register.UpgradeTests, patterns, 0, rerun, pltfrm, outputDir, propagateTestErrors, disableNonExclusive)
+func RunUpgradeTests(patterns []string, rerun bool, pltfrm, outputDir string, propagateTestErrors bool) error {
+	return runProvidedTests(register.UpgradeTests, patterns, 0, rerun, pltfrm, outputDir, propagateTestErrors)
 }
 
 // externalTestMeta is parsed from kola.json in external tests
@@ -1106,12 +1106,6 @@ func makeNonExclusiveTest(tests []*register.Test, flight platform.Flight) regist
 			for _, t := range tests {
 				t := t
 				run := func(h *harness.H) {
-					defer func() {
-						if h.Failed() {
-							failedTests = append(failedTests, t)
-						}
-					}()
-
 					// Install external test executable
 					if t.ExternalTest != "" {
 						setupExternalTest(h, t, tcluster)


### PR DESCRIPTION
Reruns are not always needed (such as in local testing). Lets
disable reruns by default and add an option to enable them.

Since reruns are not enabled by default, we can seralize the rerun data
so that it may be read again via `kola rerun` command. Rerun data is
stored in tmp/kola/rerun-data, where each line is the name of a failed
test.