### PR TITLE
[rhcos-4.10] oscontainer: Push in v2s2 format by default

### DIFF
--- a/src/cmd-upload-oscontainer
+++ b/src/cmd-upload-oscontainer
@@ -25,6 +25,7 @@ parser.add_argument("--name", help="oscontainer name",
                     action='store', required=True)
 parser.add_argument("--from", help="Base image", default='scratch',
                     dest='from_image')
+parser.add_argument("--format", help="Format to use for push")
 parser.add_argument("--add-directory", help="Copy in all content from referenced directory DIR",
                     metavar='DIR', action='append', default=[])
 
@@ -113,6 +114,8 @@ cosa_argv.append(f"--display-name={display_name}")
 if 'labeled-packages' in configyaml:
     pkgs = ' '.join(configyaml['labeled-packages'])
     cosa_argv.append(f"--labeled-packages={pkgs}")
+if args.format is not None:
+    cosa_argv.append(f'--format={args.format}')
 subprocess.check_call(cosa_argv +
     [f'--digestfile={digestfile}',
         '--push', tmprepo,

--- a/src/oscontainer.py
+++ b/src/oscontainer.py
@@ -95,7 +95,7 @@ def oscontainer_extract(containers_storage, tmpdir, src, dest,
 # Given an OSTree repository at src (and exactly one ref) generate an
 # oscontainer with it.
 def oscontainer_build(containers_storage, tmpdir, src, ref, image_name_and_tag,
-                      base_image, push=False, tls_verify=True,
+                      base_image, push=False, tls_verify=True, pushformat=None,
                       add_directories=[], cert_dir="", authfile="", digestfile=None,
                       display_name=None, labeled_pkgs=[]):
     r = OSTree.Repo.new(Gio.File.new_for_path(src))
@@ -236,6 +236,9 @@ def oscontainer_build(containers_storage, tmpdir, src, ref, image_name_and_tag,
         if digestfile is not None:
             podCmd.append(f'--digestfile={digestfile}')
 
+        if pushformat is not None:
+            podCmd.append(f'--format={pushformat}')
+
         podCmd.append(image_name_and_tag)
 
         run_verbose(podCmd)
@@ -276,6 +279,8 @@ def main():
     parser_build.add_argument("--add-directory", help="Copy in all content from referenced directory DIR",
                               metavar='DIR', action='append', default=[])
     parser_build.add_argument("--labeled-packages", help="Packages whose NEVRAs are included as labels on the image")
+    # For now we forcibly override to v2s2 https://bugzilla.redhat.com/show_bug.cgi?id=2058421
+    parser_build.add_argument("--format", help="Pass through push format to buildah", default="v2s2")
     parser_build.add_argument(
         "--digestfile",
         help="Write image digest to file",
@@ -318,6 +323,7 @@ def main():
                 digestfile=args.digestfile,
                 add_directories=args.add_directory,
                 push=args.push,
+                pushformat=args.format,
                 tls_verify=not args.disable_tls_verify,
                 cert_dir=args.cert_dir,
                 authfile=args.authfile,


### PR DESCRIPTION
There was a big quay.io update recently, and the new version supports
OCI natively.  Which is awesome and will unblock other things
such as OCI artifacts.

However...it turns out some of the OCP tooling around disconnected
installs only works with Docker schema v2s2, not OCI.

Let's use v2s2 by default for *this* code which is currently
OCP/RHCOS specific.

But let's continue to use OCI by default for the new
"ostree native container" format push code which lives in
`cosa push-container`.

(cherry picked from commit 2c8eda187408f4818d2858846ac1a6888e9e322d)