### PR TITLE
Prep patches for storing `image.json` in the ostree

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -207,11 +207,7 @@ ks_path="${configdir}"/image.ks
 if [ -f "${ks_path}" ]; then
     fatal "Kickstart support was removed; migrate to image.yaml"
 fi
-image_input="${image_yaml}"
-if ! [ -f "${image_input}" ]; then
-    fatal "Failed to find ${image_input}"
-fi
-image_config_checksum=$(< "${image_input}" sha256sum_str)
+image_config_checksum=$(< "${image_json}" sha256sum_str)
 if [ -n "${previous_build}" ]; then
     previous_image_input_checksum=$(jq -r '.["coreos-assembler.image-input-checksum"]' < "${previous_builddir}/meta.json")
 fi

--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -47,7 +47,7 @@ if not args.build:
 print(f"Targeting build: {args.build}")
 
 image_json = generate_image_json('src/config/image.yaml')
-squashfs_compression = 'lz4' if args.fast else image_json.get('squashfs-compression', 'zstd')
+squashfs_compression = 'lz4' if args.fast else image_json['squashfs-compression']
 
 srcdir_prefix = "src/config/live/"
 

--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -18,7 +18,7 @@ import time
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from cosalib.builds import Builds
-from cosalib.cmdlib import run_verbose, sha256sum_file, flatten_image_yaml
+from cosalib.cmdlib import run_verbose, sha256sum_file, generate_image_json
 from cosalib.cmdlib import import_ostree_commit, get_basearch, ensure_glob
 from cosalib.meta import GenericBuildMeta
 
@@ -46,8 +46,8 @@ if not args.build:
     args.build = builds.get_latest()
 print(f"Targeting build: {args.build}")
 
-image_yaml = flatten_image_yaml('src/config/image.yaml')
-squashfs_compression = 'lz4' if args.fast else image_yaml.get('squashfs-compression', 'zstd')
+image_json = generate_image_json('src/config/image.yaml')
+squashfs_compression = 'lz4' if args.fast else image_json.get('squashfs-compression', 'zstd')
 
 srcdir_prefix = "src/config/live/"
 

--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -170,7 +170,7 @@ case "${image_type}" in
         rootfs_size=0
         ;;
     qemu)
-        image_size="$(python3 -c 'import sys, yaml; print(yaml.safe_load(sys.stdin)["size"])' < "${image_yaml}")G"
+        image_size="$(jq -r ".size" < "${image_json}")G"
         rootfs_size="${rootfs_size}M"
         ;;
     *) fatal "unreachable image_type ${image_type}";;
@@ -181,7 +181,7 @@ if [ "${image_type}" == metal4k ]; then
 fi
 
 set -x
-kargs="$(python3 -c 'import sys, yaml; args = yaml.safe_load(sys.stdin).get("extra-kargs", []); print(" ".join(args))' < "${image_yaml}")"
+kargs="$(python3 -c 'import sys, json; args = json.load(sys.stdin).get("extra-kargs", []); print(" ".join(args))' < "${image_json}")"
 tty="console=tty0 console=${DEFAULT_TERMINAL},115200n8"
 # On each s390x hypervisor, a tty would be automatically detected by the kernel
 # and systemd, there is no need to specify one. However, we keep DEFAULT_TERMINAL

--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -181,7 +181,7 @@ if [ "${image_type}" == metal4k ]; then
 fi
 
 set -x
-kargs="$(python3 -c 'import sys, json; args = json.load(sys.stdin).get("extra-kargs", []); print(" ".join(args))' < "${image_json}")"
+kargs="$(python3 -c 'import sys, json; args = json.load(sys.stdin)["extra-kargs"]; print(" ".join(args))' < "${image_json}")"
 tty="console=tty0 console=${DEFAULT_TERMINAL},115200n8"
 # On each s390x hypervisor, a tty would be automatically detected by the kernel
 # and systemd, there is no need to specify one. However, we keep DEFAULT_TERMINAL

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -183,16 +183,8 @@ prepare_build() {
     manifest_lock_arch_overrides=$(pick_yaml_or_else_json "${configdir}/manifest-lock.overrides.${basearch}")
     fetch_stamp="${workdir}"/cache/fetched-stamp
 
-    image_yaml="${workdir}/tmp/image.yaml"
-    flatten_image_yaml_to_file "${configdir}/image.yaml" "${image_yaml}"
-    # Convert the image.yaml to JSON so that it can be more easily parsed
-    # by the shell script in create_disk.sh.
-    yaml2json "/usr/lib/coreos-assembler/image-default.yaml" image-default.json
-    # Combine with the defaults
-    yaml2json "${image_yaml}" repo-image.json
     export image_json="${workdir}/tmp/image.json"
-    cat image-default.json repo-image.json | jq -S -s add > "${image_json}"
-    rm image-default.json repo-image.json
+    write_image_json "${configdir}/image.yaml" "${image_json}"
 
     export workdir configdir manifest manifest_lock manifest_lock_overrides manifest_lock_arch_overrides
     export fetch_stamp
@@ -882,14 +874,14 @@ builds.bump_timestamp()
 print('Build ${buildid} was inserted ${arch:+for $arch}')")
 }
 
-flatten_image_yaml_to_file() {
+write_image_json() {
     local srcfile=$1; shift
     local outfile=$1; shift
     (python3 -c "
 import sys
 sys.path.insert(0, '${DIR}')
 from cosalib import cmdlib
-cmdlib.flatten_image_yaml_to_file('${srcfile}', '${outfile}')")
+cmdlib.write_image_json('${srcfile}', '${outfile}')")
 }
 
 # Shell wrapper for the Python import_ostree_commit

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -149,7 +149,7 @@ pick_yaml_or_else_json() {
 
 # Given a YAML file at first path, write it as JSON to file at second path
 yaml2json() {
-    python3 -c 'import sys, json, yaml; json.dump(yaml.safe_load(sys.stdin), sys.stdout)' < "$1" > "$2"
+    python3 -c 'import sys, json, yaml; json.dump(yaml.safe_load(sys.stdin), sys.stdout, sort_keys=True)' < "$1" > "$2"
 }
 
 prepare_build() {
@@ -191,7 +191,7 @@ prepare_build() {
     # Combine with the defaults
     yaml2json "${image_yaml}" repo-image.json
     export image_json="${workdir}/tmp/image.json"
-    cat image-default.json repo-image.json | jq -s add > "${image_json}"
+    cat image-default.json repo-image.json | jq -S -s add > "${image_json}"
     rm image-default.json repo-image.json
 
     export workdir configdir manifest manifest_lock manifest_lock_overrides manifest_lock_arch_overrides

--- a/src/cosalib/cmdlib.py
+++ b/src/cosalib/cmdlib.py
@@ -350,10 +350,17 @@ def cmdlib_sh(script):
     '''])
 
 
-def flatten_image_yaml_to_file(srcfile, outfile):
-    flattened = flatten_image_yaml(srcfile)
+def generate_image_json(srcfile):
+    r = yaml.safe_load(open("/usr/lib/coreos-assembler/image-default.yaml"))
+    for k, v in flatten_image_yaml(srcfile).items():
+        r[k] = v
+    return r
+
+
+def write_image_json(srcfile, outfile):
+    r = generate_image_json(srcfile)
     with open(outfile, 'w') as f:
-        yaml.dump(flattened, f)
+        json.dump(r, f, sort_keys=True)
 
 
 def merge_lists(x, y, k):

--- a/src/cosalib/ova.py
+++ b/src/cosalib/ova.py
@@ -10,7 +10,7 @@ cosa_dir = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, f"{cosa_dir}/cosalib")
 sys.path.insert(0, cosa_dir)
 
-from cosalib.cmdlib import flatten_image_yaml, image_info
+from cosalib.cmdlib import generate_image_json, image_info
 from cosalib.qemuvariants import QemuVariantImage
 
 
@@ -86,13 +86,10 @@ class OVA(QemuVariantImage):
         Returns a dictionary with the parameters needed to create an OVF file
         based on the qemu, vmdk, image.yaml, and info from the build metadata
         """
-        image_yaml = flatten_image_yaml(
-            '/usr/lib/coreos-assembler/image-default.yaml',
-            flatten_image_yaml('src/config/image.yaml')
-        )
+        image_json = generate_image_json('src/config/image.yaml')
 
-        system_type = 'vmx-{}'.format(image_yaml['vmware-hw-version'])
-        os_type = image_yaml['vmware-os-type']
+        system_type = 'vmx-{}'.format(image_json['vmware-hw-version'])
+        os_type = image_json['vmware-os-type']
         disk_info = image_info(vmdk)
         vmdk_size = os.stat(vmdk).st_size
         image = self.summary

--- a/src/image-default.yaml
+++ b/src/image-default.yaml
@@ -6,6 +6,9 @@ rootfs: "xfs"
 rootfs-args: ""
 grub-script: "/usr/lib/coreos-assembler/grub.cfg"
 
+# Additional default kernel arguments injected into disk images
+extra-kargs: []
+
 # Can also be oci-chunked
 ostree-format: oci
 # True if we should use `ostree container image deploy`

--- a/src/image-default.yaml
+++ b/src/image-default.yaml
@@ -17,6 +17,9 @@ deploy-via-container: false
 # Set this to a target container reference, e.g. ostree-unverified-registry:quay.io/example/os:latest
 # container-imgref: ""
 
+# Format used when generating a squashfs image.  Can also be e.g. gzip or lz4
+squashfs-compression: zstd
+
 # Defaults for VMware OVA, matching historical behavior
 vmware-hw-version: 13
 vmware-os-type: rhel7_64Guest


### PR DESCRIPTION
build: Ensure JSON is sorted for reproducibility

Prep for sticking the rendered `image.json` into the ostree commit;
we want reproducibility here to avoid spurious rebuilds.

---

buildextend-metal: Parse image JSON, not YAML

We're centralizing the input to disk image generation as JSON.
Also, this way we'll correctly honor the defaults.

---

build: Move `extra-kargs` default into `image-default.yaml`

The `image-default.yaml` file should act as the canonical
reference for possible keys, along with their default values.

---

build: Checksum image JSON, not YAML

Part of canonically processing the merged JSON so we correctly
honor defaults.

---

build: Clean up image JSON generation, use it consistently

A few more places were parsing the image YAML, change things
so that we generate the canonicalized/flattened JSON in Python
code that can be called by the Python helpers that want it, and
call that same code as part of the shell script build preparation.

---

live: Move `squashfs-compression` def into `image-default.yaml`

This YAML file should have the list of all values parsed by
code.

---

