### PR TITLE
src/grub.cfg: Source user.cfg in grub.cfg

### DIFF
--- a/src/grub.cfg
+++ b/src/grub.cfg
@@ -84,4 +84,10 @@ if [ -f "/ignition.firstboot" ]; then
     set ignition_firstboot="ignition.firstboot ${ignition_network_kcmdline}"
 fi
 
+# Import user defined configuration
+# tracker: https://github.com/coreos/fedora-coreos-tracker/issues/805
+if [ -f $prefix/user.cfg ]; then
+  source $prefix/user.cfg
+fi
+
 blscfg


### PR DESCRIPTION
To allow users to make changes to the GRUB configuration
we will source a user created user.cfg in the statically defined
grub.cfg.