### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/gangplank/internal/ocp/bc_test.go
+++ b/gangplank/internal/ocp/bc_test.go
@@ -11,8 +11,7 @@ import (
 const testDataFile = "build.json"
 
 func TestOCPBuild(t *testing.T) {
-	tmpd, _ := ioutil.TempDir("", "test")
-	defer os.RemoveAll(tmpd)
+	tmpd := t.TempDir()
 	cosaSrvDir = tmpd
 
 	bData, err := ioutil.ReadFile(testDataFile)

--- a/gangplank/internal/ocp/filer_test.go
+++ b/gangplank/internal/ocp/filer_test.go
@@ -15,11 +15,7 @@ import (
 )
 
 func TestFiler(t *testing.T) {
-	tmpd, err := ioutil.TempDir("", "cosa-test")
-	if err != nil {
-		t.Fatalf("Failed to create tempdir")
-	}
-	defer os.RemoveAll(tmpd)
+	tmpd := t.TempDir()
 
 	testBucket := "testbucket"
 	testFileContents := "this is a test"

--- a/gangplank/internal/ocp/remotes_test.go
+++ b/gangplank/internal/ocp/remotes_test.go
@@ -12,10 +12,9 @@ import (
 )
 
 func TestRemote(t *testing.T) {
-	tmpd, _ := ioutil.TempDir("", "remotes")
+	tmpd := t.TempDir()
 	srvd := filepath.Join(tmpd, "serve")
 	destd := filepath.Join(tmpd, "in")
-	//defer os.RemoveAll(tmpd)
 
 	testBucket := "source"
 	if err := os.MkdirAll(filepath.Join(srvd, testBucket), 0755); err != nil {

--- a/gangplank/internal/ocp/return_test.go
+++ b/gangplank/internal/ocp/return_test.go
@@ -14,11 +14,10 @@ import (
 )
 
 func TestTarballRemote(t *testing.T) {
-	tmpd, _ := ioutil.TempDir("", "remotes")
+	tmpd := t.TempDir()
 	srvd := filepath.Join(tmpd, "serve")
 	srcd := filepath.Join(tmpd, "src")
 	destd := filepath.Join(tmpd, "dest")
-	defer os.RemoveAll(tmpd) //nolint
 
 	for _, d := range []string{srvd, srcd, destd} {
 		if err := os.MkdirAll(d, 0777); err != nil {

--- a/gangplank/internal/spec/jobspec_test.go
+++ b/gangplank/internal/spec/jobspec_test.go
@@ -26,11 +26,7 @@ func setMockHttpGet(data []byte, status int, err error) {
 }
 
 func TestURL(t *testing.T) {
-	tmpd, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("unable to create tmpdir")
-	}
-	defer os.RemoveAll(tmpd) //nolint
+	tmpd := t.TempDir()
 
 	cases := []struct {
 		repo       Repo

--- a/gangplank/internal/spec/stage_test.go
+++ b/gangplank/internal/spec/stage_test.go
@@ -3,7 +3,6 @@ package spec
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -37,8 +36,7 @@ stages:
 `, MockOSJobSpec)
 
 func TestStages(t *testing.T) {
-	tmpd, _ := ioutil.TempDir("", "teststages")
-	defer os.RemoveAll(tmpd)
+	tmpd := t.TempDir()
 
 	rd := &RenderData{
 		JobSpec: new(JobSpec),
@@ -196,9 +194,8 @@ func TestStages(t *testing.T) {
 func TestStageYaml(t *testing.T) {
 	myD, _ := os.Getwd()
 	defer os.Chdir(myD) //nolint
-	tmpd, _ := ioutil.TempDir("", "stagetest")
+	tmpd := t.TempDir()
 	_ = os.Chdir(tmpd)
-	defer os.RemoveAll(tmpd)
 
 	r := strings.NewReader(MockStageYaml)
 	js, err := JobSpecReader(r)

--- a/mantle/harness/harness_test.go
+++ b/mantle/harness/harness_test.go
@@ -18,7 +18,6 @@ package harness
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -330,13 +329,7 @@ func makeRegexp(s string) string {
 }
 
 func TestOutputDir(t *testing.T) {
-	var suitedir string
-	if dir, err := ioutil.TempDir("", ""); err != nil {
-		t.Fatal(err)
-	} else {
-		defer os.RemoveAll(dir)
-		suitedir = filepath.Join(dir, "_test_temp")
-	}
+	suitedir := filepath.Join(t.TempDir(), "_test_temp")
 
 	var testdirs []string
 	adddir := func(h *H) {
@@ -370,13 +363,7 @@ func TestOutputDir(t *testing.T) {
 }
 
 func TestSubDirs(t *testing.T) {
-	var suitedir string
-	if dir, err := ioutil.TempDir("", ""); err != nil {
-		t.Fatal(err)
-	} else {
-		defer os.RemoveAll(dir)
-		suitedir = filepath.Join(dir, "_test_temp")
-	}
+	suitedir := t.TempDir()
 
 	var testdirs []string
 	adddir := func(h *H) {
@@ -410,13 +397,7 @@ func TestSubDirs(t *testing.T) {
 }
 
 func TestTempDir(t *testing.T) {
-	var suitedir string
-	if dir, err := ioutil.TempDir("", ""); err != nil {
-		t.Fatal(err)
-	} else {
-		defer os.RemoveAll(dir)
-		suitedir = filepath.Join(dir, "_test_temp")
-	}
+	suitedir := t.TempDir()
 
 	var testdirs []string
 	opts := Options{
@@ -460,13 +441,7 @@ func TestTempDir(t *testing.T) {
 }
 
 func TestTempFile(t *testing.T) {
-	var suitedir string
-	if dir, err := ioutil.TempDir("", ""); err != nil {
-		t.Fatal(err)
-	} else {
-		defer os.RemoveAll(dir)
-		suitedir = filepath.Join(dir, "_test_temp")
-	}
+	suitedir := t.TempDir()
 
 	var testfiles []string
 	opts := Options{

--- a/mantle/system/copy_test.go
+++ b/mantle/system/copy_test.go
@@ -45,11 +45,7 @@ func checkFile(t *testing.T, path string, data []byte, mode os.FileMode) {
 
 func TestCopyRegularFile(t *testing.T) {
 	data := []byte("test")
-	tmp, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 
 	src := filepath.Join(tmp, "src")
 	if err := ioutil.WriteFile(src, data, 0600); err != nil {

--- a/schema/cosa/builds_test.go
+++ b/schema/cosa/builds_test.go
@@ -23,8 +23,7 @@ var testData = `
 `
 
 func TestBuildsMeta(t *testing.T) {
-	tmpd, _ := ioutil.TempDir("", "buildjson")
-	defer os.RemoveAll(tmpd)
+	tmpd := t.TempDir()
 	_ = os.MkdirAll(filepath.Join(tmpd, "builds"), 0755)
 
 	bjson := filepath.Join(tmpd, CosaBuildsJSON)

--- a/schema/cosa/schema_test.go
+++ b/schema/cosa/schema_test.go
@@ -43,11 +43,7 @@ func TestSchema(t *testing.T) {
 
 // Test that we can write a file
 func TestWriteMeta(t *testing.T) {
-	tmpd, err := ioutil.TempDir("", "test-writemeta-*****")
-	if err != nil {
-		t.Errorf("failed to create tmpdir: %v", err)
-	}
-	defer os.RemoveAll(tmpd)
+	tmpd := t.TempDir()
 
 	for _, df := range testMeta {
 		b, err := ParseBuild(df)
@@ -152,11 +148,7 @@ func TestMergeMeta(t *testing.T) {
 	b.CosaDelayedMetaMerge = true
 
 	// Create a fake build structure
-	tmpd, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal("unable to create a tmpdir")
-	}
-	defer os.RemoveAll(tmpd) //nolint
+	tmpd := t.TempDir()
 
 	// Create a fake build dir
 	fakeBuildID := "999.1"


### PR DESCRIPTION
A testing cleanup. 

This pull request replaces `ioutil.TempDir` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

Reference: https://pkg.go.dev/testing#T.TempDir