### PR TITLE
Enable `module_hotfixes=true` for overrides/rpm

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -415,6 +415,7 @@ name=coreos-assembler-local-overrides
 baseurl=file://${workdir}/overrides/rpm
 gpgcheck=0
 cost=500
+module_hotfixes=true
 EOF
     else
         rm -vf "${local_overrides_lockfile}"


### PR DESCRIPTION
I was trying to drop an updated `skopeo` in `overrides/rpm` but
it was failing because cosa generates a lockfiles that includes it,
but in rhcos we're installing the `virt-tools` module, which filters
out everything that's not in that module.

Allow the overrides repo to override things.