### PR TITLE
push-container: Support `--format`

### DIFF
--- a/src/cmd-push-container
+++ b/src/cmd-push-container
@@ -18,6 +18,7 @@ from cosalib import cmdlib
 parser = argparse.ArgumentParser()
 parser.add_argument("--authfile", help="Authentication file",
                     action='store')
+parser.add_argument("--format", help="Image format for destination", choices=['oci', 'v2s2'], action='store')
 parser.add_argument("name", help="destination image reference")
 
 args = parser.parse_args()
@@ -40,6 +41,8 @@ if args.authfile is None:
     args.authfile = os.environ.get("REGISTRY_AUTH_FILE")
 if args.authfile is not None:
     skopeoargs.extend(['--authfile', args.authfile])
+if args.format is not None:
+    skopeoargs.extend(['--format', args.format])
 container_name = args.name
 if ":" not in container_name:
     container_name = f"{container_name}:{latest_build}-{arch}"


### PR DESCRIPTION
For similar reasons as https://github.com/coreos/coreos-assembler/pull/2726
we need to support pushing our containers in v2s2 format, not oci.

(Unlike that patch, we don't flip the default though here)