### PR TITLE
generate-release-meta: make kubevirt image ref use tag on FCOS

### DIFF
--- a/src/cmd-generate-release-meta
+++ b/src/cmd-generate-release-meta
@@ -169,8 +169,21 @@ def append_build(out, input_):
 
     # KubeVirt specific additions: https://github.com/coreos/stream-metadata-go/pull/41
     if input_.get("kubevirt", None) is not None:
+        i = input_["kubevirt"]
         arch_dict["media"].setdefault("kubevirt", {}).setdefault("image", {})
-        arch_dict["media"]["kubevirt"]["image"].update(input_.get("kubevirt", {}))
+        if "image" in i:
+            if args.distro == 'rhcos':
+                # RHCOS pins to a digest rather than using tags
+                kubevirt_image = i["image"]
+            else:
+                # The tag-based pullspec isn't in meta.json because the FCOS
+                # pipeline moves the tag without invoking cosa.  Just
+                # hardcode the convention used by the release job.
+                kubevirt_image = f'{i["image"].split("@")[0]}:{out["stream"]}'
+            arch_dict["media"]["kubevirt"]["image"] = {
+                "image": kubevirt_image,
+                "digest-ref": i["image"],
+            }
 
     # Azure: https://github.com/coreos/stream-metadata-go/issues/13
     inputaz = input_.get("azure")


### PR DESCRIPTION
On FCOS, we want users to pull using image tags.  The tags will be configured by code in https://github.com/coreos/fedora-coreos-pipeline/pull/515, presumably by manually executing skopeo etc. since cosa doesn't have code for that.  Thus, since we can't read the tag out of `meta.json` directly, have the release metadata generator predict what the tag will be and put it in the release metadata `image` field.  Put the digest-based pullspec in the `digest-ref` field added in https://github.com/coreos/stream-metadata-go/pull/46.

On RHCOS, we want to pin to specific digests, so put the digest-based pullspec in both fields.

cc @rmohr @dustymabe 