### PR TITLE
kola: Add SCOS distribution as alias for RHCOS

### DIFF
--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -37,7 +37,7 @@ var (
 	kolaPlatform      string
 	kolaArchitectures = []string{"amd64"}
 	kolaPlatforms     = []string{"aws", "azure", "do", "esx", "gce", "openstack", "packet", "qemu", "qemu-unpriv", "qemu-iso"}
-	kolaDistros       = []string{"fcos", "rhcos"}
+	kolaDistros       = []string{"fcos", "rhcos", "scos"}
 )
 
 func init() {
@@ -294,6 +294,9 @@ func syncOptionsImpl(useCosa bool) error {
 
 	if kola.Options.Distribution == "" {
 		kola.Options.Distribution = kolaDistros[0]
+	} else if kola.Options.Distribution == "scos" {
+		// Consider SCOS the same as RHCOS for now
+		kola.Options.Distribution = "rhcos"
 	} else if err := validateOption("distro", kola.Options.Distribution, kolaDistros); err != nil {
 		return err
 	}

--- a/mantle/cmd/kola/qemuexec.go
+++ b/mantle/cmd/kola/qemuexec.go
@@ -174,7 +174,7 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 		cpuCountHost = true
 		usernet = true
 		// Can't use 9p on RHEL8, need https://virtio-fs.gitlab.io/ instead in the future
-		if kola.Options.CosaWorkdir != "" && !strings.HasPrefix(filepath.Base(kola.QEMUOptions.DiskImage), "rhcos") {
+		if kola.Options.CosaWorkdir != "" && !strings.HasPrefix(filepath.Base(kola.QEMUOptions.DiskImage), "rhcos") && !strings.HasPrefix(filepath.Base(kola.QEMUOptions.DiskImage), "scos") && kola.Options.Distribution != "rhcos" && kola.Options.Distribution != "scos" {
 			// Conservatively bind readonly to avoid anything in the guest (stray tests, whatever)
 			// from destroying stuff
 			bindro = append(bindro, fmt.Sprintf("%s,/var/mnt/workdir", kola.Options.CosaWorkdir))

--- a/mantle/util/distros.go
+++ b/mantle/util/distros.go
@@ -38,6 +38,8 @@ func TargetDistro(build *cosa.Build) (string, error) {
 	switch build.Name {
 	case "rhcos":
 		return "rhcos", nil
+	case "scos":
+		return "rhcos", nil
 	case "fedora-coreos":
 		return "fcos", nil
 	default:


### PR DESCRIPTION
kola: Add SCOS distribution as alias for RHCOS

Add a new distribution option but keep as an alias for RHCOS for now.

---

kola: Setup 9p mounts only for non-SCOS & non-RHCOS

Keep this as a long denylist of conditions to try to use 9p by default
and only not use it in cases where we know it won't work.