### PR TITLE
Revert "Update for renamed osmet/miniso pack subcommands"

### DIFF
--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -653,7 +653,7 @@ boot
     if basearch == "x86_64":
         run_verbose(['/usr/bin/isohybrid', '--uefi', f'{tmpisofile}.minimal'])
     # this consumes the minimal image
-    run_verbose(['coreos-installer', 'pack', 'minimal-iso',
+    run_verbose(['coreos-installer', 'iso', 'extract', 'pack-minimal-iso',
                  tmpisofile, f'{tmpisofile}.minimal', "--consume"])
 
     buildmeta['images'].update({

--- a/src/osmet-pack
+++ b/src/osmet-pack
@@ -79,7 +79,7 @@ esac
 
 # We don't want double quotes (for both `coreinst` and `fast`, which may be '')
 # shellcheck disable=SC2086
-RUST_BACKTRACE=full ${coreinst} pack osmet /dev/disk/by-id/virtio-osmet \
+RUST_BACKTRACE=full ${coreinst} osmet pack /dev/disk/by-id/virtio-osmet \
     --description "${description}" \
     --checksum "${checksum}" \
     --output /tmp/osmet.bin $fast


### PR DESCRIPTION
We need to wait until coreos-installer 0.13.1 is in FCOS stable.

This reverts #2631.