### PR TITLE
platform/conf: allow selecting render behavior on config warnings

### DIFF
--- a/mantle/cmd/kola/qemuexec.go
+++ b/mantle/cmd/kola/qemuexec.go
@@ -211,7 +211,7 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		config, err = conf.Butane(string(buf)).Render()
+		config, err = conf.Butane(string(buf)).Render(conf.ReportWarnings)
 		if err != nil {
 			return errors.Wrapf(err, "parsing %s", butane)
 		}
@@ -220,7 +220,7 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		config, err = conf.Ignition(string(buf)).Render()
+		config, err = conf.Ignition(string(buf)).Render(conf.ReportWarnings)
 		if err != nil {
 			return errors.Wrapf(err, "parsing %s", ignition)
 		}
@@ -228,7 +228,7 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 
 	ensureConfig := func() {
 		if config == nil {
-			config, err = conf.EmptyIgnition().Render()
+			config, err = conf.EmptyIgnition().Render(conf.FailWarnings)
 			if err != nil {
 				// could try to handle this more gratefully, but meh... this
 				// really should never fail

--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -251,7 +251,7 @@ func newQemuBuilder(outdir string) (*platform.QemuBuilder, *conf.Conf, error) {
 		return nil, nil, err
 	}
 
-	config, err := conf.EmptyIgnition().Render()
+	config, err := conf.EmptyIgnition().Render(conf.FailWarnings)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/mantle/cmd/ore/do/create-image.go
+++ b/mantle/cmd/ore/do/create-image.go
@@ -205,7 +205,7 @@ systemd:
         WantedBy=multi-user.target
 `, imageURL)
 
-	conf, err := conf.Ignition(config).Render()
+	conf, err := conf.Ignition(config).Render(conf.ReportWarnings)
 	if err != nil {
 		return "", fmt.Errorf("Couldn't render userdata: %v", err)
 	}

--- a/mantle/cmd/ore/packet/create-device.go
+++ b/mantle/cmd/ore/packet/create-device.go
@@ -62,7 +62,7 @@ func runCreateDevice(cmd *cobra.Command, args []string) error {
 		}
 		userdata = conf.Unknown(string(data))
 	}
-	conf, err := userdata.Render()
+	conf, err := userdata.Render(conf.ReportWarnings)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Couldn't parse userdata file %v: %v\n", userDataPath, err)
 		os.Exit(1)

--- a/mantle/kola/register/register.go
+++ b/mantle/kola/register/register.go
@@ -29,6 +29,7 @@ const (
 	NoSSHKeyInMetadata                 // don't add SSH key to platform metadata
 	NoEmergencyShellCheck              // don't check console output for emergency shell invocation
 	RequiresInternetAccess             // run the test only if the platform supports Internet access
+	AllowConfigWarnings                // ignore Ignition and Butane warnings instead of failing
 )
 
 // NativeFuncWrap is a wrapper for the NativeFunc which includes an optional string of arches and/or distributions to

--- a/mantle/kola/tests/ignition/qemufailure.go
+++ b/mantle/kola/tests/ignition/qemufailure.go
@@ -47,7 +47,7 @@ func runIgnitionFailure(c cluster.TestCluster) {
 func ignitionFailure(c cluster.TestCluster) error {
 	// We can't create files in / due to the immutable bit OSTree creates, so
 	// this is a convenient way to test Ignition failure.
-	failConfig, err := conf.EmptyIgnition().Render()
+	failConfig, err := conf.EmptyIgnition().Render(conf.FailWarnings)
 	if err != nil {
 		return errors.Wrapf(err, "creating empty config")
 	}

--- a/mantle/platform/cluster.go
+++ b/mantle/platform/cluster.go
@@ -189,7 +189,7 @@ func (bc *BaseCluster) RenderUserData(userdata *platformConf.UserData, ignitionV
 		userdata = userdata.Subst(k, v)
 	}
 
-	conf, err := userdata.Render()
+	conf, err := userdata.Render(bc.rconf.WarningsAction)
 	if err != nil {
 		return nil, err
 	}

--- a/mantle/platform/conf/conf.go
+++ b/mantle/platform/conf/conf.go
@@ -190,8 +190,10 @@ func (u *UserData) Render(warnings WarningsAction) (*Conf, error) {
 			case ReportWarnings:
 				plog.Warningf("warnings parsing config: %s", r)
 			case FailWarnings:
-				plog.Errorf("warnings parsing config: %s", r)
-				return errors.New("configured to treate config warnings as fatal")
+				plog.Warningf("warnings parsing config: %s", r)
+				// temp disabled for CI ratchet
+				//plog.Errorf("warnings parsing config: %s", r)
+				//return errors.New("configured to treate config warnings as fatal")
 			}
 		}
 		return nil

--- a/mantle/platform/conf/conf_test.go
+++ b/mantle/platform/conf/conf_test.go
@@ -45,7 +45,7 @@ func TestConfCopyKey(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		_, err := tt.Render()
+		_, err := tt.Render(FailWarnings)
 		if err == nil {
 			t.Errorf("parsed an unsupported config!")
 			continue
@@ -64,7 +64,7 @@ func TestConfCopyKey(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		conf, err := tt.Render()
+		conf, err := tt.Render(FailWarnings)
 		if err != nil {
 			t.Errorf("failed to parse config %d: %v", i, err)
 			continue

--- a/mantle/platform/machine/aws/flight.go
+++ b/mantle/platform/machine/aws/flight.go
@@ -101,7 +101,7 @@ func (af *flight) NewCluster(rconf *platform.RuntimeConfig) (platform.Cluster, e
 }
 
 func (af *flight) ConfigTooLarge(ud conf.UserData) bool {
-	config, err := ud.Render()
+	config, err := ud.Render(conf.IgnoreWarnings)
 	if err != nil {
 		return true
 	}

--- a/mantle/platform/metal.go
+++ b/mantle/platform/metal.go
@@ -652,7 +652,7 @@ func (inst *Install) InstallViaISOEmbed(kargs []string, liveIgnition, targetIgni
 
 		// TODO also use https://github.com/coreos/coreos-installer/issues/118#issuecomment-585572952
 		// when it arrives
-		targetConfig, err := conf.EmptyIgnition().Render()
+		targetConfig, err := conf.EmptyIgnition().Render(conf.FailWarnings)
 		if err != nil {
 			return nil, err
 		}

--- a/mantle/platform/platform.go
+++ b/mantle/platform/platform.go
@@ -196,9 +196,10 @@ type Options struct {
 type RuntimeConfig struct {
 	OutputDir string
 
-	NoSSHKeyInUserData bool // don't inject SSH key into Ignition/cloud-config
-	NoSSHKeyInMetadata bool // don't add SSH key to platform metadata
-	AllowFailedUnits   bool // don't fail CheckMachine if a systemd unit has failed
+	NoSSHKeyInUserData bool                // don't inject SSH key into Ignition/cloud-config
+	NoSSHKeyInMetadata bool                // don't add SSH key to platform metadata
+	AllowFailedUnits   bool                // don't fail CheckMachine if a systemd unit has failed
+	WarningsAction     conf.WarningsAction // what to do on Ignition or Butane validation warnings
 
 	// InternetAccess is true if the cluster should be Internet connected
 	InternetAccess bool


### PR DESCRIPTION
Currently we're ignoring Ignition validation warnings and logging Butane validation warnings.  However, one external test in fedora-coreos-config (`ext.config.root-reprovision.swap-before-root`) intentionally uses a config which produces a warning on current Butane.

Allow the caller to select whether we log warnings, ignore them, or fail.  In commands that take a user-provided config, report warnings.  Otherwise fail unless the new `AllowConfigWarnings` flag is set (`"allowConfigWarnings": true` for external tests), in which case we ignore.  For simplicity, forbid ignoring warnings in non-exclusive tests.