### PR TITLE
cosalib.vmware: rename to `ova`

### DIFF
--- a/src/cmd-artifact-disk
+++ b/src/cmd-artifact-disk
@@ -10,7 +10,7 @@ sys.path.insert(0, cosa_dir)
 from cosalib.build import BuildExistsError
 from cosalib.cli import BuildCli
 import cosalib.qemuvariants as QVariants
-import cosalib.vmware as VmwareOVA
+import cosalib.ova as OVA
 
 
 def get_builder(imgtype, build_root, build="latest", force=False, compress=False, schema=None):
@@ -27,8 +27,8 @@ def get_builder(imgtype, build_root, build="latest", force=False, compress=False
         log.info(f"Target '{imgtype.upper()}' is a Qemu Variant image")
         return QVariants.QemuVariantImage(**kargs)
 
-    if imgtype in VmwareOVA.VARIANTS:
-        return VmwareOVA.VmwareOVA(**kargs)
+    if imgtype in OVA.VARIANTS:
+        return OVA.OVA(**kargs)
 
     raise Exception(f"{imgtype} is not supported by this command")
 
@@ -40,7 +40,7 @@ def artifact_cli():
         level=log.INFO)
 
     targets = list(QVariants.VARIANTS.keys())
-    targets.extend(VmwareOVA.VARIANTS.keys())
+    targets.extend(OVA.VARIANTS.keys())
     targets.append("manual")
 
     parser = BuildCli()

--- a/src/cmd-artifact-disk
+++ b/src/cmd-artifact-disk
@@ -57,7 +57,7 @@ def artifact_cli():
     for k in targets:
         if sys.argv[0].endswith(f"cmd-buildextend-{k}"):
             symlink = k
-            log.info(f"CLI is a symlink for cmd-buildextends-{k}")
+            log.info(f"CLI is a symlink for cmd-buildextend-{k}")
             break
 
     # Predefined mode

--- a/src/cosalib/ova.py
+++ b/src/cosalib/ova.py
@@ -14,7 +14,7 @@ from cosalib.cmdlib import image_info
 from cosalib.qemuvariants import QemuVariantImage
 
 
-OVA_TEMPLATE_FILE = '/usr/lib/coreos-assembler/vmware-template.xml'
+OVA_TEMPLATE_DIR = '/usr/lib/coreos-assembler'
 
 
 # Variant are OVA types that are derived from qemu images.
@@ -22,6 +22,7 @@ OVA_TEMPLATE_FILE = '/usr/lib/coreos-assembler/vmware-template.xml'
 # add its definition below:
 VARIANTS = {
     "vmware": {
+        'template': 'vmware-template.xml',
         "image_format": "vmdk",
         "image_suffix": "ova",
         "platform": "vmware",
@@ -41,9 +42,9 @@ VARIANTS = {
 }
 
 
-class VmwareOVA(QemuVariantImage):
+class OVA(QemuVariantImage):
     """
-    VmwareOVA's are based on the QemuVariant Image. This Class tries to do
+    OVA's are based on the QemuVariant Image. This Class tries to do
     the absolute bare minium, and is effectively a wrapper around the
     QemuVariantImage Class. The only added functionality is the generation
     of the OVF paramters.
@@ -55,6 +56,7 @@ class VmwareOVA(QemuVariantImage):
     def __init__(self, **kwargs):
         variant = kwargs.pop("variant", "vmware")
         kwargs.update(VARIANTS.get(variant, {}))
+        self.template_name = kwargs.pop('template')
         QemuVariantImage.__init__(self, **kwargs)
         # Set the QemuVariant mutate_callback so that OVA is called.
         self.mutate_callback = self.write_ova
@@ -102,7 +104,7 @@ class VmwareOVA(QemuVariantImage):
         """
         ovf_params = self.generate_ovf_parameters(image_name)
 
-        with open(OVA_TEMPLATE_FILE) as f:
+        with open(os.path.join(OVA_TEMPLATE_DIR, self.template_name)) as f:
             template = f.read()
         ovf_xml = template.format(**ovf_params)
 


### PR DESCRIPTION
It's not really VMware-specific.

Broken out of #2489.