### PR TITLE
Revert "Insert generated image.json into the ostree commit"

### DIFF
--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -18,7 +18,7 @@ import time
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from cosalib.builds import Builds
-from cosalib.cmdlib import run_verbose, sha256sum_file, extract_image_json
+from cosalib.cmdlib import run_verbose, sha256sum_file, generate_image_json
 from cosalib.cmdlib import import_ostree_commit, get_basearch, ensure_glob
 from cosalib.meta import GenericBuildMeta
 
@@ -46,6 +46,9 @@ if not args.build:
     args.build = builds.get_latest()
 print(f"Targeting build: {args.build}")
 
+image_json = generate_image_json('src/config/image.yaml')
+squashfs_compression = 'lz4' if args.fast else image_json['squashfs-compression']
+
 srcdir_prefix = "src/config/live/"
 
 if not os.path.isdir(srcdir_prefix):
@@ -55,15 +58,6 @@ workdir = os.path.abspath(os.getcwd())
 builddir = builds.get_build_dir(args.build)
 buildmeta_path = os.path.join(builddir, 'meta.json')
 buildmeta = GenericBuildMeta(workdir=workdir, build=args.build)
-repo = os.path.join(workdir, 'tmp/repo')
-
-# Grab the commit hash for this build
-buildmeta_commit = buildmeta['ostree-commit']
-
-import_ostree_commit(repo, builddir, buildmeta)
-
-image_json = extract_image_json(repo, buildmeta_commit)
-squashfs_compression = 'lz4' if args.fast else image_json['squashfs-compression']
 
 base_name = buildmeta['name']
 if base_name == "rhcos" and args.fast:
@@ -76,6 +70,12 @@ build_semaphore = os.path.join(buildmeta.build_dir, ".live.building")
 if os.path.exists(build_semaphore):
     raise Exception(
         f"{build_semaphore} exists: another process is building live")
+
+
+# Grab the commit hash for this build
+buildmeta_commit = buildmeta['ostree-commit']
+
+repo = os.path.join(workdir, 'tmp/repo')
 
 # Don't run if it's already been done, unless forced
 if 'live-iso' in buildmeta['images'] and not args.force:
@@ -695,6 +695,8 @@ boot
     buildmeta.write(artifact_name='live')
     print(f"Updated: {buildmeta_path}")
 
+
+import_ostree_commit(repo, builddir, buildmeta)
 
 # lock and build
 with open(build_semaphore, 'w') as f:

--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -118,9 +118,6 @@ ostree_repo=${tmprepo}
 # Ensure that we have the cached unpacked commit
 import_ostree_commit_for_build "${build}"
 
-image_json=image.json
-extract_image_json "${tmprepo}" "${commit}" > "${image_json}"
-
 image_format=raw
 if [[ $image_type == qemu ]]; then
     image_format=qcow2

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -387,13 +387,6 @@ EOF
         done
     fi
 
-    local imagejsondir="${tmp_overridesdir}/imagejson"
-    export ostree_image_json="/usr/share/coreos-assembler/image.json"
-    mkdir -p "${imagejsondir}/usr/share/coreos-assembler/"
-    cp "${image_json}" "${imagejsondir}${ostree_image_json}"
-    commit_overlay cosa-image-json "${imagejsondir}"
-    layers="${layers} cosa-image-json"
-
     local_overrides_lockfile="${tmp_overridesdir}/local-overrides.json"
     if [ -n "${with_cosa_overrides}" ] && [[ -n $(ls "${overridesdir}/rpm/"*.rpm 2> /dev/null) ]]; then
         (cd "${overridesdir}"/rpm && rm -rf .repodata && createrepo_c .)
@@ -876,7 +869,6 @@ builds.bump_timestamp()
 print('Build ${buildid} was inserted ${arch:+for $arch}')")
 }
 
-# Prepare the image.json as part of an ostree image build
 write_image_json() {
     local srcfile=$1; shift
     local outfile=$1; shift
@@ -885,19 +877,6 @@ import sys
 sys.path.insert(0, '${DIR}')
 from cosalib import cmdlib
 cmdlib.write_image_json('${srcfile}', '${outfile}')")
-}
-
-# Fetch the image.json from the ostree commit to stdout.
-# Should be used by disk image builds.
-extract_image_json() {
-    local repo=$1; shift
-    local commit=$1; shift
-    (python3 -c "
-import sys, json
-sys.path.insert(0, '${DIR}')
-from cosalib import cmdlib
-json.dump(cmdlib.extract_image_json('${repo}', '${commit}'), sys.stdout, sort_keys=True)
-")
 }
 
 # Shell wrapper for the Python import_ostree_commit

--- a/src/cosalib/cmdlib.py
+++ b/src/cosalib/cmdlib.py
@@ -350,13 +350,6 @@ def cmdlib_sh(script):
     '''])
 
 
-# Should be used by disk image builds to extract the image.json from the
-# ostree commit.
-def extract_image_json(repo, commit):
-    out = subprocess.check_output(['ostree', f'--repo={repo}', 'cat', commit, '/usr/share/coreos-assembler/image.json'])
-    return json.loads(out)
-
-
 def generate_image_json(srcfile):
     r = yaml.safe_load(open("/usr/lib/coreos-assembler/image-default.yaml"))
     for k, v in flatten_image_yaml(srcfile).items():

--- a/src/cosalib/ova.py
+++ b/src/cosalib/ova.py
@@ -10,7 +10,7 @@ cosa_dir = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, f"{cosa_dir}/cosalib")
 sys.path.insert(0, cosa_dir)
 
-from cosalib.cmdlib import extract_image_json, image_info
+from cosalib.cmdlib import generate_image_json, image_info
 from cosalib.qemuvariants import QemuVariantImage
 
 
@@ -86,7 +86,7 @@ class OVA(QemuVariantImage):
         Returns a dictionary with the parameters needed to create an OVF file
         based on the qemu, vmdk, image.yaml, and info from the build metadata
         """
-        image_json = extract_image_json(os.path.join(self._workdir, 'tmp/repo'), self.meta['ostree-commit'])
+        image_json = generate_image_json('src/config/image.yaml')
 
         system_type = 'vmx-{}'.format(image_json['vmware-hw-version'])
         os_type = image_json['vmware-os-type']

--- a/src/cosalib/qemuvariants.py
+++ b/src/cosalib/qemuvariants.py
@@ -20,8 +20,7 @@ from cosalib.cmdlib import (
     get_basearch,
     image_info,
     run_verbose,
-    sha256sum_file,
-    import_ostree_commit
+    sha256sum_file
 )
 
 # BASEARCH is the current machine architecture
@@ -183,9 +182,6 @@ class QemuVariantImage(_Build):
             "platform_image_name", self.platform)
 
         _Build.__init__(self, **kwargs)
-
-        repo = os.path.join(self._workdir, 'tmp/repo')
-        import_ostree_commit(repo, self._tmpdir, self.meta)
 
     @property
     def image_qemu(self):


### PR DESCRIPTION
This reverts commit e0c32968778f93aacc834da9b34ece439d5c196c.

This broke the `next` stream release at the `cosa aws-replicate` step:

https://github.com/coreos/fedora-coreos-streams/issues/496#issuecomment-1116285820