### PR TITLE
[rhcos-4.9] buildextend-live: fix grub.cfg path in kargs.json on ppc64le

### DIFF
--- a/ci/prow-rhcos.sh
+++ b/ci/prow-rhcos.sh
@@ -15,5 +15,5 @@ esac
 export COSA_SKIP_OVERLAY=1
 # Create a temporary cosa workdir
 cd "$(mktemp -d)"
-cosa init -b "${BRANCH}" https://github.com/openshift/os
+cosa init -b "${RHCOS_BRANCH}" https://github.com/openshift/os
 exec src/config/ci/prow-build-test-qemu.sh

--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -414,8 +414,14 @@ def generate_iso():
         os.makedirs(os.path.join(tmpisoroot, 'boot/grub'))
         # can be EFI/fedora or EFI/redhat
         grubpath = glob.glob(os.path.join(tmpisoroot, 'EFI/*/grub.cfg'))
-        shutil.move(grubpath[0], os.path.join(tmpisoroot, 'boot/grub/grub.cfg'))
-
+        grubpath = grubpath[0]
+        boot_grubpath = os.path.join(tmpisoroot, 'boot/grub/grub.cfg')
+        shutil.move(grubpath, boot_grubpath)
+        for key in list(files_with_karg_embed_areas):
+            if key == grubpath:
+                files_with_karg_embed_areas[boot_grubpath] = files_with_karg_embed_areas[key]
+                del files_with_karg_embed_areas[key]
+        
         # safely remove things we don't need in the final ISO tree
         for d in ['EFI', 'isolinux', 'zipl.prm']:
             run_verbose(['rm', '-rf', os.path.join(tmpisoroot, d)])


### PR DESCRIPTION
This is an adapted backport of a bug fix in https://github.com/mrcxavier/coreos-assembler/commit/0846cfc66c3005e02653f570d5eee89ae4d4d011.
It was reporting "Error: No karg embed areas found; corrupted CoreOS ISO image."
Now it is inserting the correct path as also cleaning the dict.
We decided do not backport since 4.9 does not have the kargs.json file

Signed-off-by: Marcio Xavier <marcioas@br.ibm.com>