### PR TITLE
Add Nutanix platform 

### DIFF
--- a/schema/cosa/cosa_v1.go
+++ b/schema/cosa/cosa_v1.go
@@ -93,6 +93,7 @@ type BuildArtifacts struct {
 	LiveRootfs         *Artifact `json:"live-rootfs,omitempty"`
 	Metal              *Artifact `json:"metal,omitempty"`
 	Metal4KNative      *Artifact `json:"metal4k,omitempty"`
+	Nutanix            *Artifact `json:"nutanix,omitempty"`
 	OpenStack          *Artifact `json:"openstack,omitempty"`
 	Ostree             Artifact  `json:"ostree"`
 	PowerVirtualServer *Artifact `json:"powervs,omitempty"`

--- a/schema/v1.json
+++ b/schema/v1.json
@@ -406,6 +406,7 @@
        "live-rootfs",
        "metal",
        "metal4k",
+       "nutanix",
        "openstack",
        "qemu",
        "vmware",
@@ -490,6 +491,12 @@
          "title":"Live Rootfs",
          "$ref": "#/definitions/artifact"
         },
+        "nutanix": {
+          "$id":"#/properties/images/properties/nutanix",
+          "type":"object",
+          "title":"Nutanix",
+          "$ref": "#/definitions/artifact"
+         }, 
        "openstack": {
          "$id":"#/properties/images/properties/openstack",
          "type":"object",

--- a/src/cmd-buildextend-nutanix
+++ b/src/cmd-buildextend-nutanix
@@ -1,0 +1,1 @@
+cmd-artifact-disk

--- a/src/cmd-generate-release-meta
+++ b/src/cmd-generate-release-meta
@@ -124,7 +124,7 @@ def append_build(out, input_):
     # build the architectures dict
     arch_dict = {"media": {}}
     ensure_dup(input_, arch_dict, "ostree-commit", "commit")
-    platforms = ["aliyun", "aws", "azure", "azurestack", "digitalocean", "exoscale", "gcp", "ibmcloud", "metal", "openstack", "powervs", "qemu", "vmware", "vultr"]
+    platforms = ["aliyun", "aws", "azure", "azurestack", "digitalocean", "exoscale", "gcp", "ibmcloud", "metal", "nutanix", "openstack", "powervs", "qemu", "vmware", "vultr"]
     for platform in platforms:
         if input_.get("images", {}).get(platform, None) is not None:
             print(f"   - {platform}")

--- a/src/coreos-assembler
+++ b/src/coreos-assembler
@@ -44,7 +44,7 @@ cmd=${1:-}
 build_commands="init fetch build run prune clean list"
 # commands more likely to be used in a prod pipeline only
 advanced_build_commands="buildfetch buildupload oc-adm-release upload-oscontainer"
-buildextend_commands="aliyun aws azure digitalocean exoscale gcp ibmcloud live metal metal4k openstack qemu vmware vultr"
+buildextend_commands="aliyun aws azure digitalocean exoscale gcp ibmcloud live metal metal4k nutanix openstack qemu vmware vultr"
 utility_commands="aws-replicate compress generate-hashlist koji-upload kola remote-prune sign tag"
 other_commands="shell meta"
 if [ -z "${cmd}" ]; then

--- a/src/cosalib/qemuvariants.py
+++ b/src/cosalib/qemuvariants.py
@@ -95,6 +95,10 @@ VARIANTS = {
         "image_format": "qcow2",
         "platform": "openstack",
     },
+    "nutanix": {
+        "image_format": "qcow2",
+        "platform": "nutanix",
+    },
     "vmware_vmdk": {
         "image_format": "vmdk",
         "image_suffix": "vmdk",

--- a/src/v1.json
+++ b/src/v1.json
@@ -406,6 +406,7 @@
        "live-rootfs",
        "metal",
        "metal4k",
+       "nutanix",
        "openstack",
        "qemu",
        "vmware",
@@ -490,6 +491,12 @@
          "title":"Live Rootfs",
          "$ref": "#/definitions/artifact"
         },
+        "nutanix": {
+          "$id":"#/properties/images/properties/nutanix",
+          "type":"object",
+          "title":"Nutanix",
+          "$ref": "#/definitions/artifact"
+         },
        "openstack": {
          "$id":"#/properties/images/properties/openstack",
          "type":"object",


### PR DESCRIPTION
Related to https://github.com/coreos/fedora-coreos-tracker/issues/1007
Build a raw image with the Ignition provider set to `nutanix` to correspond with https://github.com/coreos/ignition/pull/1284

I'm not sure if there's a way to upload a qcow2 image to Nutanix AHV via some external APIs. Let me get some confirmation before making those changes.