### PR TITLE
build: Add support for `ostree-format: oci-chunked`

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -384,20 +384,21 @@ if [ "${commit}" == "${previous_commit}" ] && \
     fi
 else
     ostree_format=$(jq -r '.["ostree-format"]' < "${image_json}")
+    ostree_tarfile_path="${name}-${buildid}-ostree.${basearch}.ociarchive"
+    gitsrc=$(jq -r .git.origin < "${PWD}/coreos-assembler-config-git.json")
+    cmd=(ostree container encapsulate)
     case "${ostree_format}" in
-        null|oci)
-            ostree_tarfile_path="${name}-${buildid}-ostree.${basearch}.ociarchive"
-            gitsrc=$(jq -r .git.origin < "${PWD}/coreos-assembler-config-git.json")
-            runv ostree container encapsulate --repo="${tmprepo}" \
-                --label="coreos-assembler.image-config-checksum=${image_config_checksum}" \
-                --label="coreos-assembler.image-input-checksum=${image_input_checksum}" \
-                --label="org.opencontainers.image.source=${gitsrc}" \
-                --label="org.opencontainers.image.revision=${config_gitrev}" \
-                "${buildid}" \
-                oci-archive:"${ostree_tarfile_path}".tmp:latest
-            ;;
+        oci) ;;
+        oci-chunked) cmd=(rpm-ostree container-encapsulate) ;;
         *) fatal "Unknown ostree-format: ${ostree_format}"
     esac
+    runv "${cmd[@]}" --repo="${tmprepo}" \
+        --label="coreos-assembler.image-config-checksum=${image_config_checksum}" \
+        --label="coreos-assembler.image-input-checksum=${image_input_checksum}" \
+        --label="org.opencontainers.image.source=${gitsrc}" \
+        --label="org.opencontainers.image.revision=${config_gitrev}" \
+        "${buildid}" \
+        oci-archive:"${ostree_tarfile_path}".tmp:latest
     /usr/lib/coreos-assembler/finalize-artifact "${ostree_tarfile_path}"{.tmp,}
     ostree_tarfile_sha256=$(sha256sum "${ostree_tarfile_path}" | awk '{print$1}')
 fi

--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -132,18 +132,14 @@ if [ "${image_type}" = dasd ] || [ "${image_type}" = metal4k ]; then
     ignition_platform_id=metal
 fi
 
-yaml2json "/usr/lib/coreos-assembler/image-default.yaml" image-default.json
-# Combine with the defaults
-cat image-default.json "${image_json}" | jq -s add > image-configured.json
-
 # We do some extra handling of the rootfs here; it feeds into size estimation.
-rootfs_type=$(jq -re .rootfs < image-configured.json)
+rootfs_type=$(jq -re .rootfs < "${image_json}")
 
 deploy_via_container=""
-if jq -re '.["deploy-via-container"]' < image-configured.json; then
+if jq -re '.["deploy-via-container"]' < "${image_json}"; then
     deploy_via_container="true"
 fi
-container_imgref=$(jq -r '.["container-imgref"]//""' < image-configured.json)
+container_imgref=$(jq -r '.["container-imgref"]//""' < "${image_json}")
 # Nowadays we pull the container across 9p rather than accessing the repo, see
 # https://github.com/openshift/os/issues/594
 ostree_container=ostree-unverified-image:oci-archive:$builddir/$(meta_key images.ostree.path)
@@ -220,10 +216,10 @@ cat >image-dynamic.json << EOF
     "ostree-container": "${ostree_container}"
 }
 EOF
-cat image-configured.json image-dynamic.json | jq -s add > image.json
+cat "${image_json}" image-dynamic.json | jq -s add > image-for-disk.json
 runvm "${target_drive[@]}" -- \
         /usr/lib/coreos-assembler/create_disk.sh \
-            --config "$(pwd)"/image.json \
+            --config "$(pwd)"/image-for-disk.json \
             --kargs "\"${kargs}\"" \
             "${disk_args[@]}"
 /usr/lib/coreos-assembler/finalize-artifact "${path}.tmp" "${path}"

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -187,11 +187,15 @@ prepare_build() {
     flatten_image_yaml_to_file "${configdir}/image.yaml" "${image_yaml}"
     # Convert the image.yaml to JSON so that it can be more easily parsed
     # by the shell script in create_disk.sh.
-    image_json="${workdir}/tmp/image.json"
-    yaml2json "${image_yaml}" "${image_json}"
+    yaml2json "/usr/lib/coreos-assembler/image-default.yaml" image-default.json
+    # Combine with the defaults
+    yaml2json "${image_yaml}" repo-image.json
+    export image_json="${workdir}/tmp/image.json"
+    cat image-default.json repo-image.json | jq -s add > "${image_json}"
+    rm image-default.json repo-image.json
 
     export workdir configdir manifest manifest_lock manifest_lock_overrides manifest_lock_arch_overrides
-    export fetch_stamp image_json
+    export fetch_stamp
 
     if ! [ -f "${manifest}" ]; then
         fatal "Failed to find ${manifest}"

--- a/src/image-default.yaml
+++ b/src/image-default.yaml
@@ -4,6 +4,8 @@ bootfs: "ext4"
 rootfs: "xfs"
 grub-script: "/usr/lib/coreos-assembler/grub.cfg"
 
+# Can also be oci-chunked
+ostree-format: oci
 # True if we should use `ostree container image deploy`
 deploy-via-container: false
 


### PR DESCRIPTION
Move `image-default.yaml` merge into main build

A while ago we added an `image-default.yaml`, but were only using
it in the disk image builds.  Move it into the main build setup,
so we can consistently refer to values that may have defaults there
too.

Prep for extending `ostree-format`.

---

build: Add support for `ostree-format: oci-chunked`

This *opts in* to using https://github.com/coreos/rpm-ostree/pull/3478
so we can safely ratchet in the change, and more easily test in
in non-production CI configurations but still using coreos-assembler.

---

