### PR TITLE
lib: Add internal qcow2 compression for Nutanix image

### DIFF
--- a/src/cosalib/qemuvariants.py
+++ b/src/cosalib/qemuvariants.py
@@ -102,6 +102,7 @@ VARIANTS = {
     "nutanix": {
         "image_format": "qcow2",
         "platform": "nutanix",
+        "skip_compression": True,
         "convert_options": {
             '-c': None
         }
@@ -178,6 +179,7 @@ class QemuVariantImage(_Build):
         self.gzip = kwargs.pop("gzip", False)
         self.virtual_size = kwargs.pop("virtual_size", None)
         self.mutate_callback_creates_final_image = False
+        self.skip_compression = kwargs.pop("skip_compression", False)
 
         # this is used in case the image has a different disk
         # name than the platform
@@ -303,6 +305,11 @@ class QemuVariantImage(_Build):
                 'skip-compression': True,
                 'uncompressed-sha256': sha256,
                 'uncompressed-size': size,
+            })
+
+        if self.skip_compression:
+            meta_patch.update({
+                'skip-compression': True
             })
 
         return meta_patch

--- a/src/cosalib/qemuvariants.py
+++ b/src/cosalib/qemuvariants.py
@@ -102,6 +102,9 @@ VARIANTS = {
     "nutanix": {
         "image_format": "qcow2",
         "platform": "nutanix",
+        "convert_options": {
+            '-c': None
+        }
     },
     "vmware_vmdk": {
         "image_format": "vmdk",
@@ -249,7 +252,9 @@ class QemuVariantImage(_Build):
         cmd = ['qemu-img', 'convert', '-f', 'qcow2', '-O',
                self.image_format, self.tmp_image]
         for k, v in self.convert_options.items():
-            cmd.extend([k, v])
+            cmd.extend([k])
+            if v is not None:
+                cmd.extend([v])
         cmd.extend([work_img])
         run_verbose(cmd)
 


### PR DESCRIPTION
Add a `-c` convert option for Nutanix image which will help reduce
size of the image for Nutanix.

This PR also sets `skip_compression` value to True for Nutanix variant
in order to ensure `cosa compress` doesn't gzip the image.

Fixes https://github.com/coreos/fedora-coreos-tracker/issues/1191