### PR TITLE
build: Drop hardcoded `--cmd`, add more metadata into exported container

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -402,7 +402,14 @@ else
             ;;
         null|oci)
             ostree_tarfile_path="${name}-${buildid}-ostree.${basearch}.ociarchive"
-            ostree container encapsulate --repo="${tmprepo}" "${buildid}" oci-archive:"${ostree_tarfile_path}".tmp:latest
+            gitsrc=$(jq -r .git.origin < "${PWD}/coreos-assembler-config-git.json")
+            runv ostree container encapsulate --repo="${tmprepo}" \
+                --label="coreos-assembler.image-config-checksum=${image_config_checksum}" \
+                --label="coreos-assembler.image-input-checksum=${image_input_checksum}" \
+                --label="org.opencontainers.image.source=${gitsrc}" \
+                --label="org.opencontainers.image.revision=${config_gitrev}" \
+                "${buildid}" \
+                oci-archive:"${ostree_tarfile_path}".tmp:latest
             ;;
         *) fatal "Unknown ostree-format: ${ostree_format}"
     esac

--- a/src/cmd-build
+++ b/src/cmd-build
@@ -402,7 +402,7 @@ else
             ;;
         null|oci)
             ostree_tarfile_path="${name}-${buildid}-ostree.${basearch}.ociarchive"
-            ostree container 'export' --cmd /usr/bin/bash --repo="${tmprepo}" "${buildid}" oci-archive:"${ostree_tarfile_path}".tmp:latest
+            ostree container encapsulate --repo="${tmprepo}" "${buildid}" oci-archive:"${ostree_tarfile_path}".tmp:latest
             ;;
         *) fatal "Unknown ostree-format: ${ostree_format}"
     esac

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -30,6 +30,12 @@ fatal() {
     exit 1
 }
 
+# Execute a command, also writing the cmdline to stdout
+runv() {
+    echo "Running: " "$@"
+    "$@"
+}
+
 # Get target base architecture
 basearch=$(python3 -c '
 import gi


### PR DESCRIPTION
build: Drop hardcoded `--cmd /usr/bin/bash`

Depends https://github.com/coreos/fedora-coreos-config/pull/1484

Also while we have the patient open, use the new preferred verb
`encapsulate` instead of `export`.

---

build: Add more metadata into exported container

Today we gather the input config git repository and commit hash
and inject them into our homegrown object-storage+JSON schema.

But OCI containers have standard annotations for this, so inject
that.

Also, include the image checksum bits; this will hopefully get
us to the point where we can `cosa buildprep docker://quay.io/...`
xref
https://github.com/coreos/coreos-assembler/issues/2685

---

