### PR TITLE
cmdlib: support `overlay.d/cosa-no-autolayer` option

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -381,7 +381,7 @@ EOF
             fi
             local bn ovlname
             bn=$(basename "${n}")
-            ovlname="${name}-config-overlay-${bn}"
+            ovlname="overlay/${bn}"
             commit_overlay "${ovlname}" "${n}"
             layers="${layers} ${ovlname}"
         done

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -375,6 +375,9 @@ EOF
     fi
 
     if [ -d "${ovld}" ]; then
+        if [ -e "${ovld}/cosa-no-autolayer" ]; then
+            cosa_no_autolayer=1
+        fi
         for n in "${ovld}"/*; do
             if ! [ -d "${n}" ]; then
                 continue
@@ -383,7 +386,9 @@ EOF
             bn=$(basename "${n}")
             ovlname="overlay/${bn}"
             commit_overlay "${ovlname}" "${n}"
-            layers="${layers} ${ovlname}"
+            if [ -z "${cosa_no_autolayer:-}" ]; then
+                layers="${layers} ${ovlname}"
+            fi
         done
     fi
 


### PR DESCRIPTION
When this file is present in the config dir, coreos-assembler will still
automatically commit the `overlay.d` subdirectories to the OSTree repo,
but will not automatically add them to the treefile.

This provides more flexibility on the config side, where e.g. overlays
may be conditionally added or may only be added on certain streams.
This has come up multiple times already in FCOS, more recently as part
of the `iptables-nft` migration work.

See also: https://github.com/coreos/fedora-coreos-config/pull/180#issuecomment-534706218

So this is sort of a halfway approach between what we have now and
teaching rpm-ostree about the overlay directories directly (via a new
e.g. `add-dirs` file, see previous discussions about this in
#639). Except that this
is much easier to do and doesn't require any rpm-ostree modification.