### PR TITLE
Enable Dependabot checks for Butane, Ignition, stream-metadata-go

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+- package-ecosystem: gomod
+  directory: "/mantle"
+  schedule:
+    interval: daily
+  allow:
+    # For now, only enable the deps we know we want to keep fresh
+    - dependency-name: "github.com/coreos/butane"
+    - dependency-name: "github.com/coreos/ignition/v2"
+    - dependency-name: "github.com/coreos/stream-metadata-go"


### PR DESCRIPTION
We want to keep stream-metadata-go fresh for the same reason as in https://github.com/coreos/fedora-coreos-stream-generator/pull/27.  In addition, the release processes for Butane and Ignition vendor the new version here, so while we're at it, add some automation to help with that.