### PR TITLE
kola: follow symlinks for kola external data dir

### DIFF
--- a/mantle/platform/platform.go
+++ b/mantle/platform/platform.go
@@ -324,7 +324,7 @@ func CopyDirToMachine(inputdir string, m Machine, destdir string) error {
 	defer session.Close()
 
 	// Use compression level 1 for speed
-	compressArgv := []string{"-c", "tar cf - . | gzip -1"}
+	compressArgv := []string{"-c", "tar chf - . | gzip -1"}
 
 	clientCmd := exec.Command("/bin/sh", compressArgv...)
 	clientCmd.Dir = inputdir


### PR DESCRIPTION
Kola tars and gzips up the data directory and extracts it over an SSH
connection.  If the data directory contains relative symlinks to a
location out of the data directory, it will be a dangling symlink once
it is copied into the test machine. Adding the `-h` flag will follow the
symlinks and adds the actual files. This is useful for things such as
shared libraries between external tests.