### PR TITLE
Add `skip-compression` field to `meta.json`

### DIFF
--- a/mantle/vendor/github.com/coreos/coreos-assembler-schema/cosa/cosa_v1.go
+++ b/mantle/vendor/github.com/coreos/coreos-assembler-schema/cosa/cosa_v1.go
@@ -21,6 +21,7 @@ type Artifact struct {
 	Path               string  `json:"path"`
 	Sha256             string  `json:"sha256"`
 	SizeInBytes        float64 `json:"size,omitempty"`
+	SkipCompression    bool    `json:"skip-compression,omitempty"`
 	UncompressedSha256 string  `json:"uncompressed-sha256,omitempty"`
 	UncompressedSize   int     `json:"uncompressed-size,omitempty"`
 }

--- a/mantle/vendor/github.com/coreos/coreos-assembler-schema/cosa/schema_doc.go
+++ b/mantle/vendor/github.com/coreos/coreos-assembler-schema/cosa/schema_doc.go
@@ -23,6 +23,13 @@ var generatedSchemaJSON = `{
              "type":"number",
              "title":"Size in bytes"
             },
+           "skip-compression": {
+             "$id": "#/artifact/skip-compression",
+             "type":"boolean",
+             "title":"Skip compression",
+             "description":"Artifact should not be compressed or decompressed before use",
+             "default":false
+            },
            "uncompressed-sha256": {
              "$id": "#/artifact/uncompressed-sha256",
              "type":"string",
@@ -37,7 +44,8 @@ var generatedSchemaJSON = `{
           "optional": [
               "size",
               "uncompressed-sha256",
-              "uncompressed-size"
+              "uncompressed-size",
+              "skip-compression"
           ],
           "required": [
               "path",

--- a/mantle/vendor/github.com/coreos/coreos-assembler-schema/cosa/schema_doc.go
+++ b/mantle/vendor/github.com/coreos/coreos-assembler-schema/cosa/schema_doc.go
@@ -411,6 +411,7 @@ var generatedSchemaJSON = `{
        "live-rootfs",
        "metal",
        "metal4k",
+       "nutanix",
        "openstack",
        "qemu",
        "vmware",
@@ -495,6 +496,12 @@ var generatedSchemaJSON = `{
          "title":"Live Rootfs",
          "$ref": "#/definitions/artifact"
         },
+        "nutanix": {
+          "$id":"#/properties/images/properties/nutanix",
+          "type":"object",
+          "title":"Nutanix",
+          "$ref": "#/definitions/artifact"
+         }, 
        "openstack": {
          "$id":"#/properties/images/properties/openstack",
          "type":"object",

--- a/schema/cosa/cosa_v1.go
+++ b/schema/cosa/cosa_v1.go
@@ -21,6 +21,7 @@ type Artifact struct {
 	Path               string  `json:"path"`
 	Sha256             string  `json:"sha256"`
 	SizeInBytes        float64 `json:"size,omitempty"`
+	SkipCompression    bool    `json:"skip-compression,omitempty"`
 	UncompressedSha256 string  `json:"uncompressed-sha256,omitempty"`
 	UncompressedSize   int     `json:"uncompressed-size,omitempty"`
 }

--- a/schema/cosa/schema_doc.go
+++ b/schema/cosa/schema_doc.go
@@ -23,6 +23,13 @@ var generatedSchemaJSON = `{
              "type":"number",
              "title":"Size in bytes"
             },
+           "skip-compression": {
+             "$id": "#/artifact/skip-compression",
+             "type":"boolean",
+             "title":"Skip compression",
+             "description":"Artifact should not be compressed or decompressed before use",
+             "default":false
+            },
            "uncompressed-sha256": {
              "$id": "#/artifact/uncompressed-sha256",
              "type":"string",
@@ -37,7 +44,8 @@ var generatedSchemaJSON = `{
           "optional": [
               "size",
               "uncompressed-sha256",
-              "uncompressed-size"
+              "uncompressed-size",
+              "skip-compression"
           ],
           "required": [
               "path",

--- a/schema/cosa/schema_doc.go
+++ b/schema/cosa/schema_doc.go
@@ -411,6 +411,7 @@ var generatedSchemaJSON = `{
        "live-rootfs",
        "metal",
        "metal4k",
+       "nutanix",
        "openstack",
        "qemu",
        "vmware",
@@ -495,6 +496,12 @@ var generatedSchemaJSON = `{
          "title":"Live Rootfs",
          "$ref": "#/definitions/artifact"
         },
+        "nutanix": {
+          "$id":"#/properties/images/properties/nutanix",
+          "type":"object",
+          "title":"Nutanix",
+          "$ref": "#/definitions/artifact"
+         }, 
        "openstack": {
          "$id":"#/properties/images/properties/openstack",
          "type":"object",

--- a/schema/v1.json
+++ b/schema/v1.json
@@ -18,6 +18,13 @@
              "type":"number",
              "title":"Size in bytes"
             },
+           "skip-compression": {
+             "$id": "#/artifact/skip-compression",
+             "type":"boolean",
+             "title":"Skip compression",
+             "description":"Artifact should not be compressed or decompressed before use",
+             "default":false
+            },
            "uncompressed-sha256": {
              "$id": "#/artifact/uncompressed-sha256",
              "type":"string",
@@ -32,7 +39,8 @@
           "optional": [
               "size",
               "uncompressed-sha256",
-              "uncompressed-size"
+              "uncompressed-size",
+              "skip-compression"
           ],
           "required": [
               "path",

--- a/src/cmd-build
+++ b/src/cmd-build
@@ -440,7 +440,8 @@ cat > tmp/images.json <<EOF
     "ostree": {
         "path": "${ostree_tarfile_path}",
         "sha256": "${ostree_tarfile_sha256}",
-        "size": ${ostree_tarfile_size}
+        "size": ${ostree_tarfile_size},
+        "skip-compression": true
     }
   }
 }

--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -739,7 +739,8 @@ boot
     buildmeta['images'].update({
         'live-iso': {
             'path': iso_name,
-            'sha256': sha256sum_file(tmpisofile)
+            'sha256': sha256sum_file(tmpisofile),
+            'skip-compression': True,
         }
     })
     shutil.move(tmpisofile, f"{builddir}/{iso_name}")
@@ -756,15 +757,18 @@ boot
     buildmeta['images'].update({
         'live-kernel': {
             'path': kernel_name,
-            'sha256': sha256sum_file(kernel_file)
+            'sha256': sha256sum_file(kernel_file),
+            'skip-compression': True,
         },
         'live-initramfs': {
             'path': initramfs_name,
-            'sha256': sha256sum_file(initramfs_file)
+            'sha256': sha256sum_file(initramfs_file),
+            'skip-compression': True,
         },
         'live-rootfs': {
             'path': rootfs_name,
-            'sha256': sha256sum_file(rootfs_file)
+            'sha256': sha256sum_file(rootfs_file),
+            'skip-compression': True,
         }
     })
 

--- a/src/cmd-compress
+++ b/src/cmd-compress
@@ -54,7 +54,7 @@ else:
 print(f"Targeting build: {build}")
 
 # Don't compress certain images
-imgs_to_skip = ["ostree", "iso", "live-iso", "vmware", "initramfs", "live-initramfs", "kernel", "live-kernel", "live-rootfs"]
+imgs_to_skip = ["ostree", "live-iso", "vmware", "live-initramfs", "live-kernel", "live-rootfs"]
 
 
 def get_cpu_param(param):

--- a/src/cmd-compress
+++ b/src/cmd-compress
@@ -107,14 +107,13 @@ def compress_one_builddir(builddir):
     if len(args.artifact) > 0:
         only_artifacts = set(args.artifact)
 
-    for img_format in buildmeta['images']:
+    for img_format, img in buildmeta['images'].items():
         if img_format in imgs_to_skip:
             print(f"Skipping {img_format}")
             continue
         if only_artifacts is not None and img_format not in only_artifacts:
             continue
 
-        img = buildmeta['images'][img_format]
         file = img['path']
         filepath = os.path.join(builddir, file)
         # check if it's not already compressed, even if with a different

--- a/src/cmd-compress
+++ b/src/cmd-compress
@@ -53,9 +53,6 @@ else:
 
 print(f"Targeting build: {build}")
 
-# Don't compress certain images
-imgs_to_skip = ["ostree", "live-iso", "vmware", "live-initramfs", "live-kernel", "live-rootfs"]
-
 
 def get_cpu_param(param):
     with open(f'/sys/fs/cgroup/cpu/cpu.{param}') as f:
@@ -108,7 +105,7 @@ def compress_one_builddir(builddir):
         only_artifacts = set(args.artifact)
 
     for img_format, img in buildmeta['images'].items():
-        if img_format in imgs_to_skip:
+        if img.get('skip-compression', False):
             print(f"Skipping {img_format}")
             continue
         if only_artifacts is not None and img_format not in only_artifacts:
@@ -116,10 +113,7 @@ def compress_one_builddir(builddir):
 
         file = img['path']
         filepath = os.path.join(builddir, file)
-        # check if it's not already compressed, even if with a different
-        # compressor (like for GCP, which needs .tar.gz, see:
-        # https://github.com/coreos/coreos-assembler/pull/1009)
-        if not file.endswith(tuple(ext_dict.values())):
+        if img.get('uncompressed-sha256') is None:
             tmpfile = os.path.join(tmpdir, (file + ext))
             # SHA256 + size for uncompressed image was already calculated
             # during 'build'
@@ -147,6 +141,7 @@ def compress_one_builddir(builddir):
             at_least_one = True
             print(f"Compressed: {file_with_ext}")
         else:
+            # we've already compressed this in a previous pass
             # try to delete the original file if it's somehow still around
             rm_allow_noent(filepath[:-3])
 

--- a/src/cosalib/ova.py
+++ b/src/cosalib/ova.py
@@ -115,3 +115,7 @@ class OVA(QemuVariantImage):
         # OVF descriptor must come first, then the manifest, then
         # References in order
         self.tar_members.insert(0, self.ovf_path)
+
+        return {
+            'skip-compression': True,
+        }

--- a/src/cosalib/qemuvariants.py
+++ b/src/cosalib/qemuvariants.py
@@ -291,6 +291,7 @@ class QemuVariantImage(_Build):
                 run_verbose(['gzip', '-9c', final_img], stdout=fh)
             shutil.move(temp_path, final_img)
             meta_patch.update({
+                'skip-compression': True,
                 'uncompressed-sha256': sha256,
                 'uncompressed-size': size,
             })

--- a/src/v1.json
+++ b/src/v1.json
@@ -496,7 +496,7 @@
           "type":"object",
           "title":"Nutanix",
           "$ref": "#/definitions/artifact"
-         },
+         }, 
        "openstack": {
          "$id":"#/properties/images/properties/openstack",
          "type":"object",

--- a/src/v1.json
+++ b/src/v1.json
@@ -18,6 +18,13 @@
              "type":"number",
              "title":"Size in bytes"
             },
+           "skip-compression": {
+             "$id": "#/artifact/skip-compression",
+             "type":"boolean",
+             "title":"Skip compression",
+             "description":"Artifact should not be compressed or decompressed before use",
+             "default":false
+            },
            "uncompressed-sha256": {
              "$id": "#/artifact/uncompressed-sha256",
              "type":"string",
@@ -32,7 +39,8 @@
           "optional": [
               "size",
               "uncompressed-sha256",
-              "uncompressed-size"
+              "uncompressed-size",
+              "skip-compression"
           ],
           "required": [
               "path",


### PR DESCRIPTION
There are three cases where `cmd-compress` won't compress an artifact:

1. it's in `imgs_to_skip`,
2. it's precompressed by `qemuvariants.py`,
3. it was already compressed by an earlier `cmd-compress` run.

Case 2 currently covers `digitalocean` and `gcp`, since those platforms have opinions about which compression algorithm to use.  Case 1 covers the ostree, live artifacts, and `vmware` OVA.  Cases 2 and 3 are handled by the same test: `cmd-compress` looks for a known compression suffix.

Case 2 artifacts must not be decompressed for testing etc., since the compression is part of the definition of the artifact.  However, we don't currently write that down anywhere.  The `meta.json` `uncompressed-*` fields would have been useful for this, but #2158 added those to case 2 artifacts as well.

Add a `skip-compression` `meta.json` field, set it when generating all case 1 and case 2 artifacts, and use that to decide whether to compress.  That lets us drop the `imgs_to_skip` list.

In addition, detect case 3 by looking for the `uncompressed-sha256` `meta.json` field, which seems cleaner than detecting by file extension.