### PR TITLE
build: Ship `ci/` directory installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,8 @@ install:
 	install -d $(DESTDIR)$(PREFIX)/lib/coreos-assembler
 	install -D -t $(DESTDIR)$(PREFIX)/lib/coreos-assembler $$(find src/ -maxdepth 1 -type f)
 	cp -df -t $(DESTDIR)$(PREFIX)/lib/coreos-assembler $$(find src/ -maxdepth 1 -type l)
+	install -d $(DESTDIR)$(PREFIX)/lib/coreos-assembler/ci
+	cp -df -t $(DESTDIR)$(PREFIX)/lib/coreos-assembler/ci $$(find ci/ -maxdepth 1 -type f)
 	install -d $(DESTDIR)$(PREFIX)/lib/coreos-assembler/cosalib
 	install -D -t $(DESTDIR)$(PREFIX)/lib/coreos-assembler/cosalib $$(find src/cosalib/ -maxdepth 1 -type f)
 	install -d $(DESTDIR)$(PREFIX)/bin


### PR DESCRIPTION
The Prow flow is really oriented towards building a container
and then testing it.  It's really maximally convenient if that
container ships the test code too.  This is distinct from what
we're doing with Jenkins which makes it easy to just inject code
into a running a container.

coreos-assembler is huge, these scripts are tiny, so let's just ship
them unconditionally.  Prep for testing cosa `rhcos-4.9` via OpenShift
Prow.