### PR TITLE
ganplank: Fix koji secret

### DIFF
--- a/gangplank/internal/ocp/sa_secrets.go
+++ b/gangplank/internal/ocp/sa_secrets.go
@@ -136,12 +136,11 @@ var (
 		},
 		// Koji Keytab
 		{
-			label: "koji-keytab",
+			label: "keytab",
 			fileVarMap: varMap{
 				"keytab": "KOJI_KEYTAB",
-			},
-			envVarMap: varMap{
-				"principal": "KOJI_PRINCIPAL",
+				"principle": "KOJI_PRINCIPAL",
+				"config": "KOJI_CONFIG",
 			},
 		},
 	}


### PR DESCRIPTION
 - We need to properly mount koji secret as 3 files:
keytab, principle and config.

Signed-off-by: Renata Ravanelli <rravanel@redhat.com>