### PR TITLE
tests/ostree/unlock: use G_MESSAGES_DEBUG=rpm-ostreed

### DIFF
--- a/mantle/kola/tests/ostree/unlock.go
+++ b/mantle/kola/tests/ostree/unlock.go
@@ -52,7 +52,7 @@ systemd:
     - name: 10-debug.conf
       contents: |-
         [Service]
-        Environment=G_MESSAGES_DEBUG=all`),
+        Environment=G_MESSAGES_DEBUG=rpm-ostreed`),
 	})
 
 }


### PR DESCRIPTION
`all` means debug logging for the whole stack, and ostree can be really
noisy when traversing commits. This makes archived test logs fat enough
that we're approaching the PVC cap in prod.

Of course, eventually we'll remove this once we fix that flake but
short-term let's at least reduce logging to what we need.