### PR TITLE
mantle/kola: update manifest.yaml parsing to account for recent change

### DIFF
--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -317,9 +317,9 @@ type DenyListObj struct {
 }
 
 type ManifestData struct {
-	AddCommitMetadata struct {
-		FcosStream string `yaml:"fedora-coreos.stream"`
-	} `yaml:"add-commit-metadata"`
+	Variables struct {
+		Stream string `yaml:"stream"`
+	} `yaml:"variables"`
 }
 
 func parseDenyListYaml(pltfrm string) error {
@@ -357,7 +357,7 @@ func parseDenyListYaml(pltfrm string) error {
 		return err
 	}
 
-	stream := manifest.AddCommitMetadata.FcosStream
+	stream := manifest.Variables.Stream
 	arch := Options.CosaBuildArch
 	plog.Debugf("Arch: %v detected.", arch)
 	today := time.Now()


### PR DESCRIPTION
In https://github.com/coreos/fedora-coreos-config/pull/1538 we changed
manifest.yaml to specify the stream in a toplevel variable and we moved
the `add-commit-metadata: fedora-coreos.stream` information into a
shared manifest. This broke the denylist parsing of the `stream`.

Let's update to handle the changes.