### PR TITLE
buildextend-live: add `features.json` directly to ISO

### DIFF
--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -130,8 +130,8 @@ def align_initrd_for_uncompressed_append(destf):
         destf.write(b'\0' * (4 - offset % 4))
 
 
-# Return OS features table for features.json, which is added to the initrd
-# for coreos-installer {iso|pxe} customize
+# Return OS features table for features.json, which is read by
+# coreos-installer {iso|pxe} customize
 def get_os_features():
     features = {}
 
@@ -286,13 +286,16 @@ def generate_iso():
     with open(os.path.join(tmpisoimages, ignition_img), 'wb') as fdst:
         fdst.write(bytes(ignition_img_size))
 
-    # Generate initramfs JSON file that lists OS features available to
-    # coreos-installer {iso|pxe} customize
+    # Generate JSON file that lists OS features available to
+    # coreos-installer {iso|pxe} customize.  Put it in the initramfs for
+    # pxe customize and the ISO for iso customize.
+    features = json.dumps(get_os_features(), indent=2, sort_keys=True) + '\n'
     featurespath = os.path.join(tmpinitrd_base, 'etc/coreos/features.json')
     os.makedirs(os.path.dirname(featurespath), exist_ok=True)
     with open(featurespath, 'w') as fh:
-        json.dump(get_os_features(), fh, indent=2, sort_keys=True)
-        fh.write('\n')
+        fh.write(features)
+    with open(os.path.join(tmpisocoreos, 'features.json'), 'w') as fh:
+        fh.write(features)
 
     # Add osmet files
     tmp_osmet = os.path.join(tmpinitrd_rootfs, img_metal_obj['path'] + '.osmet')


### PR DESCRIPTION
The ISO and PXE images share an initramfs, which ships `features.json` so `coreos-installer pxe customize` can read it.  This was thought to be sufficient for `coreos-installer iso customize` as well, and it is, but it requires `iso customize` to decompress the entire initramfs just to extract that file.

To avoid that, add a second copy directly to the ISO.  This wastes 2 KiB of space and makes `features.json` a more visible API, but we already have other semi-private APIs in the same ISO directory (`kargs.json`, `miniso.dat`).

On my system, with a release build of coreos-installer, this saves 1.25 seconds for a no-op `iso customize` run.