### PR TITLE
Make test filtering logic easier to understand

### DIFF
--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -382,7 +382,10 @@ func filterTests(tests map[string]*register.Test, patterns []string, pltfrm stri
 		checkPlatforms = append(checkPlatforms, "qemu")
 	}
 
-	noPattern := hasString("*", patterns)
+	// Higher-level functions default to '*' if the user didn't pass anything.
+	// Notice this. (This totally ignores the corner case where the user
+	// actually typed '*').
+	userTypedPattern := !hasString("*", patterns)
 	for name, t := range tests {
 		if NoNet && testRequiresInternet(t) {
 			plog.Debugf("Skipping test that requires network: %s", t.Name)
@@ -442,15 +445,15 @@ func filterTests(tests map[string]*register.Test, patterns []string, pltfrm stri
 
 		// default to skipping tests with required tags unless the tag was given *or* a
 		// matching non-empty name pattern matches
-		if t.RequiredTag != "" && !tagMatch && (noPattern || !nameMatch) {
+		if t.RequiredTag != "" && !tagMatch && (!userTypedPattern || !nameMatch) {
 			continue
 		}
 
-		if !noPattern && !nameMatch && !tagMatch {
+		if userTypedPattern && !nameMatch && !tagMatch {
 			continue
 		}
 
-		if !tagMatch && noPattern && len(Tags) > 0 {
+		if !tagMatch && !userTypedPattern && len(Tags) > 0 {
 			continue
 		}
 

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -392,12 +392,12 @@ func filterTests(tests map[string]*register.Test, patterns []string, pltfrm stri
 		var denylisted bool
 		// Drop anything which is denylisted directly or by pattern
 		for _, bl := range DenylistedTests {
-			match, err := filepath.Match(bl, t.Name)
+			nameMatch, err := filepath.Match(bl, t.Name)
 			if err != nil {
 				return nil, err
 			}
 			// If it matched the pattern this test is denylisted
-			if match {
+			if nameMatch {
 				denylisted = true
 				break
 			}
@@ -411,11 +411,11 @@ func filterTests(tests map[string]*register.Test, patterns []string, pltfrm stri
 			if nativedenylistindex > -1 {
 				// Check native tests for arch specific exclusion
 				for nativetestname := range t.NativeFuncs {
-					match, err := filepath.Match(bl[nativedenylistindex+1:], nativetestname)
+					nameMatch, err := filepath.Match(bl[nativedenylistindex+1:], nativetestname)
 					if err != nil {
 						return nil, err
 					}
-					if match {
+					if nameMatch {
 						delete(t.NativeFuncs, nativetestname)
 					}
 				}
@@ -427,7 +427,7 @@ func filterTests(tests map[string]*register.Test, patterns []string, pltfrm stri
 			continue
 		}
 
-		match, err := matchesPatterns(t.Name, patterns)
+		nameMatch, err := matchesPatterns(t.Name, patterns)
 		if err != nil {
 			return nil, err
 		}
@@ -442,11 +442,11 @@ func filterTests(tests map[string]*register.Test, patterns []string, pltfrm stri
 
 		// default to skipping tests with required tags unless the tag was given *or* a
 		// matching non-empty name pattern matches
-		if t.RequiredTag != "" && !tagMatch && (noPattern || !match) {
+		if t.RequiredTag != "" && !tagMatch && (noPattern || !nameMatch) {
 			continue
 		}
 
-		if (!noPattern && !match && !tagMatch) || (!tagMatch && noPattern && len(Tags) > 0) {
+		if (!noPattern && !nameMatch && !tagMatch) || (!tagMatch && noPattern && len(Tags) > 0) {
 			continue
 		}
 

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -446,7 +446,11 @@ func filterTests(tests map[string]*register.Test, patterns []string, pltfrm stri
 			continue
 		}
 
-		if (!noPattern && !nameMatch && !tagMatch) || (!tagMatch && noPattern && len(Tags) > 0) {
+		if !noPattern && !nameMatch && !tagMatch {
+			continue
+		}
+
+		if !tagMatch && noPattern && len(Tags) > 0 {
 			continue
 		}
 

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -443,18 +443,25 @@ func filterTests(tests map[string]*register.Test, patterns []string, pltfrm stri
 			}
 		}
 
-		// default to skipping tests with required tags unless the tag was given *or* a
-		// matching non-empty name pattern matches
-		if t.RequiredTag != "" && !tagMatch && (!userTypedPattern || !nameMatch) {
-			continue
+		if t.RequiredTag != "" && // if the test has a required tag...
+			!tagMatch && // and that tag was not provided by the user...
+			(!userTypedPattern || !nameMatch) { // and the user didn't request it by name...
+			continue // then skip it
 		}
 
-		if userTypedPattern && !nameMatch && !tagMatch {
-			continue
-		}
-
-		if !tagMatch && !userTypedPattern && len(Tags) > 0 {
-			continue
+		if userTypedPattern {
+			// If the user explicitly typed a pattern, then the test *must*
+			// match by name or by tag. Otherwise, we skip it.
+			if !nameMatch && !tagMatch {
+				continue
+			}
+		} else {
+			// If the user didn't explicitly type a pattern, then normally we
+			// accept all tests, but if they *did* specify tags, then we only
+			// accept tests which match those tags.
+			if len(Tags) > 0 && !tagMatch {
+				continue
+			}
 		}
 
 		isAllowed := func(item string, include, exclude []string) (bool, bool) {


### PR DESCRIPTION
As mentioned during review of https://github.com/coreos/coreos-assembler/pull/2593, these conditionals are pretty dense. Let's do some renaming and add some comments to help.