### PR TITLE
kola: add KOLA_LEAK_ON_FAIL

### DIFF
--- a/docs/kola.md
+++ b/docs/kola.md
@@ -167,6 +167,31 @@ be used to inspect a machine during a test.
 The `--ssh-on-test-failure` flag can be specified to have the kola runner
 automatically SSH into a machine when any `MustSSH` calls fail.
 
+## KOLA_LEAK_ON_FAIL
+
+Sometimes `--ssh-on-test-failure` is not good enough to debug a test. For
+example, if the failure happens during provisioning, or if it isn't an SSH
+command that fails, but something else.
+
+You can use the `KOLA_LEAK_ON_FAIL` environment variable to force kola to leak
+machines when a test fails so that you can debug manually. Specifically, this
+does a few things:
+- It enables serial console auto-login.
+- It injects the SSH public key pointed at by `KOLA_LEAK_ON_FAIL` into all test
+  instances.
+- It suppresses VM teardown if a test failed.
+
+Example usage:
+
+```
+$ while true; do KOLA_LEAK_ON_FAIL=~/.ssh/id_rsa.pub kola run my-flaky-test || break; done
+...
+KOLA_LEAK_ON_FAIL set; not tearing down node:
+{"id":"1cee7ac8-1ffb-470f-a0a5-2294ad76301d","public_ip":"127.0.0.1:45973","output_dir":"tmp/kola/qemu-unpriv-2021-11-01-1503-162948/basic/1cee7ac8-1ffb-470f-a0a5-2294ad76301d"}
+$ ssh -l core -p 45973 localhost
+$ # or if SSH is down, try using the logged in serial console in the cloud UI
+```
+
 ## kolet
 
 kolet is run on kola instances to run native functions in tests. Generally kolet

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -1156,7 +1156,14 @@ func runTest(h *harness.H, t *register.Test, pltfrm string, flight platform.Flig
 		h.Fatalf("Cluster failed: %v", err)
 	}
 	defer func() {
-		c.Destroy()
+		if h.Failed() && os.Getenv("KOLA_LEAK_ON_FAIL") != "" {
+			for _, m := range c.Machines() {
+				platform.LeakOnFail(m)
+				c.Leak(m)
+			}
+		} else {
+			c.Destroy()
+		}
 		for _, k := range t.Tags {
 			if k == SkipBaseChecksTag {
 				plog.Debugf("Skipping base checks for %s", t.Name)

--- a/mantle/platform/cluster.go
+++ b/mantle/platform/cluster.go
@@ -18,6 +18,7 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
+	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -202,6 +203,14 @@ func (bc *BaseCluster) RenderUserData(userdata *platformConf.UserData, ignitionV
 		keys, err := bc.bf.Keys()
 		if err != nil {
 			return nil, err
+		}
+
+		if keyfile := os.Getenv("KOLA_LEAK_ON_FAIL"); keyfile != "" {
+			key, err := ioutil.ReadFile(keyfile)
+			if err != nil {
+				return nil, err
+			}
+			conf.AddAuthorizedKeys("core", []string{string(key)})
 		}
 
 		conf.CopyKeys(keys)

--- a/mantle/platform/platform.go
+++ b/mantle/platform/platform.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -114,6 +115,9 @@ type Cluster interface {
 	// associated resources. It should log any failures; since they are not
 	// actionable, it does not return an error
 	Destroy()
+
+	// Leak removes the machine from the cluster without deprovisioning it.
+	Leak(m Machine)
 
 	// ConsoleOutput returns a map of console output from destroyed
 	// cluster machines.
@@ -500,4 +504,13 @@ func WriteJSONInfo(m Machine, w io.Writer) error {
 	// disable pretty printing, so we emit newline-delimited streaming JSON objects
 	e.SetIndent("", "")
 	return e.Encode(info)
+}
+
+func LeakOnFail(m Machine) bool {
+	if os.Getenv("KOLA_LEAK_ON_FAIL") != "" {
+		fmt.Printf("KOLA_LEAK_ON_FAIL set; not tearing down node: ")
+		WriteJSONInfo(m, os.Stdout)
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
Sometimes, we hit test flakes that are hard to reproduce manually or
that are cumbersome to set up the same way a test does. Add a new
`KOLA_LEAK_ON_FAIL` env var which will cause kola to:
- enable console auto-login
- print the SSH key on the console
- not deprovision the machine if the test fails

This allows an engineer to to be able to dig deeper, poking at the VM
when the failure happens, either through SSH, or through the serial
console. So then we could expose this in the pipeline as a parameter so
we can do custom runs with the variable enabled (and manually clean up
any leaked VMs after investigating).

This is more powerful than `--ssh-on-test-failure` because it applies to
any failure in general, including provisioning failures, it allows for
debugging via serial console if SSH itself is broken, and it's feasible
to use in a pipeline.

