### PR TITLE
kola: extend non-exclusive tests to multiple buckets

### DIFF
--- a/docs/kola/external-tests.md
+++ b/docs/kola/external-tests.md
@@ -197,7 +197,8 @@ Here's an example `kola.json`:
     "additionalNics": 2,
     "appendKernelArgs": "ip=bond0:dhcp bond=bond0:ens5,ens6:mode=active-backup,miimon=100"
     "timeoutMin": 8,
-    "exclusive": true
+    "exclusive": true,
+    "conflicts": ["ext.config.some-test", "podman.some-other-test"]
 }
 ```
 
@@ -252,6 +253,11 @@ is marked `false`, the test is run with other "non-exclusive" tests. If a test
 is simple and is not expected to conflict with other tests, it should be marked
 `exclusive: false`. When the `exclusive` key is not provided, tests are marked
 `exclusive: true` by default.
+
+The `conflicts` key takes a list of test names that conflict with this test.
+This key can only be specified if `exclusive` is marked `false` since
+`exclusive: true` tests are run exclusively in their own VM.  At runtime,
+this test will be separated from the tests it is conflicting with.
 
 More recently, you can also (useful for shell scripts) include the JSON file
 inline per test, like this:

--- a/mantle/cmd/kola/kola.go
+++ b/mantle/cmd/kola/kola.go
@@ -22,7 +22,6 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"strings"
 	"text/tabwriter"
 
 	"github.com/coreos/pkg/capnslog"
@@ -200,15 +199,9 @@ func runRerun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	for _, test := range data.Tests {
-		if test.Result == testresult.Fail {
-			if strings.HasPrefix(test.Name, "non-exclusive-tests") && test.Name != "non-exclusive-tests" {
-				// Extract name of non-exclusive test
-				name := strings.TrimPrefix(test.Name, "non-exclusive-tests/")
-				patterns = append(patterns, name)
-			} else if !strings.Contains(test.Name, "/") {
-				// We don't add subtests to list of patterns
-				patterns = append(patterns, test.Name)
-			}
+		name, isRerunnable := kola.GetRerunnableTestName(test.Name)
+		if test.Result == testresult.Fail && isRerunnable {
+			patterns = append(patterns, name)
 		}
 	}
 

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -591,11 +591,34 @@ func runProvidedTests(testsBank map[string]*register.Test, patterns []string, mu
 
 	if len(nonExclusiveTests) > 0 {
 		buckets := createTestBuckets(nonExclusiveTests)
-		for i, bucket := range buckets {
+		numBuckets := len(buckets)
+		for i := 0; i < numBuckets; {
 			// This test does not need to be registered since it is temporarily
 			// created to be used as a wrapper
-			nonExclusiveWrapper := makeNonExclusiveTest(i, bucket, flight)
-			tests[nonExclusiveWrapper.Name] = &nonExclusiveWrapper
+			nonExclusiveWrapper := makeNonExclusiveTest(i, buckets[i], flight)
+			if flight.ConfigTooLarge(*nonExclusiveWrapper.UserData) {
+				// Since the merged config size is too large, we will split the bucket into
+				// two buckets
+				numTests := len(buckets[i])
+				if numTests == 1 {
+					// This test bucket cannot be split further so the single test config
+					// must be too large
+					err = fmt.Errorf("test %v has a config that is too large", buckets[i][0].Name)
+					plog.Fatal(err)
+				}
+				newBucket1 := buckets[i][:numTests/2]
+				newBucket2 := buckets[i][numTests/2:]
+				buckets[i] = newBucket1
+				buckets = append(buckets, newBucket2)
+				// Since we're adding a bucket we'll bump the numBuckets and not
+				// bump `i` during this loop iteration because we want to run through
+				// the check again for the current bucket which should now have half
+				// the tests, but may still have a config that's too large.
+				numBuckets++
+			} else {
+				tests[nonExclusiveWrapper.Name] = &nonExclusiveWrapper
+				i++ // Move to the next bucket to evaluate
+			}
 		}
 	}
 

--- a/mantle/kola/register/register.go
+++ b/mantle/kola/register/register.go
@@ -99,6 +99,10 @@ type Test struct {
 	// If true, this test will be run along with other NonExclusive tests in one VM
 	// Otherwise, it is run in its own VM
 	NonExclusive bool
+
+	// Conflicts is non-empty iff nonexclusive is true
+	// Contains the tests that conflict with this particular test
+	Conflicts []string
 }
 
 // Registered tests that run as part of `kola run` live here. Mapping of names
@@ -113,6 +117,9 @@ var UpgradeTests = map[string]*Test{}
 // harnesses knows which tests it can choose from. Panics if existing name is
 // registered
 func Register(m map[string]*Test, t *Test) {
+	if len(t.Conflicts) > 0 && !t.NonExclusive {
+		panic("exclusive test cannot have non-empty conflicts entry")
+	}
 	_, ok := m[t.Name]
 	if ok {
 		panic(fmt.Sprintf("test %v already registered", t.Name))

--- a/mantle/platform/machine/aws/cluster.go
+++ b/mantle/platform/machine/aws/cluster.go
@@ -30,7 +30,7 @@ type cluster struct {
 	flight *flight
 }
 
-const maxUserDataSize = 16384
+const MaxUserDataSize = 16384
 
 func (ac *cluster) NewMachine(userdata *conf.UserData) (platform.Machine, error) {
 	return ac.NewMachineWithOptions(userdata, platform.MachineOptions{})
@@ -68,15 +68,15 @@ func (ac *cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 	// Compress via gzip if needed
 	ud := conf.String()
 	encoding := base64.StdEncoding.EncodeToString([]byte(ud))
-	if len([]byte(encoding)) > maxUserDataSize {
+	if len([]byte(encoding)) > MaxUserDataSize {
 		ud, err = conf.MaybeCompress()
 		if err != nil {
 			return nil, err
 		}
 		// Check if config is still too large
 		encoding = base64.StdEncoding.EncodeToString([]byte(ud))
-		if len([]byte(encoding)) > maxUserDataSize {
-			fmt.Printf("WARNING: compressed userdata exceeds expected limit of %d\n", maxUserDataSize)
+		if len([]byte(encoding)) > MaxUserDataSize {
+			fmt.Printf("WARNING: compressed userdata exceeds expected limit of %d\n", MaxUserDataSize)
 		}
 	}
 	instances, err := ac.flight.api.CreateInstances(ac.Name(), keyname, ud, 1, int64(options.MinDiskSize))

--- a/mantle/platform/machine/azure/flight.go
+++ b/mantle/platform/machine/azure/flight.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/coreos/mantle/platform"
 	"github.com/coreos/mantle/platform/api/azure"
+	"github.com/coreos/mantle/platform/conf"
 )
 
 const (
@@ -116,6 +117,12 @@ func (af *flight) NewCluster(rconf *platform.RuntimeConfig) (platform.Cluster, e
 	af.AddCluster(ac)
 
 	return ac, nil
+}
+
+func (af *flight) ConfigTooLarge(ud conf.UserData) bool {
+
+	// not implemented
+	return false
 }
 
 func (af *flight) Destroy() {

--- a/mantle/platform/machine/do/flight.go
+++ b/mantle/platform/machine/do/flight.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/coreos/mantle/platform"
 	"github.com/coreos/mantle/platform/api/do"
+	"github.com/coreos/mantle/platform/conf"
 )
 
 const (
@@ -104,6 +105,12 @@ func (df *flight) NewCluster(rconf *platform.RuntimeConfig) (platform.Cluster, e
 	df.AddCluster(dc)
 
 	return dc, nil
+}
+
+func (af *flight) ConfigTooLarge(ud conf.UserData) bool {
+
+	// not implemented
+	return false
 }
 
 func (df *flight) Destroy() {

--- a/mantle/platform/machine/esx/flight.go
+++ b/mantle/platform/machine/esx/flight.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/coreos/mantle/platform"
 	"github.com/coreos/mantle/platform/api/esx"
+	"github.com/coreos/mantle/platform/conf"
 )
 
 const (
@@ -54,6 +55,12 @@ func NewFlight(opts *esx.Options) (platform.Flight, error) {
 	}
 
 	return ef, nil
+}
+
+func (af *flight) ConfigTooLarge(ud conf.UserData) bool {
+
+	// not implemented
+	return false
 }
 
 // NewCluster creates an instance of a Cluster suitable for spawning

--- a/mantle/platform/machine/gcloud/flight.go
+++ b/mantle/platform/machine/gcloud/flight.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/coreos/mantle/platform"
 	"github.com/coreos/mantle/platform/api/gcloud"
+	"github.com/coreos/mantle/platform/conf"
 )
 
 type flight struct {
@@ -53,6 +54,12 @@ func NewFlight(opts *gcloud.Options) (platform.Flight, error) {
 	}
 
 	return gf, nil
+}
+
+func (af *flight) ConfigTooLarge(ud conf.UserData) bool {
+
+	// not implemented
+	return false
 }
 
 func (gf *flight) NewCluster(rconf *platform.RuntimeConfig) (platform.Cluster, error) {

--- a/mantle/platform/machine/openstack/flight.go
+++ b/mantle/platform/machine/openstack/flight.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/coreos/mantle/platform"
 	"github.com/coreos/mantle/platform/api/openstack"
+	"github.com/coreos/mantle/platform/conf"
 )
 
 const (
@@ -84,6 +85,12 @@ func (of *flight) NewCluster(rconf *platform.RuntimeConfig) (platform.Cluster, e
 	of.AddCluster(oc)
 
 	return oc, nil
+}
+
+func (af *flight) ConfigTooLarge(ud conf.UserData) bool {
+
+	// not implemented
+	return false
 }
 
 func (of *flight) Destroy() {

--- a/mantle/platform/machine/packet/flight.go
+++ b/mantle/platform/machine/packet/flight.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/coreos/mantle/platform"
 	"github.com/coreos/mantle/platform/api/packet"
+	"github.com/coreos/mantle/platform/conf"
 )
 
 const (
@@ -83,6 +84,12 @@ func (pf *flight) NewCluster(rconf *platform.RuntimeConfig) (platform.Cluster, e
 	pf.AddCluster(pc)
 
 	return pc, nil
+}
+
+func (af *flight) ConfigTooLarge(ud conf.UserData) bool {
+
+	// not implemented
+	return false
 }
 
 func (pf *flight) Destroy() {

--- a/mantle/platform/machine/qemuiso/flight.go
+++ b/mantle/platform/machine/qemuiso/flight.go
@@ -18,6 +18,7 @@ import (
 	"github.com/coreos/pkg/capnslog"
 
 	"github.com/coreos/mantle/platform"
+	"github.com/coreos/mantle/platform/conf"
 )
 
 const (
@@ -56,6 +57,12 @@ func NewFlight(opts *Options) (platform.Flight, error) {
 	}
 
 	return qf, nil
+}
+
+func (af *flight) ConfigTooLarge(ud conf.UserData) bool {
+
+	// not implemented
+	return false
 }
 
 // NewCluster creates a Cluster instance, suitable for running virtual

--- a/mantle/platform/machine/unprivqemu/flight.go
+++ b/mantle/platform/machine/unprivqemu/flight.go
@@ -18,6 +18,7 @@ import (
 	"github.com/coreos/pkg/capnslog"
 
 	"github.com/coreos/mantle/platform"
+	"github.com/coreos/mantle/platform/conf"
 )
 
 const (
@@ -66,6 +67,12 @@ func NewFlight(opts *Options) (platform.Flight, error) {
 	}
 
 	return qf, nil
+}
+
+func (af *flight) ConfigTooLarge(ud conf.UserData) bool {
+
+	// not implemented
+	return false
 }
 
 // NewCluster creates a Cluster instance, suitable for running virtual

--- a/mantle/platform/platform.go
+++ b/mantle/platform/platform.go
@@ -145,6 +145,10 @@ type Flight interface {
 	// Clusters returns a slice of the active Clusters.
 	Clusters() []Cluster
 
+	// ConfigTooLarge returns true iff the config is too
+	// large for the platform
+	ConfigTooLarge(ud conf.UserData) bool
+
 	// Destroy terminates each cluster and frees any other associated
 	// resources.  It should log any failures; since they are not
 	// actionable, it does not return an error.


### PR DESCRIPTION
Add support for multiple non-exclusive test buckets (or VMs). Tests can specify
whether another non-exclusive test is conflicting and kola will automatically
resolve these tests into different buckets.

We have seen in the past that the non-exclusive tests' merged config can
become too large to pass to cloud providers. To fix this issue we compressed
configs (for AWS), but this is only a temporary fix.

If a non-exclusive test bucket's config becomes too large, let's split the
bucket into two buckets to lower the config size.