### PR TITLE
mantle/{kola,platform}: include Ignition runtime in test timer

### DIFF
--- a/mantle/platform/machine/aws/cluster.go
+++ b/mantle/platform/machine/aws/cluster.go
@@ -106,9 +106,13 @@ func (ac *cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 		return nil, err
 	}
 
-	if err := platform.StartMachine(mach, mach.journal); err != nil {
-		mach.Destroy()
-		return nil, err
+	// Run StartMachine, which blocks on the machine being booted up enough
+	// for SSH access, but only if the caller didn't tell us not to.
+	if !options.SkipStartMachine {
+		if err := platform.StartMachine(mach, mach.journal); err != nil {
+			mach.Destroy()
+			return nil, err
+		}
 	}
 
 	ac.AddMach(mach)

--- a/mantle/platform/machine/aws/machine.go
+++ b/mantle/platform/machine/aws/machine.go
@@ -68,6 +68,10 @@ func (am *machine) IgnitionError() error {
 	return nil
 }
 
+func (am *machine) Start() error {
+	return platform.StartMachine(am, am.journal)
+}
+
 func (am *machine) Reboot() error {
 	return platform.RebootMachine(am, am.journal)
 }

--- a/mantle/platform/machine/azure/cluster.go
+++ b/mantle/platform/machine/azure/cluster.go
@@ -40,6 +40,23 @@ func (ac *cluster) vmname() string {
 }
 
 func (ac *cluster) NewMachine(userdata *conf.UserData) (platform.Machine, error) {
+	return ac.NewMachineWithOptions(userdata, platform.MachineOptions{})
+}
+
+func (ac *cluster) NewMachineWithOptions(userdata *conf.UserData, options platform.MachineOptions) (platform.Machine, error) {
+	if len(options.AdditionalDisks) > 0 {
+		return nil, errors.New("platform azure does not yet support additional disks")
+	}
+	if options.MultiPathDisk {
+		return nil, errors.New("platform azure does not support multipathed disks")
+	}
+	if options.AdditionalNics > 0 {
+		return nil, errors.New("platform azure does not support additional nics")
+	}
+	if options.AppendKernelArgs != "" {
+		return nil, errors.New("platform azure does not support appending kernel arguments")
+	}
+
 	conf, err := ac.RenderUserData(userdata, map[string]string{
 		"$private_ipv4": "${COREOS_AZURE_IPV4_DYNAMIC}",
 	})
@@ -87,22 +104,6 @@ func (ac *cluster) NewMachine(userdata *conf.UserData) (platform.Machine, error)
 	ac.AddMach(mach)
 
 	return mach, nil
-}
-
-func (ac *cluster) NewMachineWithOptions(userdata *conf.UserData, options platform.MachineOptions) (platform.Machine, error) {
-	if len(options.AdditionalDisks) > 0 {
-		return nil, errors.New("platform azure does not yet support additional disks")
-	}
-	if options.MultiPathDisk {
-		return nil, errors.New("platform azure does not support multipathed disks")
-	}
-	if options.AdditionalNics > 0 {
-		return nil, errors.New("platform azure does not support additional nics")
-	}
-	if options.AppendKernelArgs != "" {
-		return nil, errors.New("platform azure does not support appending kernel arguments")
-	}
-	return ac.NewMachine(userdata)
 }
 
 func (ac *cluster) Destroy() {

--- a/mantle/platform/machine/azure/cluster.go
+++ b/mantle/platform/machine/azure/cluster.go
@@ -96,9 +96,13 @@ func (ac *cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 		return nil, err
 	}
 
-	if err := platform.StartMachine(mach, mach.journal); err != nil {
-		mach.Destroy()
-		return nil, err
+	// Run StartMachine, which blocks on the machine being booted up enough
+	// for SSH access, but only if the caller didn't tell us not to.
+	if !options.SkipStartMachine {
+		if err := platform.StartMachine(mach, mach.journal); err != nil {
+			mach.Destroy()
+			return nil, err
+		}
 	}
 
 	ac.AddMach(mach)

--- a/mantle/platform/machine/azure/machine.go
+++ b/mantle/platform/machine/azure/machine.go
@@ -88,6 +88,10 @@ func (am *machine) refetchIPs() error {
 	return nil
 }
 
+func (am *machine) Start() error {
+	return platform.StartMachine(am, am.journal)
+}
+
 func (am *machine) Reboot() error {
 	err := platform.RebootMachine(am, am.journal)
 	if err != nil {

--- a/mantle/platform/machine/do/cluster.go
+++ b/mantle/platform/machine/do/cluster.go
@@ -33,6 +33,23 @@ type cluster struct {
 }
 
 func (dc *cluster) NewMachine(userdata *conf.UserData) (platform.Machine, error) {
+	return dc.NewMachineWithOptions(userdata, platform.MachineOptions{})
+}
+
+func (dc *cluster) NewMachineWithOptions(userdata *conf.UserData, options platform.MachineOptions) (platform.Machine, error) {
+	if len(options.AdditionalDisks) > 0 {
+		return nil, errors.New("platform do does not yet support additional disks")
+	}
+	if options.MultiPathDisk {
+		return nil, errors.New("platform do does not support multipathed disks")
+	}
+	if options.AdditionalNics > 0 {
+		return nil, errors.New("platform do does not support additional nics")
+	}
+	if options.AppendKernelArgs != "" {
+		return nil, errors.New("platform do does not support appending kernel arguments")
+	}
+
 	conf, err := dc.RenderUserData(userdata, map[string]string{
 		"$public_ipv4":  "${COREOS_DIGITALOCEAN_IPV4_PUBLIC_0}",
 		"$private_ipv4": "${COREOS_DIGITALOCEAN_IPV4_PRIVATE_0}",
@@ -86,22 +103,6 @@ func (dc *cluster) NewMachine(userdata *conf.UserData) (platform.Machine, error)
 	dc.AddMach(mach)
 
 	return mach, nil
-}
-
-func (dc *cluster) NewMachineWithOptions(userdata *conf.UserData, options platform.MachineOptions) (platform.Machine, error) {
-	if len(options.AdditionalDisks) > 0 {
-		return nil, errors.New("platform do does not yet support additional disks")
-	}
-	if options.MultiPathDisk {
-		return nil, errors.New("platform do does not support multipathed disks")
-	}
-	if options.AdditionalNics > 0 {
-		return nil, errors.New("platform do does not support additional nics")
-	}
-	if options.AppendKernelArgs != "" {
-		return nil, errors.New("platform do does not support appending kernel arguments")
-	}
-	return dc.NewMachine(userdata)
 }
 
 func (dc *cluster) vmname() string {

--- a/mantle/platform/machine/do/cluster.go
+++ b/mantle/platform/machine/do/cluster.go
@@ -95,9 +95,13 @@ func (dc *cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 		return nil, err
 	}
 
-	if err := platform.StartMachine(mach, mach.journal); err != nil {
-		mach.Destroy()
-		return nil, err
+	// Run StartMachine, which blocks on the machine being booted up enough
+	// for SSH access, but only if the caller didn't tell us not to.
+	if !options.SkipStartMachine {
+		if err := platform.StartMachine(mach, mach.journal); err != nil {
+			mach.Destroy()
+			return nil, err
+		}
 	}
 
 	dc.AddMach(mach)

--- a/mantle/platform/machine/do/machine.go
+++ b/mantle/platform/machine/do/machine.go
@@ -65,6 +65,10 @@ func (dm *machine) IgnitionError() error {
 	return nil
 }
 
+func (dm *machine) Start() error {
+	return platform.StartMachine(dm, dm.journal)
+}
+
 func (dm *machine) Reboot() error {
 	return platform.RebootMachine(dm, dm.journal)
 }

--- a/mantle/platform/machine/esx/cluster.go
+++ b/mantle/platform/machine/esx/cluster.go
@@ -37,6 +37,23 @@ func (ec *cluster) vmname() string {
 }
 
 func (ec *cluster) NewMachine(userdata *platformConf.UserData) (platform.Machine, error) {
+	return ec.NewMachineWithOptions(userdata, platform.MachineOptions{})
+}
+
+func (ec *cluster) NewMachineWithOptions(userdata *platformConf.UserData, options platform.MachineOptions) (platform.Machine, error) {
+	if len(options.AdditionalDisks) > 0 {
+		return nil, errors.New("platform esx does not yet support additional disks")
+	}
+	if options.MultiPathDisk {
+		return nil, errors.New("platform esx does not support multipathed disks")
+	}
+	if options.AdditionalNics > 0 {
+		return nil, errors.New("platform esx does not support additional nics")
+	}
+	if options.AppendKernelArgs != "" {
+		return nil, errors.New("platform esx does not support appending kernel arguments")
+	}
+
 	conf, err := ec.RenderUserData(userdata, map[string]string{
 		"$public_ipv4":  "${COREOS_ESX_IPV4_PUBLIC_0}",
 		"$private_ipv4": "${COREOS_ESX_IPV4_PRIVATE_0}",
@@ -89,22 +106,6 @@ ExecStart=/usr/bin/bash -c 'echo "COREOS_ESX_IPV4_PRIVATE_0=$(ip addr show ens19
 	ec.AddMach(mach)
 
 	return mach, nil
-}
-
-func (ec *cluster) NewMachineWithOptions(userdata *platformConf.UserData, options platform.MachineOptions) (platform.Machine, error) {
-	if len(options.AdditionalDisks) > 0 {
-		return nil, errors.New("platform esx does not yet support additional disks")
-	}
-	if options.MultiPathDisk {
-		return nil, errors.New("platform esx does not support multipathed disks")
-	}
-	if options.AdditionalNics > 0 {
-		return nil, errors.New("platform esx does not support additional nics")
-	}
-	if options.AppendKernelArgs != "" {
-		return nil, errors.New("platform esx does not support appending kernel arguments")
-	}
-	return ec.NewMachine(userdata)
 }
 
 func (ec *cluster) Destroy() {

--- a/mantle/platform/machine/esx/cluster.go
+++ b/mantle/platform/machine/esx/cluster.go
@@ -98,9 +98,13 @@ ExecStart=/usr/bin/bash -c 'echo "COREOS_ESX_IPV4_PRIVATE_0=$(ip addr show ens19
 		return nil, err
 	}
 
-	if err := platform.StartMachine(mach, mach.journal); err != nil {
-		mach.Destroy()
-		return nil, err
+	// Run StartMachine, which blocks on the machine being booted up enough
+	// for SSH access, but only if the caller didn't tell us not to.
+	if !options.SkipStartMachine {
+		if err := platform.StartMachine(mach, mach.journal); err != nil {
+			mach.Destroy()
+			return nil, err
+		}
 	}
 
 	ec.AddMach(mach)

--- a/mantle/platform/machine/esx/machine.go
+++ b/mantle/platform/machine/esx/machine.go
@@ -66,6 +66,10 @@ func (em *machine) IgnitionError() error {
 	return nil
 }
 
+func (em *machine) Start() error {
+	return platform.StartMachine(em, em.journal)
+}
+
 func (em *machine) Reboot() error {
 	return platform.RebootMachine(em, em.journal)
 }

--- a/mantle/platform/machine/gcloud/cluster.go
+++ b/mantle/platform/machine/gcloud/cluster.go
@@ -97,9 +97,13 @@ func (gc *cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 		return nil, err
 	}
 
-	if err := platform.StartMachine(gm, gm.journal); err != nil {
-		gm.Destroy()
-		return nil, err
+	// Run StartMachine, which blocks on the machine being booted up enough
+	// for SSH access, but only if the caller didn't tell us not to.
+	if !options.SkipStartMachine {
+		if err := platform.StartMachine(gm, gm.journal); err != nil {
+			gm.Destroy()
+			return nil, err
+		}
 	}
 
 	gc.AddMach(gm)

--- a/mantle/platform/machine/gcloud/cluster.go
+++ b/mantle/platform/machine/gcloud/cluster.go
@@ -32,8 +32,24 @@ type cluster struct {
 	flight *flight
 }
 
-// Calling in parallel is ok
 func (gc *cluster) NewMachine(userdata *conf.UserData) (platform.Machine, error) {
+	return gc.NewMachineWithOptions(userdata, platform.MachineOptions{})
+}
+
+func (gc *cluster) NewMachineWithOptions(userdata *conf.UserData, options platform.MachineOptions) (platform.Machine, error) {
+	if len(options.AdditionalDisks) > 0 {
+		return nil, errors.New("platform gce does not yet support additional disks")
+	}
+	if options.MultiPathDisk {
+		return nil, errors.New("platform gce does not support multipathed disks")
+	}
+	if options.AdditionalNics > 0 {
+		return nil, errors.New("platform gce does not support additional nics")
+	}
+	if options.AppendKernelArgs != "" {
+		return nil, errors.New("platform gce does not support appending kernel arguments")
+	}
+
 	conf, err := gc.RenderUserData(userdata, map[string]string{
 		"$public_ipv4":  "${COREOS_GCE_IP_EXTERNAL_0}",
 		"$private_ipv4": "${COREOS_GCE_IP_LOCAL_0}",
@@ -89,22 +105,6 @@ func (gc *cluster) NewMachine(userdata *conf.UserData) (platform.Machine, error)
 	gc.AddMach(gm)
 
 	return gm, nil
-}
-
-func (gc *cluster) NewMachineWithOptions(userdata *conf.UserData, options platform.MachineOptions) (platform.Machine, error) {
-	if len(options.AdditionalDisks) > 0 {
-		return nil, errors.New("platform gce does not yet support additional disks")
-	}
-	if options.MultiPathDisk {
-		return nil, errors.New("platform gce does not support multipathed disks")
-	}
-	if options.AdditionalNics > 0 {
-		return nil, errors.New("platform gce does not support additional nics")
-	}
-	if options.AppendKernelArgs != "" {
-		return nil, errors.New("platform gce does not support appending kernel arguments")
-	}
-	return gc.NewMachine(userdata)
 }
 
 func (gc *cluster) Destroy() {

--- a/mantle/platform/machine/gcloud/machine.go
+++ b/mantle/platform/machine/gcloud/machine.go
@@ -66,6 +66,10 @@ func (gm *machine) IgnitionError() error {
 	return nil
 }
 
+func (gm *machine) Start() error {
+	return platform.StartMachine(gm, gm.journal)
+}
+
 func (gm *machine) Reboot() error {
 	return platform.RebootMachine(gm, gm.journal)
 }

--- a/mantle/platform/machine/openstack/cluster.go
+++ b/mantle/platform/machine/openstack/cluster.go
@@ -87,9 +87,13 @@ func (oc *cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 		return nil, err
 	}
 
-	if err := platform.StartMachine(mach, mach.journal); err != nil {
-		mach.Destroy()
-		return nil, err
+	// Run StartMachine, which blocks on the machine being booted up enough
+	// for SSH access, but only if the caller didn't tell us not to.
+	if !options.SkipStartMachine {
+		if err := platform.StartMachine(mach, mach.journal); err != nil {
+			mach.Destroy()
+			return nil, err
+		}
 	}
 
 	oc.AddMach(mach)

--- a/mantle/platform/machine/openstack/cluster.go
+++ b/mantle/platform/machine/openstack/cluster.go
@@ -31,6 +31,23 @@ type cluster struct {
 }
 
 func (oc *cluster) NewMachine(userdata *conf.UserData) (platform.Machine, error) {
+	return oc.NewMachineWithOptions(userdata, platform.MachineOptions{})
+}
+
+func (oc *cluster) NewMachineWithOptions(userdata *conf.UserData, options platform.MachineOptions) (platform.Machine, error) {
+	if len(options.AdditionalDisks) > 0 {
+		return nil, errors.New("platform openstack does not yet support additional disks")
+	}
+	if options.MultiPathDisk {
+		return nil, errors.New("platform openstack does not support multipathed disks")
+	}
+	if options.AdditionalNics > 0 {
+		return nil, errors.New("platform openstack does not support additional nics")
+	}
+	if options.AppendKernelArgs != "" {
+		return nil, errors.New("platform openstack does not support appending kernel arguments")
+	}
+
 	conf, err := oc.RenderUserData(userdata, map[string]string{
 		"$public_ipv4":  "${COREOS_OPENSTACK_IPV4_PUBLIC}",
 		"$private_ipv4": "${COREOS_OPENSTACK_IPV4_LOCAL}",
@@ -78,22 +95,6 @@ func (oc *cluster) NewMachine(userdata *conf.UserData) (platform.Machine, error)
 	oc.AddMach(mach)
 
 	return mach, nil
-}
-
-func (oc *cluster) NewMachineWithOptions(userdata *conf.UserData, options platform.MachineOptions) (platform.Machine, error) {
-	if len(options.AdditionalDisks) > 0 {
-		return nil, errors.New("platform openstack does not yet support additional disks")
-	}
-	if options.MultiPathDisk {
-		return nil, errors.New("platform openstack does not support multipathed disks")
-	}
-	if options.AdditionalNics > 0 {
-		return nil, errors.New("platform openstack does not support additional nics")
-	}
-	if options.AppendKernelArgs != "" {
-		return nil, errors.New("platform openstack does not support appending kernel arguments")
-	}
-	return oc.NewMachine(userdata)
 }
 
 func (oc *cluster) vmname() string {

--- a/mantle/platform/machine/openstack/machine.go
+++ b/mantle/platform/machine/openstack/machine.go
@@ -87,6 +87,10 @@ func (om *machine) IgnitionError() error {
 	return nil
 }
 
+func (om *machine) Start() error {
+	return platform.StartMachine(om, om.journal)
+}
+
 func (om *machine) Reboot() error {
 	return platform.RebootMachine(om, om.journal)
 }

--- a/mantle/platform/machine/packet/cluster.go
+++ b/mantle/platform/machine/packet/cluster.go
@@ -33,6 +33,23 @@ type cluster struct {
 }
 
 func (pc *cluster) NewMachine(userdata *conf.UserData) (platform.Machine, error) {
+	return pc.NewMachineWithOptions(userdata, platform.MachineOptions{})
+}
+
+func (pc *cluster) NewMachineWithOptions(userdata *conf.UserData, options platform.MachineOptions) (platform.Machine, error) {
+	if len(options.AdditionalDisks) > 0 {
+		return nil, errors.New("platform packet does not yet support additional disks")
+	}
+	if options.MultiPathDisk {
+		return nil, errors.New("platform packet does not support multipathed disks")
+	}
+	if options.AdditionalNics > 0 {
+		return nil, errors.New("platform packet does not support additional nics")
+	}
+	if options.AppendKernelArgs != "" {
+		return nil, errors.New("platform packet does not support appending kernel arguments")
+	}
+
 	conf, err := pc.RenderUserData(userdata, map[string]string{
 		"$public_ipv4":  "${COREOS_PACKET_IPV4_PUBLIC_0}",
 		"$private_ipv4": "${COREOS_PACKET_IPV4_PRIVATE_0}",
@@ -110,22 +127,6 @@ func (pc *cluster) NewMachine(userdata *conf.UserData) (platform.Machine, error)
 	pc.AddMach(mach)
 
 	return mach, nil
-}
-
-func (pc *cluster) NewMachineWithOptions(userdata *conf.UserData, options platform.MachineOptions) (platform.Machine, error) {
-	if len(options.AdditionalDisks) > 0 {
-		return nil, errors.New("platform packet does not yet support additional disks")
-	}
-	if options.MultiPathDisk {
-		return nil, errors.New("platform packet does not support multipathed disks")
-	}
-	if options.AdditionalNics > 0 {
-		return nil, errors.New("platform packet does not support additional nics")
-	}
-	if options.AppendKernelArgs != "" {
-		return nil, errors.New("platform packet does not support appending kernel arguments")
-	}
-	return pc.NewMachine(userdata)
 }
 
 func (pc *cluster) vmname() string {

--- a/mantle/platform/machine/packet/cluster.go
+++ b/mantle/platform/machine/packet/cluster.go
@@ -119,9 +119,13 @@ func (pc *cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 		return nil, err
 	}
 
-	if err := platform.StartMachine(mach, mach.journal); err != nil {
-		mach.Destroy()
-		return nil, err
+	// Run StartMachine, which blocks on the machine being booted up enough
+	// for SSH access, but only if the caller didn't tell us not to.
+	if !options.SkipStartMachine {
+		if err := platform.StartMachine(mach, mach.journal); err != nil {
+			mach.Destroy()
+			return nil, err
+		}
 	}
 
 	pc.AddMach(mach)

--- a/mantle/platform/machine/packet/machine.go
+++ b/mantle/platform/machine/packet/machine.go
@@ -65,6 +65,10 @@ func (pm *machine) IgnitionError() error {
 	return nil
 }
 
+func (pm *machine) Start() error {
+	return platform.StartMachine(pm, pm.journal)
+}
+
 func (pm *machine) Reboot() error {
 	return platform.RebootMachine(pm, pm.journal)
 }

--- a/mantle/platform/machine/qemuiso/cluster.go
+++ b/mantle/platform/machine/qemuiso/cluster.go
@@ -155,9 +155,13 @@ func (qc *Cluster) NewMachineWithQemuOptions(userdata *conf.UserData, options pl
 		return nil, err
 	}
 
-	if err := platform.StartMachine(qm, qm.journal); err != nil {
-		qm.Destroy()
-		return nil, err
+	// Run StartMachine, which blocks on the machine being booted up enough
+	// for SSH access, but only if the caller didn't tell us not to.
+	if !options.SkipStartMachine {
+		if err := platform.StartMachine(qm, qm.journal); err != nil {
+			qm.Destroy()
+			return nil, err
+		}
 	}
 
 	qc.AddMach(qm)

--- a/mantle/platform/machine/qemuiso/machine.go
+++ b/mantle/platform/machine/qemuiso/machine.go
@@ -75,6 +75,10 @@ func (m *machine) IgnitionError() error {
 	return errors.New(buf)
 }
 
+func (m *machine) Start() error {
+	return platform.StartMachine(m, m.journal)
+}
+
 func (m *machine) Reboot() error {
 	return platform.RebootMachine(m, m.journal)
 }

--- a/mantle/platform/machine/unprivqemu/cluster.go
+++ b/mantle/platform/machine/unprivqemu/cluster.go
@@ -185,9 +185,13 @@ func (qc *Cluster) NewMachineWithQemuOptions(userdata *conf.UserData, options pl
 		return nil, err
 	}
 
-	if err := platform.StartMachine(qm, qm.journal); err != nil {
-		qm.Destroy()
-		return nil, err
+	// Run StartMachine, which blocks on the machine being booted up enough
+	// for SSH access, but only if the caller didn't tell us not to.
+	if !options.SkipStartMachine {
+		if err := platform.StartMachine(qm, qm.journal); err != nil {
+			qm.Destroy()
+			return nil, err
+		}
 	}
 
 	qc.AddMach(qm)

--- a/mantle/platform/machine/unprivqemu/machine.go
+++ b/mantle/platform/machine/unprivqemu/machine.go
@@ -75,6 +75,10 @@ func (m *machine) IgnitionError() error {
 	return errors.New(buf)
 }
 
+func (m *machine) Start() error {
+	return platform.StartMachine(m, m.journal)
+}
+
 func (m *machine) Reboot() error {
 	return platform.RebootMachine(m, m.journal)
 }

--- a/mantle/platform/platform.go
+++ b/mantle/platform/platform.go
@@ -68,6 +68,9 @@ type Machine interface {
 	// SSH runs a single command over a new SSH connection.
 	SSH(cmd string) ([]byte, []byte, error)
 
+	// Start sets up the journal and performs sanity checks via platform.StartMachine().
+	Start() error
+
 	// Reboot restarts the machine and waits for it to come back.
 	Reboot() error
 
@@ -152,6 +155,7 @@ type MachineOptions struct {
 	MinDiskSize      int
 	AdditionalNics   int
 	AppendKernelArgs string
+	SkipStartMachine bool // Skip platform.StartMachine on machine bringup
 }
 
 // SystemdDropin is a userdata type agnostic struct representing a systemd dropin

--- a/mantle/platform/platform.go
+++ b/mantle/platform/platform.go
@@ -35,12 +35,6 @@ import (
 	"github.com/coreos/mantle/util"
 )
 
-const (
-	// Encryption takes a long time--retry more before failing
-	sshRetries = 60
-	sshTimeout = 10 * time.Second
-)
-
 var (
 	plog = capnslog.NewPackageLogger("github.com/coreos/mantle", "platform")
 )
@@ -452,7 +446,7 @@ func CheckMachine(ctx context.Context, m Machine) error {
 		return nil
 	}
 
-	if err := util.Retry(sshRetries, sshTimeout, sshChecker); err != nil {
+	if err := util.RetryUntilTimeout(10*time.Minute, 10*time.Second, sshChecker); err != nil {
 		return errors.Wrapf(err, "ssh unreachable")
 	}
 

--- a/mantle/util/retry.go
+++ b/mantle/util/retry.go
@@ -57,8 +57,6 @@ func WaitUntilReady(timeout, delay time.Duration, checkFunction func() (bool, er
 		default:
 		}
 
-		time.Sleep(delay)
-
 		// Log how long it took checkFunction to run. This will help gather information about
 		// how long it takes remote API requests (like provisioning machines) to finish.
 		start := time.Now()
@@ -67,10 +65,10 @@ func WaitUntilReady(timeout, delay time.Duration, checkFunction func() (bool, er
 		if err != nil {
 			return err
 		}
-
 		if done {
 			break
 		}
+		time.Sleep(delay)
 	}
 	return nil
 }


### PR DESCRIPTION
There are a few commits in here that should be reviewed individually. THe main commit is

```
mantle/{kola,platform}: include Ignition runtime in test timer

platform.StartMachine() blocks on SSH being available:

StartMachine()
     |-> StartMachineAfterReboot()
         |-> j.Start()
             | -> util.Retry() <- ssh retry

So if we call it as part of our NewMachine() bringup there's
no way to start the test execution timer and have it include
the time it takes to execute Ignition (which has to complete
before SSH will become available).

Let's add a Machine Option (SkipStartMachine) that will tell the
NewMachine code to skip the call to StartMachine() and return as
soon as the platform thinks the machine is running. Then in our
test code we can start the timer and then call StartMachine()
(via the new mach.Start() interface) manually to set up journal
forwarding and perform sanity checks.

This should help with issues like one we had recently [1] where our
timeouts weren't properly timing out. This was because the provider
timeout (implemented via WaitUntilReady()), had already moved out of
that code but the test timeout (via ExecTimer) hadn't started yet
because everything was blocking under StartMachine().

NOTE: This commit doesn't solve the problem for tests that bring up
      machines themselves by calling NewMachine() but should solve it
      for the large majority of tests.

[1] https://github.com/coreos/fedora-coreos-tracker/issues/1066#issuecomment-1009978326
```
