### PR TITLE
tests/rpm-ostree: Mask zincati when we're doing a synthetic commit

### DIFF
--- a/mantle/kola/tests/rpmostree/deployments.go
+++ b/mantle/kola/tests/rpmostree/deployments.go
@@ -94,6 +94,9 @@ func rpmOstreeUpgradeRollback(c cluster.TestCluster) {
 		createCommit := "sudo ostree commit -b " + newBranch + " --tree ref=" + originalCsum + " --add-metadata-string version=" + newVersion
 		newCommit := c.MustSSH(m, createCommit)
 
+		// And no zincati because we're intentionally overriding, also it fails
+		c.RunCmdSync(m, "sudo systemctl mask --now zincati")
+
 		// use "rpm-ostree rebase" to get to the "new" commit
 		c.RunCmdSync(m, "sudo rpm-ostree rebase :"+newBranch)
 


### PR DESCRIPTION
The manual `ostree commit` is dropping all metadata from the
previous commit, including key bits like `coreos-assembler.basearch`
which zincati needs.  We could fix that, but in this flow zincati
won't be useful anyways, so just disable it.