### PR TITLE
`image.yaml`: Add `bigtime` option to deal with year 2038 problem

### DIFF
--- a/src/image-default.yaml
+++ b/src/image-default.yaml
@@ -2,6 +2,10 @@
 
 bootfs: "ext4"
 rootfs: "xfs"
+# 0: don't change filesystem defaults
+# 1: Enable bigtime for /boot
+# 2: Enable bigtime for /boot and /
+bigtime: 0
 # Add arguments here that will be passed to e.g. mkfs.xfs
 rootfs-args: ""
 grub-script: "/usr/lib/coreos-assembler/grub.cfg"


### PR DESCRIPTION
Creating this based on discussion in https://github.com/coreos/fedora-coreos-config/pull/1650
around supporting bigtime for our XFS `/`.

We want to enable gradual rollout of this; any changes today to
coreos-assembler's defaults become "insta stable" for FCOS and
current rhcos-4.11.  Having things stored in config git enables
CI and control.

Keep the default `0` to mean today's status quo (no bigtime).
We support opting-in just `/boot`, as well as doing both `/boot`
and `/`.

Re `/boot` which is ext4 today, the docs for this say:

> The larger the inode-size the more space the inode table will consume, and this reduces the usable space in the filesystem and can also negatively impact performance.

But for `/boot` we have a *tiny* number of files.  We also aren't
optimizing for performance here - `/boot` is rarely touched.

I think now is a good time to ensure we aren't subject to the year 2038
problem for it (as well as our other filesystems, but this one can
come first).

Then we can do `/` too.