### PR TITLE
Skip coreos.boot-mirror.luks for ppc64le

### DIFF
--- a/mantle/kola/tests/misc/boot-mirror.go
+++ b/mantle/kola/tests/misc/boot-mirror.go
@@ -76,7 +76,7 @@ func init() {
 		Platforms:   []string{"qemu-unpriv"},
 		// Can't mirror boot disk on s390x, and qemu s390x doesn't
 		// support TPM
-		ExcludeArchitectures: []string{"s390x"},
+		ExcludeArchitectures: []string{"s390x", "ppc64le"},
 		// skipping this test on UEFI until https://github.com/coreos/coreos-assembler/issues/2039
 		// gets resolved.
 		ExcludeFirmwares: []string{"uefi"},


### PR DESCRIPTION
 - Issue #2725: This test is failing blocking the Power CI.
Let's skip it for now.

Signed-off-by: Renata Ravanelli <rravanel@redhat.com>