### PR TITLE
Insert generated image.json into the ostree commit

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts = --cov=cosalib.cli --cov=cosalib.meta --cov=cosalib.cmdlib --cov-report term --cov-fail-under=80
+addopts = --cov=cosalib.cli --cov=cosalib.meta --cov=cosalib.cmdlib --cov-report term --cov-fail-under=75

--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -18,7 +18,7 @@ import time
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from cosalib.builds import Builds
-from cosalib.cmdlib import run_verbose, sha256sum_file, generate_image_json
+from cosalib.cmdlib import run_verbose, sha256sum_file, extract_image_json
 from cosalib.cmdlib import import_ostree_commit, get_basearch, ensure_glob
 from cosalib.meta import GenericBuildMeta
 
@@ -46,9 +46,6 @@ if not args.build:
     args.build = builds.get_latest()
 print(f"Targeting build: {args.build}")
 
-image_json = generate_image_json('src/config/image.yaml')
-squashfs_compression = 'lz4' if args.fast else image_json['squashfs-compression']
-
 srcdir_prefix = "src/config/live/"
 
 if not os.path.isdir(srcdir_prefix):
@@ -58,6 +55,15 @@ workdir = os.path.abspath(os.getcwd())
 builddir = builds.get_build_dir(args.build)
 buildmeta_path = os.path.join(builddir, 'meta.json')
 buildmeta = GenericBuildMeta(workdir=workdir, build=args.build)
+repo = os.path.join(workdir, 'tmp/repo')
+
+# Grab the commit hash for this build
+buildmeta_commit = buildmeta['ostree-commit']
+
+import_ostree_commit(repo, builddir, buildmeta)
+
+image_json = extract_image_json(repo, buildmeta_commit)
+squashfs_compression = 'lz4' if args.fast else image_json['squashfs-compression']
 
 base_name = buildmeta['name']
 if base_name == "rhcos" and args.fast:
@@ -70,12 +76,6 @@ build_semaphore = os.path.join(buildmeta.build_dir, ".live.building")
 if os.path.exists(build_semaphore):
     raise Exception(
         f"{build_semaphore} exists: another process is building live")
-
-
-# Grab the commit hash for this build
-buildmeta_commit = buildmeta['ostree-commit']
-
-repo = os.path.join(workdir, 'tmp/repo')
 
 # Don't run if it's already been done, unless forced
 if 'live-iso' in buildmeta['images'] and not args.force:
@@ -695,8 +695,6 @@ boot
     buildmeta.write(artifact_name='live')
     print(f"Updated: {buildmeta_path}")
 
-
-import_ostree_commit(repo, builddir, buildmeta)
 
 # lock and build
 with open(build_semaphore, 'w') as f:

--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -118,6 +118,9 @@ ostree_repo=${tmprepo}
 # Ensure that we have the cached unpacked commit
 import_ostree_commit_for_build "${build}"
 
+image_json=image.json
+extract_image_json "${tmprepo}" "${commit}" > "${image_json}"
+
 image_format=raw
 if [[ $image_type == qemu ]]; then
     image_format=qcow2

--- a/src/cosalib/cmdlib.py
+++ b/src/cosalib/cmdlib.py
@@ -354,6 +354,9 @@ def generate_image_json(srcfile):
     r = yaml.safe_load(open("/usr/lib/coreos-assembler/image-default.yaml"))
     for k, v in flatten_image_yaml(srcfile).items():
         r[k] = v
+    # Serialize our default GRUB config
+    with open("/usr/lib/coreos-assembler/grub.cfg") as f:
+        r['grub-script'] = f.read()
     return r
 
 

--- a/src/cosalib/cmdlib.py
+++ b/src/cosalib/cmdlib.py
@@ -350,6 +350,13 @@ def cmdlib_sh(script):
     '''])
 
 
+# Should be used by disk image builds to extract the image.json from the
+# ostree commit.
+def extract_image_json(repo, commit):
+    out = subprocess.check_output(['ostree', f'--repo={repo}', 'cat', commit, '/usr/share/coreos-assembler/image.json'])
+    return json.loads(out)
+
+
 def generate_image_json(srcfile):
     r = yaml.safe_load(open("/usr/lib/coreos-assembler/image-default.yaml"))
     for k, v in flatten_image_yaml(srcfile).items():

--- a/src/cosalib/ova.py
+++ b/src/cosalib/ova.py
@@ -10,7 +10,7 @@ cosa_dir = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, f"{cosa_dir}/cosalib")
 sys.path.insert(0, cosa_dir)
 
-from cosalib.cmdlib import generate_image_json, image_info
+from cosalib.cmdlib import extract_image_json, image_info
 from cosalib.qemuvariants import QemuVariantImage
 
 
@@ -86,7 +86,7 @@ class OVA(QemuVariantImage):
         Returns a dictionary with the parameters needed to create an OVF file
         based on the qemu, vmdk, image.yaml, and info from the build metadata
         """
-        image_json = generate_image_json('src/config/image.yaml')
+        image_json = extract_image_json(os.path.join(self._workdir, 'tmp/repo'), self.meta['ostree-commit'])
 
         system_type = 'vmx-{}'.format(image_json['vmware-hw-version'])
         os_type = image_json['vmware-os-type']

--- a/src/cosalib/qemuvariants.py
+++ b/src/cosalib/qemuvariants.py
@@ -20,7 +20,8 @@ from cosalib.cmdlib import (
     get_basearch,
     image_info,
     run_verbose,
-    sha256sum_file
+    sha256sum_file,
+    import_ostree_commit
 )
 
 # BASEARCH is the current machine architecture
@@ -182,6 +183,9 @@ class QemuVariantImage(_Build):
             "platform_image_name", self.platform)
 
         _Build.__init__(self, **kwargs)
+
+        repo = os.path.join(self._workdir, 'tmp/repo')
+        import_ostree_commit(repo, self._tmpdir, self.meta)
 
     @property
     def image_qemu(self):

--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -364,7 +364,7 @@ install_grub_cfg() {
     # 0700 to match the RPM permissions which I think are mainly in case someone has
     # manually set a grub password
     mkdir -p -m 0700 $rootfs/boot/grub2
-    cp -v $grub_script $rootfs/boot/grub2/grub.cfg
+    printf "%s" "$grub_script" > $rootfs/boot/grub2/grub.cfg
 }
 
 # Other arch-specific bootloader changes

--- a/src/image-default.yaml
+++ b/src/image-default.yaml
@@ -4,7 +4,6 @@ bootfs: "ext4"
 rootfs: "xfs"
 # Add arguments here that will be passed to e.g. mkfs.xfs
 rootfs-args: ""
-grub-script: "/usr/lib/coreos-assembler/grub.cfg"
 
 # Additional default kernel arguments injected into disk images
 extra-kargs: []


### PR DESCRIPTION
Depends https://github.com/coreos/coreos-assembler/pull/2806

---


Serialize `grub-script` literally into image.json

Prep for injecting `image.json` into the ostree commit.  To make
that meaningful, it has to be entirely independent of coreos-assembler.

This bit is crucial for being able to do image builds in a manner
independent of coreos-assembler's content, using solely the ostree
commit as input.

---

Insert generated image.json into the ostree commit

This is part of https://github.com/coreos/fedora-coreos-tracker/issues/1151

Our generated disk images are largely just a "shell" around the egg
of an ostree commit.  There is almost nothing that lives
in the disk image that isn't in the commit.

(This is especially true now that a preparatory commit previous to
 this moved the *content* of our static `grub.cfg` into `image.json`)

In the original coreos-assembler design I'd tried to cleanly
separate builds of the ostree from disk image builds, but also
support linking them together (with matching version numbers, etc.)
The separate `image.yaml` was part of this.  This...mostly worked.

This change furthers that separation by having image builds input from
*just the ostree commit*.  Crucially we would no longer need the config
git repository to perform an image build.

And this in turn unlocks truly better separating ostree builds from
disk image builds in the pipeline *and* supporting
downstream tooling generating disk images from custom containers.

One neat thing here is we will finally fix a longstanding issue
where coreos-assembler fails when just the `image.yaml` changes:

Closes: #972


---

