### PR TITLE
kola/external-tests: add support for `minDisk` field

### DIFF
--- a/docs/kola/external-tests.md
+++ b/docs/kola/external-tests.md
@@ -193,6 +193,7 @@ Here's an example `kola.json`:
     "requiredTag": "special",
     "additionalDisks": [ "5G" ],
     "minMemory": 4096,
+    "minDisk": 15,
     "timeoutMin": 8,
     "exclusive": true
 }
@@ -223,6 +224,11 @@ In the example above, the test would only run if `--tag special` was provided.
 
 The `additionalDisks` key has the same semantics as the `--add-disk` argument
 to `qemuexec`. It is currently only supported on `qemu-unpriv`.
+
+The `minDisk` key takes a size in GB and ensures that an instance type with at
+least the specified amount of primary disk space is used. On QEMU, this is
+equivalent to the `--qemu-size` argument to `qemuexec`. This is currently only
+enforced on `qemu-unpriv` and `aws`.
 
 The `minMemory` key takes a size in MB and ensures that an instance type with
 at least the specified amount of memory is used. On QEMU, this is equivalent to

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -694,6 +694,7 @@ type externalTestMeta struct {
 	RequiredTag     string   `json:"requiredTag,omitempty"`
 	AdditionalDisks []string `json:"additionalDisks,omitempty"`
 	MinMemory       int      `json:"minMemory,omitempty"`
+	MinDiskSize     int      `json:"minDisk,omitempty"`
 	Exclusive       bool     `json:"exclusive"`
 	TimeoutMin      int      `json:"timeoutMin"`
 }
@@ -861,6 +862,7 @@ ExecStart=%s
 
 		AdditionalDisks: targetMeta.AdditionalDisks,
 		MinMemory:       targetMeta.MinMemory,
+		MinDiskSize:     targetMeta.MinDiskSize,
 		NonExclusive:    !targetMeta.Exclusive,
 
 		Run: func(c cluster.TestCluster) {
@@ -1221,6 +1223,7 @@ func runTest(h *harness.H, t *register.Test, pltfrm string, flight platform.Flig
 			MultiPathDisk:   t.MultiPathDisk,
 			AdditionalDisks: t.AdditionalDisks,
 			MinMemory:       t.MinMemory,
+			MinDiskSize:     t.MinDiskSize,
 		}
 		ioCompleted := make(chan bool)
 		go func() {

--- a/mantle/kola/register/register.go
+++ b/mantle/kola/register/register.go
@@ -75,7 +75,7 @@ type Test struct {
 	// "5G:mpath,foo,bar"]) -- defaults to none.
 	AdditionalDisks []string
 
-	// Minimum amount of memory required for test.
+	// Minimum amount of memory in MB required for test.
 	MinMemory int
 
 	// ExternalTest is a path to a binary that will be uploaded

--- a/mantle/kola/register/register.go
+++ b/mantle/kola/register/register.go
@@ -78,6 +78,9 @@ type Test struct {
 	// Minimum amount of memory in MB required for test.
 	MinMemory int
 
+	// Minimum amount of primary disk in GB required for test.
+	MinDiskSize int
+
 	// ExternalTest is a path to a binary that will be uploaded
 	ExternalTest string
 	// DependencyDir is a path to directory that will be uploaded, normally used by external tests

--- a/mantle/platform/machine/aws/cluster.go
+++ b/mantle/platform/machine/aws/cluster.go
@@ -33,6 +33,18 @@ type cluster struct {
 const maxUserDataSize = 16384
 
 func (ac *cluster) NewMachine(userdata *conf.UserData) (platform.Machine, error) {
+	return ac.NewMachineWithOptions(userdata, platform.MachineOptions{})
+}
+
+func (ac *cluster) NewMachineWithOptions(userdata *conf.UserData, options platform.MachineOptions) (platform.Machine, error) {
+	if len(options.AdditionalDisks) > 0 {
+		return nil, errors.New("platform aws does not yet support additional disks")
+	}
+
+	if options.MultiPathDisk {
+		return nil, errors.New("platform aws does not support multipathed disks")
+	}
+
 	conf, err := ac.RenderUserData(userdata, map[string]string{
 		"$public_ipv4":  "${COREOS_EC2_IPV4_PUBLIC}",
 		"$private_ipv4": "${COREOS_EC2_IPV4_LOCAL}",
@@ -94,16 +106,6 @@ func (ac *cluster) NewMachine(userdata *conf.UserData) (platform.Machine, error)
 	ac.AddMach(mach)
 
 	return mach, nil
-}
-
-func (ac *cluster) NewMachineWithOptions(userdata *conf.UserData, options platform.MachineOptions) (platform.Machine, error) {
-	if len(options.AdditionalDisks) > 0 {
-		return nil, errors.New("platform aws does not yet support additional disks")
-	}
-	if options.MultiPathDisk {
-		return nil, errors.New("platform aws does not support multipathed disks")
-	}
-	return ac.NewMachine(userdata)
 }
 
 func (ac *cluster) Destroy() {

--- a/mantle/platform/machine/aws/cluster.go
+++ b/mantle/platform/machine/aws/cluster.go
@@ -71,7 +71,7 @@ func (ac *cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 			fmt.Printf("WARNING: compressed userdata exceeds expected limit of %d\n", maxUserDataSize)
 		}
 	}
-	instances, err := ac.flight.api.CreateInstances(ac.Name(), keyname, ud, 1)
+	instances, err := ac.flight.api.CreateInstances(ac.Name(), keyname, ud, 1, int64(options.MinDiskSize))
 	if err != nil {
 		return nil, err
 	}

--- a/mantle/platform/machine/unprivqemu/cluster.go
+++ b/mantle/platform/machine/unprivqemu/cluster.go
@@ -125,10 +125,16 @@ func (qc *Cluster) NewMachineWithQemuOptions(userdata *conf.UserData, options pl
 		sectorSize = 4096
 	}
 	multiPathDisk := options.MultiPathDisk || qc.flight.opts.MultiPathDisk
+	var diskSize string
+	if options.MinDiskSize > 0 {
+		diskSize = fmt.Sprintf("%dG", options.MinDiskSize)
+	} else {
+		diskSize = qc.flight.opts.DiskSize
+	}
 	primaryDisk := platform.Disk{
 		BackingFile:   qc.flight.opts.DiskImage,
 		Channel:       channel,
-		Size:          qc.flight.opts.DiskSize,
+		Size:          diskSize,
 		SectorSize:    sectorSize,
 		MultiPathDisk: multiPathDisk,
 	}

--- a/mantle/platform/platform.go
+++ b/mantle/platform/platform.go
@@ -155,6 +155,7 @@ type MachineOptions struct {
 	MultiPathDisk   bool
 	AdditionalDisks []string
 	MinMemory       int
+	MinDiskSize     int
 }
 
 // SystemdDropin is a userdata type agnostic struct representing a systemd dropin


### PR DESCRIPTION
For the Kubernetes node external test, we want to be able to run it in
both QEMU and AWS. But it's a storage heavy test, so the default 10G
image size is not enough. There's `additionalDisks` which works on QEMU,
but not on AWS. But really, we don't need it to be an additional disk.
Having the root disk itself be larger works just as well.

Add a new `minDisk` knob for this and plumb it through QEMU and AWS.