### PR TITLE
misc/network.go: add ConditionKernelCommandLine for setup-ovs.service

### DIFF
--- a/mantle/kola/tests/misc/network.go
+++ b/mantle/kola/tests/misc/network.go
@@ -698,7 +698,7 @@ func setupMultipleNetworkTest(c cluster.TestCluster, primaryMac, secondaryMac st
 					"name": "capture-macs.service"
 				},
 				{
-					"contents": "[Unit]\nDescription=Setup OVS bonding\nBefore=ovs-configuration.service\nAfter=NetworkManager.service\nAfter=openvswitch.service\nAfter=capture-macs.service\n\n[Service]\nType=oneshot\nExecStart=/usr/local/bin/setup-ovs\n\n[Install]\nRequiredBy=multi-user.target\n",
+					"contents": "[Unit]\nDescription=Setup OVS bonding\nBefore=ovs-configuration.service\nAfter=NetworkManager.service\nAfter=openvswitch.service\nAfter=capture-macs.service\nConditionKernelCommandLine=macAddressList\n\n[Service]\nType=oneshot\nExecStart=/usr/local/bin/setup-ovs\n\n[Install]\nRequiredBy=multi-user.target\n",
 					"enabled": true,
 					"name": "setup-ovs.service"
 				}


### PR DESCRIPTION
This is the workaround for https://github.com/coreos/coreos-assembler/pull/2766
When create VM with config service, setup-ovs.service will fail as
it depends on later steps to append kernel agrs. Add check kernel
arguments before running will avoid the service fail.