### PR TITLE
mantle/platform: Consider 'centos-coreos' like rhcos for now

### DIFF
--- a/mantle/platform/platform.go
+++ b/mantle/platform/platform.go
@@ -465,7 +465,7 @@ func CheckMachine(ctx context.Context, m Machine) error {
 	switch string(out) {
 	case `fedora-coreos`:
 		distribution = "fcos"
-	case `rhcos-`:
+	case `centos-coreos`, `rhcos-`:
 		distribution = "rhcos"
 	default:
 		return fmt.Errorf("not a supported instance: %v", string(out))


### PR DESCRIPTION
Tests for CentOS Stream 9 should behave the same way as they do on RHCOS
9 thus use the same logic for now.