### PR TITLE
kola/devshell: use built-in SSH agent

### DIFF
--- a/mantle/cmd/kola/devshell.go
+++ b/mantle/cmd/kola/devshell.go
@@ -505,7 +505,7 @@ func (sc *sshClient) start() {
 	if sc.cmd != "" {
 		sshArgs = append(sshArgs, "--", sc.cmd)
 	}
-	fmt.Println("") // line break for prettier output
+	fmt.Printf("\033[2K\r") // clear serial console line
 	sshCmd := exec.Command(sshArgs[0], sshArgs[1:]...)
 	sshCmd.Stdin = os.Stdin
 	sshCmd.Stdout = os.Stdout

--- a/mantle/cmd/kola/devshell.go
+++ b/mantle/cmd/kola/devshell.go
@@ -498,6 +498,7 @@ func (sc *sshClient) start() {
 		"-i", sc.privKey,
 		"-o", "StrictHostKeyChecking=no",
 		"-o", "CheckHostIP=no",
+		"-o", "PreferredAuthentications=publickey",
 		"-p", sc.port,
 		fmt.Sprintf("%s@%s", sc.user, sc.host),
 	}

--- a/mantle/cmd/kola/devshell.go
+++ b/mantle/cmd/kola/devshell.go
@@ -505,7 +505,8 @@ func (sc *sshClient) start() {
 	if sc.cmd != "" {
 		sshArgs = append(sshArgs, "--", sc.cmd)
 	}
-	fmt.Printf("\033[2K\r") // clear serial console line
+	fmt.Printf("\033[2K\r")                // clear serial console line
+	fmt.Printf("[SESSION] Starting SSH\r") // and stage a status msg which will be erased
 	sshCmd := exec.Command(sshArgs[0], sshArgs[1:]...)
 	sshCmd.Stdin = os.Stdin
 	sshCmd.Stdout = os.Stdout

--- a/mantle/cmd/kola/devshell.go
+++ b/mantle/cmd/kola/devshell.go
@@ -498,7 +498,6 @@ func (sc *sshClient) start() {
 		"-i", sc.privKey,
 		"-o", "StrictHostKeyChecking=no",
 		"-o", "CheckHostIP=no",
-		"-o", "IdentityFile=/dev/null",
 		"-p", sc.port,
 		fmt.Sprintf("%s@%s", sc.user, sc.host),
 	}


### PR DESCRIPTION
By default, SSH will try the public keys from the SSH agent if one is
running. Surprisingly, SSH will try all the keys in the agent *before*
trying the key we explicitly passed in via `-i`.

In my case, I have quite a few keys in my agent. Because the SSH server
in the guest will close the connection if too many unauthorized keys are
tried, the client never even gets to the actual private key we passed
in, and SSH just fails.

This doesn't happen if using cosa as a container since no SSH agent
exists inside. I started hitting this after moving my pet container
environment to toolbox, where the `SSH_AUTH_SOCK` env var is forwarded
and the GNOME Keyring dir is bind-mounted in.

Instead of creating a custom SSH key to pass it to SSH, use the built-in
support for spawning an agent with an ephemeral key and point SSH to it.
We then set `IdentityAgent` to its socket path, which also means SSH
will ignore `SSH_AUTH_SOCK`, fixing the issue above.

That should make SSH faster too anyway since the agent only has the one
key we know will work. This also makes `cosa run` more similar to how
tests are run, which would have let us catch regressions like this
faster:

https://github.com/coreos/coreos-assembler/pull/2765