### PR TITLE
build: Add support for `rootfs-args`

### DIFF
--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -91,6 +91,7 @@ case "${rootfs_type}" in
     xfs|ext4verity|btrfs) ;;
     *) echo "Invalid rootfs type: ${rootfs_type}" 1>&2; exit 1;;
 esac
+rootfs_args=$(getconfig_def "rootfs-args" "")
 
 bootfs=$(getconfig "bootfs")
 grub_script=$(getconfig "grub-script")
@@ -211,13 +212,13 @@ case "${rootfs_type}" in
         # So basically, we're choosing performance over half-implemented security.
         # Eventually, we'd like both - once XFS gains verity (probably not too hard),
         # we could unconditionally enable it there.
-        mkfs.ext4 -b $(getconf PAGE_SIZE) -O verity -L root "${root_dev}" -U "${rootfs_uuid}"
+        mkfs.ext4 -b $(getconf PAGE_SIZE) -O verity -L root "${root_dev}" -U "${rootfs_uuid}" ${rootfs_args}
         ;;
     btrfs)
-        mkfs.btrfs -L root "${root_dev}" -U "${rootfs_uuid}"
+        mkfs.btrfs -L root "${root_dev}" -U "${rootfs_uuid}" ${rootfs_args}
         ;;
     xfs|"")
-        mkfs.xfs "${root_dev}" -L root -m reflink=1 -m uuid="${rootfs_uuid}"
+        mkfs.xfs "${root_dev}" -L root -m reflink=1 -m uuid="${rootfs_uuid}" ${rootfs_args}
         ;;
     *)
         echo "Unknown rootfs_type: $rootfs_type" 1>&2

--- a/src/image-default.yaml
+++ b/src/image-default.yaml
@@ -2,6 +2,8 @@
 
 bootfs: "ext4"
 rootfs: "xfs"
+# Add arguments here that will be passed to e.g. mkfs.xfs
+rootfs-args: ""
 grub-script: "/usr/lib/coreos-assembler/grub.cfg"
 
 # True if we should use `ostree container image deploy`


### PR DESCRIPTION
Add the infrastructure for the config git repository to extend
the options passed to `mkfs.$fs`.

My intention is to add `-m bigtime=1` for xfs.