### PR TITLE
cmdlib: Drop dead "is fedora" or "is RHEL" detection code

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -5,18 +5,6 @@ set -euo pipefail
 DIR=$(dirname "$(realpath "${BASH_SOURCE[0]}")")
 RFC3339="%Y-%m-%dT%H:%M:%SZ"
 
-# Detect what platform we are on
-if grep -q '^Fedora' /etc/redhat-release; then
-    export ISFEDORA=1
-    export ISEL=''
-elif grep -q '^Red Hat' /etc/redhat-release; then
-    export ISFEDORA=''
-    export ISEL=1
-else
-    echo 1>&2 "should be on either RHEL or Fedora"
-    exit 1
-fi
-
 info() {
     echo "info: $*" 1>&2
 }


### PR DESCRIPTION
I was trying to do stuff related to C9S and this code was just
in my way.  Detecting specific distributions this way is really
an anti-pattern and we should stop it.  Most of this should
be replaced with feature detection, but in *this* case the
code is just a dead relic of a previous attempt to do a RHEL8-based
coreos-assembler.

(I personally do think a C9S-based coreos-assembler could make
 sense, but that's a future topic)