### PR TITLE
ci: add .ci-operator.yml

### DIFF
--- a/.ci-operator.yml
+++ b/.ci-operator.yml
@@ -1,0 +1,8 @@
+# This file is used by OpenShift to know the base image to use when building the
+# Dockerfile. It should always match the Fedora version there. When changing
+# this, ensure that the Fedora tag is defined in:
+# https://github.com/openshift/release/blob/master/clusters/app.ci/supplemental-ci-images/coreos/fedora-is.yaml
+build_root_image:
+  name: fedora
+  namespace: coreos
+  tag: "35"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-# When rebasing to new Fedora, also update openshift/release:
-# https://github.com/openshift/release/tree/master/ci-operator/config/coreos/coreos-assembler/coreos-coreos-assembler-main.yaml
+# When rebasing to new Fedora, also update `.ci-operator.yml`.
 FROM registry.fedoraproject.org/fedora:35
 WORKDIR /root/containerbuild
 


### PR DESCRIPTION
This will allow us to shed the Fedora version hardcoding in
openshift/release, which will make rebasing easier.