### PR TITLE
mantle/kola/tests, Add timeout to network tests

### DIFF
--- a/mantle/kola/tests/misc/network.go
+++ b/mantle/kola/tests/misc/network.go
@@ -53,6 +53,7 @@ func init() {
 		Run:         NetworkSecondaryNics,
 		ClusterSize: 0,
 		Name:        "rhcos.network.multiple-nics",
+		Timeout:     20 * time.Minute,
 		Distros:     []string{"rhcos"},
 		Platforms:   []string{"qemu-unpriv"},
 	})
@@ -63,6 +64,7 @@ func init() {
 		Run:         NetworkBondWithDhcp,
 		ClusterSize: 0,
 		Name:        "rhcos.network.bond-with-dhcp",
+		Timeout:     20 * time.Minute,
 		Distros:     []string{"rhcos"},
 		Platforms:   []string{"qemu-unpriv"},
 	})
@@ -73,6 +75,7 @@ func init() {
 		Run:         NetworkBondWithRestart,
 		ClusterSize: 0,
 		Name:        "rhcos.network.bond-with-restart",
+		Timeout:     20 * time.Minute,
 		Distros:     []string{"rhcos"},
 		Platforms:   []string{"qemu-unpriv"},
 	})


### PR DESCRIPTION
The following tests also run in setups where it takes
~10 min/test to run:
rhcos.network.multiple-nics, rhcos.network.bond-with-dhcp, rhcos.network.bond-with-restart.
In order to avoid falling in the
border of the current timeout default (=10min), increasing
the tests to 20 minutes.

Signed-off-by: Ram Lavi <ralavi@redhat.com>