### PR TITLE
Bump rpm ostree

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN rm -rfv /usr/lib/coreos-assembler /usr/bin/coreos-assembler
 COPY ./src/print-dependencies.sh ./src/deps*.txt ./src/vmdeps*.txt ./src/build-deps.txt /root/containerbuild/src/
 COPY ./build.sh /root/containerbuild/
 RUN ./build.sh configure_yum_repos
-RUN ./build.sh install_rpms  # nocache 20220111
+RUN ./build.sh install_rpms  # nocache 20220207
 
 # This allows Prow jobs for other projects to use our cosa image as their
 # buildroot image (so clonerefs can copy the repo into `/go`). For cosa itself,

--- a/build.sh
+++ b/build.sh
@@ -53,6 +53,10 @@ install_rpms() {
     # Process our base dependencies + build dependencies and install
     (echo "${builddeps}" && "${srcdir}"/src/print-dependencies.sh) | xargs yum -y install
 
+    # Add fast-tracked packages here.  We don't want to wait on bodhi for rpm-ostree
+    # as we want to enable fast iteration there.
+    yum --enablerepo=updates-testing upgrade rpm-ostree
+
     # Commented out for now, see above
     #dnf remove -y ${builddeps}
     # can't remove grubby on el7 because libguestfs-tools depends on it


### PR DESCRIPTION
build: Pull rpm-ostree from updates-testing

To get the new authselect fixes, among other things.  I think
we want to do this in general going forward.  In the future really
we should track rpm-ostree git main (at least, make it easy to do so).

---

Dockerfile: Blow out quay.io cache

To get the new rpm-ostree.

---

