### PR TITLE
harness: fixes and tweaks related to required tags

### DIFF
--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -440,7 +440,9 @@ func filterTests(tests map[string]*register.Test, patterns []string, pltfrm stri
 			}
 		}
 
-		if t.RequiredTag != "" && !tagMatch {
+		// default to skipping tests with required tags unless the tag was given *or* a
+		// matching non-empty name pattern matches
+		if t.RequiredTag != "" && !tagMatch && (noPattern || !match) {
 			continue
 		}
 

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -434,13 +434,13 @@ func filterTests(tests map[string]*register.Test, patterns []string, pltfrm stri
 
 		tagMatch := false
 		for _, tag := range Tags {
-			tagMatch = hasString(tag, t.Tags)
+			tagMatch = hasString(tag, t.Tags) || tag == t.RequiredTag
 			if tagMatch {
 				break
 			}
 		}
 
-		if t.RequiredTag != "" && !hasString(t.RequiredTag, Tags) {
+		if t.RequiredTag != "" && !tagMatch {
 			continue
 		}
 


### PR DESCRIPTION
```
commit 9095a8a76192eb50c97815cfb75db54f7b95eb7a
Author: Jonathan Lebon <jonathan@jlebon.com>
Date:   Wed Dec 1 15:33:37 2021 -0500

    harness: fix handling of required tags

    I didn't fully retest this while reworking #2505. We need to treat the
    required tag as just another tag. I.e. we need to set `tagMatch` so that
    the if-statement that follows this hunk doesn't skip over it.
```

```
commit fd2c85df46915749e067d4955d86c2ec8b5a1b85
Author: Jonathan Lebon <jonathan@jlebon.com>
Date:   Wed Dec 1 15:42:37 2021 -0500

    harness: run tests with required tags if specified by name

    Even if a required tag was not given, I think it's more ergonomic to
    still run that test if the name was provided.
```