### PR TITLE
grub: support searching for boot by UUID

### DIFF
--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -339,7 +339,14 @@ if [ -e (md/md-boot) ]; then
   # the main grub.cfg.
   set prefix=md/md-boot
 else
-  search --label boot --set prefix --no-floppy
+  if [ -f ${config_directory}/bootuuid.cfg ]; then
+    source ${config_directory}/bootuuid.cfg
+  fi
+  if [ -n "${BOOT_UUID}" ]; then
+    search --fs-uuid "${BOOT_UUID}" --set prefix --no-floppy
+  else
+    search --label boot --set prefix --no-floppy
+  fi
 fi
 set prefix=($prefix)/grub2
 configfile $prefix/grub.cfg

--- a/src/grub.cfg
+++ b/src/grub.cfg
@@ -19,7 +19,14 @@ if [ -d (md/md-boot)/grub2 ]; then
   set boot=md/md-boot
   set prefix=($boot)/grub2
 else
-  search --label boot --set boot --no-floppy
+  if [ -f ${config_directory}/bootuuid.cfg ]; then
+    source ${config_directory}/bootuuid.cfg
+  fi
+  if [ -n "${BOOT_UUID}" ]; then
+    search --fs-uuid "${BOOT_UUID}" --set boot --no-floppy
+  else
+    search --label boot --set boot --no-floppy
+  fi
 fi
 set root=$boot
 


### PR DESCRIPTION
This adds support for a `boot_uuid` dropin sitting alongside both the
BIOS and EFI GRUB configs to specify the UUID to scan for instead of
relying on labels.

Part of https://github.com/coreos/fedora-coreos-tracker/issues/976.