### PR TITLE
schema: sync up shema updates to gangplank vendor dir

### DIFF
--- a/gangplank/vendor/github.com/coreos/coreos-assembler-schema/cosa/cosa_v1.go
+++ b/gangplank/vendor/github.com/coreos/coreos-assembler-schema/cosa/cosa_v1.go
@@ -21,6 +21,7 @@ type Artifact struct {
 	Path               string  `json:"path"`
 	Sha256             string  `json:"sha256"`
 	SizeInBytes        float64 `json:"size,omitempty"`
+	SkipCompression    bool    `json:"skip-compression,omitempty"`
 	UncompressedSha256 string  `json:"uncompressed-sha256,omitempty"`
 	UncompressedSize   int     `json:"uncompressed-size,omitempty"`
 }
@@ -93,6 +94,7 @@ type BuildArtifacts struct {
 	LiveRootfs         *Artifact `json:"live-rootfs,omitempty"`
 	Metal              *Artifact `json:"metal,omitempty"`
 	Metal4KNative      *Artifact `json:"metal4k,omitempty"`
+	Nutanix            *Artifact `json:"nutanix,omitempty"`
 	OpenStack          *Artifact `json:"openstack,omitempty"`
 	Ostree             Artifact  `json:"ostree"`
 	PowerVirtualServer *Artifact `json:"powervs,omitempty"`

--- a/gangplank/vendor/github.com/coreos/coreos-assembler-schema/cosa/schema_doc.go
+++ b/gangplank/vendor/github.com/coreos/coreos-assembler-schema/cosa/schema_doc.go
@@ -23,6 +23,13 @@ var generatedSchemaJSON = `{
              "type":"number",
              "title":"Size in bytes"
             },
+           "skip-compression": {
+             "$id": "#/artifact/skip-compression",
+             "type":"boolean",
+             "title":"Skip compression",
+             "description":"Artifact should not be compressed or decompressed before use",
+             "default":false
+            },
            "uncompressed-sha256": {
              "$id": "#/artifact/uncompressed-sha256",
              "type":"string",
@@ -37,7 +44,8 @@ var generatedSchemaJSON = `{
           "optional": [
               "size",
               "uncompressed-sha256",
-              "uncompressed-size"
+              "uncompressed-size",
+              "skip-compression"
           ],
           "required": [
               "path",
@@ -411,6 +419,7 @@ var generatedSchemaJSON = `{
        "live-rootfs",
        "metal",
        "metal4k",
+       "nutanix",
        "openstack",
        "qemu",
        "vmware",
@@ -495,6 +504,12 @@ var generatedSchemaJSON = `{
          "title":"Live Rootfs",
          "$ref": "#/definitions/artifact"
         },
+        "nutanix": {
+          "$id":"#/properties/images/properties/nutanix",
+          "type":"object",
+          "title":"Nutanix",
+          "$ref": "#/definitions/artifact"
+         }, 
        "openstack": {
          "$id":"#/properties/images/properties/openstack",
          "type":"object",


### PR DESCRIPTION
This gets the vendored schema under gangplank to match
the rest of the copies of the schema. Fixup for 015fd34
(Nutanix platform add) and 1893293 (addition of
skip-compression field).