### PR TITLE
Clean up POWER wrapper in libguestfish

### DIFF
--- a/src/libguestfish.sh
+++ b/src/libguestfish.sh
@@ -12,14 +12,7 @@ export LIBGUESTFS_BACKEND=direct
 arch=$(uname -m)
 
 if [ "$arch" = "ppc64le" ] ; then
-    tmp_qemu_wrapper=$(mktemp -tdp /tmp gf-vsmt.XXXXXX)
-    qemu_wrapper=${tmp_qemu_wrapper}/qemu-wrapper.sh
-	cat <<-'EOF' > "${qemu_wrapper}"
-	#!/bin/bash -
-	exec qemu-system-ppc64 "$@" -machine pseries,accel=kvm:tcg,vsmt=8,cap-fwnmi=off
-	EOF
-    chmod +x "${qemu_wrapper}"
-    export LIBGUESTFS_HV="${qemu_wrapper}"
+    export LIBGUESTFS_HV="/usr/lib/coreos-assembler/libguestfs-ppc64le-wrapper.sh"
 fi
 
 # http://libguestfs.org/guestfish.1.html#using-remote-control-robustly-from-shell-scripts
@@ -37,9 +30,6 @@ coreos_gf_launch() {
 
 _coreos_gf_cleanup () {
     guestfish --remote -- exit >/dev/null 2>&1 ||:
-    if [ -n "${tmp_qemu_wrapper:-}" ] ; then
-        rm -rf "${tmp_qemu_wrapper}";
-    fi
 }
 trap _coreos_gf_cleanup EXIT
 


### PR DESCRIPTION
- It is a follow up for the issue https://github.com/openshift/os/issues/720  and for #2714

- POWER never really used the newGuestfish function in
mantle/platform/qemu.go, with the new tests now using setupPreboot function
that was recently added, the issue happened because there is no call for the
POWER wrapper in the newGuestfish. Nonetheless, it is not a libguestfish issue
since POWER8 (cluster) needs the vsmt set to 8.

Signed-off-by: Renata Ravanelli <rravanel@redhat.com>