### PR TITLE
Drop support for writing ostree as `tar`

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -385,21 +385,6 @@ if [ "${commit}" == "${previous_commit}" ] && \
 else
     ostree_format=$(jq -r '.["ostree-format"]' < "${image_json}")
     case "${ostree_format}" in
-        tar)
-            ostree_tarfile_path=${name}-${buildid}-ostree.${basearch}.tar
-            ostree init --repo=repo --mode=archive
-            # Pass the ref if it's set
-            # shellcheck disable=SC2086
-            if ! ostree pull-local --repo=repo "${tmprepo}" "${buildid}" ${ref}; then
-                echo '(maybe https://github.com/coreos/coreos-assembler/issues/972 ?)'
-                exit 1
-            fi
-            # Don't compress; archive repos are already compressed individually and we'd
-            # gain ~20M at best. We could probably have better gains if we compress the
-            # whole repo in bare/bare-user mode, but that's a different story...
-            tar -cf "${ostree_tarfile_path}".tmp -C repo .
-            rm -rf repo
-            ;;
         null|oci)
             ostree_tarfile_path="${name}-${buildid}-ostree.${basearch}.ociarchive"
             gitsrc=$(jq -r .git.origin < "${PWD}/coreos-assembler-config-git.json")

--- a/src/cmd-sign
+++ b/src/cmd-sign
@@ -11,7 +11,6 @@ import os
 import shutil
 import subprocess
 import sys
-import tarfile
 import tempfile
 
 import boto3
@@ -179,24 +178,11 @@ def robosign_ostree(args, s3, build, gpgkey):
         # We've validated the commit, now re-export the repo
         ostree_image = build['images']['ostree']
         exported_ostree_path = os.path.join(builddir, ostree_image['path'])
-        if exported_ostree_path.endswith('.ociarchive'):
-            # Files stored in the build directory are mode 0600 to prevent
-            # accidental mutation.  Remove the existing one because otherwise
-            # we'll try to `open(O_TRUNC)` it and fail.
-            os.unlink(exported_ostree_path)
-            subprocess.check_call(['ostree', 'container', 'export', '--repo=tmp/repo', checksum, f'oci-archive:{exported_ostree_path}:latest'])
-        else:
-            tmp_tar = os.path.join(d, ostree_image['path'])
-            # To make things a bit more efficient, append the commitmeta at
-            # the end of the archive after reflinking.
-            subprocess.check_call(['cp-reflink', exported_ostree_path, tmp_tar])
-            # Normally we make our artifacts 0600 to avoid accidental mutation, but since
-            # we can efficiently *append* to an existing tar archive, do that instead of
-            # copying and rewriting.  We just need to temporarily make it writable
-            os.chmod(tmp_tar, 0o660)
-            with tarfile.open(tmp_tar, 'a:') as t:
-                t.add(metapath, arcname=f'objects/{checksum[:2]}/{checksum[2:]}.commitmeta')
-            shutil.move(tmp_tar, exported_ostree_path)
+        # Files stored in the build directory are mode 0600 to prevent
+        # accidental mutation.  Remove the existing one because otherwise
+        # we'll try to `open(O_TRUNC)` it and fail.
+        os.unlink(exported_ostree_path)
+        subprocess.check_call(['ostree', 'container', 'export', '--repo=tmp/repo', checksum, f'oci-archive:{exported_ostree_path}:latest'])
         # Finalize the export by making it not writable.
         os.chmod(exported_ostree_path, 0o400)
         ostree_image['size'] = os.path.getsize(exported_ostree_path)


### PR DESCRIPTION
The container bits should have propagated everywhere we care about now.