### PR TITLE
kola: add subtest runner which logs entry and exit

### DIFF
--- a/mantle/kola/cluster/cluster.go
+++ b/mantle/kola/cluster/cluster.go
@@ -180,6 +180,10 @@ func (t *TestCluster) MustSSHf(m platform.Machine, f string, args ...interface{}
 	return t.MustSSH(m, fmt.Sprintf(f, args...))
 }
 
+func (t *TestCluster) JournalLog(m platform.Machine, f string, args ...interface{}) []byte {
+	return t.MustSSH(m, fmt.Sprintf("logger --tag kola '%s'", fmt.Sprintf(f, args...)))
+}
+
 // RunCmdSync synchronously exectues a command, logging the output to the journal
 func (t *TestCluster) RunCmdSync(m platform.Machine, cmd string) {
 	t.LogJournal(m, "+ "+cmd)

--- a/mantle/kola/cluster/cluster.go
+++ b/mantle/kola/cluster/cluster.go
@@ -62,6 +62,16 @@ func (t *TestCluster) Run(name string, f func(c TestCluster)) bool {
 
 }
 
+// Same as Run, but logs a message in the machines' journal logs before and
+// after running the function.
+func (t *TestCluster) RunLogged(name string, f func(c TestCluster)) bool {
+	for _, m := range t.Machines() {
+		t.JournalLog(m, "=== RUN: %s/%s ===", t.H.Name(), name)
+		defer t.JournalLog(m, "=== DONE: %s/%s ===", t.H.Name(), name)
+	}
+	return t.Run(name, f)
+}
+
 // RunNative runs a registered NativeFunc on a remote machine
 func (t *TestCluster) RunNative(funcName string, m platform.Machine) bool {
 	command := fmt.Sprintf("./kolet run %q %q", t.H.Name(), funcName)

--- a/mantle/kola/tests/ostree/basic.go
+++ b/mantle/kola/tests/ostree/basic.go
@@ -132,7 +132,7 @@ func ostreeBasicTest(c cluster.TestCluster) {
 	}
 
 	// verify the output from `ostree admin status`
-	c.Run("admin status", func(c cluster.TestCluster) {
+	c.RunLogged("admin status", func(c cluster.TestCluster) {
 		if oas.Checksum != ros.Deployments[0].Checksum {
 			c.Fatalf(`Checksums do not match; expected %q, got %q`, ros.Deployments[0].Checksum, oas.Checksum)
 		}
@@ -147,13 +147,13 @@ func ostreeBasicTest(c cluster.TestCluster) {
 	// verify the output from `ostree rev-parse`
 	// this is kind of moot since the origin for RHCOS is just
 	// the checksum now
-	c.Run("rev-parse", func(c cluster.TestCluster) {
+	c.RunLogged("rev-parse", func(c cluster.TestCluster) {
 		// check the output of `ostree rev-parse`
 		c.AssertCmdOutputContains(m, ("ostree rev-parse " + oas.Origin), oas.Checksum)
 	})
 
 	// verify the output of 'ostree show'
-	c.Run("show", func(c cluster.TestCluster) {
+	c.RunLogged("show", func(c cluster.TestCluster) {
 		oShowOut := c.MustSSH(m, ("ostree show " + oas.Checksum))
 		oShowOutSplit := strings.Split(string(oShowOut), "\n")
 		// we need at least the first 4 lines (commit, ContentChecksum, Date, Version)

--- a/mantle/kola/tests/ostree/unlock.go
+++ b/mantle/kola/tests/ostree/unlock.go
@@ -189,7 +189,7 @@ func ostreeHotfixTest(c cluster.TestCluster) {
 	m := c.Machines()[0]
 
 	// unlock the deployment into "hotfix" mode
-	c.Run("unlock", func(c cluster.TestCluster) {
+	c.RunLogged("unlock", func(c cluster.TestCluster) {
 		unlockErr := ostreeAdminUnlock(c, m, true)
 		if unlockErr != nil {
 			c.Fatal(unlockErr)
@@ -197,7 +197,7 @@ func ostreeHotfixTest(c cluster.TestCluster) {
 	})
 
 	// try to install an RPM via HTTP
-	c.Run("install", func(c cluster.TestCluster) {
+	c.RunLogged("install", func(c cluster.TestCluster) {
 		rpmInstallErr := rpmInstallVerify(c, m, rpmUrl, rpmName)
 		if rpmInstallErr != nil {
 			c.Fatal(rpmInstallErr)
@@ -205,7 +205,7 @@ func ostreeHotfixTest(c cluster.TestCluster) {
 	})
 
 	// uninstall the RPM
-	c.Run("uninstall", func(c cluster.TestCluster) {
+	c.RunLogged("uninstall", func(c cluster.TestCluster) {
 		rpmUninstallErr := rpmUninstallVerify(c, m, rpmName)
 		if rpmUninstallErr != nil {
 			c.Fatal(rpmUninstallErr)
@@ -214,7 +214,7 @@ func ostreeHotfixTest(c cluster.TestCluster) {
 
 	// install the RPM again, reboot, verify it the "hotfix" deployment
 	// and RPM have persisted
-	c.Run("persist", func(c cluster.TestCluster) {
+	c.RunLogged("persist", func(c cluster.TestCluster) {
 		c.RunCmdSync(m, ("sudo rpm -i " + rpmUrl))
 
 		unlockRebootErr := m.Reboot()
@@ -237,7 +237,7 @@ func ostreeHotfixTest(c cluster.TestCluster) {
 	})
 
 	// roll back the deployment and verify the "hotfix" is no longer present
-	c.Run("rollback", func(c cluster.TestCluster) {
+	c.RunLogged("rollback", func(c cluster.TestCluster) {
 		c.RunCmdSync(m, "sudo rpm-ostree rollback")
 
 		rollbackRebootErr := m.Reboot()


### PR DESCRIPTION
Use the new `JournalLog` function to add a new `RunLogged` function to
`TestCluster` which has the same semantics as `Run`, i.e. starting a
subtest, but additionally logs in the machines' journals on entry and
exit of the subtest.

Use this in `ostree.basic` and `ostree.hotfix`, the latter of which has
been giving us issues. This should make it easier to read the logs.