### PR TITLE
cosalib: make ibmcloud.py pick up on provided --arch

### DIFF
--- a/src/cosalib/ibmcloud.py
+++ b/src/cosalib/ibmcloud.py
@@ -264,5 +264,6 @@ def get_ibmcloud_variant(variant, parser, kwargs={}):
         schema=parser.schema,
         variant=variant,
         force=parser.force,
+        arch=parser.arch,
         compress=parser.compress,
         **kwargs)


### PR DESCRIPTION
Now if someone runs `cosa buildextend-ibmcloud --arch=s390x` it
will get honored.

This is really only useful if there was a s390x qcow2 natively that
someone downloaded and then wanted to make an ibmcloud artifact out
of (IBM Cloud now has s390x instances).

This bit was missed in 539a63b.