### PR TITLE
mantle/platform/util.go: catch 'dial tcp' error during reboot

### DIFF
--- a/mantle/platform/util.go
+++ b/mantle/platform/util.go
@@ -157,6 +157,10 @@ func WaitForMachineReboot(m Machine, j *Journal, timeout time.Duration, oldBootI
 		} else if strings.Contains(err.Error(), "handshake failed: EOF") {
 			// This can also happen if we're killed during handshake
 			c <- nil
+		} else if strings.Contains(err.Error(), "dial tcp") {
+			// Catch "dial tcp xx.xx.xx.xx:xx: connect: connection refused"
+			// error which occcurs when rebooting on online platforms.
+			c <- nil
 		} else {
 			c <- fmt.Errorf("waiting for reboot failed: %s: %s: %s", out, err, stderr)
 		}


### PR DESCRIPTION
When we run the kdump test using online platforms we get the `reboot failed: :dial tcp xx.xx.xx.xx:xx: connect: connection refused` error which is not catched in the `WaitForMachineReboot` function. Adding the above change makes sure we don't return and exit with that error while the machine reboots.
Linked issue: https://github.com/coreos/fedora-coreos-tracker/issues/860 