### PR TITLE
cmdlib: drop support for `overlay.d/cosa-no-autolayer`

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -375,9 +375,6 @@ EOF
     fi
 
     if [ -d "${ovld}" ]; then
-        if [ -e "${ovld}/cosa-no-autolayer" ]; then
-            cosa_no_autolayer=1
-        fi
         for n in "${ovld}"/*; do
             if ! [ -d "${n}" ]; then
                 continue
@@ -386,9 +383,6 @@ EOF
             bn=$(basename "${n}")
             ovlname="overlay/${bn}"
             commit_overlay "${ovlname}" "${n}"
-            if [ -z "${cosa_no_autolayer:-}" ]; then
-                layers="${layers} ${ovlname}"
-            fi
         done
     fi
 


### PR DESCRIPTION
Both RHCOS and FCOS have been migrated now, so we can stop supporting
this. We still need support for injecting OSTree layers since the
`content_sets.yaml` stuff uses it.