### PR TITLE
build: Support `builds/` in workdir being a symlink outside workdir

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -652,10 +652,15 @@ EOF
                     -append "root=/dev/vda console=${DEFAULT_TERMINAL} selinux=1 enforcing=0 autorelabel=1" \
                    )
 
-    # support local dev cases where src/config is a symlink
+    # support local dev cases where src/config is a symlink.  Note if you change or extend to this set,
+    # you also need to update supermin-init-prelude.sh to mount it inside the VM.
     if [ -L "${workdir}/src/config" ]; then
         # qemu follows symlinks
         base_qemu_args+=("-virtfs" 'local,id=source,path='"${workdir}"'/src/config,security_model=none,mount_tag=source')
+    fi
+    # Current RHCOS pipeline makes builds/ a PVC
+    if [ -L "${workdir}/builds" ]; then
+        base_qemu_args+=("-virtfs" 'local,id=builds,path='"${workdir}"'/builds,security_model=none,mount_tag=builds')
     fi
 
     if [ -z "${RUNVM_SHELL:-}" ]; then

--- a/src/supermin-init-prelude.sh
+++ b/src/supermin-init-prelude.sh
@@ -37,9 +37,14 @@ umask 002
 # https://github.com/coreos/coreos-assembler/issues/2171
 mkdir -p "${workdir:?}"
 mount -t 9p -o rw,trans=virtio,version=9p2000.L,msize=10485760 workdir "${workdir}"
+# These two invocations pair with virtfs setups for qemu in cmdlib.sh.  Keep them in sync.
 if [ -L "${workdir}"/src/config ]; then
     mkdir -p "$(readlink "${workdir}"/src/config)"
     mount -t 9p -o rw,trans=virtio,version=9p2000.L,msize=10485760 source "${workdir}"/src/config
+fi
+if [ -L "${workdir}"/builds ]; then
+    mkdir -p "$(readlink "${workdir}"/builds)"
+    mount -t 9p -o rw,trans=virtio,version=9p2000.L,msize=10485760 builds "${workdir}"/builds
 fi
 mkdir -p "${workdir}"/cache
 cachedev=$(blkid -lt LABEL=cosa-cache -o device || true)


### PR DESCRIPTION
This is the case in the RHCOS pipeline today, and we can support
it in the same way we support `src/config` being a symlink to
outside the workdir.

Note: This only works for absolute symlinks today.

Side note: At some point we should use virtiofs which AIUI will
just fix this by supporting symlinks natively.

Closes: https://github.com/openshift/os/issues/754