### PR TITLE
kola/tests/rpmostree: refactor install-uninstall test

### DIFF
--- a/mantle/kola/tests/rpmostree/deployments.go
+++ b/mantle/kola/tests/rpmostree/deployments.go
@@ -15,6 +15,7 @@
 package rpmostree
 
 import (
+	"fmt"
 	"reflect"
 	"regexp"
 
@@ -37,42 +38,30 @@ func init() {
 		ClusterSize: 1,
 		Name:        "rpmostree.install-uninstall",
 		Tags:        []string{"rpm-ostree"},
-		// this Ignition config lands the EPEL repo + key
+		// this Ignition config lands the dummy RPM
 		UserData: conf.Ignition(`{
-  "ignition": {
-    "version": "3.0.0"
-  },
-  "storage": {
-    "files": [
-      {
-        "group": {
-          "name": "root"
-        },
-        "path": "/etc/yum.repos.d/epel.repo",
-        "user": {
-          "name": "root"
-        },
-        "contents": {
-          "source": "data:,%5Bepel%5D%0Aname%3DExtra%20Packages%20for%20Enterprise%20Linux%208%20-%20%24basearch%0Ametalink%3Dhttps%3A%2F%2Fmirrors.fedoraproject.org%2Fmetalink%3Frepo%3Depel-8%26arch%3D%24basearch%0Afailovermethod%3Dpriority%0Aenabled%3D1%0Agpgcheck%3D1%0Agpgkey%3Dfile%3A%2F%2F%2Fetc%2Fpki%2Frpm-gpg%2FRPM-GPG-KEY-EPEL-8%0A"
-        },
-        "mode": 420
-      },
-      {
-        "group": {
-          "name": "root"
-        },
-        "path": "/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-8",
-        "user": {
-          "name": "root"
-        },
-        "contents": {
-          "source": "data:text/plain;charset=utf-8,-----BEGIN%20PGP%20PUBLIC%20KEY%20BLOCK-----%0D%0A%0D%0AmQINBFz3zvsBEADJOIIWllGudxnpvJnkxQz2CtoWI7godVnoclrdl83kVjqSQp%2B2%0D%0AdgxuG5mUiADUfYHaRQzxKw8efuQnwxzU9kZ70ngCxtmbQWGmUmfSThiapOz00018%0D%0A%2Beo5MFabd2vdiGo1y%2B51m2sRDpN8qdCaqXko65cyMuLXrojJHIuvRA%2Fx7iqOrRfy%0D%0Aa8x3OxC4PEgl5pgDnP8pVK0lLYncDEQCN76D9ubhZQWhISF%2FzJI%2Be806V71hzfyL%0D%0A%2FMt3mQm%2Fli%2BlRKU25Usk9dWaf4NH%2FwZHMIPAkVJ4uD4H%2FuS49wqWnyiTYGT7hUbi%0D%0AecF7crhLCmlRzvJR8mkRP6%2F4T%2FF3tNDPWZeDNEDVFUkTFHNU6%2Fh2%2BO398MNY%2FfOh%0D%0AyKaNK3nnE0g6QJ1dOH31lXHARlpFOtWt3VmZU0JnWLeYdvap4Eff9qTWZJhI7Cq0%0D%0AWm8DgLUpXgNlkmquvE7P2W5EAr2E5AqKQoDbfw%2FGiWdRvHWKeNGMRLnGI3QuoX3U%0D%0ApAlXD7v13VdZxNydvpeypbf%2FAfRyrHRKhkUj3cU1pYkM3DNZE77C5JUe6%2F0nxbt4%0D%0AETUZBTgLgYJGP8c7PbkVnO6I%2FKgL1jw%2B7MW6Az8Ox%2BRXZLyGMVmbW%2FTMc8haJfKL%0D%0AMoUo3TVk8nPiUhoOC0%2FkI7j9ilFrBxBU5dUtF4ITAWc8xnG6jJs%2FIsvRpQARAQAB%0D%0AtChGZWRvcmEgRVBFTCAoOCkgPGVwZWxAZmVkb3JhcHJvamVjdC5vcmc%2BiQI4BBMB%0D%0AAgAiBQJc9877AhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAKCRAh6kWrL4bW%0D%0AoWagD%2F4xnLWws34GByVDQkjprk0fX7Iyhpm%2FU7BsIHKspHLL%2BY46vAAGY%2F9vMvdE%0D%0A0fcr9Ek2Zp7zE1RWmSCzzzUgTG6BFoTG1H4Fho%2F7Z8BXK%2FjybowXSZfqXnTOfhSF%0D%0AalwDdwlSJvfYNV9MbyvbxN8qZRU1z7PEWZrIzFDDToFRk0R71zHpnPTNIJ5%2FYXTw%0D%0ANqU9OxII8hMQj4ufF11040AJQZ7br3rzerlyBOB%2BJd1zSPVrAPpeMyJppWFHSDAI%0D%0AWK6x%2Bam13VIInXtqB%2FCz4GBHLFK5d2%2FIYspVw47Solj8jiFEtnAq6%2B1Aq5WH3iB4%0D%0AbE2e6z00DSF93frwOyWN7WmPIoc2QsNRJhgfJC%2BisGQAwwq8xAbHEBeuyMG8GZjz%0D%0Axohg0H4bOSEujVLTjH1xbAG4DnhWO%2F1VXLX%2BLXELycO8ZQTcjj%2F4AQKuo4wvMPrv%0D%0A9A169oETG%2BVwQlNd74VBPGCvhnzwGXNbTK%2FKH1%2BWRH0YSb%2B41flB3NKhMSU6dGI0%0D%0ASGtIxDSHhVVNmx2%2F6XiT9U%2FznrZsG5Kw8nIbbFz%2B9MGUUWgJMsd1Zl9R8gz7V9fp%0D%0An7L7y5LhJ8HOCMsY%2FZ7%2F7HUs%2Bt%2FA1MI4g7Q5g5UuSZdgi0zxukiWuCkLeAiAP4y7%0D%0AzKK4OjJ644NDcWCHa36znwVmkz3ixL8Q0auR15Oqq2BjR%2Ffyog%3D%3D%0D%0A%3D84m8%0D%0A-----END%20PGP%20PUBLIC%20KEY%20BLOCK-----%0A"
-        },
-        "mode": 420
-      }
-    ]
-  }
-}`),
+			"ignition": {
+			  "version": "3.1.0"
+			},
+			"storage": {
+			  "files": [
+				{
+				  "path": "/var/home/core/aht-dummy.rpm",
+				  "user": {
+					"name": "core"
+				  },
+				  "contents": {
+					"source": "https://github.com/projectatomic/atomic-host-tests/raw/master/rpm/aht-dummy-1.0-1.noarch.rpm",
+					"verification": {
+					  "hash": "sha512-da29ae637b30647cab2386a2ce6b4223c3ad7120ae8dd32d9ce275f26a11946400bba0b86f6feabb9fb83622856ef39f8cecf14b4975638c4d8c0cf33b0f7b26"
+					}
+				  },
+				  "mode": 420
+				}
+			  ]
+			}
+		  }
+		  `),
 		Flags: []register.Flag{register.RequiresInternetAccess}, // these need network to retrieve bits
 	})
 }
@@ -193,21 +182,18 @@ func rpmOstreeUpgradeRollback(c cluster.TestCluster) {
 // rpmOstreeInstallUninstall verifies that we can install a package
 // and then uninstall it
 //
-// 'bird' is available in EPEL(8) and installs on Fedora 29 and RHEL 8
-// on all arches
-//
-// NOTE: we could be churning on the package choice going forward as
-// we need something that is a) small, b) has no dependencies, and c)
-// can be installed on Fedora + RHEL + all arches from the EPEL repo that we are
-// currently using.  We've already had to swap from `fpaste`-`bcrypt`-`bird`
+// This uses a dummy RPM that was originally created for the atomic-host-tests;
+// see: https://github.com/projectatomic/atomic-host-tests
 func rpmOstreeInstallUninstall(c cluster.TestCluster) {
-	var installPkgName = "bird"
-	var installPkgBin string
+	var ahtRpmPath = "/var/home/core/aht-dummy.rpm"
+	var installPkgName = "aht-dummy-1.0-1.noarch"
+	var installBinName = "aht-dummy"
+	var installBinPath string
 
 	if c.Distribution() == "fcos" {
-		installPkgBin = "/usr/sbin/bird"
+		installBinPath = fmt.Sprintf("/usr/bin/%v", installBinName)
 	} else {
-		installPkgBin = "/sbin/bird"
+		installBinPath = fmt.Sprintf("/bin/%v", installBinName)
 	}
 
 	m := c.Machines()[0]
@@ -225,7 +211,7 @@ func rpmOstreeInstallUninstall(c cluster.TestCluster) {
 
 	c.Run("install", func(c cluster.TestCluster) {
 		// install package and reboot
-		c.RunCmdSync(m, "sudo rpm-ostree install "+installPkgName)
+		c.RunCmdSync(m, "sudo rpm-ostree install "+ahtRpmPath)
 
 		installRebootErr := m.Reboot()
 		if installRebootErr != nil {
@@ -242,30 +228,19 @@ func rpmOstreeInstallUninstall(c cluster.TestCluster) {
 		}
 
 		// check the command is present, in the rpmdb, and usable
-		c.AssertCmdOutputContains(m, "command -v "+installPkgName, installPkgBin)
+		c.AssertCmdOutputContains(m, "command -v "+installBinName, installBinPath)
 		c.AssertCmdOutputMatches(m, "rpm -q "+installPkgName, regexp.MustCompile("^"+installPkgName))
 
 		// package should be in the metadata
 		var reqPkg bool = false
-		for _, pkg := range postInstallStatus.Deployments[0].RequestedPackages {
+		for _, pkg := range postInstallStatus.Deployments[0].RequestedLocalPackages {
 			if pkg == installPkgName {
 				reqPkg = true
 				break
 			}
 		}
 		if !reqPkg {
-			c.Fatalf(`Unable to find "%q" in requested-packages: %v`, installPkgName, postInstallStatus.Deployments[0].RequestedPackages)
-		}
-
-		var installPkg bool = false
-		for _, pkg := range postInstallStatus.Deployments[0].Packages {
-			if pkg == installPkgName {
-				installPkg = true
-				break
-			}
-		}
-		if !installPkg {
-			c.Fatalf(`Unable to find "%q" in packages: %v`, installPkgName, postInstallStatus.Deployments[0].Packages)
+			c.Fatalf(`Unable to find "%q" in requested-local-packages: %v`, installPkgName, postInstallStatus.Deployments[0].RequestedLocalPackages)
 		}
 
 		// checksum should be different
@@ -297,12 +272,8 @@ func rpmOstreeInstallUninstall(c cluster.TestCluster) {
 			c.Fatalf(`Checksum is incorrect; expected %q, got %q`, originalCsum, postUninstallStatus.Deployments[0].Checksum)
 		}
 
-		if len(postUninstallStatus.Deployments[0].RequestedPackages) != 0 {
-			c.Fatalf(`Found unexpected requested-packages: %q`, postUninstallStatus.Deployments[0].RequestedPackages)
-		}
-
-		if len(postUninstallStatus.Deployments[0].Packages) != 0 {
-			c.Fatalf(`Found unexpected packages: %q`, postUninstallStatus.Deployments[0].Packages)
+		if len(postUninstallStatus.Deployments[0].RequestedLocalPackages) != 0 {
+			c.Fatalf(`Found unexpected requested-local-packages: %q`, postUninstallStatus.Deployments[0].RequestedLocalPackages)
 		}
 
 		// cleanup our mess

--- a/mantle/kola/tests/util/rpmostree.go
+++ b/mantle/kola/tests/util/rpmostree.go
@@ -25,15 +25,16 @@ import (
 
 // RpmOstreeDeployment represents some of the data of an rpm-ostree deployment
 type RpmOstreeDeployment struct {
-	Booted            bool     `json:"booted"`
-	Checksum          string   `json:"checksum"`
-	Origin            string   `json:"origin"`
-	Osname            string   `json:"osname"`
-	Packages          []string `json:"packages"`
-	RequestedPackages []string `json:"requested-packages"`
-	Timestamp         int64    `json:"timestamp"`
-	Unlocked          string   `json:"unlocked"`
-	Version           string   `json:"version"`
+	Booted                 bool     `json:"booted"`
+	Checksum               string   `json:"checksum"`
+	Origin                 string   `json:"origin"`
+	Osname                 string   `json:"osname"`
+	Packages               []string `json:"packages"`
+	RequestedPackages      []string `json:"requested-packages"`
+	RequestedLocalPackages []string `json:"requested-local-packages"`
+	Timestamp              int64    `json:"timestamp"`
+	Unlocked               string   `json:"unlocked"`
+	Version                string   `json:"version"`
 
 	// instead of making it a generic map of strings to "value", we just
 	// special-case the keys we're interested in for now


### PR DESCRIPTION
The downstream RHCOS pipeline recently started failing because the
`bird` package we were using from EPEL was no longer available. This
is the third time we have had to deal with a package on a remote repo
that no longer worked for the `install-uninstall` use case.

This change moves away from using a remote yum repo and instead does
an install with a locally downloaded RPM. This uses the `aht-dummy`
RPM that was used in the `atomic-host-tests` of yesteryear. It has no
external dependencies and should work across all arches.