### PR TITLE
mantle/platform: use stable spec for non-exclusive test config merging

### DIFF
--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -1139,16 +1139,15 @@ func makeNonExclusiveTest(tests []*register.Test, flight platform.Flight) regist
 			}
 		}
 
-		// We upgrade each config to V3.4exp so they can be merged into one config
-		conf, err := test.UserData.RenderToV34exp()
+		conf, err := test.UserData.Render()
 		if err != nil {
-			plog.Fatal(err)
+			plog.Fatalf("Error rendering config: %v", err)
 		}
 		nonExclusiveTestConfs = append(nonExclusiveTestConfs, conf)
 	}
 
 	// Merge configs together
-	mergedConfig, err := conf.MergeAllV34exp(nonExclusiveTestConfs)
+	mergedConfig, err := conf.MergeAllConfigs(nonExclusiveTestConfs)
 	if err != nil {
 		plog.Fatalf("Error merging configs: %v", err)
 	}


### PR DESCRIPTION
Currently test ignition configs are merged into a single V3.4.0
(experimental) config so that they may be run non-exclusively on
one VM. This will become an obstacle when we want to stabilise
the experimental spec, potentially causing issues with CI. Lets
change the code to use the latest stable spec instead.

Original discussion here: https://github.com/coreos/coreos-assembler/pull/2588#discussion_r759541692