### PR TITLE
kola/external-tests: add appendKernelArgs support in kola.json

### DIFF
--- a/docs/kola/external-tests.md
+++ b/docs/kola/external-tests.md
@@ -195,6 +195,7 @@ Here's an example `kola.json`:
     "minMemory": 4096,
     "minDisk": 15,
     "additionalNics": 2,
+    "appendKernelArgs": "ip=bond0:dhcp bond=bond0:ens5,ens6:mode=active-backup,miimon=100"
     "timeoutMin": 8,
     "exclusive": true
 }
@@ -238,6 +239,9 @@ the `--memory` argument to `qemuexec`. This is currently only enforced on
 
 The `additionalNics` key has the same semantics as the `--additional-nics` argument
 to `qemuexec`. It is currently only supported on `qemu-unpriv`.
+
+The `appendKernelArgs` key has the same semantics at the `--kargs` argument to
+`qemuexec`. It is currently only supported on `qemu-unpriv`.
 
 The `timeoutMin` key takes a positive integer and specifies a timeout for the test
 in minutes. After the specified amount of time, the test will be interrupted.

--- a/mantle/cmd/kola/qemuexec.go
+++ b/mantle/cmd/kola/qemuexec.go
@@ -263,7 +263,7 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 	if len(knetargs) > 0 {
 		builder.IgnitionNetworkKargs = knetargs
 	}
-	builder.AppendKernelArguments = strings.Join(kargs, " ")
+	builder.AppendKernelArgs = strings.Join(kargs, " ")
 	builder.Firmware = kola.QEMUOptions.Firmware
 	if kola.QEMUOptions.DiskImage != "" {
 		channel := "virtio"

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -697,17 +697,18 @@ func RunUpgradeTests(patterns []string, rerun bool, pltfrm, outputDir string, pr
 
 // externalTestMeta is parsed from kola.json in external tests
 type externalTestMeta struct {
-	Architectures   string   `json:"architectures,omitempty"`
-	Platforms       string   `json:"platforms,omitempty"`
-	Distros         string   `json:"distros,omitempty"`
-	Tags            string   `json:"tags,omitempty"`
-	RequiredTag     string   `json:"requiredTag,omitempty"`
-	AdditionalDisks []string `json:"additionalDisks,omitempty"`
-	MinMemory       int      `json:"minMemory,omitempty"`
-	MinDiskSize     int      `json:"minDisk,omitempty"`
-	AdditionalNics  int      `json:"additionalNics,omitempty"`
-	Exclusive       bool     `json:"exclusive"`
-	TimeoutMin      int      `json:"timeoutMin"`
+	Architectures    string   `json:"architectures,omitempty"`
+	Platforms        string   `json:"platforms,omitempty"`
+	Distros          string   `json:"distros,omitempty"`
+	Tags             string   `json:"tags,omitempty"`
+	RequiredTag      string   `json:"requiredTag,omitempty"`
+	AdditionalDisks  []string `json:"additionalDisks,omitempty"`
+	MinMemory        int      `json:"minMemory,omitempty"`
+	MinDiskSize      int      `json:"minDisk,omitempty"`
+	AdditionalNics   int      `json:"additionalNics,omitempty"`
+	AppendKernelArgs string   `json:"appendKernelArgs,omitempty"`
+	Exclusive        bool     `json:"exclusive"`
+	TimeoutMin       int      `json:"timeoutMin"`
 }
 
 // metadataFromTestBinary extracts JSON-in-comment like:
@@ -871,11 +872,12 @@ ExecStart=%s
 		DependencyDir: destDirs,
 		Tags:          []string{"external"},
 
-		AdditionalDisks: targetMeta.AdditionalDisks,
-		MinMemory:       targetMeta.MinMemory,
-		MinDiskSize:     targetMeta.MinDiskSize,
-		AdditionalNics:  targetMeta.AdditionalNics,
-		NonExclusive:    !targetMeta.Exclusive,
+		AdditionalDisks:  targetMeta.AdditionalDisks,
+		MinMemory:        targetMeta.MinMemory,
+		MinDiskSize:      targetMeta.MinDiskSize,
+		AdditionalNics:   targetMeta.AdditionalNics,
+		AppendKernelArgs: targetMeta.AppendKernelArgs,
+		NonExclusive:     !targetMeta.Exclusive,
 
 		Run: func(c cluster.TestCluster) {
 			mach := c.Machines()[0]
@@ -1234,11 +1236,12 @@ func runTest(h *harness.H, t *register.Test, pltfrm string, flight platform.Flig
 		var userdata *conf.UserData = t.UserData
 
 		options := platform.MachineOptions{
-			MultiPathDisk:   t.MultiPathDisk,
-			AdditionalDisks: t.AdditionalDisks,
-			MinMemory:       t.MinMemory,
-			MinDiskSize:     t.MinDiskSize,
-			AdditionalNics:  t.AdditionalNics,
+			MultiPathDisk:    t.MultiPathDisk,
+			AdditionalDisks:  t.AdditionalDisks,
+			MinMemory:        t.MinMemory,
+			MinDiskSize:      t.MinDiskSize,
+			AdditionalNics:   t.AdditionalNics,
+			AppendKernelArgs: t.AppendKernelArgs,
 		}
 
 		_, err = platform.NewMachines(c, userdata, t.ClusterSize, options)

--- a/mantle/kola/register/register.go
+++ b/mantle/kola/register/register.go
@@ -84,6 +84,9 @@ type Test struct {
 	// Additional amount of NICs required for test.
 	AdditionalNics int
 
+	// Additional kernel arguments to append to the defaults.
+	AppendKernelArgs string
+
 	// ExternalTest is a path to a binary that will be uploaded
 	ExternalTest string
 	// DependencyDir is a path to directory that will be uploaded, normally used by external tests

--- a/mantle/platform/machine/aws/cluster.go
+++ b/mantle/platform/machine/aws/cluster.go
@@ -49,6 +49,10 @@ func (ac *cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 		return nil, errors.New("platform aws does not support additional nics")
 	}
 
+	if options.AppendKernelArgs != "" {
+		return nil, errors.New("platform aws does not support appending kernel arguments")
+	}
+
 	conf, err := ac.RenderUserData(userdata, map[string]string{
 		"$public_ipv4":  "${COREOS_EC2_IPV4_PUBLIC}",
 		"$private_ipv4": "${COREOS_EC2_IPV4_LOCAL}",

--- a/mantle/platform/machine/azure/cluster.go
+++ b/mantle/platform/machine/azure/cluster.go
@@ -99,6 +99,9 @@ func (ac *cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 	if options.AdditionalNics > 0 {
 		return nil, errors.New("platform azure does not support additional nics")
 	}
+	if options.AppendKernelArgs != "" {
+		return nil, errors.New("platform azure does not support appending kernel arguments")
+	}
 	return ac.NewMachine(userdata)
 }
 

--- a/mantle/platform/machine/do/cluster.go
+++ b/mantle/platform/machine/do/cluster.go
@@ -98,6 +98,9 @@ func (dc *cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 	if options.AdditionalNics > 0 {
 		return nil, errors.New("platform do does not support additional nics")
 	}
+	if options.AppendKernelArgs != "" {
+		return nil, errors.New("platform do does not support appending kernel arguments")
+	}
 	return dc.NewMachine(userdata)
 }
 

--- a/mantle/platform/machine/esx/cluster.go
+++ b/mantle/platform/machine/esx/cluster.go
@@ -101,6 +101,9 @@ func (ec *cluster) NewMachineWithOptions(userdata *platformConf.UserData, option
 	if options.AdditionalNics > 0 {
 		return nil, errors.New("platform esx does not support additional nics")
 	}
+	if options.AppendKernelArgs != "" {
+		return nil, errors.New("platform esx does not support appending kernel arguments")
+	}
 	return ec.NewMachine(userdata)
 }
 

--- a/mantle/platform/machine/gcloud/cluster.go
+++ b/mantle/platform/machine/gcloud/cluster.go
@@ -101,6 +101,9 @@ func (gc *cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 	if options.AdditionalNics > 0 {
 		return nil, errors.New("platform gce does not support additional nics")
 	}
+	if options.AppendKernelArgs != "" {
+		return nil, errors.New("platform gce does not support appending kernel arguments")
+	}
 	return gc.NewMachine(userdata)
 }
 

--- a/mantle/platform/machine/openstack/cluster.go
+++ b/mantle/platform/machine/openstack/cluster.go
@@ -90,6 +90,9 @@ func (oc *cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 	if options.AdditionalNics > 0 {
 		return nil, errors.New("platform openstack does not support additional nics")
 	}
+	if options.AppendKernelArgs != "" {
+		return nil, errors.New("platform openstack does not support appending kernel arguments")
+	}
 	return oc.NewMachine(userdata)
 }
 

--- a/mantle/platform/machine/packet/cluster.go
+++ b/mantle/platform/machine/packet/cluster.go
@@ -122,6 +122,9 @@ func (pc *cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 	if options.AdditionalNics > 0 {
 		return nil, errors.New("platform packet does not support additional nics")
 	}
+	if options.AppendKernelArgs != "" {
+		return nil, errors.New("platform packet does not support appending kernel arguments")
+	}
 	return pc.NewMachine(userdata)
 }
 

--- a/mantle/platform/machine/qemuiso/cluster.go
+++ b/mantle/platform/machine/qemuiso/cluster.go
@@ -133,6 +133,9 @@ func (qc *Cluster) NewMachineWithQemuOptions(userdata *conf.UserData, options pl
 	if options.AdditionalNics > 0 {
 		builder.AddAdditionalNics(options.AdditionalNics)
 	}
+	if options.AppendKernelArgs != "" {
+		builder.AppendKernelArgs = options.AppendKernelArgs
+	}
 
 	inst, err := builder.Exec()
 	if err != nil {

--- a/mantle/platform/machine/unprivqemu/cluster.go
+++ b/mantle/platform/machine/unprivqemu/cluster.go
@@ -160,6 +160,9 @@ func (qc *Cluster) NewMachineWithQemuOptions(userdata *conf.UserData, options pl
 	if options.AdditionalNics > 0 {
 		builder.AddAdditionalNics(options.AdditionalNics)
 	}
+	if options.AppendKernelArgs != "" {
+		builder.AppendKernelArgs = options.AppendKernelArgs
+	}
 	if !qc.RuntimeConf().InternetAccess {
 		builder.RestrictNetworking = true
 	}

--- a/mantle/platform/platform.go
+++ b/mantle/platform/platform.go
@@ -152,11 +152,12 @@ type Flight interface {
 }
 
 type MachineOptions struct {
-	MultiPathDisk   bool
-	AdditionalDisks []string
-	MinMemory       int
-	MinDiskSize     int
-	AdditionalNics  int
+	MultiPathDisk    bool
+	AdditionalDisks  []string
+	MinMemory        int
+	MinDiskSize      int
+	AdditionalNics   int
+	AppendKernelArgs string
 }
 
 // SystemdDropin is a userdata type agnostic struct representing a systemd dropin


### PR DESCRIPTION
Add the ability to specify kernel arguments to append to the default
kernel arguments set in the image. This will be useful when testing
workflows that use kernel arguments for network configuration.

For now, this only supports the qemu platform.

Fixes https://github.com/coreos/coreos-assembler/issues/2621
