### PR TITLE
Update for renamed osmet/miniso pack subcommands

### DIFF
--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -733,7 +733,7 @@ boot
             print(f'Embedded {ignition_img_size} bytes Ignition config space at {offset}')
 
     # this consumes the minimal image
-    run_verbose(['coreos-installer', 'iso', 'extract', 'pack-minimal-iso',
+    run_verbose(['coreos-installer', 'pack', 'minimal-iso',
                  tmpisofile, f'{tmpisofile}.minimal', "--consume"])
 
     buildmeta['images'].update({

--- a/src/osmet-pack
+++ b/src/osmet-pack
@@ -79,7 +79,7 @@ esac
 
 # We don't want double quotes (for both `coreinst` and `fast`, which may be '')
 # shellcheck disable=SC2086
-RUST_BACKTRACE=full ${coreinst} osmet pack /dev/disk/by-id/virtio-osmet \
+RUST_BACKTRACE=full ${coreinst} pack osmet /dev/disk/by-id/virtio-osmet \
     --description "${description}" \
     --checksum "${checksum}" \
     --output /tmp/osmet.bin $fast


### PR DESCRIPTION
They were moved in https://github.com/coreos/coreos-installer/pull/741 and the old commands deprecated.

Requires https://github.com/coreos/coreos-installer/pull/741 to land in a coreos-installer release.