### PR TITLE
mantle/kola: add check for QEMU image

### DIFF
--- a/mantle/cmd/kola/kola.go
+++ b/mantle/cmd/kola/kola.go
@@ -558,6 +558,9 @@ func syncFindParentImageOptions() error {
 			}
 			qemuImageDirIsTemp = true
 		}
+		if parentCosaBuild.BuildArtifacts.Qemu == nil {
+			return fmt.Errorf("No QEMU in parent meta.json")
+		}
 		qcowURL := parentBaseURL + parentCosaBuild.BuildArtifacts.Qemu.Path
 		qcowLocal := filepath.Join(qemuImageDir, parentCosaBuild.BuildArtifacts.Qemu.Path)
 		decompressedQcowLocal, err := util.DownloadImageAndDecompress(qcowURL, qcowLocal, skipSignature)


### PR DESCRIPTION
Let's make sure the QEMU image exists in the parant meta.json.
This shouldn't ever happen but we hit an issue recently [1] and
it happened. Let's not segfault.

[1] https://github.com/coreos/fedora-coreos-pipeline/pull/487