### PR TITLE
ci: don't use sudo to run test_pruning.sh

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -54,7 +54,7 @@ pod(image: imageName + ":latest", kvm: true, memory: "10Gi") {
     stage("CLI Tests") {
         shwrap("""
             cd /srv
-            sudo -u builder ${env.WORKSPACE}/tests/test_pruning.sh
+            ${env.WORKSPACE}/tests/test_pruning.sh
         """)
     }
 }


### PR DESCRIPTION
We can't use `sudo` here because we're running as a fully unprivileged
user. I'm not sure how this worked before.