### PR TITLE
deps: temporarily stop shipping osbuild-composer

### DIFF
--- a/src/deps.txt
+++ b/src/deps.txt
@@ -18,7 +18,9 @@ dnf-utils
 
 # We don't actually use this right now but we intend to share
 # code in the future.
-osbuild-composer
+# XXX: temporarily disabled until we fix
+# https://github.com/osbuild/osbuild-composer/issues/1915
+# osbuild-composer
 
 # For generating ISO images
 genisoimage


### PR DESCRIPTION
It's causing a lot of pain right now on each package bump because of
https://github.com/osbuild/osbuild-composer/issues/1915
and our double-layered Quay.io caching.

Let's just stop including it for now since we're not using it yet.