### PR TITLE
cosalib/ova: template VMware HW and OS versions from `image.yaml`; enable UEFI

### DIFF
--- a/src/cosalib/ova.py
+++ b/src/cosalib/ova.py
@@ -65,8 +65,7 @@ class OVA(QemuVariantImage):
 
     def generate_ovf_parameters(self, vmdk, cpu=2,
                                 memory=4096, system_type="vmx-13",
-                                os_type="rhel7_64Guest", scsi="VirtualSCSI",
-                                network="VmxNet3"):
+                                os_type="rhel7_64Guest"):
         """
         Returns a dictionary with the parameters needed to create an OVF file
         based on the qemu, vmdk, and info from the build metadata
@@ -87,8 +86,6 @@ class OVA(QemuVariantImage):
             'vsphere_product_version':          version,
             'vsphere_virtual_system_type':      system_type,
             'vsphere_os_type':                  os_type,
-            'vsphere_scsi_controller_type':     scsi,
-            'vsphere_network_controller_type':  network,
             'vmdk_capacity':                    disk_info.get("virtual-size"),
             'vmdk_size':                        str(vmdk_size),
         }

--- a/src/cosalib/ova.py
+++ b/src/cosalib/ova.py
@@ -10,7 +10,7 @@ cosa_dir = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, f"{cosa_dir}/cosalib")
 sys.path.insert(0, cosa_dir)
 
-from cosalib.cmdlib import image_info
+from cosalib.cmdlib import flatten_image_yaml, image_info
 from cosalib.qemuvariants import QemuVariantImage
 
 
@@ -63,13 +63,18 @@ class OVA(QemuVariantImage):
         # Ensure that coreos.ovf is included in the tar
         self.ovf_path = os.path.join(self._tmpdir, "coreos.ovf")
 
-    def generate_ovf_parameters(self, vmdk, cpu=2,
-                                memory=4096, system_type="vmx-13",
-                                os_type="rhel7_64Guest"):
+    def generate_ovf_parameters(self, vmdk, cpu=2, memory=4096):
         """
         Returns a dictionary with the parameters needed to create an OVF file
-        based on the qemu, vmdk, and info from the build metadata
+        based on the qemu, vmdk, image.yaml, and info from the build metadata
         """
+        image_yaml = flatten_image_yaml(
+            '/usr/lib/coreos-assembler/image-default.yaml',
+            flatten_image_yaml('src/config/image.yaml')
+        )
+
+        system_type = 'vmx-{}'.format(image_yaml['vmware-hw-version'])
+        os_type = image_yaml['vmware-os-type']
         disk_info = image_info(vmdk)
         vmdk_size = os.stat(vmdk).st_size
         image = self.summary

--- a/src/image-default.yaml
+++ b/src/image-default.yaml
@@ -1,8 +1,15 @@
-# This file contains defaults for image.yaml that is used by create_disk.sh
+# This file contains defaults for image.yaml
+
 bootfs: "ext4"
 rootfs: "xfs"
 grub-script: "/usr/lib/coreos-assembler/grub.cfg"
+
 # True if we should use `ostree container image deploy`
 deploy-via-container: false
+
 # Set this to a target container reference, e.g. ostree-unverified-registry:quay.io/example/os:latest
 # container-imgref: ""
+
+# Defaults for VMware OVA, matching historical behavior
+vmware-hw-version: 13
+vmware-os-type: rhel7_64Guest

--- a/src/vmware-template.xml
+++ b/src/vmware-template.xml
@@ -16,7 +16,7 @@
   <VirtualSystem ovf:id="image">
     <Info>A virtual machine</Info>
     <Name>{vsphere_image_name}</Name>
-    <OperatingSystemSection ovf:id="80" ovf:version="6" vmw:osType="{vsphere_os_type}">
+    <OperatingSystemSection ovf:id="100" vmw:osType="{vsphere_os_type}">
       <Info>The kind of installed guest operating system</Info>
     </OperatingSystemSection>
     <VirtualHardwareSection ovf:transport="com.vmware.guestInfo">

--- a/src/vmware-template.xml
+++ b/src/vmware-template.xml
@@ -56,7 +56,7 @@
         <rasd:Description>SCSI Controller</rasd:Description>
         <rasd:ElementName>SCSI Controller 0</rasd:ElementName>
         <rasd:InstanceID>3</rasd:InstanceID>
-	<rasd:ResourceSubType>{vsphere_scsi_controller_type}</rasd:ResourceSubType>
+	<rasd:ResourceSubType>VirtualSCSI</rasd:ResourceSubType>
         <rasd:ResourceType>6</rasd:ResourceType>
       </Item>
       <Item>
@@ -75,7 +75,7 @@
         <rasd:Description>VmxNet3 ethernet adapter on "VM Network"</rasd:Description>
         <rasd:ElementName>Network adapter 1</rasd:ElementName>
         <rasd:InstanceID>5</rasd:InstanceID>
-	<rasd:ResourceSubType>{vsphere_network_controller_type}</rasd:ResourceSubType>
+	<rasd:ResourceSubType>VmxNet3</rasd:ResourceSubType>
         <rasd:ResourceType>10</rasd:ResourceType>
         <vmw:Config ovf:required="false" vmw:key="connectable.allowGuestControl" vmw:value="true"/>
         <vmw:Config ovf:required="false" vmw:key="wakeOnLanEnabled" vmw:value="false"/>

--- a/src/vmware-template.xml
+++ b/src/vmware-template.xml
@@ -80,6 +80,8 @@
         <vmw:Config ovf:required="false" vmw:key="connectable.allowGuestControl" vmw:value="true"/>
         <vmw:Config ovf:required="false" vmw:key="wakeOnLanEnabled" vmw:value="false"/>
       </Item>
+      <vmw:Config ovf:required="false" vmw:key="bootOptions.efiSecureBootEnabled" vmw:value="false"/>
+      <vmw:Config ovf:required="false" vmw:key="firmware" vmw:value="efi"/>
     </VirtualHardwareSection>
     <ProductSection>
       <Info>Information about the installed software</Info>


### PR DESCRIPTION
FCOS and RHCOS want to set different VMware hardware versions and OS type IDs.  Read both from `image.yaml`, defaulting to the values we currently use.

OVF images created by VMware Workstation 16.2.3 respectively record Fedora and RHEL 8 guests as:

```
    <OperatingSystemSection ovf:id="100" vmw:osType="fedora64Guest">
    <OperatingSystemSection ovf:id="80" ovf:version="8" vmw:osType="rhel8_64Guest">
```

The `ovf:id` values are defined to come from `CIM_OperatingSystem.OsType`, which defines 80 as `RedHat Enterprise Linux 64-Bit` and 100 as `Linux 2.6.x 64-Bit`.  (2.6.x seems to be the last explicit kernel version listed in the spec.)  `ovf:version` appears to be the major version of the OS.  VMware's `ovftool` doesn't seem to care about either of those fields, only the `vmw:osType`, so we hardcode the `ovf:id` to 100 and call it a day.

While we're at it, switch to UEFI, which we can do even with hardware version 13.  Disable Secure Boot, though, due to https://github.com/coreos/ignition/issues/1092.

For https://github.com/coreos/fedora-coreos-tracker/issues/1119.  Alternative to https://github.com/coreos/coreos-assembler/pull/2740.  Fixes https://github.com/coreos/fedora-coreos-config/issues/1494.