### PR TITLE
mantle/platform/api/gcloud: drop interactive OAuth flow

### DIFF
--- a/mantle/README.md
+++ b/mantle/README.md
@@ -313,12 +313,9 @@ The JSON file exported to the variable `AZURE_AUTH_LOCATION` should be generated
 ```
 
 ### gce
-`gce` uses the `~/.boto` file. When the `gce` platform is first used, it will print
-a link that can be used to log into your account with gce and get a verification code
-you can paste in. This will populate the `.boto` file.
-
-See [Google Cloud Platform's Documentation](https://cloud.google.com/storage/docs/boto-gsutil)
-for more information about the `.boto` file.
+`gce` uses `~/.config/gce.json`, which contains a JSON-formatted service
+account key. This can be downloaded from the Google Cloud console under
+IAM > Service Accounts > [account] > Keys.
 
 ### openstack
 `openstack` uses `~/.config/openstack.json`. This can be configured manually:

--- a/mantle/auth/google.go
+++ b/mantle/auth/google.go
@@ -17,11 +17,16 @@ package auth
 
 import (
 	"context"
+	"io/ioutil"
 	"net/http"
+	"os/user"
+	"path/filepath"
 
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 )
+
+const GCEConfigPath = ".config/gce.json"
 
 var scopes = []string{
 	"https://www.googleapis.com/auth/devstorage.full_control",
@@ -43,6 +48,21 @@ func GoogleServiceClient() *http.Client {
 // the same manner as GoogleServiceClient().
 func GoogleServiceTokenSource() oauth2.TokenSource {
 	return google.ComputeTokenSource("")
+}
+
+func GoogleClientFromKeyFile(path string, scope ...string) (*http.Client, error) {
+	if path == "" {
+		user, err := user.Current()
+		if err != nil {
+			return nil, err
+		}
+		path = filepath.Join(user.HomeDir, GCEConfigPath)
+	}
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return GoogleClientFromJSONKey(b, scope...)
 }
 
 // GoogleClientFromJSONKey  provides an http.Client authorized with an

--- a/mantle/auth/google.go
+++ b/mantle/auth/google.go
@@ -17,121 +17,15 @@ package auth
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
-	"log"
 	"net/http"
-	"os"
-	"os/user"
-	"path/filepath"
 
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 )
 
-// client registered under the coreos-gce-testing project as 'mantle'
-var conf = oauth2.Config{
-	ClientID:     "1053977531921-s05q1c3kf23pdq86bmqv5qcga21c0ra3.apps.googleusercontent.com",
-	ClientSecret: "pgt0XUBTCfMwsqf2Q6cVdxTO",
-	Endpoint: oauth2.Endpoint{
-		AuthURL:  "https://accounts.google.com/o/oauth2/auth",
-		TokenURL: "https://accounts.google.com/o/oauth2/token",
-	},
-	RedirectURL: "urn:ietf:wg:oauth:2.0:oob",
-	Scopes: []string{"https://www.googleapis.com/auth/devstorage.full_control",
-		"https://www.googleapis.com/auth/compute"},
-}
-
-func writeCache(cachePath string, tok *oauth2.Token) error {
-	file, err := os.OpenFile(cachePath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-
-	if err := json.NewEncoder(file).Encode(tok); err != nil {
-		return err
-	}
-	return nil
-}
-
-func readCache(cachePath string) (*oauth2.Token, error) {
-	file, err := os.Open(cachePath)
-	if err != nil {
-		return nil, err
-	}
-	defer file.Close()
-
-	tok := &oauth2.Token{}
-	if err := json.NewDecoder(file).Decode(tok); err != nil {
-		return nil, err
-	}
-
-	// make sure token is refreshable
-	if tok != nil && !tok.Valid() {
-		ts := conf.TokenSource(context.TODO(), tok)
-		tok, err = ts.Token()
-		if err != nil || !tok.Valid() {
-			fmt.Printf("Could not refresh cached token: %v\n", err)
-			return nil, nil
-		}
-	}
-	return tok, nil
-}
-
-func getToken() (*oauth2.Token, error) {
-	userInfo, err := user.Current()
-	if err != nil {
-		return nil, err
-	}
-
-	cachePath := filepath.Join(userInfo.HomeDir, ".mantle-cache-google.json")
-	tok, err := readCache(cachePath)
-	if err != nil {
-		log.Printf("Error reading google token cache file: %v", err)
-	}
-	if tok == nil {
-		url := conf.AuthCodeURL("state", oauth2.AccessTypeOffline)
-		fmt.Printf("Visit the URL for the auth dialog: %v\n", url)
-		fmt.Print("Enter token: ")
-
-		var code string
-		if _, err := fmt.Scan(&code); err != nil {
-			return nil, err
-		}
-		tok, err = conf.Exchange(context.TODO(), code)
-		if err != nil {
-			return nil, err
-		}
-		err = writeCache(cachePath, tok)
-		if err != nil {
-			log.Printf("Error writing google token cache file: %v", err)
-		}
-	}
-	return tok, nil
-}
-
-// GoogleClient provides an http.Client authorized with an oauth2 token
-// that is automatically cached and refreshed from a file named
-// '.mantle-cache-google.json'. This uses interactive oauth2
-// authorization and requires a user follow to follow a web link and
-// paste in an authorization token.
-func GoogleClient() (*http.Client, error) {
-	tok, err := getToken()
-	if err != nil {
-		return nil, err
-	}
-	return conf.Client(context.TODO(), tok), nil
-}
-
-// GoogleTokenSource provides an outh2.TokenSource authorized in the
-// same manner as GoogleClient.
-func GoogleTokenSource() (oauth2.TokenSource, error) {
-	tok, err := getToken()
-	if err != nil {
-		return nil, err
-	}
-	return conf.TokenSource(context.TODO(), tok), nil
+var scopes = []string{
+	"https://www.googleapis.com/auth/devstorage.full_control",
+	"https://www.googleapis.com/auth/compute",
 }
 
 // GoogleServiceClient fetchs a token from Google Compute Engine's
@@ -156,7 +50,7 @@ func GoogleServiceTokenSource() oauth2.TokenSource {
 // private JSON key file.
 func GoogleClientFromJSONKey(jsonKey []byte, scope ...string) (*http.Client, error) {
 	if scope == nil {
-		scope = conf.Scopes
+		scope = scopes
 	}
 	jwtConf, err := google.JWTConfigFromJSON(jsonKey, scope...)
 	if err != nil {
@@ -171,7 +65,7 @@ func GoogleClientFromJSONKey(jsonKey []byte, scope ...string) (*http.Client, err
 // authorized in the same manner as GoogleClientFromJSONKey.
 func GoogleTokenSourceFromJSONKey(jsonKey []byte, scope ...string) (oauth2.TokenSource, error) {
 	if scope == nil {
-		scope = conf.Scopes
+		scope = scopes
 	}
 
 	jwtConf, err := google.JWTConfigFromJSON(jsonKey, scope...)

--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -108,7 +108,7 @@ func init() {
 
 	// gce-specific options
 	sv(&kola.GCEOptions.Image, "gce-image", "", "GCE image, full api endpoints names are accepted if resource is in a different project")
-	sv(&kola.GCEOptions.Project, "gce-project", "coreos-gce-testing", "GCE project name")
+	sv(&kola.GCEOptions.Project, "gce-project", "fedora-coreos-devel", "GCE project name")
 	sv(&kola.GCEOptions.Zone, "gce-zone", "us-central1-a", "GCE zone name")
 	sv(&kola.GCEOptions.MachineType, "gce-machinetype", "n1-standard-1", "GCE machine type")
 	sv(&kola.GCEOptions.DiskType, "gce-disktype", "pd-ssd", "GCE disk type")

--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -114,7 +114,7 @@ func init() {
 	sv(&kola.GCEOptions.DiskType, "gce-disktype", "pd-ssd", "GCE disk type")
 	sv(&kola.GCEOptions.Network, "gce-network", "default", "GCE network")
 	bv(&kola.GCEOptions.ServiceAuth, "gce-service-auth", false, "for non-interactive auth when running within GCE")
-	sv(&kola.GCEOptions.JSONKeyFile, "gce-json-key", "", "use a service account's JSON key for authentication")
+	sv(&kola.GCEOptions.JSONKeyFile, "gce-json-key", "", "use a service account's JSON key for authentication (default \"~/"+auth.GCEConfigPath+"\")")
 
 	// openstack-specific options
 	sv(&kola.OpenStackOptions.ConfigPath, "openstack-config-file", "", "Path to a clouds.yaml formatted OpenStack config file. The underlying library defaults to ./clouds.yaml")

--- a/mantle/cmd/ore/gcloud/gcloud.go
+++ b/mantle/cmd/ore/gcloud/gcloud.go
@@ -40,7 +40,7 @@ func init() {
 	sv := GCloud.PersistentFlags().StringVar
 
 	sv(&opts.Image, "image", "", "image name")
-	sv(&opts.Project, "project", "coreos-gce-testing", "project")
+	sv(&opts.Project, "project", "fedora-coreos-devel", "project")
 	sv(&opts.Zone, "zone", "us-central1-a", "zone")
 	sv(&opts.MachineType, "machinetype", "n1-standard-1", "machine type")
 	sv(&opts.DiskType, "disktype", "pd-ssd", "disk type")

--- a/mantle/platform/api/gcloud/api.go
+++ b/mantle/platform/api/gcloud/api.go
@@ -17,6 +17,7 @@ package gcloud
 
 import (
 	"context"
+	"fmt"
 	"google.golang.org/api/option"
 	"io/ioutil"
 	"net/http"
@@ -77,7 +78,9 @@ func New(opts *Options) (*API, error) {
 			plog.Error(err)
 		}
 	} else {
-		client, err = auth.GoogleClient()
+		err = fmt.Errorf("must specify --gce-json-key or --gce-service-auth")
+		plog.Error(err)
+		return nil, err
 	}
 
 	if err != nil {

--- a/mantle/platform/api/gcloud/api.go
+++ b/mantle/platform/api/gcloud/api.go
@@ -17,9 +17,7 @@ package gcloud
 
 import (
 	"context"
-	"fmt"
 	"google.golang.org/api/option"
-	"io/ioutil"
 	"net/http"
 	"time"
 
@@ -68,23 +66,12 @@ func New(opts *Options) (*API, error) {
 
 	if opts.ServiceAuth {
 		client = auth.GoogleServiceClient()
-	} else if opts.JSONKeyFile != "" {
-		b, err := ioutil.ReadFile(opts.JSONKeyFile)
+	} else {
+		client, err = auth.GoogleClientFromKeyFile(opts.JSONKeyFile)
 		if err != nil {
 			plog.Fatal(err)
+			return nil, err
 		}
-		client, err = auth.GoogleClientFromJSONKey(b)
-		if err != nil {
-			plog.Error(err)
-		}
-	} else {
-		err = fmt.Errorf("must specify --gce-json-key or --gce-service-auth")
-		plog.Error(err)
-		return nil, err
-	}
-
-	if err != nil {
-		return nil, err
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
The OAuth client ID corresponds to an app registration that's been dead for a while now.  We can't usefully create a new registration because the out-of-band credential flow has been [disabled for new apps](https://developers.googleblog.com/2022/02/making-oauth-flows-safer.html#disallowed-oob).

The recommended alternative is to have OAuth redirect to a web server listening on localhost, but we usually run in a container, so that would be awkward.  In practice, we just use `--gce-json-key` these days, so it's not worth trying to fix this functionality.  Default to reading a key from `~/.config/gce.json` instead.

Also change the default GCP project from the defunct `coreos-gce-testing` to `fedora-coreos-devel`.