### PR TITLE
mantle/network/ssh: use ExtendedAgent for SSHAgent

### DIFF
--- a/mantle/network/ssh.go
+++ b/mantle/network/ssh.go
@@ -45,7 +45,7 @@ type Dialer interface {
 // SSHAgent can manage keys, updates cloud config, and loves ponies.
 // The embedded dialer is used for establishing new SSH connections.
 type SSHAgent struct {
-	agent.Agent
+	agent.ExtendedAgent
 	Dialer
 	User         string
 	Socket       string
@@ -99,13 +99,13 @@ func NewSSHAgent(dialer Dialer) (*SSHAgent, error) {
 	}
 
 	a := &SSHAgent{
-		Agent:        keyring,
-		Dialer:       dialer,
-		User:         defaultUser,
-		Socket:       sockPath,
-		sockDir:      sockDir,
-		sockdirOwned: sockdirOwned,
-		listener:     listener,
+		ExtendedAgent: keyring.(agent.ExtendedAgent),
+		Dialer:        dialer,
+		User:          defaultUser,
+		Socket:        sockPath,
+		sockDir:       sockDir,
+		sockdirOwned:  sockdirOwned,
+		listener:      listener,
 	}
 
 	go func() {


### PR DESCRIPTION
The `Agent` interface doesn't support `SignWithFlags`. So when trying to
use `ssh` with the mantle agent to SSH into a VM, the signing request
during handshake has its flags stripped:

https://cs.opensource.google/go/x/crypto/+/3147a52a:ssh/agent/server.go;l=133-137

This causes the wrong algorithm to be used, which leads to:

    agent key RSA SHA256:<hash> returned incorrect signature type

The reason kola itself doesn't hit this is because it doesn't go through
the socket.

The underlying `keyring` object does implement `ExtendedAgent` though,
which does support `SignWithFlags`, so just cast it.

Fixes: dcd432d2a ("mantle: switch back to RSA SSH keys")