### PR TITLE
push-container: tag with build id and arch by default

### DIFF
--- a/src/cmd-push-container
+++ b/src/cmd-push-container
@@ -40,6 +40,9 @@ if args.authfile is None:
     args.authfile = os.environ.get("REGISTRY_AUTH_FILE")
 if args.authfile is not None:
     skopeoargs.extend(['--authfile', args.authfile])
-skopeoargs.extend([f"oci-archive:{ociarchive}", f"docker://{args.name}"])
+container_name = args.name
+if ":" not in container_name:
+    container_name = f"{container_name}:{latest_build}-{arch}"
+skopeoargs.extend([f"oci-archive:{ociarchive}", f"docker://{container_name}"])
 print(subprocess.list2cmdline(skopeoargs))
 os.execvp('skopeo', skopeoargs)


### PR DESCRIPTION
Modifies `cosa push-container` to tag the container with the current build ID and architecture if a tag is not provided.
