### PR TITLE
Revert "cmdlib: drop support for `overlay.d/cosa-no-autolayer`"

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -375,6 +375,9 @@ EOF
     fi
 
     if [ -d "${ovld}" ]; then
+        if [ -e "${ovld}/cosa-no-autolayer" ]; then
+            cosa_no_autolayer=1
+        fi
         for n in "${ovld}"/*; do
             if ! [ -d "${n}" ]; then
                 continue
@@ -383,6 +386,9 @@ EOF
             bn=$(basename "${n}")
             ovlname="overlay/${bn}"
             commit_overlay "${ovlname}" "${n}"
+            if [ -z "${cosa_no_autolayer:-}" ]; then
+                layers="${layers} ${ovlname}"
+            fi
         done
     fi
 


### PR DESCRIPTION
This reverts commit 73a7eb6be0a0a82d2d3478746a53c03e04a9a554.

Because of the classic cosa <--> FCOS binding issue, we actually need to
wait until manifest updates propagate to all the production streams
before we remove support for the previous method.