### PR TITLE
kola/external-tests: add additionalNics support in kola.json

### DIFF
--- a/docs/kola/external-tests.md
+++ b/docs/kola/external-tests.md
@@ -194,6 +194,7 @@ Here's an example `kola.json`:
     "additionalDisks": [ "5G" ],
     "minMemory": 4096,
     "minDisk": 15,
+    "additionalNics": 2,
     "timeoutMin": 8,
     "exclusive": true
 }
@@ -234,6 +235,9 @@ The `minMemory` key takes a size in MB and ensures that an instance type with
 at least the specified amount of memory is used. On QEMU, this is equivalent to
 the `--memory` argument to `qemuexec`. This is currently only enforced on
 `qemu-unpriv`.
+
+The `additionalNics` key has the same semantics as the `--secondary-nics` argument
+to `qemuexec`. It is currently only supported on `qemu-unpriv`.
 
 The `timeoutMin` key takes a positive integer and specifies a timeout for the test
 in minutes. After the specified amount of time, the test will be interrupted.

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -695,6 +695,7 @@ type externalTestMeta struct {
 	AdditionalDisks []string `json:"additionalDisks,omitempty"`
 	MinMemory       int      `json:"minMemory,omitempty"`
 	MinDiskSize     int      `json:"minDisk,omitempty"`
+	AdditionalNics  int      `json:"additionalNics,omitempty"`
 	Exclusive       bool     `json:"exclusive"`
 	TimeoutMin      int      `json:"timeoutMin"`
 }
@@ -863,6 +864,7 @@ ExecStart=%s
 		AdditionalDisks: targetMeta.AdditionalDisks,
 		MinMemory:       targetMeta.MinMemory,
 		MinDiskSize:     targetMeta.MinDiskSize,
+		AdditionalNics:  targetMeta.AdditionalNics,
 		NonExclusive:    !targetMeta.Exclusive,
 
 		Run: func(c cluster.TestCluster) {
@@ -1224,6 +1226,7 @@ func runTest(h *harness.H, t *register.Test, pltfrm string, flight platform.Flig
 			AdditionalDisks: t.AdditionalDisks,
 			MinMemory:       t.MinMemory,
 			MinDiskSize:     t.MinDiskSize,
+			AdditionalNics:  t.AdditionalNics,
 		}
 		ioCompleted := make(chan bool)
 		go func() {

--- a/mantle/kola/register/register.go
+++ b/mantle/kola/register/register.go
@@ -81,6 +81,9 @@ type Test struct {
 	// Minimum amount of primary disk in GB required for test.
 	MinDiskSize int
 
+	// Additional amount of NICs required for test.
+	AdditionalNics int
+
 	// ExternalTest is a path to a binary that will be uploaded
 	ExternalTest string
 	// DependencyDir is a path to directory that will be uploaded, normally used by external tests

--- a/mantle/kola/tests/misc/network.go
+++ b/mantle/kola/tests/misc/network.go
@@ -663,7 +663,9 @@ func setupMultipleNetworkTest(c cluster.TestCluster, primaryMac, secondaryMac st
 	var err error
 
 	options := platform.QemuMachineOptions{
-		SecondaryNics: 2,
+		MachineOptions: platform.MachineOptions{
+			AdditionalNics: 2,
+		},
 	}
 
 	var userdata *conf.UserData = conf.Ignition(fmt.Sprintf(`{

--- a/mantle/platform/machine/aws/cluster.go
+++ b/mantle/platform/machine/aws/cluster.go
@@ -45,6 +45,10 @@ func (ac *cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 		return nil, errors.New("platform aws does not support multipathed disks")
 	}
 
+	if options.AdditionalNics > 0 {
+		return nil, errors.New("platform aws does not support additional nics")
+	}
+
 	conf, err := ac.RenderUserData(userdata, map[string]string{
 		"$public_ipv4":  "${COREOS_EC2_IPV4_PUBLIC}",
 		"$private_ipv4": "${COREOS_EC2_IPV4_LOCAL}",

--- a/mantle/platform/machine/azure/cluster.go
+++ b/mantle/platform/machine/azure/cluster.go
@@ -91,6 +91,9 @@ func (ac *cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 	if options.MultiPathDisk {
 		return nil, errors.New("platform azure does not support multipathed disks")
 	}
+	if options.AdditionalNics > 0 {
+		return nil, errors.New("platform azure does not support additional nics")
+	}
 	return ac.NewMachine(userdata)
 }
 

--- a/mantle/platform/machine/do/cluster.go
+++ b/mantle/platform/machine/do/cluster.go
@@ -95,6 +95,9 @@ func (dc *cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 	if options.MultiPathDisk {
 		return nil, errors.New("platform do does not support multipathed disks")
 	}
+	if options.AdditionalNics > 0 {
+		return nil, errors.New("platform do does not support additional nics")
+	}
 	return dc.NewMachine(userdata)
 }
 

--- a/mantle/platform/machine/esx/cluster.go
+++ b/mantle/platform/machine/esx/cluster.go
@@ -98,6 +98,9 @@ func (ec *cluster) NewMachineWithOptions(userdata *platformConf.UserData, option
 	if options.MultiPathDisk {
 		return nil, errors.New("platform esx does not support multipathed disks")
 	}
+	if options.AdditionalNics > 0 {
+		return nil, errors.New("platform esx does not support additional nics")
+	}
 	return ec.NewMachine(userdata)
 }
 

--- a/mantle/platform/machine/gcloud/cluster.go
+++ b/mantle/platform/machine/gcloud/cluster.go
@@ -98,6 +98,9 @@ func (gc *cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 	if options.MultiPathDisk {
 		return nil, errors.New("platform gce does not support multipathed disks")
 	}
+	if options.AdditionalNics > 0 {
+		return nil, errors.New("platform gce does not support additional nics")
+	}
 	return gc.NewMachine(userdata)
 }
 

--- a/mantle/platform/machine/openstack/cluster.go
+++ b/mantle/platform/machine/openstack/cluster.go
@@ -87,6 +87,9 @@ func (oc *cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 	if options.MultiPathDisk {
 		return nil, errors.New("platform openstack does not support multipathed disks")
 	}
+	if options.AdditionalNics > 0 {
+		return nil, errors.New("platform openstack does not support additional nics")
+	}
 	return oc.NewMachine(userdata)
 }
 

--- a/mantle/platform/machine/packet/cluster.go
+++ b/mantle/platform/machine/packet/cluster.go
@@ -119,6 +119,9 @@ func (pc *cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 	if options.MultiPathDisk {
 		return nil, errors.New("platform packet does not support multipathed disks")
 	}
+	if options.AdditionalNics > 0 {
+		return nil, errors.New("platform packet does not support additional nics")
+	}
 	return pc.NewMachine(userdata)
 }
 

--- a/mantle/platform/machine/qemuiso/cluster.go
+++ b/mantle/platform/machine/qemuiso/cluster.go
@@ -130,6 +130,10 @@ func (qc *Cluster) NewMachineWithQemuOptions(userdata *conf.UserData, options pl
 		builder.EnableUsermodeNetworking(h)
 	}
 
+	if options.AdditionalNics > 0 {
+		builder.AddSecondaryNics(options.AdditionalNics)
+	}
+
 	inst, err := builder.Exec()
 	if err != nil {
 		return nil, err

--- a/mantle/platform/machine/unprivqemu/cluster.go
+++ b/mantle/platform/machine/unprivqemu/cluster.go
@@ -157,8 +157,8 @@ func (qc *Cluster) NewMachineWithQemuOptions(userdata *conf.UserData, options pl
 		}
 		builder.EnableUsermodeNetworking(h)
 	}
-	if options.SecondaryNics > 0 {
-		builder.AddSecondaryNics(options.SecondaryNics)
+	if options.AdditionalNics > 0 {
+		builder.AddSecondaryNics(options.AdditionalNics)
 	}
 	if !qc.RuntimeConf().InternetAccess {
 		builder.RestrictNetworking = true

--- a/mantle/platform/platform.go
+++ b/mantle/platform/platform.go
@@ -156,6 +156,7 @@ type MachineOptions struct {
 	AdditionalDisks []string
 	MinMemory       int
 	MinDiskSize     int
+	AdditionalNics  int
 }
 
 // SystemdDropin is a userdata type agnostic struct representing a systemd dropin

--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -69,7 +69,6 @@ type QemuMachineOptions struct {
 	MachineOptions
 	HostForwardPorts    []HostForwardPort
 	DisablePDeathSig    bool
-	SecondaryNics       int
 	OverrideBackingFile string
 }
 


### PR DESCRIPTION
Add the ability to specify additional nics in kola.json for use by
external tests. This will be useful for testing with multiple nics.
Refer to the secondaryNics work in https://github.com/coreos/coreos-assembler/pull/2122

For now, this only supports the qemu platform.
Feature Request: https://github.com/coreos/coreos-assembler/issues/2602