### PR TITLE
Revert "Switch from `rpm-ostree ex-container` to `ostree container`"

### DIFF
--- a/mantle/kola/tests/rhcos/upgrade.go
+++ b/mantle/kola/tests/rhcos/upgrade.go
@@ -119,7 +119,7 @@ func setup(c cluster.TestCluster) {
 			outputname="%s"
 			commit="%s"
 			ostree --repo=tmp/repo-cache init --mode=bare-user
-			ostree container import --repo=tmp/repo ostree-unverified-image:oci-archive:$tarname:latest
+			rpm-ostree ex-container import --repo=tmp/repo ostree-unverified-image:oci-archive:$tarname:latest
 			ostree --repo=tmp/repo pull-local tmp/repo-cache "$commit"
 			tar -cf "$outputname" -C tmp/repo .
 			rm tmp/repo-cache -rf

--- a/mantle/kola/tests/upgrade/basic.go
+++ b/mantle/kola/tests/upgrade/basic.go
@@ -150,7 +150,7 @@ func fcosUpgradeBasic(c cluster.TestCluster) {
 			tmprepo := workdir + "/repo-bare"
 			// TODO: https://github.com/ostreedev/ostree-rs-ext/issues/34
 			c.RunCmdSyncf(m, "ostree --repo=%s init --mode=bare-user", tmprepo)
-			c.RunCmdSyncf(m, "ostree container import --repo=%s --write-ref %s ostree-unverified-image:oci-archive:%s:latest", tmprepo, ostreeref, ostreeblob)
+			c.RunCmdSyncf(m, "rpm-ostree ex-container import --repo=%s --write-ref %s ostree-unverified-image:oci-archive:%s:latest", tmprepo, ostreeref, ostreeblob)
 			c.RunCmdSyncf(m, "ostree --repo=%s init --mode=archive", ostreeRepo)
 			c.RunCmdSyncf(m, "ostree --repo=%s pull-local %s %s", ostreeRepo, tmprepo, ostreeref)
 		} else {

--- a/src/cmd-build
+++ b/src/cmd-build
@@ -402,7 +402,7 @@ else
             ;;
         null|oci)
             ostree_tarfile_path="${name}-${buildid}-ostree.${basearch}.ociarchive"
-            ostree container 'export' --cmd /usr/bin/bash --repo="${tmprepo}" "${buildid}" oci-archive:"${ostree_tarfile_path}".tmp:latest
+            rpm-ostree ex-container 'export' --cmd /usr/bin/bash --repo="${tmprepo}" "${buildid}" oci-archive:"${ostree_tarfile_path}".tmp:latest
             ;;
         *) fatal "Unknown ostree-format: ${ostree_format}"
     esac

--- a/src/cmd-sign
+++ b/src/cmd-sign
@@ -184,7 +184,7 @@ def robosign_ostree(args, s3, build, gpgkey):
             # accidental mutation.  Remove the existing one because otherwise
             # we'll try to `open(O_TRUNC)` it and fail.
             os.unlink(exported_ostree_path)
-            subprocess.check_call(['ostree', 'container', 'export', '--repo=tmp/repo', checksum, f'oci-archive:{exported_ostree_path}:latest'])
+            subprocess.check_call(['rpm-ostree', 'ex-container', 'export', '--repo=tmp/repo', checksum, f'oci-archive:{exported_ostree_path}:latest'])
         else:
             tmp_tar = os.path.join(d, ostree_image['path'])
             # To make things a bit more efficient, append the commitmeta at

--- a/src/cosalib/cmdlib.py
+++ b/src/cosalib/cmdlib.py
@@ -270,7 +270,7 @@ def import_ostree_commit(repo, buildpath, buildmeta, force=False):
         # to `repo-build`, though it might be good to change this by default.
         if os.environ.get('COSA_PRIVILEGED', '') == '1':
             build_repo = os.path.join(repo, '../../cache/repo-build')
-            subprocess.check_call(['sudo', 'ostree', 'container', 'import', '--repo', build_repo,
+            subprocess.check_call(['sudo', 'rpm-ostree', 'ex-container', 'import', '--repo', build_repo,
                                    '--write-ref', buildmeta['buildid'], 'ostree-unverified-image:oci-archive:' + tarfile])
             subprocess.check_call(['sudo', 'ostree', f'--repo={repo}', 'pull-local', build_repo, buildmeta['buildid']])
             uid = os.getuid()
@@ -279,7 +279,7 @@ def import_ostree_commit(repo, buildpath, buildmeta, force=False):
         else:
             with tempfile.TemporaryDirectory() as tmpd:
                 subprocess.check_call(['ostree', 'init', '--repo', tmpd, '--mode=bare-user'])
-                subprocess.check_call(['ostree', 'container', 'import', '--repo', tmpd,
+                subprocess.check_call(['rpm-ostree', 'ex-container', 'import', '--repo', tmpd,
                                        '--write-ref', buildmeta['buildid'], 'ostree-unverified-image:oci-archive:' + tarfile])
                 subprocess.check_call(['ostree', f'--repo={repo}', 'pull-local', tmpd, buildmeta['buildid']])
 

--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -268,7 +268,7 @@ if test -n "${deploy_container}"; then
     do
         kargsargs+="--karg=$karg "
     done
-    ostree container image deploy --imgref "${deploy_container}" \
+    rpm-ostree ex-container image deploy --imgref "${deploy_container}" \
         ${container_imgref:+--target-imgref $container_imgref} \
         --stateroot "$os_name" --sysroot $rootfs $kargsargs
 else

--- a/src/image-default.yaml
+++ b/src/image-default.yaml
@@ -2,7 +2,7 @@
 bootfs: "ext4"
 rootfs: "xfs"
 grub-script: "/usr/lib/coreos-assembler/grub.cfg"
-# True if we should use `ostree container image deploy`
+# True if we should use `rpm-ostree ex-container image deploy`
 deploy-via-container: false
 # Set this to a target container reference, e.g. ostree-unverified-registry:quay.io/example/os:latest
 # container-imgref: ""


### PR DESCRIPTION
This reverts commit e45761755aa1cb4f35b79365adf755f669f4f48d.

A version of `ostree container` isn't available in our prod streams
yet so those builds with older rpm content will fail upgrade tests
until they get the newer ostree. We need to either wait until those
streams have the newer ostree or create a git tag we can build COSA
containers from and reference.