### PR TITLE
Dockerfile: tickly Quay.io cache for rust-coreos-installer-0.11.0-2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /root/containerbuild
 COPY ./src/print-dependencies.sh ./src/deps*.txt ./src/vmdeps*.txt ./src/build-deps.txt /root/containerbuild/src/
 COPY ./build.sh /root/containerbuild/
 RUN ./build.sh configure_yum_repos
-RUN ./build.sh install_rpms  # nocache 20211124
+RUN ./build.sh install_rpms  # nocache 20211129
 
 # This allows Prow jobs for other projects to use our cosa image as their
 # buildroot image (so clonerefs can copy the repo into `/go`). For cosa itself,


### PR DESCRIPTION
Which contains https://github.com/coreos/coreos-installer/pull/694 for
https://github.com/coreos/coreos-assembler/issues/2583.

Closes: https://github.com/coreos/coreos-assembler/issues/2583