### PR TITLE
kola: also use by-partlabel for mount tests on s390x

### DIFF
--- a/mantle/kola/tests/ignition/mount.go
+++ b/mantle/kola/tests/ignition/mount.go
@@ -24,7 +24,6 @@ import (
 	"github.com/coreos/mantle/kola/register"
 	"github.com/coreos/mantle/platform"
 	"github.com/coreos/mantle/platform/conf"
-	"github.com/coreos/mantle/system"
 	"github.com/coreos/mantle/util"
 )
 
@@ -144,10 +143,6 @@ func createClusterValidate(c cluster.TestCluster, config types.Config, options p
 func setupIgnitionConfig() types.Config {
 	containerpartdeviceid := "by-partlabel/CONTR"
 	logpartdeviceid := "by-partlabel/LOG"
-	if system.RpmArch() == "s390x" {
-		containerpartdeviceid = "by-partuuid/63194b49-e4b7-43f9-9a8b-df0fd8279bb7"
-		logpartdeviceid = "by-partuuid/6385b84e-2c7b-4488-a870-667c565e01a8"
-	}
 
 	config := types.Config{
 		Ignition: types.Ignition{


### PR DESCRIPTION
This is an alternative take on re-gaining coverage for `by-partlabel` on s390x - and feels much better than https://github.com/coreos/fedora-coreos-config/pull/1285. We'll still need to deny-list the tests in RHCOS for a little while until an updated `gdisk` has landed (see https://bugzilla.redhat.com/show_bug.cgi?id=1899990).

Note that I kept the `by-partuuid` infrastructure around for now, in case we want to make future use of it. Or for additional coverage maybe mount one disk with `by-partlabel`, and the second with `by-partuuid`? Opinions?