### PR TITLE
cmdlib: set permissions on /usr/share/buildinfo

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -426,6 +426,8 @@ EOF
         # available in content_sets.yaml. The mapped repos are then available in content_manifest.json
         # Feature: https://issues.redhat.com/browse/GRPA-3731
         create_content_manifest "$configdir"/content_sets.yaml "${tmp_overridesdir}/contentsetrootfs/usr/share/buildinfo/content_manifest.json"
+        # adjust permissions to appease the ext.config.shared.files.file-directory-permissions test
+        chmod 0644 "${tmp_overridesdir}/contentsetrootfs/usr/share/buildinfo/content_manifest.json"
 
         echo -n "Committing ${tmp_overridesdir}/contentsetrootfs... "
         commit_ostree_layer "${tmp_overridesdir}/contentsetrootfs" contentset


### PR DESCRIPTION
When building RHCOS and generating the `content_manifest.json` file,
the permissions on the file and containing directory included the
`g+w` bit, which causes the directory/file to be flagged by the
`ext.config.shared.files.file-directory-permissions` test. Add a step
in the creation of the ostree layer to set the permissions on the
directory + file before the ostree layer is committed.

Hat tip to @jlebon for the help!