### PR TITLE
 Add `deploy-via-container` key for `image.yaml`

### DIFF
--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -139,6 +139,12 @@ cat image-default.json "${image_json}" | jq -s add > image-configured.json
 # We do some extra handling of the rootfs here; it feeds into size estimation.
 rootfs_type=$(jq -re .rootfs < image-configured.json)
 
+deploy_container=
+container_imgref=$(jq -r '.["container-imgref"]//""' < image-configured.json)
+if test -n "${container_imgref}" || jq -re '.["deploy-via-container"]' < image-configured.json >/dev/null; then
+    deploy_container=ostree-unverified-image:oci-archive:$builddir/$(meta_key images.ostree.path)
+fi
+
 # fs-verity requires block size = page size. We need to take that into account
 # in the disk size estimation due to higher fragmentation on larger blocks.
 BLKSIZE=""
@@ -204,6 +210,8 @@ cat >image-dynamic.json << EOF
     "osname": "${name}",
     "buildid": "${build}",
     "imgid": "${img}",
+    "deploy-container": "${deploy_container}",
+    "container-imgref": "${container_imgref}",
     "ostree-commit": "${commit}",
     "ostree-ref": "${ref}",
     "ostree-repo": "${ostree_repo}"

--- a/src/image-default.yaml
+++ b/src/image-default.yaml
@@ -2,3 +2,7 @@
 bootfs: "ext4"
 rootfs: "xfs"
 grub-script: "/usr/lib/coreos-assembler/grub.cfg"
+# True if we should use `rpm-ostree ex-container image deploy`
+deploy-via-container: false
+# Set this to a target container reference, e.g. ostree-unverified-registry:quay.io/example/os:latest
+# container-imgref: ""


### PR DESCRIPTION
create_disk: Initialize stateroot earlier

We can do this earlier rather than intermixing it with
the pull/deploy.  Prep for further work.

---


Add `deploy-via-container` key for `image.yaml`

This builds on the `image-format: oci` key to switch to using
the new ostree-container code to do the deployment (via rpm-ostree).

Unlike the above though, this is not something we can turn on
by default until we intend to hard cut over to fetching updates
via containers.

The intention is to use this to produce image builds that are
initially provisioned via a container image so that we can more
easily experiment with the "container native" flow.

A side note; I suspect this will indirectly fix
https://github.com/openshift/os/issues/594
because now we're opening a single large file and pulling that
over virtio instead of lots of smaller files.

---

