### PR TITLE
[rhcos-4.10] backports of Aliyun ehancements to ore

### DIFF
--- a/mantle/cmd/ore/aliyun/copy-image.go
+++ b/mantle/cmd/ore/aliyun/copy-image.go
@@ -38,6 +38,7 @@ After a successful run, the final line of output will be a line of JSON describi
 	sourceImageID        string
 	destImageName        string
 	destImageDescription string
+	waitForReady         bool
 )
 
 func init() {
@@ -45,6 +46,7 @@ func init() {
 	cmdCopyImage.Flags().StringVar(&sourceImageID, "image", "", "source image")
 	cmdCopyImage.Flags().StringVar(&destImageName, "name", "", "destination image name")
 	cmdCopyImage.Flags().StringVar(&destImageDescription, "description", "", "destination image description")
+	cmdCopyImage.Flags().BoolVar(&waitForReady, "wait-for-ready", false, "wait for the copied image to be marked available")
 }
 
 func runCopyImage(cmd *cobra.Command, args []string) error {
@@ -55,7 +57,7 @@ func runCopyImage(cmd *cobra.Command, args []string) error {
 
 	ids := make(map[string]string)
 	for _, region := range args {
-		id, err := API.CopyImage(sourceImageID, destImageName, region, destImageDescription, "", false)
+		id, err := API.CopyImage(sourceImageID, destImageName, region, destImageDescription, "", false, waitForReady)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Copying image to region %q: %v\n", region, err)
 			os.Exit(1)

--- a/mantle/platform/api/aliyun/api.go
+++ b/mantle/platform/api/aliyun/api.go
@@ -215,6 +215,12 @@ func (a *API) ImportImage(format, bucket, object, image_size, device, name, desc
 	request.ImageName = name
 	request.Description = description
 	request.Architecture = architecture
+	request.Tag = &[]ecs.ImportImageTag{
+		{
+			Key:   "created-by",
+			Value: "mantle",
+		},
+	}
 
 	plog.Infof("importing image")
 	response, err := a.ecs.ImportImage(request)


### PR DESCRIPTION
```
    cosalib/aliyun: extend commands to mark images public
    
    This extends the `aliyun-replicate` and `buildextend-aliyun`
    commands to support a `--public` option, which will mark any
    uploaded images as publicly available.
    
    Requires #2670
    
    (cherry picked from commit a6e8c0fd097473ed601c3229aa50cc692ffa8611)
```

```
    mantle/aliyun: allow CopyImage to wait for image readiness
    
    In my experience, trying to operate on an image immediately after it
    had been copied to a region can be unreliable. The `CopyImage()` API
    call is "fire and forget", with no native way to monitor the status of
    the request. (Unlike `ImportImage()`, which returns a TaskID that
    *can* be monitored).
    
    This change introduces a new function that checks the status of an
    image until it becomes available or a timeout (10min). This is made
    available to the `ore aliyun copy-image` command via a new
    `--wait-for-ready` flag that causes the command to wait until the
    image can be operated on.
    
    (cherry picked from commit c2a1e81d16f9cfbef40181bf5c55ccb906a3cdb9)
```

```
    mantle/aliyun: add tags when doing ImportImage
    
    This adds tags indicating that `mantle` created the image in the
    Aliyun cloud. This matches the behavior when we do `CopyImage()`
    during replication operations and makes the discoverability of images
    uploaded via `mantle`/`ore` easier.
    
    (cherry picked from commit 5d0ca3647a69f889d85f5b3f83672f344dc64693)
```