### PR TITLE
ci: set cpu requests and `GOMAXPROCS` when building image

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -2,7 +2,8 @@
 
 // Build coreos-assembler image and create
 // an imageStream for it
-def imageName = buildImage(env: [ENABLE_GO_RACE_DETECTOR: "1"])
+def cpuCount = "8".toString()
+def imageName = buildImage(env: [ENABLE_GO_RACE_DETECTOR: "1", GOMAXPROCS: cpuCount], cpu: cpuCount)
 
 pod(image: imageName + ":latest", kvm: true, memory: "10Gi") {
     checkout scm


### PR DESCRIPTION
Something changed recently (maybe just the codebase getting larger)
where the golang compiler is hitting up more easily against its
allocated limit of CPU threads.

Let's explicitly request some amount of CPU for the image build and and
also set `GOMAXPROCS` to respect it.