### PR TITLE
kola: rename `secondary-nics` to `additional-nics`

### DIFF
--- a/docs/kola/external-tests.md
+++ b/docs/kola/external-tests.md
@@ -236,7 +236,7 @@ at least the specified amount of memory is used. On QEMU, this is equivalent to
 the `--memory` argument to `qemuexec`. This is currently only enforced on
 `qemu-unpriv`.
 
-The `additionalNics` key has the same semantics as the `--secondary-nics` argument
+The `additionalNics` key has the same semantics as the `--additional-nics` argument
 to `qemuexec`. It is currently only supported on `qemu-unpriv`.
 
 The `timeoutMin` key takes a positive integer and specifies a timeout for the test

--- a/mantle/cmd/kola/qemuexec.go
+++ b/mantle/cmd/kola/qemuexec.go
@@ -68,10 +68,10 @@ var (
 
 	sshCommand string
 
-	secondaryNics int
+	additionalNics int
 )
 
-const maxSecondaryNics = 16
+const maxAdditionalNics = 16
 
 func init() {
 	root.AddCommand(cmdQemuExec)
@@ -93,7 +93,7 @@ func init() {
 	cmdQemuExec.Flags().BoolVarP(&forceConfigInjection, "inject-ignition", "", false, "Force injecting Ignition config using guestfs")
 	cmdQemuExec.Flags().BoolVar(&propagateInitramfsFailure, "propagate-initramfs-failure", false, "Error out if the system fails in the initramfs")
 	cmdQemuExec.Flags().StringVarP(&consoleFile, "console-to-file", "", "", "Filepath in which to save serial console logs")
-	cmdQemuExec.Flags().IntVarP(&secondaryNics, "secondary-nics", "", 0, "Number of secondary NICs to add")
+	cmdQemuExec.Flags().IntVarP(&additionalNics, "additional-nics", "", 0, "Number of additional NICs to add")
 	cmdQemuExec.Flags().StringVarP(&sshCommand, "ssh-command", "x", "", "Command to execute instead of spawning a shell")
 
 }
@@ -313,11 +313,11 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 		}
 		builder.EnableUsermodeNetworking(h)
 	}
-	if secondaryNics != 0 {
-		if secondaryNics < 0 || secondaryNics > maxSecondaryNics {
-			return errors.Wrapf(nil, "secondary-nics value cannot be negative or greater than %d", maxSecondaryNics)
+	if additionalNics != 0 {
+		if additionalNics < 0 || additionalNics > maxAdditionalNics {
+			return errors.Wrapf(nil, "additional-nics value cannot be negative or greater than %d", maxAdditionalNics)
 		}
-		builder.AddSecondaryNics(secondaryNics)
+		builder.AddAdditionalNics(additionalNics)
 	}
 	builder.InheritConsole = true
 	builder.ConsoleFile = consoleFile

--- a/mantle/kola/tests/misc/network.go
+++ b/mantle/kola/tests/misc/network.go
@@ -50,7 +50,7 @@ func init() {
 	// This test follows the same network configuration used on https://github.com/RHsyseng/rhcos-slb
 	// with a slight change, where the MCO script is run from ignition: https://github.com/RHsyseng/rhcos-slb/blob/main/setup-ovs.sh.
 	register.RegisterTest(&register.Test{
-		Run:         NetworkSecondaryNics,
+		Run:         NetworkAdditionalNics,
 		ClusterSize: 0,
 		Name:        "rhcos.network.multiple-nics",
 		Timeout:     20 * time.Minute,
@@ -557,8 +557,8 @@ func setupBondWithDhcpTest(c cluster.TestCluster, primaryMac, secondaryMac, prim
 	addKernelArgs(c, m, []string{fmt.Sprintf("macAddressList=%s,%s", primaryMac, secondaryMac)})
 }
 
-// NetworkSecondaryNics verifies that secondary NICs are created on the node
-func NetworkSecondaryNics(c cluster.TestCluster) {
+// NetworkAdditionalNics verifies that additional NICs are created on the node
+func NetworkAdditionalNics(c cluster.TestCluster) {
 	primaryMac := "52:55:00:d1:56:00"
 	secondaryMac := "52:55:00:d1:56:01"
 	ovsBridgeInterface := "ovs-brcnv-iface"

--- a/mantle/platform/machine/qemuiso/cluster.go
+++ b/mantle/platform/machine/qemuiso/cluster.go
@@ -131,7 +131,7 @@ func (qc *Cluster) NewMachineWithQemuOptions(userdata *conf.UserData, options pl
 	}
 
 	if options.AdditionalNics > 0 {
-		builder.AddSecondaryNics(options.AdditionalNics)
+		builder.AddAdditionalNics(options.AdditionalNics)
 	}
 
 	inst, err := builder.Exec()

--- a/mantle/platform/machine/unprivqemu/cluster.go
+++ b/mantle/platform/machine/unprivqemu/cluster.go
@@ -158,7 +158,7 @@ func (qc *Cluster) NewMachineWithQemuOptions(userdata *conf.UserData, options pl
 		builder.EnableUsermodeNetworking(h)
 	}
 	if options.AdditionalNics > 0 {
-		builder.AddSecondaryNics(options.AdditionalNics)
+		builder.AddAdditionalNics(options.AdditionalNics)
 	}
 	if !qc.RuntimeConf().InternetAccess {
 		builder.RestrictNetworking = true

--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -431,7 +431,7 @@ type QemuBuilder struct {
 	UsermodeNetworking        bool
 	RestrictNetworking        bool
 	requestedHostForwardPorts []HostForwardPort
-	secondaryNics             int
+	additionalNics            int
 
 	finalized bool
 	diskID    uint
@@ -538,8 +538,8 @@ func (builder *QemuBuilder) EnableUsermodeNetworking(h []HostForwardPort) {
 	builder.requestedHostForwardPorts = h
 }
 
-func (builder *QemuBuilder) AddSecondaryNics(secondaryNics int) {
-	builder.secondaryNics = secondaryNics
+func (builder *QemuBuilder) AddAdditionalNics(additionalNics int) {
+	builder.additionalNics = additionalNics
 }
 
 func (builder *QemuBuilder) setupNetworking() error {
@@ -570,10 +570,10 @@ func (builder *QemuBuilder) setupNetworking() error {
 	return nil
 }
 
-func (builder *QemuBuilder) setupSecondaryNetworking() error {
+func (builder *QemuBuilder) setupAdditionalNetworking() error {
 	macCounter := 0
 	netOffset := 30
-	for i := 1; i <= builder.secondaryNics; i++ {
+	for i := 1; i <= builder.additionalNics; i++ {
 		idSuffix := fmt.Sprintf("%d", i)
 		netSuffix := fmt.Sprintf("%d", netOffset+i)
 		macSuffix := fmt.Sprintf("%02x", macCounter)
@@ -1446,9 +1446,9 @@ func (builder *QemuBuilder) Exec() (*QemuInstance, error) {
 		inst.hostForwardedPorts = builder.requestedHostForwardPorts
 	}
 
-	// Handle Secondary NICs networking
-	if builder.secondaryNics > 0 {
-		if err := builder.setupSecondaryNetworking(); err != nil {
+	// Handle Additional NICs networking
+	if builder.additionalNics > 0 {
+		if err := builder.setupAdditionalNetworking(); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
This is to follow https://github.com/coreos/coreos-assembler/pull/2606 to rename the switch `--secondary-nics` to
`--additional-nics` to be consistent, also change the related `secondayNics`
to `additionalNics`