### PR TITLE
[rhcos-4.10] tests/multipath.partition: create /var/lib/containers before mount

### DIFF
--- a/mantle/kola/tests/misc/multipath.go
+++ b/mantle/kola/tests/misc/multipath.go
@@ -67,6 +67,8 @@ systemd:
         [Service]
         Type=oneshot
         ExecStart=/usr/sbin/mkfs.xfs -L containers -m reflink=1 /dev/mapper/mpatha
+        # This is usually created by tmpfiles.d, but we run earlier than that.
+        ExecStart=/usr/bin/mkdir -p /var/lib/containers
 
         [Install]
         WantedBy=multi-user.target


### PR DESCRIPTION
Otherwise, `/var/lib/containers` may not exist yet and the mount will
fail. It's usually created via tmpfiles, but we run earlier than that.

Fixes part of: https://github.com/openshift/os/issues/743

(cherry picked from commit d04cc2f2c3ffcf78b63f77af5253add76dfc8da1)