### PR TITLE
ci: Blow out quay.io cache

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /root/containerbuild
 COPY ./src/print-dependencies.sh ./src/deps*.txt ./src/vmdeps*.txt ./src/build-deps.txt /root/containerbuild/src/
 COPY ./build.sh /root/containerbuild/
 RUN ./build.sh configure_yum_repos
-RUN ./build.sh install_rpms  # nocache 20211021
+RUN ./build.sh install_rpms  # nocache 20211102
 
 # Allow Prow to work
 RUN mkdir -p /go && chown 0777 /go


### PR DESCRIPTION
To pick up new ostree 2021.5 for https://github.com/coreos/enhancements/pull/7