### PR TITLE
Revert "Revert "cmdlib: drop support for `overlay.d/cosa-no-autolayer`""

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -381,9 +381,6 @@ EOF
     fi
 
     if [ -d "${ovld}" ]; then
-        if [ -e "${ovld}/cosa-no-autolayer" ]; then
-            cosa_no_autolayer=1
-        fi
         for n in "${ovld}"/*; do
             if ! [ -d "${n}" ]; then
                 continue
@@ -392,9 +389,6 @@ EOF
             bn=$(basename "${n}")
             ovlname="overlay/${bn}"
             commit_overlay "${ovlname}" "${n}"
-            if [ -z "${cosa_no_autolayer:-}" ]; then
-                layers="${layers} ${ovlname}"
-            fi
         done
     fi
 


### PR DESCRIPTION
This reverts commit fc8c5f07e80ff623753ed7456d816d69607cde59.

The `stable` stream now has the manifest changes needed now, so we can
drop support for this again.