### PR TITLE
kola/harness.go: fix denylist architecture detection

### DIFF
--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -329,7 +329,8 @@ func parseDenyListYaml(pltfrm string) error {
 	}
 
 	stream := manifest.AddCommitMetadata.FcosStream
-	arch := system.RpmArch()
+	arch := Options.CosaBuildArch
+	plog.Debugf("Arch: %v detected.", arch)
 	today := time.Now()
 
 	// Accumulate patterns filtering by set policies


### PR DESCRIPTION
The denylist logic incorrectly uses the base system architecture 
instead of the architecture that is passed in. Let fix this