### PR TITLE
docs/kola, kola/harness: non external tests must be exclusive

### DIFF
--- a/docs/kola.md
+++ b/docs/kola.md
@@ -159,6 +159,16 @@ For more examples, look at the
 suite of tests under kola. These tests were ported into kola and make
 heavy use of the native code interface.
 
+## kola non-exclusive tests
+
+Some tests are light weight and do not involve complex interactions like reboots
+and multiple machines. Tests that are not expected to conflict with other tests can be
+marked as "non-exclusive", so that they are run in the same VM to save resources.
+
+External tests can be marked as non-exclusive via kola.json or an inline tag. 
+Note: tests compiled in kola (non external tests) cannot be marked as non-exclusive. 
+This is deliberate as tests compiled in kola should be complex and thus exclusive.
+
 ## Manhole
 
 The `platform.Manhole()` function creates an interactive SSH session which can

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -586,6 +586,9 @@ func runProvidedTests(testsBank map[string]*register.Test, patterns []string, mu
 	var nonExclusiveTests []*register.Test
 	for _, test := range tests {
 		if test.NonExclusive {
+			if test.ExternalTest == "" {
+				plog.Fatalf("Tests compiled in kola must be exclusive: %v", test.Name)
+			}
 			nonExclusiveTests = append(nonExclusiveTests, test)
 			delete(tests, test.Name)
 		}


### PR DESCRIPTION
Whether or not tests compiled in kola can be marked as nonexclusive
has been ambiguous thus far. Since tests compiled in kola should be
complex and thus exclusive, let's disallow this scenario and make
it explicit.