### PR TITLE
cmd-sign: extend ROBOSIGNATORY_REQUEST_TIMEOUT_SEC

### DIFF
--- a/src/cmd-sign
+++ b/src/cmd-sign
@@ -29,7 +29,7 @@ gi.require_version('OSTree', '1.0')
 from gi.repository import GLib, Gio, OSTree
 
 # this is really the worst case scenario, it's usually pretty fast otherwise
-ROBOSIGNATORY_REQUEST_TIMEOUT_SEC = 60 * 60
+ROBOSIGNATORY_REQUEST_TIMEOUT_SEC = 60 * 60 * 4
 
 fedenv = 'prod'
 


### PR DESCRIPTION
The F36 mass rebuild is going on right now and robosignatory is super
backed up. Let's extend the timeout in an effort to get some build
signing working.