### PR TITLE
tests/multipath: check for /etc/multipath.conf

### DIFF
--- a/mantle/kola/tests/misc/multipath.go
+++ b/mantle/kola/tests/misc/multipath.go
@@ -119,6 +119,7 @@ func verifyMultipathBoot(c cluster.TestCluster, m platform.Machine) {
 	for _, mnt := range []string{"/sysroot", "/boot"} {
 		verifyMultipath(c, m, mnt)
 	}
+	c.MustSSH(m, "test -f /etc/multipath.conf")
 }
 
 func verifyMultipath(c cluster.TestCluster, m platform.Machine, path string) {


### PR DESCRIPTION
Verify that `multipath.conf` is populated in both the day-1 and day-2
workflows.

Verifies https://github.com/coreos/fedora-coreos-config/pull/1476.