### PR TITLE
clean: Add --all option to also remove `cache/`

### DIFF
--- a/src/cmd-clean
+++ b/src/cmd-clean
@@ -8,14 +8,15 @@ dn=$(dirname "$0")
 print_help() {
     cat 1>&2 <<'EOF'
 Usage: coreos-assembler clean --help
-       coreos-assembler clean
+       coreos-assembler clean [--all]
 
-  Delete all build artifacts.
+  Delete all build artifacts.  Use --all to also clean the cache/ directory.
 EOF
 }
 
 rc=0
-options=$(getopt --options h --longoptions help -- "$@") || rc=$?
+all=0
+options=$(getopt --options ah --longoptions all,help -- "$@") || rc=$?
 [ $rc -eq 0 ] || {
     print_help
     exit 1
@@ -26,6 +27,9 @@ while true; do
         -h | --help)
             print_help
             exit 0
+            ;;
+        -a | --all)
+            all=1
             ;;
         --)
             shift
@@ -51,5 +55,14 @@ prepare_build
 
 # But go back to the toplevel
 cd "${workdir:?}"
-# Note we don't prune the cache.  If you want that, just rm -rf them.
+# We don't clean the cache by default.
+if test "${all}" = "1"; then
+    if has_privileges; then
+        sudo rm -rf cache/*
+    else
+        rm -rf cache/*
+    fi
+else
+    echo "Note: retaining cache/"
+fi
 rm -rf builds/* tmp/*


### PR DESCRIPTION
xref https://github.com/coreos/rpm-ostree/issues/3473

Today how rpm-ostree caches packages has problems, we need to make
it a bit more obvious how to also blow away all of our cached data.