### PR TITLE
buildfetch: Allow 'all' in --artifact argument

### DIFF
--- a/src/cmd-buildfetch
+++ b/src/cmd-buildfetch
@@ -113,7 +113,12 @@ def main():
 
         buildmeta = load_json(f'builds/{builddir}/meta.json')
 
-        for imgname in args.artifact:
+        if args.artifact == ['all']:
+            artifacts = buildmeta['images']
+        else:
+            artifacts = args.artifact
+
+        for imgname in artifacts:
             if imgname not in buildmeta['images']:
                 raise Exception(f"Requested artifact {imgname} not available in build")
             img = buildmeta['images'][imgname]


### PR DESCRIPTION
 - Get all existing artifacts for the given build.
 - In particular cases (brew improvements) we do want to
 downlaod all available artifacts.

Signed-off-by: Renata Ravanelli <rravanel@redhat.com>