### PR TITLE
mantle/platform/api/aws: tag network resources atomically

### DIFF
--- a/mantle/platform/api/aws/api.go
+++ b/mantle/platform/api/aws/api.go
@@ -115,8 +115,16 @@ func (a *API) PreflightCheck() error {
 	return err
 }
 
-func (a *API) tagCreatedByMantle(resources []string) error {
-	return a.CreateTags(resources, map[string]string{
-		"CreatedBy": "mantle",
-	})
+func tagSpecCreatedByMantle(resourceType string) []*ec2.TagSpecification {
+	return []*ec2.TagSpecification{
+		{
+			ResourceType: aws.String(resourceType),
+			Tags: []*ec2.Tag{
+				&ec2.Tag{
+					Key:   aws.String("CreatedBy"),
+					Value: aws.String("mantle"),
+				},
+			},
+		},
+	}
 }


### PR DESCRIPTION
EC2 is eventually consistent.  When creating network resources and tagging them immediately afterward, we were hitting `NotFound` errors like:

    harness.go:1213: Cluster failed starting machines: error resolving security group: error creating tags: InvalidVpcID.NotFound: The vpc ID 'vpc-0c11b5ac46ad8dc80' does not exist
    harness.go:1213: Cluster failed starting machines: error resolving security group: creating subnets: error creating tags: InvalidSubnetID.NotFound: The subnet ID 'subnet-02d91caef7b71e4d5' does not exist
    harness.go:1213: Cluster failed starting machines: error resolving security group: creating RouteTable: creating internet gateway: error creating tags: InvalidInternetGatewayID.NotFound: The internetGateway ID 'igw-0b35ecf4dfe47f621' does not exist

It's possible to specify tags in the initial creation call, so do that instead.