### PR TITLE
build: Copy `rpmostree.inputhash` key for current container flow

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -386,9 +386,10 @@ else
     ostree_format=$(jq -r '.["ostree-format"]' < "${image_json}")
     ostree_tarfile_path="${name}-${buildid}-ostree.${basearch}.ociarchive"
     gitsrc=$(jq -r .git.origin < "${PWD}/coreos-assembler-config-git.json")
-    cmd=(ostree container encapsulate)
+    cmd=(ostree container encapsulate --copymeta="rpmostree.inputhash")
     case "${ostree_format}" in
         oci) ;;
+        # Note rpm-ostree always copies the rpmostree.inputhash key
         oci-chunked) cmd=(rpm-ostree container-encapsulate) ;;
         *) fatal "Unknown ostree-format: ${ostree_format}"
     esac


### PR DESCRIPTION
As the comment says, this is something that `rpm-ostree container-encapsulate`
does by default.

But we aren't shipping that yet.  This will help me bridge the
two worlds by ensuring they contain identical metadata.