### PR TITLE
kola/harness: check console for oom-killer

### DIFF
--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -180,6 +180,10 @@ var (
 			desc:  "systemd ordering cycle",
 			match: regexp.MustCompile("Ordering cycle found"),
 		},
+		{
+			desc:  "oom killer",
+			match: regexp.MustCompile("invoked oom-killer"),
+		},
 	}
 )
 


### PR DESCRIPTION
Verify that oom-killer does not show up in the console.

https://bugzilla.redhat.com/show_bug.cgi?id=1931467