### PR TITLE
Add RAID1 and multipath coverage for bootfs dropins from `rdcore bind-boot`

### DIFF
--- a/mantle/kola/tests/misc/boot-mirror.go
+++ b/mantle/kola/tests/misc/boot-mirror.go
@@ -14,7 +14,6 @@
 package misc
 
 import (
-	"encoding/json"
 	"strings"
 	"time"
 
@@ -228,68 +227,12 @@ func verifyBootMirrorAfterReboot(c cluster.TestCluster, m platform.Machine) {
 	})
 }
 
-type lsblkOutput struct {
-	Blockdevices []blockdevice `json:"blockdevices"`
-}
-
-type blockdevice struct {
-	Name       string  `json:"name"`
-	Type       string  `json:"type"`
-	Mountpoint *string `json:"mountpoint"`
-	// new lsblk outputs `mountpoints` instead of
-	// `mountpoint`; we handle both
-	Mountpoints []string      `json:"mountpoints"`
-	Children    []blockdevice `json:"children"`
-}
-
 // checkIfMountpointIsRaid will check if a given machine has a device of type
 // raid1 mounted at the given mountpoint. If it does not, the test is failed.
 func checkIfMountpointIsRaid(c cluster.TestCluster, m platform.Machine, mountpoint string) {
-	output := c.MustSSH(m, "lsblk --json")
-
-	l := lsblkOutput{}
-	err := json.Unmarshal(output, &l)
-	if err != nil {
-		c.Fatalf("couldn't unmarshal lsblk output: %v", err)
+	backing_device := string(c.MustSSH(m, "findmnt -no SOURCE "+mountpoint))
+	device_type := string(c.MustSSH(m, "lsblk -no TYPE "+backing_device))
+	if device_type != "raid1" {
+		c.Fatalf("expected mountpoint backed by raid1, but got %q", device_type)
 	}
-
-	foundDevice := checkIfMountpointIsRaidWalker(c, l.Blockdevices, mountpoint)
-	if !foundDevice {
-		c.Fatalf("didn't find %q mountpoint in lsblk output", mountpoint)
-	}
-}
-
-// checkIfMountpointIsRaidWalker will iterate over bs and recurse into its
-// children, looking for a device mounted at / with type raid1. true is returned
-// if such a device is found. The test is failed if a device of a different type
-// is found to be mounted at /.
-func checkIfMountpointIsRaidWalker(c cluster.TestCluster, bs []blockdevice, mountpoint string) bool {
-	for _, b := range bs {
-		if checkIfBlockdevHasMountPoint(b, mountpoint) {
-			if b.Type != "raid1" {
-				c.Fatalf("device %q is mounted at %q with type %q (was expecting raid1)", b.Name, mountpoint, b.Type)
-			}
-			return true
-		}
-		foundDevice := checkIfMountpointIsRaidWalker(c, b.Children, mountpoint)
-		if foundDevice {
-			return true
-		}
-	}
-	return false
-}
-
-// checkIfBlockdevHasMountPoint checks if a given block device has the
-// required mountpoint.
-func checkIfBlockdevHasMountPoint(b blockdevice, mountpoint string) bool {
-	if b.Mountpoint != nil && *b.Mountpoint == mountpoint {
-		return true
-	} else if len(b.Mountpoints) != 0 {
-		for _, mnt := range b.Mountpoints {
-			if mnt != "" && mnt == mountpoint {
-				return true
-			}
-		}
-	}
-	return false
 }


### PR DESCRIPTION
```
commit 8282d2be344aa122fc9555c51e2ab261572088ea
Author: Jonathan Lebon <jonathan@jlebon.com>
Date:   Thu Dec 2 12:03:31 2021 -0500

    kola/boot-mirror: simplify check for RAID1 mountpoint

    To check if a mountpoint is on RAID1, instead of going from the top and
    querying all devices on the system, we can directly check the type of
    the device backing the mountpoint.
```
```
commit a9fd9e4253d328bcead42c48437f5dd30c8d681c
Author: Jonathan Lebon <jonathan@jlebon.com>
Date:   Thu Dec 2 12:04:08 2021 -0500

    kola/boot-mirror: check bootfs dropins from `rdcore bind-boot`

    This is similar to the tests added in `ext.config.reboot` as part of
    https://github.com/coreos/fedora-coreos-config/pull/1316, but for the
    boot mirroring tests.

    Specifically, it adds coverage for ESP devices discovery in a RAID1
    setup (https://github.com/coreos/coreos-installer/pull/700).
```
```
commit 0894d12ea9a2c61e46537286af825193cd78df05
Author: Jonathan Lebon <jonathan@jlebon.com>
Date:   Thu Dec 2 12:14:35 2021 -0500

    kola/multipath: check bootfs dropins from `rdcore bind-boot`

    This is similar to the tests added in `ext.config.reboot` as part of
    https://github.com/coreos/fedora-coreos-config/pull/1316, but for the
    multipath tests.

    Specifically, it adds coverage for correct handling of the multipathed
    ESP partition (https://github.com/coreos/coreos-installer/pull/700).
```

Requires: https://github.com/coreos/fedora-coreos-config/pull/1316
And requires that PR and the associated coreos-installer PR to land in RHCOS.