### PR TITLE
create_disk: Pull ostree-container over 9p, instead of pull-local

### DIFF
--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -139,11 +139,14 @@ cat image-default.json "${image_json}" | jq -s add > image-configured.json
 # We do some extra handling of the rootfs here; it feeds into size estimation.
 rootfs_type=$(jq -re .rootfs < image-configured.json)
 
-deploy_container=
-container_imgref=$(jq -r '.["container-imgref"]//""' < image-configured.json)
-if test -n "${container_imgref}" || jq -re '.["deploy-via-container"]' < image-configured.json >/dev/null; then
-    deploy_container=ostree-unverified-image:oci-archive:$builddir/$(meta_key images.ostree.path)
+deploy_via_container=""
+if jq -re '.["deploy-via-container"]' < image-configured.json; then
+    deploy_via_container="true"
 fi
+container_imgref=$(jq -r '.["container-imgref"]//""' < image-configured.json)
+# Nowadays we pull the container across 9p rather than accessing the repo, see
+# https://github.com/openshift/os/issues/594
+ostree_container=ostree-unverified-image:oci-archive:$builddir/$(meta_key images.ostree.path)
 
 # fs-verity requires block size = page size. We need to take that into account
 # in the disk size estimation due to higher fragmentation on larger blocks.
@@ -210,11 +213,11 @@ cat >image-dynamic.json << EOF
     "osname": "${name}",
     "buildid": "${build}",
     "imgid": "${img}",
-    "deploy-container": "${deploy_container}",
+    "deploy-via-container": "${deploy_via_container}",
     "container-imgref": "${container_imgref}",
     "ostree-commit": "${commit}",
     "ostree-ref": "${ref}",
-    "ostree-repo": "${ostree_repo}"
+    "ostree-container": "${ostree_container}"
 }
 EOF
 cat image-configured.json image-dynamic.json | jq -s add > image.json

--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -94,12 +94,12 @@ esac
 
 bootfs=$(getconfig "bootfs")
 grub_script=$(getconfig "grub-script")
-ostree=$(getconfig "ostree-repo")
+ostree_container=$(getconfig "ostree-container")
 commit=$(getconfig "ostree-commit")
 ref=$(getconfig "ostree-ref")
 # We support not setting a remote name (used by RHCOS)
 remote_name=$(getconfig_def "ostree-remote" "")
-deploy_container=$(getconfig "deploy-container" "")
+deploy_via_container=$(getconfig "deploy-via-container" "")
 container_imgref=$(getconfig "container-imgref" "")
 os_name=$(getconfig "osname")
 rootfs_size=$(getconfig "rootfs-size")
@@ -262,18 +262,18 @@ fi
 # *not* the shell here.  Hence the backslash escape.
 allkargs="$extrakargs \$ignition_firstboot"
 
-if test -n "${deploy_container}"; then
+if test -n "${deploy_via_container}"; then
     kargsargs=""
     for karg in $allkargs
     do
         kargsargs+="--karg=$karg "
     done
-    ostree container image deploy --imgref "${deploy_container}" \
+    ostree container image deploy --imgref "${ostree_container}" \
         ${container_imgref:+--target-imgref $container_imgref} \
         --stateroot "$os_name" --sysroot $rootfs $kargsargs
 else
     # Pull the commit
-    time ostree pull-local --repo $rootfs/ostree/repo "$ostree" "$commit"
+    time ostree container unencapsulate --repo=$rootfs/ostree/repo "${ostree_container}"
     # Deploy it, using an optional remote prefix
     if test -n "${remote_name}"; then
         deploy_ref="${remote_name}:${ref}"


### PR DESCRIPTION
This should fix https://github.com/openshift/os/issues/594

Basically I think 9p has a bug where under memory pressure, having
it *free* an inode requires allocation, which can fail.

This works around that bug by pulling the ostree-container archive
instead, which is a single big file.

Note that this code path does *not* change the semantics at all
for the generated disk.  The information about the pulled container
is discarded and lost.  Actually making use of the container bits
natively is the `deploy-via-container` image option which is
still experimental, but will be used when we progress the
ostree native containers work.