### PR TITLE
build.sh: freeze on kernel-5.15.18-200.fc35.x86_64

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -35,6 +35,12 @@ configure_yum_repos() {
 }
 
 install_rpms() {
+    local builddeps
+    local frozendeps
+
+    # no frozen deps right now
+    frozendeps=""
+
     # First, a general update; this is best practice.  We also hit an issue recently
     # where qemu implicitly depended on an updated libusbx but didn't have a versioned
     # requires https://bugzilla.redhat.com/show_bug.cgi?id=1625641
@@ -51,7 +57,7 @@ install_rpms() {
     builddeps=$(grep -v '^#' "${srcdir}"/src/build-deps.txt)
 
     # Process our base dependencies + build dependencies and install
-    (echo "${builddeps}" && "${srcdir}"/src/print-dependencies.sh) | xargs yum -y install
+    (echo "${builddeps}" && echo "${frozendeps}" && "${srcdir}"/src/print-dependencies.sh) | xargs yum -y install
 
     # Add fast-tracked packages here.  We don't want to wait on bodhi for rpm-ostree
     # as we want to enable fast iteration there.

--- a/build.sh
+++ b/build.sh
@@ -38,8 +38,8 @@ install_rpms() {
     local builddeps
     local frozendeps
 
-    # no frozen deps right now
-    frozendeps=""
+    # freeze kernel due to https://github.com/coreos/coreos-assembler/issues/2707
+    frozendeps=$(echo kernel{,-core,-modules}-5.15.18-200.fc35)
 
     # First, a general update; this is best practice.  We also hit an issue recently
     # where qemu implicitly depended on an updated libusbx but didn't have a versioned


### PR DESCRIPTION
There seems to be a regression in the 5.16 kernel causing intermittent
compose failures. For the full details, see:

https://github.com/coreos/coreos-assembler/issues/2707

We still need to actually investigate what exactly regressed here. But
at least for now let's unblock CI.