### PR TITLE
kola/harness: drop obsolete log checks and the check for lockdep warnings

### DIFF
--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -144,12 +144,6 @@ var (
 			match: regexp.MustCompile("rejecting I/O to offline device"),
 		},
 		{
-			// Failure to set up Packet networking in initramfs,
-			// perhaps due to unresponsive metadata server
-			desc:  "coreos-metadata failure to set up initramfs network",
-			match: regexp.MustCompile("Failed to start CoreOS Static Network Agent"),
-		},
-		{
 			// https://github.com/coreos/bugs/issues/2065
 			desc:  "excessive bonding link status messages",
 			match: regexp.MustCompile("(?s:link status up for interface [^,]+, enabling it in [0-9]+ ms.*?){10}"),
@@ -173,11 +167,6 @@ var (
 			// https://github.com/coreos/bugs/issues/2526
 			desc:  "initrd-cleanup.service terminated",
 			match: regexp.MustCompile(`initrd-cleanup\.service: Main process exited, code=killed, status=15/TERM`),
-		},
-		{
-			// kernel 4.14.11
-			desc:  "bad page table",
-			match: regexp.MustCompile(`mm/pgtable-generic.c:\d+: bad (p.d|pte)`),
 		},
 		{
 			desc:  "Go panic",

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -136,10 +136,6 @@ var (
 			match: regexp.MustCompile(`WARNING: CPU: \d+ PID: \d+ at (.+)`),
 		},
 		{
-			desc:  "kernel circular locking dependency warning",
-			match: regexp.MustCompile("WARNING: possible circular locking dependency detected"),
-		},
-		{
 			desc:  "failure of disk under I/O",
 			match: regexp.MustCompile("rejecting I/O to offline device"),
 		},


### PR DESCRIPTION
The only Fedora kernels built with lockdep enabled are non-rc Rawhide kernels, and we don't intend to actively pursue any warnings that occur in those.  Drop the check for lockdep warnings so they don't cause CI failures.

In addition, the kernel 4.14.11 bug is long gone, and we no longer ship a unit described as `CoreOS Static Network Agent`.  Drop those checks.

Fixes https://github.com/coreos/fedora-coreos-tracker/issues/1152.