### PR TITLE
mantle/platform/qemu: update deprecated 'readonly' option

### DIFF
--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -594,7 +594,7 @@ func (builder *QemuBuilder) Mount9p(source, destHint string, readonly bool) {
 	builder.fs9pID++
 	readonlyStr := ""
 	if readonly {
-		readonlyStr = ",readonly"
+		readonlyStr = ",readonly=on"
 	}
 	builder.Append("--fsdev", fmt.Sprintf("local,id=fs%d,path=%s,security_model=mapped%s", builder.fs9pID, source, readonlyStr))
 	builder.Append("-device", virtio("9p", fmt.Sprintf("fsdev=fs%d,mount_tag=%s", builder.fs9pID, destHint)))


### PR DESCRIPTION
Fix another qemu deprecation warning when running "cosa run" with a 9p device.

Spotted in some test output that @miabbott recently posted into slack.