### PR TITLE
[rhcos4.8] tests/rpmostree: use UserDataV3 for Ignition config snippet

### DIFF
--- a/mantle/kola/tests/rpmostree/deployments.go
+++ b/mantle/kola/tests/rpmostree/deployments.go
@@ -39,7 +39,7 @@ func init() {
 		Name:        "rpmostree.install-uninstall",
 		Tags:        []string{"rpm-ostree"},
 		// this Ignition config lands the dummy RPM
-		UserData: conf.Ignition(`{
+		UserDataV3: conf.Ignition(`{
 			"ignition": {
 			  "version": "3.1.0"
 			},


### PR DESCRIPTION
It was observed that RHCOS 4.8 builds were failing the
`rpmostree.install-uninstall` test after the backport (#2554)
had landed. I observed that the dummy RPM wasn't being written to the
filesystem. Further investigation showed that the Ignition
configuration be passed to the system was missing the test snippet
entirely. After changing the UserData to use V3, the merged Ignition
configuration was correctly generated and the test passed.

(Not sure how I missed this as part of #2554...)