### PR TITLE
Revert "cmd-sign: extend ROBOSIGNATORY_REQUEST_TIMEOUT_SEC"

### DIFF
--- a/src/cmd-sign
+++ b/src/cmd-sign
@@ -29,7 +29,7 @@ gi.require_version('OSTree', '1.0')
 from gi.repository import GLib, Gio, OSTree
 
 # this is really the worst case scenario, it's usually pretty fast otherwise
-ROBOSIGNATORY_REQUEST_TIMEOUT_SEC = 60 * 60 * 4
+ROBOSIGNATORY_REQUEST_TIMEOUT_SEC = 60 * 60
 
 fedenv = 'prod'
 


### PR DESCRIPTION
This reverts commit abd4dc67a7ea6747e70a8f35e0ba84f8aa01c3ac.

Now that the mass rebuild is over we should be OK back with the
old robosignatory timeouts.