### PR TITLE
kola/tests/ignition/security.go: drop do and packet platform exclusions

### DIFF
--- a/mantle/kola/tests/ignition/security.go
+++ b/mantle/kola/tests/ignition/security.go
@@ -61,9 +61,8 @@ func init() {
 			"TLSServe": register.CreateNativeFuncWrap(TLSServe),
 		},
 		Tags: []string{"ignition"},
-		// DO: https://github.com/coreos/bugs/issues/2205
-		// Packet & QEMU: https://github.com/coreos/ignition/issues/645
-		ExcludePlatforms: []string{"do", "packet", "qemu"},
+		// QEMU unprivileged doesn't support multiple VMs communicating with each other.
+		ExcludePlatforms: []string{"qemu"},
 		Timeout:          20 * time.Minute,
 	})
 }


### PR DESCRIPTION
Fixes #2532 