### PR TITLE
kola/tests: bump timeout to 20 mins

### DIFF
--- a/mantle/kola/tests/ignition/resource.go
+++ b/mantle/kola/tests/ignition/resource.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 
 	"github.com/pin/tftp"
 
@@ -73,6 +74,7 @@ func init() {
 		Tags: []string{"ignition"},
 		// https://github.com/coreos/bugs/issues/2205
 		ExcludePlatforms: []string{"do", "qemu-unpriv"},
+		Timeout:          20 * time.Minute,
 	})
 	register.RegisterTest(&register.Test{
 		Name:        "coreos.ignition.resource.remote",

--- a/mantle/kola/tests/ignition/security.go
+++ b/mantle/kola/tests/ignition/security.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"time"
 
 	"github.com/vincent-petithory/dataurl"
 
@@ -63,6 +64,7 @@ func init() {
 		// DO: https://github.com/coreos/bugs/issues/2205
 		// Packet & QEMU: https://github.com/coreos/ignition/issues/645
 		ExcludePlatforms: []string{"do", "packet", "qemu"},
+		Timeout:          20 * time.Minute,
 	})
 }
 

--- a/mantle/kola/tests/podman/podman.go
+++ b/mantle/kola/tests/podman/podman.go
@@ -53,6 +53,7 @@ func init() {
 		// Not really but podman blows up if there's no /etc/resolv.conf
 		Tags:    []string{kola.NeedsInternetTag},
 		Distros: []string{"fcos"},
+		Timeout: 20 * time.Minute,
 	})
 	// https://github.com/coreos/mantle/pull/1080
 	// register.RegisterTest(&register.Test{


### PR DESCRIPTION
Some tests have been failing since timeouts were added. 
Let's readjust their timeouts.