### PR TITLE
Revert "platform/conf: temporarily disable failing on config warnings"

### DIFF
--- a/mantle/platform/conf/conf.go
+++ b/mantle/platform/conf/conf.go
@@ -190,10 +190,8 @@ func (u *UserData) Render(warnings WarningsAction) (*Conf, error) {
 			case ReportWarnings:
 				plog.Warningf("warnings parsing config: %s", r)
 			case FailWarnings:
-				plog.Warningf("warnings parsing config: %s", r)
-				// temp disabled for CI ratchet
-				//plog.Errorf("warnings parsing config: %s", r)
-				//return errors.New("configured to treate config warnings as fatal")
+				plog.Errorf("warnings parsing config: %s", r)
+				return errors.New("configured to treate config warnings as fatal")
 			}
 		}
 		return nil


### PR DESCRIPTION
Now that external tests have been updated, we can treat warnings as hard errors by default.

Finishes implementation of #2686.