### PR TITLE
cosalib/ova: enable Secure Boot in VMware OVA

### DIFF
--- a/src/vmware-template.xml
+++ b/src/vmware-template.xml
@@ -80,7 +80,7 @@
         <vmw:Config ovf:required="false" vmw:key="connectable.allowGuestControl" vmw:value="true"/>
         <vmw:Config ovf:required="false" vmw:key="wakeOnLanEnabled" vmw:value="false"/>
       </Item>
-      <vmw:Config ovf:required="false" vmw:key="bootOptions.efiSecureBootEnabled" vmw:value="false"/>
+      <vmw:Config ovf:required="false" vmw:key="bootOptions.efiSecureBootEnabled" vmw:value="true"/>
       <vmw:Config ovf:required="false" vmw:key="firmware" vmw:value="efi"/>
     </VirtualHardwareSection>
     <ProductSection>


### PR DESCRIPTION
The `iopl(2)` issue is worked around upstream in https://github.com/coreos/ignition/pull/1332, and until that lands in a release, both FCOS and RHCOS are shipping downstream patches.