### PR TITLE
Add libguestfs workaround for ppc64le

### DIFF
--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -657,6 +657,10 @@ func newGuestfish(diskImagePath string, diskSectorSize int) (*coreosGuestfish, e
 	guestfishArgs = append(guestfishArgs, "-a", diskImagePath)
 	cmd := exec.Command("guestfish", guestfishArgs...)
 	cmd.Env = append(os.Environ(), "LIBGUESTFS_BACKEND=direct")
+	switch system.RpmArch() {
+	case "ppc64le":
+		cmd.Env = append(os.Environ(), "LIBGUESTFS_HV=/usr/lib/coreos-assembler/libguestfs-ppc64le-wrapper.sh")
+	}
 	// make sure it inherits stderr so we see any error message
 	cmd.Stderr = os.Stderr
 	stdout, err := cmd.StdoutPipe()

--- a/src/libguestfs-ppc64le-wrapper.sh
+++ b/src/libguestfs-ppc64le-wrapper.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec qemu-system-ppc64 "$@" -machine pseries,accel=kvm:tcg,vsmt=8,cap-fwnmi=off


### PR DESCRIPTION
 Add a workaround for the issue:
 https://github.com/openshift/os/issues/720

The kola tests failing are using guestfish, for some
reason the libguestfs is not able to create the wrapped to
add the vmst value, required for the POWER8 cluster.
Until we can debug it better, let's unlock the power builds

Signed-off-by: Renata Ravanelli <rravanel@redhat.com>