### PR TITLE
kola: Add failed subtests to report.json

### DIFF
--- a/mantle/harness/reporters/json.go
+++ b/mantle/harness/reporters/json.go
@@ -39,6 +39,7 @@ type jsonReporter struct {
 
 type jsonTest struct {
 	Name     string                `json:"name"`
+	Subtests []string              `json:"subtests"`
 	Result   testresult.TestResult `json:"result"`
 	Duration time.Duration         `json:"duration"`
 	Output   string                `json:"output"`
@@ -70,12 +71,13 @@ func NewJSONReporter(filename, platform, version string) *jsonReporter {
 	}
 }
 
-func (r *jsonReporter) ReportTest(name string, result testresult.TestResult, duration time.Duration, b []byte) {
+func (r *jsonReporter) ReportTest(name string, subtests []string, result testresult.TestResult, duration time.Duration, b []byte) {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 
 	r.Tests = append(r.Tests, jsonTest{
 		Name:     name,
+		Subtests: subtests,
 		Result:   result,
 		Duration: duration,
 		Output:   string(b),

--- a/mantle/harness/reporters/reporter.go
+++ b/mantle/harness/reporters/reporter.go
@@ -22,9 +22,9 @@ import (
 
 type Reporters []Reporter
 
-func (reps Reporters) ReportTest(name string, result testresult.TestResult, duration time.Duration, b []byte) {
+func (reps Reporters) ReportTest(name string, subtests []string, result testresult.TestResult, duration time.Duration, b []byte) {
 	for _, r := range reps {
-		r.ReportTest(name, result, duration, b)
+		r.ReportTest(name, subtests, result, duration, b)
 	}
 }
 
@@ -45,7 +45,7 @@ func (reps Reporters) SetResult(s testresult.TestResult) {
 }
 
 type Reporter interface {
-	ReportTest(string, testresult.TestResult, time.Duration, []byte)
+	ReportTest(string, []string, testresult.TestResult, time.Duration, []byte)
 	Output(string) error
 	SetResult(testresult.TestResult)
 }

--- a/mantle/kola/register/register.go
+++ b/mantle/kola/register/register.go
@@ -51,6 +51,7 @@ func CreateNativeFuncWrap(f func() error, exclusions ...string) NativeFuncWrap {
 // function is run.
 type Test struct {
 	Name                 string // should be unique
+	Subtests             []string
 	Run                  func(cluster.TestCluster)
 	NativeFuncs          map[string]NativeFuncWrap
 	UserData             *conf.UserData


### PR DESCRIPTION

Add the failed subtests of non-exclusive wrapper to report.json. The subtests
allow us to use them for re-run purposes via --rerun arg and kola rerun command

Fixes: coreos#2638
