### PR TITLE
mantle/platform: azure: allow for not passing SSH key through API

### DIFF
--- a/mantle/platform/machine/azure/cluster.go
+++ b/mantle/platform/machine/azure/cluster.go
@@ -47,7 +47,12 @@ func (ac *cluster) NewMachine(userdata *conf.UserData) (platform.Machine, error)
 		return nil, err
 	}
 
-	instance, err := ac.flight.api.CreateInstance(ac.vmname(), conf.String(), ac.sshKey, ac.ResourceGroup, ac.StorageAccount)
+	sshkey := ""
+	if !ac.RuntimeConf().NoSSHKeyInMetadata {
+		sshkey = ac.sshKey
+	}
+
+	instance, err := ac.flight.api.CreateInstance(ac.vmname(), conf.String(), sshkey, ac.ResourceGroup, ac.StorageAccount)
 	if err != nil {
 		return nil, err
 	}

--- a/mantle/platform/machine/azure/flight.go
+++ b/mantle/platform/machine/azure/flight.go
@@ -86,21 +86,17 @@ func (af *flight) NewCluster(rconf *platform.RuntimeConfig) (platform.Cluster, e
 		flight:      af,
 	}
 
-	if !rconf.NoSSHKeyInMetadata {
-		// We have worked around the golang library limitation for
-		// keyexchange algorithm by switching to an ecdsa key in
-		// network/ssh.go.  However, Azure requires an RSA key.  For
-		// now (until we get an updated golang library) we'll just
-		// satisfy the requirement by using a fake key and disabling
-		// the fcos.ignition.misc.empty and fcos.ignition.v3.noop
-		// tests on Azure.
-		// https://github.com/coreos/coreos-assembler/issues/1772
-		// https://docs.microsoft.com/en-us/azure/virtual-machines/linux/mac-create-ssh-keys#supported-ssh-key-formats
-		ac.sshKey = af.FakeSSHKey
-		//ac.sshKey = af.SSHKey
-	} else {
-		ac.sshKey = af.FakeSSHKey
-	}
+	// We have worked around the golang library limitation for
+	// keyexchange algorithm by switching to an ecdsa key in
+	// network/ssh.go.  However, Azure requires an RSA key.  For
+	// now (until we get an updated golang library) we'll just
+	// satisfy the requirement by using a fake key and disabling
+	// the fcos.ignition.misc.empty and fcos.ignition.v3.noop
+	// tests on Azure.
+	// https://github.com/coreos/coreos-assembler/issues/1772
+	// https://docs.microsoft.com/en-us/azure/virtual-machines/linux/mac-create-ssh-keys#supported-ssh-key-formats
+	ac.sshKey = af.FakeSSHKey
+	//ac.sshKey = af.SSHKey
 
 	ac.ResourceGroup, err = af.api.CreateResourceGroup("kola-cluster")
 	if err != nil {


### PR DESCRIPTION
Azure requires that either a username/password be set or an SSH key.
Previously we were unconditionally passing an SSH key but we have tests
(like coreos.ignition.ssh.key) that don't want an SSH key to be passed
via the API and set a NoSSHKeyInMetadata flag for that.

Let's start passing a username/password via the API so we can then bring
up instances without having to specify an SSH key. The username/password
we give won't be used because we don't install their agent.