### PR TITLE
[rhcos-4.9] cmdlib.sh: bump supermin VM to 8G of RAM on ppc64le

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -570,7 +570,7 @@ EOF
     case $arch in
     # Power 8 page faults with 2G of memory in rpm-ostree
     # Most probably due to radix and 64k overhead.
-    "ppc64le") memory_default=4096 ;;
+    "ppc64le") memory_default=8192 ;;
     esac
 
     kola_args=(kola qemuexec -m "${COSA_SUPERMIN_MEMORY:-${memory_default}}" --auto-cpus -U --workdir none \


### PR DESCRIPTION
The RHCOS 4.9 Power pipeline is hitting the second variant in
https://github.com/openshift/os/issues/594#issuecomment-1033000457.

This is worked around in more recent pipelines by the move to OCI
containers, but 4.9 doesn't have this code and it seems risky to
backport. So let's just bump the memory there for that release.