### PR TITLE
mantle/kola/tests: re-enable RAID tests on aarch64/ppc64le

### DIFF
--- a/mantle/kola/tests/misc/boot-mirror.go
+++ b/mantle/kola/tests/misc/boot-mirror.go
@@ -60,10 +60,8 @@ func init() {
 		ClusterSize: 0,
 		Name:        `coreos.boot-mirror`,
 		Platforms:   []string{"qemu-unpriv"},
-		// aarch64 and ppc64le have buggy partition layouts
-		// https://github.com/coreos/fedora-coreos-tracker/issues/855#issuecomment-896387343
 		// Can't mirror boot disk on s390x
-		ExcludeArchitectures: []string{"aarch64", "ppc64le", "s390x"},
+		ExcludeArchitectures: []string{"s390x"},
 		// skipping this test on UEFI until https://github.com/coreos/coreos-assembler/issues/2039
 		// gets resolved.
 		ExcludeFirmwares: []string{"uefi"},
@@ -76,11 +74,9 @@ func init() {
 		ClusterSize: 0,
 		Name:        `coreos.boot-mirror.luks`,
 		Platforms:   []string{"qemu-unpriv"},
-		// aarch64 and ppc64le have buggy partition layouts
-		// https://github.com/coreos/fedora-coreos-tracker/issues/855#issuecomment-896387343
 		// Can't mirror boot disk on s390x, and qemu s390x doesn't
 		// support TPM
-		ExcludeArchitectures: []string{"aarch64", "ppc64le", "s390x"},
+		ExcludeArchitectures: []string{"s390x"},
 		// skipping this test on UEFI until https://github.com/coreos/coreos-assembler/issues/2039
 		// gets resolved.
 		ExcludeFirmwares: []string{"uefi"},


### PR DESCRIPTION
As of https://github.com/coreos/butane/pull/278 in Butane 0.14.0, Butane RAID templates now create reserved partitions on aarch64 and ppc64le to keep partition numbers aligned across platforms.

Fixes https://github.com/coreos/fedora-coreos-tracker/issues/855.  Reverts #2354.