### PR TITLE
mantle/build: allow overriding kolet arches to build

### DIFF
--- a/mantle/build
+++ b/mantle/build
@@ -11,6 +11,7 @@ if [[ $# -eq 0 ]]; then
 fi
 
 declare -A BASEARCH_TO_GOARCH=([s390x]=s390x [x86_64]=amd64 [aarch64]=arm64 [ppc64le]=ppc64le)
+KOLET_ARCHES="${KOLET_ARCHES:-s390x x86_64 aarch64 ppc64le}"
 
 race=
 if [ -n "${ENABLE_GO_RACE_DETECTOR:-}" ] && [[ ! "$(uname -m)" =~ "s390" ]]; then
@@ -36,7 +37,7 @@ host_build() {
 cross_static_build() {
     local cmd=$1; shift
     local a
-	for a in "${!BASEARCH_TO_GOARCH[@]}"; do \
+	for a in ${KOLET_ARCHES}; do \
         mkdir -p "bin/$a"
         echo "Building $a/$cmd (static)"
         CGO_ENABLED=0 GOARCH=${BASEARCH_TO_GOARCH[$a]} \

--- a/mantle/build
+++ b/mantle/build
@@ -10,6 +10,8 @@ if [[ $# -eq 0 ]]; then
     set -- cmd/* schema
 fi
 
+declare -A BASEARCH_TO_GOARCH=([s390x]=s390x [x86_64]=amd64 [aarch64]=arm64 [ppc64le]=ppc64le)
+
 race=
 if [ -n "${ENABLE_GO_RACE_DETECTOR:-}" ] && [[ ! "$(uname -m)" =~ "s390" ]]; then
     race="-race"
@@ -34,11 +36,10 @@ host_build() {
 cross_static_build() {
     local cmd=$1; shift
     local a
-	declare -A arches=([s390x]=s390x [x86_64]=amd64 [aarch64]=arm64 [ppc64le]=ppc64le)
-	for a in "${!arches[@]}"; do \
+	for a in "${!BASEARCH_TO_GOARCH[@]}"; do \
         mkdir -p "bin/$a"
         echo "Building $a/$cmd (static)"
-        CGO_ENABLED=0 GOARCH=${arches[$a]} \
+        CGO_ENABLED=0 GOARCH=${BASEARCH_TO_GOARCH[$a]} \
         go build \
             -ldflags "${ldflags} -extldflags=-static" \
             -mod vendor \


### PR DESCRIPTION
It's annoying to have to build kolet for e.g. s390x locally. Let's add
an env var to allow configuring this. Now, a developer can do e.g.

```
make kolet KOLET_ARCHES=x86_64
```