### PR TITLE
kola/coretest: tighten a bunch of uses of goroutines

### DIFF
--- a/mantle/kola/tests/coretest/core.go
+++ b/mantle/kola/tests/coretest/core.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pborman/uuid"
 
 	"github.com/coreos/mantle/kola/register"
+	"github.com/coreos/mantle/util"
 )
 
 const (
@@ -103,97 +104,27 @@ func TestPortSsh() error {
 
 func TestDockerEcho() error {
 	//t.Parallel()
-	errc := make(chan error, 1)
-	go func() {
-		c := exec.Command("docker", "run", "busybox", "echo")
-		err := c.Run()
-		errc <- err
-	}()
-	select {
-	case <-time.After(DockerTimeout):
-		return fmt.Errorf("DockerEcho timed out after %s.", DockerTimeout)
-	case err := <-errc:
-		if err != nil {
-			return fmt.Errorf("DockerEcho: %v", err)
-		}
-		return nil
-	}
+	return util.RunCmdTimeout(DockerTimeout, "docker", "run", "busybox", "echo")
 }
 
 func TestDockerPing() error {
 	//t.Parallel()
-	errc := make(chan error, 1)
-	go func() {
-		c := exec.Command("docker", "run", "busybox", "ping", "-c4", "coreos.com")
-		err := c.Run()
-		errc <- err
-	}()
-	select {
-	case <-time.After(DockerTimeout):
-		return fmt.Errorf("DockerPing timed out after %s.", DockerTimeout)
-	case err := <-errc:
-		if err != nil {
-			return err
-		}
-		return nil
-	}
+	return util.RunCmdTimeout(DockerTimeout, "docker", "run", "busybox", "ping", "-c4", "coreos.com")
 }
 
 func TestPodmanEcho() error {
 	//t.Parallel()
-	errc := make(chan error, 1)
-	go func() {
-		c := exec.Command("podman", "run", "busybox", "echo")
-		err := c.Run()
-		errc <- err
-	}()
-	select {
-	case <-time.After(DockerTimeout):
-		return fmt.Errorf("PodmanEcho timed out after %s.", DockerTimeout)
-	case err := <-errc:
-		if err != nil {
-			return fmt.Errorf("PodmanEcho: %v", err)
-		}
-		return nil
-	}
+	return util.RunCmdTimeout(DockerTimeout, "podman", "run", "busybox", "echo")
 }
 
 func TestPodmanPing() error {
 	//t.Parallel()
-	errc := make(chan error, 1)
-	go func() {
-		c := exec.Command("podman", "run", "busybox", "ping", "-c4", "coreos.com")
-		err := c.Run()
-		errc <- err
-	}()
-	select {
-	case <-time.After(DockerTimeout):
-		return fmt.Errorf("PodmanPing timed out after %s.", DockerTimeout)
-	case err := <-errc:
-		if err != nil {
-			return err
-		}
-		return nil
-	}
+	return util.RunCmdTimeout(DockerTimeout, "podman", "run", "busybox", "ping", "-c4", "coreos.com")
 }
 
 func TestPodmanWgetHead() error {
 	//t.Parallel()
-	errc := make(chan error, 1)
-	go func() {
-		c := exec.Command("podman", "run", "busybox", "wget", "--spider", "http://fedoraproject.org/static/hotspot.txt")
-		err := c.Run()
-		errc <- err
-	}()
-	select {
-	case <-time.After(DockerTimeout):
-		return fmt.Errorf("PodmanWgetHead timed out after %s.", DockerTimeout)
-	case err := <-errc:
-		if err != nil {
-			return err
-		}
-		return nil
-	}
+	return util.RunCmdTimeout(DockerTimeout, "podman", "run", "busybox", "wget", "--spider", "http://fedoraproject.org/static/hotspot.txt")
 }
 
 // This execs gdbus, because we need to change uses to test perms.

--- a/mantle/kola/tests/coretest/helpers.go
+++ b/mantle/kola/tests/coretest/helpers.go
@@ -2,7 +2,6 @@ package coretest
 
 import (
 	"bufio"
-	"fmt"
 	"io/ioutil"
 	"net"
 	"os"
@@ -11,18 +10,8 @@ import (
 )
 
 func CheckPort(network, address string, timeout time.Duration) error {
-	errc := make(chan error, 1)
-	go func() {
-		_, err := net.Dial(network, address)
-		errc <- err
-	}()
-	select {
-	case <-time.After(timeout):
-		return fmt.Errorf("%s:%s timed out after %s seconds.",
-			network, address, timeout)
-	case err := <-errc:
-		return err
-	}
+	_, err := net.DialTimeout(network, address, timeout)
+	return err
 }
 
 type MountTable struct {


### PR DESCRIPTION
Let's try to be more strict about how we use goroutines to make sure that we're not leaking a bunch of them as side-effects. This PR starts the process for a couple of callsites. There's more, but this is a start.

```
commit 01c355dc6dcfa56b37fdc3abdebca1770c88ac07
Date:   Mon Nov 1 13:15:37 2021 -0400

    kola/coretest: factor out function to run cmd and timeout

    Add a new `RunCmdTimeout` which runs a command but abandons if it's not
    done after a certain timeout. Use it in coretest to dedupe `podman` and
    `docker` runs. Additionally, the new code has no chance of leaking
    goroutines (which... doesn't really matter here since it's native tests
    running via kolet invocations, but just on principle).

commit eafd874952fcd2a9e0dd7dd77630c466fdf6c739
Date:   Mon Nov 1 12:06:53 2021 -0400

    kola/coretest/helpers: use `DialTimeout` instead of self timeout

    It's cleaner and eliminates the chance of our goroutine outliving the
    function.
```