### PR TITLE
testiso: remove `[Unit]` from NM keyfile

### DIFF
--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -183,8 +183,7 @@ RequiredBy=multi-user.target`)
 
 var nmConnectionId = "CoreOS DHCP"
 var nmConnectionFile = "coreos-dhcp.nmconnection"
-var nmConnection = fmt.Sprintf(`[Unit]
-[connection]
+var nmConnection = fmt.Sprintf(`[connection]
 id=%s
 type=ethernet
 


### PR DESCRIPTION
Harmless but confusing copy/paste remnant.
Fixes: d5dc0c502 ("testiso: add --add-nm-keyfile for NM keyfile propagation testing")