### PR TITLE
tests/rhcos/upgrade: drop use of sudo for unpriv pods

### DIFF
--- a/mantle/kola/tests/rhcos/upgrade.go
+++ b/mantle/kola/tests/rhcos/upgrade.go
@@ -355,17 +355,10 @@ func downloadLatestReleasedRHCOS(target string) (string, error) {
 		return
 	}(releaseIndex, unique)
 
-	// The origin-clients package in Fedora doesn't `oc adm release info`
-	// ability.
-	ocUrl := fmt.Sprintf("https://mirror.openshift.com/pub/openshift-v4/%s/clients/ocp/latest/openshift-client-linux.tar.gz", system.RpmArch())
-	cmdString := fmt.Sprintf("curl -Ls %s | sudo tar -zxvf - -C /usr/bin", ocUrl)
-	if err := exec.Command("bash", "-c", cmdString).Run(); err != nil {
-		return "", err
-	}
-
 	var ocpRelease *OcpRelease
 	latestOcpPayload := graph.Nodes[difference[0]].Payload
-	cmd := exec.Command("oc", "adm", "release", "info", latestOcpPayload, "-o", "json")
+	// oc should be included in cosa since https://github.com/coreos/coreos-assembler/pull/2777
+	cmd := exec.Command("/usr/bin/oc", "adm", "release", "info", latestOcpPayload, "-o", "json")
 	output, err := cmd.Output()
 	if err != nil {
 		return "", err


### PR DESCRIPTION
When running the `rhcos.upgrade.from-ocp-rhcos` test in an
unprivileged pod in the Prow clusters, the test fails during the
unpacking of the `oc` binary because it is trying to use `sudo` to
write to `/usr/bin`.

To work around this, remove the use of `sudo` and split the `curl` and
`tar` commands into separate calls. (Using `bash -c` wasn't working
for me locally or in cluster)