### PR TITLE
mantle/aliyun: add tags when doing ImportImage

### DIFF
--- a/mantle/platform/api/aliyun/api.go
+++ b/mantle/platform/api/aliyun/api.go
@@ -215,6 +215,12 @@ func (a *API) ImportImage(format, bucket, object, image_size, device, name, desc
 	request.ImageName = name
 	request.Description = description
 	request.Architecture = architecture
+	request.Tag = &[]ecs.ImportImageTag{
+		{
+			Key:   "created-by",
+			Value: "mantle",
+		},
+	}
 
 	plog.Infof("importing image")
 	response, err := a.ecs.ImportImage(request)


### PR DESCRIPTION
This adds tags indicating that `mantle` created the image in the
Aliyun cloud. This matches the behavior when we do `CopyImage()`
during replication operations and makes the discoverability of images
uploaded via `mantle`/`ore` easier.