### PR TITLE
VMware: Update to RHEL8, EFI, HW15

### DIFF
--- a/src/cosalib/ova.py
+++ b/src/cosalib/ova.py
@@ -64,8 +64,8 @@ class OVA(QemuVariantImage):
         self.ovf_path = os.path.join(self._tmpdir, "coreos.ovf")
 
     def generate_ovf_parameters(self, vmdk, cpu=2,
-                                memory=4096, system_type="vmx-13",
-                                os_type="rhel7_64Guest", scsi="VirtualSCSI",
+                                memory=4096, system_type="vmx-15",
+                                os_type="rhel8_64Guest", scsi="VirtualSCSI",
                                 network="VmxNet3"):
         """
         Returns a dictionary with the parameters needed to create an OVF file

--- a/src/vmware-template.xml
+++ b/src/vmware-template.xml
@@ -80,6 +80,8 @@
         <vmw:Config ovf:required="false" vmw:key="connectable.allowGuestControl" vmw:value="true"/>
         <vmw:Config ovf:required="false" vmw:key="wakeOnLanEnabled" vmw:value="false"/>
       </Item>
+      <vmw:Config ovf:required="false" vmw:key="bootOptions.efiSecureBootEnabled" vmw:value="false"/>
+      <vmw:Config ovf:required="false" vmw:key="firmware" vmw:value="efi"/>
     </VirtualHardwareSection>
     <ProductSection>
       <Info>Information about the installed software</Info>


### PR DESCRIPTION
This change modifies the OVF setting
the VM hardware version to 15, using the
guest os type as RHEL8 and switching from
BIOS to EFI.