### PR TITLE
cosalib/messaging: disable pylint check on addErrback

### DIFF
--- a/src/cosalib/fedora_messaging_request.py
+++ b/src/cosalib/fedora_messaging_request.py
@@ -193,5 +193,5 @@ def watch_finished_messages(cond, registered,
 
     consumers = twisted_consume(callback, bindings=bindings, queues=queues)
     consumers.addCallback(registered_cb)
-    consumers.addErrback(error_cb)
+    consumers.addErrback(error_cb)  # pylint: disable=E1101
     reactor.run(installSignalHandlers=False)  # pylint: disable=E1101


### PR DESCRIPTION
With the changes in the latest fedora-messaging package, pylint gets
confused that `addErrback` isn't a member of the consumer returned by
`twisted_consume`.

But the API is still valid and the code still works in a local test, so
let's just silence pylint.

Closes: #2649