### PR TITLE
ci/Dockerfile: tickle Quay cache 2021-10-21

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /root/containerbuild
 COPY ./src/print-dependencies.sh ./src/deps*.txt ./src/vmdeps*.txt ./src/build-deps.txt /root/containerbuild/src/
 COPY ./build.sh /root/containerbuild/
 RUN ./build.sh configure_yum_repos
-RUN ./build.sh install_rpms  # nocache 20211014
+RUN ./build.sh install_rpms  # nocache 20211021
 
 # Allow Prow to work
 RUN mkdir -p /go && chown 0777 /go


### PR DESCRIPTION
Blow out the Quay cache while we wait for osbuild-composer-worker
rpm to be fixed. Currently it can't be upgraded in a container.
See https://github.com/coreos/coreos-assembler/issues/2382