### PR TITLE
[rhcos4.8] backport patches to refactor rpmostree.install-uninstall

### DIFF
--- a/mantle/kola/cluster/cluster.go
+++ b/mantle/kola/cluster/cluster.go
@@ -183,6 +183,16 @@ func (t *TestCluster) RunCmdSyncf(m platform.Machine, f string, args ...interfac
 	return t.RunCmdSync(m, fmt.Sprintf(f, args...))
 }
 
+// AssertCmdOutputContains runs cmd via SSH and panics if stdout does not contain expected
+func (t *TestCluster) AssertCmdOutputContains(m platform.Machine, cmd string, expected string) {
+	t.LogJournal(m, "+ "+cmd)
+	outputBuf := t.MustSSH(m, cmd)
+	output := string(outputBuf)
+	if !strings.Contains(output, expected) {
+		t.Fatalf("cmd %s did not output %s", cmd, expected)
+	}
+}
+
 // Synchronously write a log message from the syslog identifier `kola` into the target
 // machine's journal (via ssh) as well as at a debug log level to the current process.
 // This is useful for debugging test failures, as we always capture the target

--- a/mantle/kola/cluster/cluster.go
+++ b/mantle/kola/cluster/cluster.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/kballard/go-shellquote"
@@ -190,6 +191,15 @@ func (t *TestCluster) AssertCmdOutputContains(m platform.Machine, cmd string, ex
 	output := string(outputBuf)
 	if !strings.Contains(output, expected) {
 		t.Fatalf("cmd %s did not output %s", cmd, expected)
+	}
+}
+
+// AssertCmdOutputContains runs cmd via SSH and panics if stdout does not contain expected
+func (t *TestCluster) AssertCmdOutputMatches(m platform.Machine, cmd string, expected *regexp.Regexp) {
+	t.LogJournal(m, "+ "+cmd)
+	output := t.MustSSH(m, cmd)
+	if !expected.Match(output) {
+		t.Fatalf("cmd %s output did not match regexp %s: %s", cmd, expected, string(output))
 	}
 }
 

--- a/mantle/kola/cluster/cluster.go
+++ b/mantle/kola/cluster/cluster.go
@@ -21,6 +21,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/kballard/go-shellquote"
+
 	"github.com/coreos/mantle/harness"
 	"github.com/coreos/mantle/platform"
 	"github.com/coreos/pkg/capnslog"
@@ -168,4 +170,27 @@ func (t *TestCluster) MustSSH(m platform.Machine, cmd string) []byte {
 
 func (t *TestCluster) MustSSHf(m platform.Machine, f string, args ...interface{}) []byte {
 	return t.MustSSH(m, fmt.Sprintf(f, args...))
+}
+
+// RunCmdSync is like MustSSH, but logs the command to the target journal before executing.
+func (t *TestCluster) RunCmdSync(m platform.Machine, cmd string) []byte {
+	t.LogJournal(m, cmd)
+	return t.MustSSH(m, cmd)
+}
+
+// RunCmdSyncf is like MustSSHf, but logs the command to the target journal before executing.
+func (t *TestCluster) RunCmdSyncf(m platform.Machine, f string, args ...interface{}) []byte {
+	return t.RunCmdSync(m, fmt.Sprintf(f, args...))
+}
+
+// Synchronously write a log message from the syslog identifier `kola` into the target
+// machine's journal (via ssh) as well as at a debug log level to the current process.
+// This is useful for debugging test failures, as we always capture the target
+// system journal.
+func (t *TestCluster) LogJournal(m platform.Machine, msg string) {
+	t.MustSSH(m, fmt.Sprintf("logger -t kola %s", shellquote.Join(msg)))
+}
+
+func (t *TestCluster) LogJournalf(m platform.Machine, f string, args ...interface{}) {
+	t.LogJournal(m, fmt.Sprintf(f, args...))
 }

--- a/mantle/kola/tests/fips/fips.go
+++ b/mantle/kola/tests/fips/fips.go
@@ -212,12 +212,6 @@ func init() {
 // Test: Run basic FIPS test
 func fipsEnableTest(c cluster.TestCluster) {
 	m := c.Machines()[0]
-	status := c.MustSSH(m, `cat /proc/sys/crypto/fips_enabled`)
-	if string(status) != "1" {
-		c.Fatal("/proc/sys/crypto/fips_enabled is not set to 1")
-	}
-	policy := c.MustSSH(m, `update-crypto-policies --show`)
-	if string(policy) != "FIPS" {
-		c.Fatal("update-crypto-policies is not in FIPS mode")
-	}
+	c.AssertCmdOutputContains(m, `cat /proc/sys/crypto/fips_enabled`, "1")
+	c.AssertCmdOutputContains(m, `update-crypto-policies --show`, "FIPS")
 }

--- a/mantle/kola/tests/ignition/mount.go
+++ b/mantle/kola/tests/ignition/mount.go
@@ -253,8 +253,5 @@ func mountValidate(c cluster.TestCluster, m platform.Machine, mountContents, pat
 	}
 
 	fPath := filepath.Join(path, "/hello.txt")
-	fileContents := c.MustSSH(m, "cat "+fPath)
-	if string(fileContents) != "hello world" {
-		c.Fatalf("Failed to write content to %s", fPath)
-	}
+	c.AssertCmdOutputContains(m, "cat "+fPath, "hello world")
 }

--- a/mantle/kola/tests/ignition/sethostname.go
+++ b/mantle/kola/tests/ignition/sethostname.go
@@ -15,8 +15,6 @@
 package ignition
 
 import (
-	"strings"
-
 	"github.com/coreos/mantle/kola/cluster"
 	"github.com/coreos/mantle/kola/register"
 	"github.com/coreos/mantle/platform/conf"
@@ -75,10 +73,5 @@ func init() {
 
 func setHostname(c cluster.TestCluster) {
 	m := c.Machines()[0]
-
-	out := c.MustSSH(m, "hostnamectl")
-
-	if !strings.Contains(string(out), "Static hostname: core1") {
-		c.Fatalf("hostname wasn't set correctly:\n%s", out)
-	}
+	c.AssertCmdOutputContains(m, "hostnamectl", "Static hostname: core1")
 }

--- a/mantle/kola/tests/ignition/symlink.go
+++ b/mantle/kola/tests/ignition/symlink.go
@@ -15,8 +15,6 @@
 package ignition
 
 import (
-	"strings"
-
 	"github.com/coreos/mantle/kola/cluster"
 	"github.com/coreos/mantle/kola/register"
 	"github.com/coreos/mantle/platform/conf"
@@ -56,9 +54,5 @@ func init() {
 func writeAbsoluteSymlink(c cluster.TestCluster) {
 	m := c.Machines()[0]
 
-	out := c.MustSSH(m, "readlink /etc/localtime")
-
-	if strings.Compare(string(out), "/usr/share/zoneinfo/Europe/Zurich") != 0 {
-		c.Fatalf("write absolute symlink failed:\n%s", out)
-	}
+	c.AssertCmdOutputContains(m, "readlink /etc/localtime", "/usr/share/zoneinfo/Europe/Zurich")
 }

--- a/mantle/kola/tests/ignition/systemd.go
+++ b/mantle/kola/tests/ignition/systemd.go
@@ -56,5 +56,5 @@ func init() {
 func enableSystemdService(c cluster.TestCluster) {
 	m := c.Machines()[0]
 
-	c.AssertCmdOutputContains(m, "systemctl status nfs-server.service", "inactive")
+	c.AssertCmdOutputContains(m, "systemctl status nfs-server.service", "active")
 }

--- a/mantle/kola/tests/ignition/systemd.go
+++ b/mantle/kola/tests/ignition/systemd.go
@@ -15,8 +15,6 @@
 package ignition
 
 import (
-	"strings"
-
 	"github.com/coreos/mantle/kola/cluster"
 	"github.com/coreos/mantle/kola/register"
 	"github.com/coreos/mantle/platform/conf"
@@ -58,8 +56,5 @@ func init() {
 func enableSystemdService(c cluster.TestCluster) {
 	m := c.Machines()[0]
 
-	out := c.MustSSH(m, "systemctl status nfs-server.service")
-	if strings.Contains(string(out), "inactive") {
-		c.Fatalf("service was not enabled or systemd-presets did not run")
-	}
+	c.AssertCmdOutputContains(m, "systemctl status nfs-server.service", "inactive")
 }

--- a/mantle/kola/tests/misc/selinux.go
+++ b/mantle/kola/tests/misc/selinux.go
@@ -135,11 +135,7 @@ func SelinuxEnforce(c cluster.TestCluster) {
 
 	testSelinuxCmds(c, m, cmdList)
 
-	output := c.MustSSH(m, "getenforce")
-
-	if string(output) != "Enforcing" {
-		c.Fatalf(`command "getenforce" has unexpected output: want %q, got %q`, "Enforcing", string(output))
-	}
+	c.AssertCmdOutputMatches(m, "getenforce", regexp.MustCompile("^Enforcing$"))
 }
 
 // SelinuxBoolean checks that you can tweak a boolean in the current session
@@ -216,11 +212,5 @@ func SelinuxManage(c cluster.TestCluster) {
 	testSelinuxCmds(c, m, cmdList)
 
 	// the change should be persisted after a reboot
-	output := c.MustSSH(m, "sudo semanage fcontext -l | grep vasd")
-
-	s := ".*system_u:object_r:httpd_log_t:s0"
-	match := regexp.MustCompile(s).MatchString(string(output))
-	if !match {
-		c.Fatalf(`The SELinux file context "/var/opt/quest/vas/vasd(/.*)?" is incorrectly configured.  Tried to match regexp %q, output was %q`, s, string(output))
-	}
+	c.AssertCmdOutputMatches(m, "sudo semanage fcontext -l | grep vasd", regexp.MustCompile(".*system_u:object_r:httpd_log_t:s0"))
 }

--- a/mantle/kola/tests/rpmostree/deployments.go
+++ b/mantle/kola/tests/rpmostree/deployments.go
@@ -242,17 +242,8 @@ func rpmOstreeInstallUninstall(c cluster.TestCluster) {
 		}
 
 		// check the command is present, in the rpmdb, and usable
-		cmdOut := c.MustSSH(m, "command -v "+installPkgName)
-		if string(cmdOut) != installPkgBin {
-			c.Fatalf(`%q binary in unexpected location. expectd %q, got %q`, installPkgName, installPkgBin, string(cmdOut))
-		}
-
-		rpmOut := c.MustSSH(m, "rpm -q "+installPkgName)
-		rpmRegex := "^" + installPkgName
-		rpmMatch := regexp.MustCompile(rpmRegex).MatchString(string(rpmOut))
-		if !rpmMatch {
-			c.Fatalf(`Output from "rpm -q" was unexpected: %q`, string(rpmOut))
-		}
+		c.AssertCmdOutputContains(m, "command -v "+installPkgName, installPkgBin)
+		c.AssertCmdOutputMatches(m, "rpm -q "+installPkgName, regexp.MustCompile("^"+installPkgName))
 
 		// package should be in the metadata
 		var reqPkg bool = false

--- a/mantle/kola/tests/rpmostree/deployments.go
+++ b/mantle/kola/tests/rpmostree/deployments.go
@@ -15,6 +15,7 @@
 package rpmostree
 
 import (
+	"fmt"
 	"reflect"
 	"regexp"
 
@@ -37,42 +38,30 @@ func init() {
 		ClusterSize: 1,
 		Name:        "rpmostree.install-uninstall",
 		Tags:        []string{"rpm-ostree"},
-		// this Ignition config lands the EPEL repo + key
-		UserDataV3: conf.Ignition(`{
-  "ignition": {
-    "version": "3.0.0"
-  },
-  "storage": {
-    "files": [
-      {
-        "group": {
-          "name": "root"
-        },
-        "path": "/etc/yum.repos.d/epel.repo",
-        "user": {
-          "name": "root"
-        },
-        "contents": {
-          "source": "data:,%5Bepel%5D%0Aname%3DExtra%20Packages%20for%20Enterprise%20Linux%208%20-%20%24basearch%0Ametalink%3Dhttps%3A%2F%2Fmirrors.fedoraproject.org%2Fmetalink%3Frepo%3Depel-8%26arch%3D%24basearch%0Afailovermethod%3Dpriority%0Aenabled%3D1%0Agpgcheck%3D1%0Agpgkey%3Dfile%3A%2F%2F%2Fetc%2Fpki%2Frpm-gpg%2FRPM-GPG-KEY-EPEL-8%0A"
-        },
-        "mode": 420
-      },
-      {
-        "group": {
-          "name": "root"
-        },
-        "path": "/etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-8",
-        "user": {
-          "name": "root"
-        },
-        "contents": {
-          "source": "data:text/plain;charset=utf-8,-----BEGIN%20PGP%20PUBLIC%20KEY%20BLOCK-----%0D%0A%0D%0AmQINBFz3zvsBEADJOIIWllGudxnpvJnkxQz2CtoWI7godVnoclrdl83kVjqSQp%2B2%0D%0AdgxuG5mUiADUfYHaRQzxKw8efuQnwxzU9kZ70ngCxtmbQWGmUmfSThiapOz00018%0D%0A%2Beo5MFabd2vdiGo1y%2B51m2sRDpN8qdCaqXko65cyMuLXrojJHIuvRA%2Fx7iqOrRfy%0D%0Aa8x3OxC4PEgl5pgDnP8pVK0lLYncDEQCN76D9ubhZQWhISF%2FzJI%2Be806V71hzfyL%0D%0A%2FMt3mQm%2Fli%2BlRKU25Usk9dWaf4NH%2FwZHMIPAkVJ4uD4H%2FuS49wqWnyiTYGT7hUbi%0D%0AecF7crhLCmlRzvJR8mkRP6%2F4T%2FF3tNDPWZeDNEDVFUkTFHNU6%2Fh2%2BO398MNY%2FfOh%0D%0AyKaNK3nnE0g6QJ1dOH31lXHARlpFOtWt3VmZU0JnWLeYdvap4Eff9qTWZJhI7Cq0%0D%0AWm8DgLUpXgNlkmquvE7P2W5EAr2E5AqKQoDbfw%2FGiWdRvHWKeNGMRLnGI3QuoX3U%0D%0ApAlXD7v13VdZxNydvpeypbf%2FAfRyrHRKhkUj3cU1pYkM3DNZE77C5JUe6%2F0nxbt4%0D%0AETUZBTgLgYJGP8c7PbkVnO6I%2FKgL1jw%2B7MW6Az8Ox%2BRXZLyGMVmbW%2FTMc8haJfKL%0D%0AMoUo3TVk8nPiUhoOC0%2FkI7j9ilFrBxBU5dUtF4ITAWc8xnG6jJs%2FIsvRpQARAQAB%0D%0AtChGZWRvcmEgRVBFTCAoOCkgPGVwZWxAZmVkb3JhcHJvamVjdC5vcmc%2BiQI4BBMB%0D%0AAgAiBQJc9877AhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAKCRAh6kWrL4bW%0D%0AoWagD%2F4xnLWws34GByVDQkjprk0fX7Iyhpm%2FU7BsIHKspHLL%2BY46vAAGY%2F9vMvdE%0D%0A0fcr9Ek2Zp7zE1RWmSCzzzUgTG6BFoTG1H4Fho%2F7Z8BXK%2FjybowXSZfqXnTOfhSF%0D%0AalwDdwlSJvfYNV9MbyvbxN8qZRU1z7PEWZrIzFDDToFRk0R71zHpnPTNIJ5%2FYXTw%0D%0ANqU9OxII8hMQj4ufF11040AJQZ7br3rzerlyBOB%2BJd1zSPVrAPpeMyJppWFHSDAI%0D%0AWK6x%2Bam13VIInXtqB%2FCz4GBHLFK5d2%2FIYspVw47Solj8jiFEtnAq6%2B1Aq5WH3iB4%0D%0AbE2e6z00DSF93frwOyWN7WmPIoc2QsNRJhgfJC%2BisGQAwwq8xAbHEBeuyMG8GZjz%0D%0Axohg0H4bOSEujVLTjH1xbAG4DnhWO%2F1VXLX%2BLXELycO8ZQTcjj%2F4AQKuo4wvMPrv%0D%0A9A169oETG%2BVwQlNd74VBPGCvhnzwGXNbTK%2FKH1%2BWRH0YSb%2B41flB3NKhMSU6dGI0%0D%0ASGtIxDSHhVVNmx2%2F6XiT9U%2FznrZsG5Kw8nIbbFz%2B9MGUUWgJMsd1Zl9R8gz7V9fp%0D%0An7L7y5LhJ8HOCMsY%2FZ7%2F7HUs%2Bt%2FA1MI4g7Q5g5UuSZdgi0zxukiWuCkLeAiAP4y7%0D%0AzKK4OjJ644NDcWCHa36znwVmkz3ixL8Q0auR15Oqq2BjR%2Ffyog%3D%3D%0D%0A%3D84m8%0D%0A-----END%20PGP%20PUBLIC%20KEY%20BLOCK-----%0A"
-        },
-        "mode": 420
-      }
-    ]
-  }
-}`),
+		// this Ignition config lands the dummy RPM
+		UserData: conf.Ignition(`{
+			"ignition": {
+			  "version": "3.1.0"
+			},
+			"storage": {
+			  "files": [
+				{
+				  "path": "/var/home/core/aht-dummy.rpm",
+				  "user": {
+					"name": "core"
+				  },
+				  "contents": {
+					"source": "https://github.com/projectatomic/atomic-host-tests/raw/master/rpm/aht-dummy-1.0-1.noarch.rpm",
+					"verification": {
+					  "hash": "sha512-da29ae637b30647cab2386a2ce6b4223c3ad7120ae8dd32d9ce275f26a11946400bba0b86f6feabb9fb83622856ef39f8cecf14b4975638c4d8c0cf33b0f7b26"
+					}
+				  },
+				  "mode": 420
+				}
+			  ]
+			}
+		  }
+		  `),
 		Flags: []register.Flag{register.RequiresInternetAccess}, // these need network to retrieve bits
 	})
 }
@@ -193,21 +182,18 @@ func rpmOstreeUpgradeRollback(c cluster.TestCluster) {
 // rpmOstreeInstallUninstall verifies that we can install a package
 // and then uninstall it
 //
-// 'bird' is available in EPEL(8) and installs on Fedora 29 and RHEL 8
-// on all arches
-//
-// NOTE: we could be churning on the package choice going forward as
-// we need something that is a) small, b) has no dependencies, and c)
-// can be installed on Fedora + RHEL + all arches from the EPEL repo that we are
-// currently using.  We've already had to swap from `fpaste`-`bcrypt`-`bird`
+// This uses a dummy RPM that was originally created for the atomic-host-tests;
+// see: https://github.com/projectatomic/atomic-host-tests
 func rpmOstreeInstallUninstall(c cluster.TestCluster) {
-	var installPkgName = "bird"
-	var installPkgBin string
+	var ahtRpmPath = "/var/home/core/aht-dummy.rpm"
+	var installPkgName = "aht-dummy-1.0-1.noarch"
+	var installBinName = "aht-dummy"
+	var installBinPath string
 
 	if c.Distribution() == "fcos" {
-		installPkgBin = "/usr/sbin/bird"
+		installBinPath = fmt.Sprintf("/usr/bin/%v", installBinName)
 	} else {
-		installPkgBin = "/sbin/bird"
+		installBinPath = fmt.Sprintf("/bin/%v", installBinName)
 	}
 
 	m := c.Machines()[0]
@@ -225,7 +211,7 @@ func rpmOstreeInstallUninstall(c cluster.TestCluster) {
 
 	c.Run("install", func(c cluster.TestCluster) {
 		// install package and reboot
-		c.MustSSH(m, "sudo rpm-ostree install "+installPkgName)
+		c.RunCmdSync(m, "sudo rpm-ostree install "+ahtRpmPath)
 
 		installRebootErr := m.Reboot()
 		if installRebootErr != nil {
@@ -242,30 +228,19 @@ func rpmOstreeInstallUninstall(c cluster.TestCluster) {
 		}
 
 		// check the command is present, in the rpmdb, and usable
-		c.AssertCmdOutputContains(m, "command -v "+installPkgName, installPkgBin)
+		c.AssertCmdOutputContains(m, "command -v "+installBinName, installBinPath)
 		c.AssertCmdOutputMatches(m, "rpm -q "+installPkgName, regexp.MustCompile("^"+installPkgName))
 
 		// package should be in the metadata
 		var reqPkg bool = false
-		for _, pkg := range postInstallStatus.Deployments[0].RequestedPackages {
+		for _, pkg := range postInstallStatus.Deployments[0].RequestedLocalPackages {
 			if pkg == installPkgName {
 				reqPkg = true
 				break
 			}
 		}
 		if !reqPkg {
-			c.Fatalf(`Unable to find "%q" in requested-packages: %v`, installPkgName, postInstallStatus.Deployments[0].RequestedPackages)
-		}
-
-		var installPkg bool = false
-		for _, pkg := range postInstallStatus.Deployments[0].Packages {
-			if pkg == installPkgName {
-				installPkg = true
-				break
-			}
-		}
-		if !installPkg {
-			c.Fatalf(`Unable to find "%q" in packages: %v`, installPkgName, postInstallStatus.Deployments[0].Packages)
+			c.Fatalf(`Unable to find "%q" in requested-local-packages: %v`, installPkgName, postInstallStatus.Deployments[0].RequestedLocalPackages)
 		}
 
 		// checksum should be different
@@ -297,12 +272,8 @@ func rpmOstreeInstallUninstall(c cluster.TestCluster) {
 			c.Fatalf(`Checksum is incorrect; expected %q, got %q`, originalCsum, postUninstallStatus.Deployments[0].Checksum)
 		}
 
-		if len(postUninstallStatus.Deployments[0].RequestedPackages) != 0 {
-			c.Fatalf(`Found unexpected requested-packages: %q`, postUninstallStatus.Deployments[0].RequestedPackages)
-		}
-
-		if len(postUninstallStatus.Deployments[0].Packages) != 0 {
-			c.Fatalf(`Found unexpected packages: %q`, postUninstallStatus.Deployments[0].Packages)
+		if len(postUninstallStatus.Deployments[0].RequestedLocalPackages) != 0 {
+			c.Fatalf(`Found unexpected requested-local-packages: %q`, postUninstallStatus.Deployments[0].RequestedLocalPackages)
 		}
 
 		// cleanup our mess

--- a/mantle/kola/tests/upgrade/basic.go
+++ b/mantle/kola/tests/upgrade/basic.go
@@ -141,14 +141,14 @@ func fcosUpgradeBasic(c cluster.TestCluster) {
 		// remounting in libostree forcing a cache flush and blocking D-Bus.
 		// Should drop this once we fix it more properly in {rpm-,}ostree.
 		// https://github.com/coreos/coreos-assembler/issues/1301
-		c.MustSSHf(m, "tar -xf %s -C %s && sync", kola.CosaBuild.Meta.BuildArtifacts.Ostree.Path, ostreeRepo)
+		c.RunCmdSyncf(m, "tar -xf %s -C %s && sync", kola.CosaBuild.Meta.BuildArtifacts.Ostree.Path, ostreeRepo)
 
 		// disable zincati; from now on, we'll start it manually whenenever we
 		// want to upgrade via Zincati
-		c.MustSSH(m, "sudo systemctl disable --now --quiet zincati.service")
-		c.MustSSH(m, "sudo rm /etc/zincati/config.d/99-updates.toml")
+		c.RunCmdSync(m, "sudo systemctl disable --now --quiet zincati.service")
+		c.RunCmdSync(m, "sudo rm /etc/zincati/config.d/99-updates.toml")
 		// delete what mantle adds (XXX: should just opt out of this upfront)
-		c.MustSSH(m, "sudo rm /etc/zincati/config.d/90-disable-auto-updates.toml")
+		c.RunCmdSync(m, "sudo rm /etc/zincati/config.d/90-disable-auto-updates.toml")
 
 	})
 

--- a/mantle/kola/tests/util/rpmostree.go
+++ b/mantle/kola/tests/util/rpmostree.go
@@ -25,15 +25,16 @@ import (
 
 // RpmOstreeDeployment represents some of the data of an rpm-ostree deployment
 type RpmOstreeDeployment struct {
-	Booted            bool     `json:"booted"`
-	Checksum          string   `json:"checksum"`
-	Origin            string   `json:"origin"`
-	Osname            string   `json:"osname"`
-	Packages          []string `json:"packages"`
-	RequestedPackages []string `json:"requested-packages"`
-	Timestamp         int64    `json:"timestamp"`
-	Unlocked          string   `json:"unlocked"`
-	Version           string   `json:"version"`
+	Booted                 bool     `json:"booted"`
+	Checksum               string   `json:"checksum"`
+	Origin                 string   `json:"origin"`
+	Osname                 string   `json:"osname"`
+	Packages               []string `json:"packages"`
+	RequestedPackages      []string `json:"requested-packages"`
+	RequestedLocalPackages []string `json:"requested-local-packages"`
+	Timestamp              int64    `json:"timestamp"`
+	Unlocked               string   `json:"unlocked"`
+	Version                string   `json:"version"`
 
 	// instead of making it a generic map of strings to "value", we just
 	// special-case the keys we're interested in for now


### PR DESCRIPTION
The cherry-picks are getting more numerous...

```
commit 5ac7e0b9d
Author: Micah Abbott <miabbott@redhat.com>
Date:   Wed Nov 10 08:35:01 2021 -0500

    tests: assert that the NFS service is active

    When the `coreos.ignition.systemd.enable-service` was changed to use
    `AssertCmdOutputContains`, the test started asserting that the output
    of `systemctl status` had the `inactive` string. However, the Ignition
    config is explicitly enabling the NFS service, so we should assert
    that the service is actually `active`

    (cherry picked from commit 37bd17dbcb9f5802f3949ea9bfb7297d5027ed0a)

commit b5fac38a9
Author: Micah Abbott <miabbott@redhat.com>
Date:   Tue Nov 9 12:32:43 2021 -0500

    kola/tests/rpmostree: refactor install-uninstall test

    The downstream RHCOS pipeline recently started failing because the
    `bird` package we were using from EPEL was no longer available. This
    is the third time we have had to deal with a package on a remote repo
    that no longer worked for the `install-uninstall` use case.

    This change moves away from using a remote yum repo and instead does
    an install with a locally downloaded RPM. This uses the `aht-dummy`
    RPM that was used in the `atomic-host-tests` of yesteryear. It has no
    external dependencies and should work across all arches.

    (cherry picked from commit 91050be95226a5b47abb620c35dadf5d981f5d03)

commit c679a54a1
Author: Colin Walters <walters@verbum.org>
Date:   Wed Sep 8 16:36:41 2021 -0400

    kola: Add AssertCmdOutputMatches

    This regexp based version can be more precise than just `Contains`,
    and we had other tests that were doing this manually.

    (cherry picked from commit ee62041f32b8f916a5f7b3b2ac0143de381e9f12)

commit 3d476a012
Author: Colin Walters <walters@verbum.org>
Date:   Tue Sep 7 11:30:32 2021 -0400

    kola: Add an AssertCmdOutputContains

    Followup to previous work on `RunCmdSync` which is aiming
    to clean up how we run processes.

    The rationale for this helper is much the same as APIs like
    https://pkg.go.dev/github.com/stretchr/testify@v1.7.0/assert#Contains

    It encapsulates this common pattern in a single line.

    Also unlike `MustSSH`, we log the command to the systemd journal
    too.

    (cherry picked from commit f361834edf2c1b1b6f5bcacc01666ae925008bc4)

commit 5ea81292c
Author: Colin Walters <walters@verbum.org>
Date:   Fri Jul 16 11:22:05 2021 -0400

    kola: Add RunCmdSync that logs cmd to target journal, use in upgrade test

    I'm trying to debug a failure in the upgrade test and not getting
    any logging around the invocations of commands makes it really hard.

    Because we always capture the target system journal by default,
    add a new wrapper for `MustSSH` that prints the command to the
    journal too.

    I considered changing `MustSSH` by default but that's used
    in a *lot* of places and I'd like to try this out in
    just the upgrade test to start.  If this works OK we can
    consider a tree-wide change.

    (cherry picked from commit ad266b3e88fdad38a173e6a201f57cac531a1e43)
```