### PR TITLE
`cosa push-container`: New command

### DIFF
--- a/src/cmd-push-container
+++ b/src/cmd-push-container
@@ -1,0 +1,45 @@
+#!/usr/bin/python3 -u
+# Upload the container to a registry.  Note this
+# is distinct from `upload-oscontainer` which
+# only applies to (hopefully soon only older)
+# versions of RHCOS but not FCOS.
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+cosa_dir = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, cosa_dir)
+
+from cosalib import cmdlib
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--authfile", help="Authentication file",
+                    action='store')
+parser.add_argument("name", help="destination image reference")
+
+args = parser.parse_args()
+
+with open('builds/builds.json') as f:
+    builds = json.load(f)['builds']
+if len(builds) == 0:
+    cmdlib.fatal("No builds found")
+latest_build = builds[0]['id']
+arch = cmdlib.get_basearch()
+latest_build_path = f"builds/{latest_build}/{arch}"
+
+metapath = f"{latest_build_path}/meta.json"
+with open(metapath) as f:
+    meta = json.load(f)
+ociarchive = os.path.join(latest_build_path, meta['images']['ostree']['path'])
+
+skopeoargs = ['skopeo', 'copy']
+if args.authfile is None:
+    args.authfile = os.environ.get("REGISTRY_AUTH_FILE")
+if args.authfile is not None:
+    skopeoargs.extend(['--authfile', args.authfile])
+skopeoargs.extend([f"oci-archive:{ociarchive}", f"docker://{args.name}"])
+print(subprocess.list2cmdline(skopeoargs))
+os.execvp('skopeo', skopeoargs)

--- a/src/coreos-assembler
+++ b/src/coreos-assembler
@@ -43,7 +43,7 @@ cmd=${1:-}
 # commands we'd expect to use in the local dev path
 build_commands="init fetch build run prune clean list"
 # commands more likely to be used in a prod pipeline only
-advanced_build_commands="buildfetch buildupload oc-adm-release upload-oscontainer"
+advanced_build_commands="buildfetch buildupload oc-adm-release push-container upload-oscontainer"
 buildextend_commands="aliyun aws azure digitalocean exoscale gcp ibmcloud live metal metal4k nutanix openstack qemu vmware vultr"
 utility_commands="aws-replicate compress generate-hashlist koji-upload kola remote-prune sign tag"
 other_commands="shell meta"


### PR DESCRIPTION
This is just very small syntatic sugar for directly pushing
the container image we have.  We don't need any of the
layers of complexity going on in the previous RHCOS-specific
old format oscontainer.