### PR TITLE
ibmcloud: remove meta file for PowerVS and set ovf id to 80

### DIFF
--- a/src/powervs-template.xml
+++ b/src/powervs-template.xml
@@ -15,7 +15,7 @@
         <ovf:Info/>
         <ovf:Product/>
       </ovf:ProductSection>
-      <ovf:OperatingSystemSection ovf:id="79">
+      <ovf:OperatingSystemSection ovf:id="80">
         <ovf:Info/>
         <ovf:Description>{image_description}</ovf:Description>
         <ns0:architecture xmlns:ns0="ibmpvc">ppc64le</ns0:architecture>


### PR DESCRIPTION
Remove the meta file that previously contained some metadata which was used by the IBMCloud UI to identify the os type for ova images. After discussions with the team it looks like they only recognize certain types of strings like 'rhel', 'centos', etc.. As of now rhcos/fcos (the strings) are not recognized as supported types and changes need to be made on the powervs side for this. Setting this to rhcos/fcos today causes problems when importing the image into the powervs instance.

Also change the ovf id to 80 which is recognized as rhcos/fcos.