### PR TITLE
mantle/kola: add platform specific (provisioning) timeouts

### DIFF
--- a/mantle/harness/timeout_test.go
+++ b/mantle/harness/timeout_test.go
@@ -27,11 +27,12 @@ func TestTimeoutBasic(t *testing.T) {
 
 	tests := make(Tests)
 	tests.Add("test-1", func(h *H) {
-		_ = h
+		h.StartExecTimer()
+		defer h.StopExecTimer()
 		select {
 		case <-time.After(3 * time.Second):
 			return
-		case <-h.TimeoutContext.Done():
+		case <-h.timeoutContext.Done():
 			return
 		}
 	}, timeToRun)
@@ -60,11 +61,12 @@ func TestTimeoutNoInterrupt(t *testing.T) {
 
 	tests := make(Tests)
 	tests.Add("test-1", func(h *H) {
-		_ = h
+		h.StartExecTimer()
+		defer h.StopExecTimer()
 		select {
 		case <-time.After(timeToRun):
 			return
-		case <-h.TimeoutContext.Done():
+		case <-h.timeoutContext.Done():
 			return
 		}
 	}, time.Duration(5)*time.Second)
@@ -89,22 +91,24 @@ func TestTimeoutMultipleTests(t *testing.T) {
 	tests := make(Tests)
 	// Will finish after 1s
 	tests.Add("test-1", func(h *H) {
-		_ = h
+		h.StartExecTimer()
+		defer h.StopExecTimer()
 		select {
 		case <-time.After(1 * time.Second):
 			return
-		case <-h.TimeoutContext.Done():
+		case <-h.timeoutContext.Done():
 			return
 		}
 	}, time.Duration(5)*time.Second)
 
 	// Will timeout after 1s
 	tests.Add("test-2", func(h *H) {
-		_ = h
+		h.StartExecTimer()
+		defer h.StopExecTimer()
 		select {
 		case <-time.After(2 * time.Second):
 			return
-		case <-h.TimeoutContext.Done():
+		case <-h.timeoutContext.Done():
 			return
 		}
 	}, time.Duration(1)*time.Second)

--- a/mantle/util/retry.go
+++ b/mantle/util/retry.go
@@ -59,7 +59,11 @@ func WaitUntilReady(timeout, delay time.Duration, checkFunction func() (bool, er
 
 		time.Sleep(delay)
 
+		// Log how long it took checkFunction to run. This will help gather information about
+		// how long it takes remote API requests (like provisioning machines) to finish.
+		start := time.Now()
 		done, err := checkFunction()
+		plog.Debugf("WaitUntilReady: checkFunction took %v", time.Since(start))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
In some cases, there is significant discrepency between provisioning times
on different platforms (ie. QEMU vs AWS). This forces us to cater timeouts
to the lowest common denominator between the platforms. To circumvent this
issue we will move the timeout so that it is started *after* the provisioning
process.

More specifically, the timeout is started when instances are brought to a
"running" state (i.e ignition begins provisioning). We ensure that another
"provisioning" timeout is checking for flakes between the "provisioning" and
"running" states of an instance.


