### PR TITLE
push-container: add option to extend image name

### DIFF
--- a/src/cmd-push-container
+++ b/src/cmd-push-container
@@ -19,6 +19,7 @@ parser = argparse.ArgumentParser()
 parser.add_argument("--authfile", help="Authentication file",
                     action='store')
 parser.add_argument("--format", help="Image format for destination", choices=['oci', 'v2s2'], action='store')
+parser.add_argument("--base-image-name", help="Append extra 'base-image' to the name of the container image", action='store_true')
 parser.add_argument("name", help="destination image reference")
 
 args = parser.parse_args()
@@ -46,6 +47,8 @@ if args.format is not None:
 container_name = args.name
 if ":" not in container_name:
     container_name = f"{container_name}:{latest_build}-{arch}"
+if args.base_image_name:
+    container_name = f"{container_name}-base-image"
 skopeoargs.extend([f"oci-archive:{ociarchive}", f"docker://{container_name}"])
 print(subprocess.list2cmdline(skopeoargs))
 os.execvp('skopeo', skopeoargs)


### PR DESCRIPTION
In the RHCOS pipeline, we want to be able to push the legacy
oscontainer and the new base-image container using the same image
reference (i.e. `quay.io/openshift-release-dev/ocp-v4.0-art-dev:411.86.202205021327-0-x86_64`).

When the base-image container is pushed to the same `image:tag`
reference, it overwrites the existing digest (as expected). But this
ends up breaking some of the ART automation around the
`machine-os-content` promotion, because the `sha256` digest in
`meta['oscontainer']['digest']` is still pointing to the digest from
the oscontainer push.

To workaround this for now, let's just provide a flag to append the
`-base-image` string to the image name of the base-image container that
is getting pushed.

i.e. `quay.io/openshift-release-dev/ocp-v4.0-art-dev:411.86.202205021327-0-x86_64-base-image`