### PR TITLE
qemuexec: automatically resize the terminal on serial

### DIFF
--- a/mantle/cmd/kola/qemuexec.go
+++ b/mantle/cmd/kola/qemuexec.go
@@ -78,7 +78,7 @@ func init() {
 	cmdQemuExec.Flags().StringVarP(&knetargs, "knetargs", "", "", "Arguments for Ignition networking on kernel commandline")
 	cmdQemuExec.Flags().StringArrayVar(&kargs, "kargs", nil, "Additional kernel arguments applied")
 	cmdQemuExec.Flags().BoolVarP(&usernet, "usernet", "U", false, "Enable usermode networking")
-	cmdQemuExec.Flags().StringSliceVar(&ignitionFragments, "add-ignition", nil, "Append well-known Ignition fragment: [\"autologin\"]")
+	cmdQemuExec.Flags().StringSliceVar(&ignitionFragments, "add-ignition", nil, "Append well-known Ignition fragment: [\"autologin\", \"autoresize\"]")
 	cmdQemuExec.Flags().StringVarP(&hostname, "hostname", "", "", "Set hostname via DHCP")
 	cmdQemuExec.Flags().IntVarP(&memory, "memory", "m", 0, "Memory in MB")
 	cmdQemuExec.Flags().StringArrayVarP(&addDisks, "add-disk", "D", []string{}, "Additional disk, human readable size (repeatable)")
@@ -103,6 +103,8 @@ func renderFragments(fragments []string, c *conf.Conf) error {
 		switch fragtype {
 		case "autologin":
 			c.AddAutoLogin()
+		case "autoresize":
+			c.AddAutoResize()
 		default:
 			return fmt.Errorf("Unknown fragment: %s", fragtype)
 		}
@@ -158,6 +160,8 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 		if consoleFile != "" {
 			return fmt.Errorf("Cannot use console devshell and --console-to-file")
 		}
+
+		ignitionFragments = append(ignitionFragments, "autoresize")
 	}
 	if devshell {
 		if directIgnition {

--- a/mantle/platform/conf/conf.go
+++ b/mantle/platform/conf/conf.go
@@ -1089,6 +1089,22 @@ func (c *Conf) AddAutoLogin() {
 	c.AddSystemdUnitDropin("serial-getty@.service", "10-autologin.conf", getAutologinUnit("serial-getty@.service", "--keep-baud 115200,38400,9600"))
 }
 
+// AddAutoResize adds an Ignition config for a `resize` function to resize serial consoles
+func (c *Conf) AddAutoResize() {
+	c.AddFile("/etc/profile.d/autoresize.sh", `
+# adapted from https://wiki.archlinux.org/title/Working_with_the_serial_console#Resizing_a_terminal
+resize_terminal() {
+	local IFS='[;' escape geometry x y
+	echo -en '\e7\e[r\e[999;999H\e[6n\e8'
+	read -sd R escape geometry
+	x=${geometry##*;} y=${geometry%%;*}
+	if [[ ${COLUMNS} -ne ${x} || ${LINES} -ne ${y} ]];then
+		stty cols ${x} rows ${y}
+	fi
+}
+PROMPT_COMMAND+=(resize_terminal)`, 0644)
+}
+
 // Mount9p adds an Ignition config to mount an folder with 9p
 func (c *Conf) Mount9p(dest string, readonly bool) {
 	readonlyStr := ""


### PR DESCRIPTION
One really annoying thing when using the serial console is that you have
to manually set (and update if you resize your terminal) the terminal
size.

I found
https://wiki.archlinux.org/title/Working_with_the_serial_console#Resizing_a_terminal
which has a function to resize the terminal which seems to work well. It
doesn't fix everything (e.g. you still get commands overwriting each
other if it gets too long), but helps a lot with for example command
output.

Create a new `autoresize` Ignition fragment which shoves a Bash-adapted
version of the function in a `profile.d` dropin and gets called on every
command prompt.  Automatically inject the fragment when using serial
console devshell.