### PR TITLE
mantle/kola: optionally attach GCP service account/AWS instance profile to instances

### DIFF
--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -113,6 +113,7 @@ func init() {
 	sv(&kola.GCEOptions.MachineType, "gce-machinetype", "n1-standard-1", "GCE machine type")
 	sv(&kola.GCEOptions.DiskType, "gce-disktype", "pd-ssd", "GCE disk type")
 	sv(&kola.GCEOptions.Network, "gce-network", "default", "GCE network")
+	sv(&kola.GCEOptions.ServiceAcct, "gce-service-account", "", "GCE service account to attach to instance (default project default)")
 	bv(&kola.GCEOptions.ServiceAuth, "gce-service-auth", false, "for non-interactive auth when running within GCE")
 	sv(&kola.GCEOptions.JSONKeyFile, "gce-json-key", "", "use a service account's JSON key for authentication (default \"~/"+auth.GCEConfigPath+"\")")
 

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -764,6 +764,7 @@ type externalTestMeta struct {
 	TimeoutMin                int      `json:"timeoutMin"`
 	Conflicts                 []string `json:"conflicts"`
 	AllowConfigWarnings       bool     `json:"allowConfigWarnings"`
+	NoInstanceCreds           bool     `json:"noInstanceCreds"`
 }
 
 // metadataFromTestBinary extracts JSON-in-comment like:
@@ -986,6 +987,9 @@ ExecStart=%s
 		t.ExcludeDistros = strings.Fields(targetMeta.Distros[1:])
 	} else {
 		t.Distros = strings.Fields(targetMeta.Distros)
+	}
+	if targetMeta.NoInstanceCreds {
+		t.Flags = append(t.Flags, register.NoInstanceCreds)
 	}
 	t.Tags = append(t.Tags, strings.Fields(targetMeta.Tags)...)
 	// TODO validate tags here
@@ -1247,6 +1251,9 @@ func makeNonExclusiveTest(bucket int, tests []*register.Test, flight platform.Fl
 		if test.HasFlag(register.NoSSHKeyInMetadata) || test.HasFlag(register.NoSSHKeyInUserData) {
 			plog.Fatalf("Non-exclusive test %v cannot have NoSSHKeyIn* flag", test.Name)
 		}
+		if test.HasFlag(register.NoInstanceCreds) {
+			plog.Fatalf("Non-exclusive test %v cannot have NoInstanceCreds flag", test.Name)
+		}
 		if test.HasFlag(register.AllowConfigWarnings) {
 			plog.Fatalf("Non-exclusive test %v cannot have AllowConfigWarnings flag", test.Name)
 		}
@@ -1333,6 +1340,7 @@ func runTest(h *harness.H, t *register.Test, pltfrm string, flight platform.Flig
 		OutputDir:          h.OutputDir(),
 		NoSSHKeyInUserData: t.HasFlag(register.NoSSHKeyInUserData),
 		NoSSHKeyInMetadata: t.HasFlag(register.NoSSHKeyInMetadata),
+		NoInstanceCreds:    t.HasFlag(register.NoInstanceCreds),
 		WarningsAction:     conf.FailWarnings,
 		InternetAccess:     testRequiresInternet(t),
 	}

--- a/mantle/kola/register/register.go
+++ b/mantle/kola/register/register.go
@@ -27,6 +27,7 @@ type Flag int
 const (
 	NoSSHKeyInUserData     Flag = iota // don't inject SSH key into Ignition/cloud-config
 	NoSSHKeyInMetadata                 // don't add SSH key to platform metadata
+	NoInstanceCreds                    // don't grant credentials (AWS instance profile, GCP service account) to the instance
 	NoEmergencyShellCheck              // don't check console output for emergency shell invocation
 	RequiresInternetAccess             // run the test only if the platform supports Internet access
 	AllowConfigWarnings                // ignore Ignition and Butane warnings instead of failing

--- a/mantle/platform/api/gcloud/api.go
+++ b/mantle/platform/api/gcloud/api.go
@@ -39,6 +39,7 @@ type Options struct {
 	MachineType string
 	DiskType    string
 	Network     string
+	ServiceAcct string
 	JSONKeyFile string
 	ServiceAuth bool
 	*platform.Options
@@ -79,6 +80,14 @@ func New(opts *Options) (*API, error) {
 	computeService, err := compute.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
 		return nil, err
+	}
+
+	if opts.ServiceAcct == "" {
+		proj, err := computeService.Projects.Get(opts.Project).Do()
+		if err != nil {
+			return nil, err
+		}
+		opts.ServiceAcct = proj.DefaultServiceAccount
 	}
 
 	api := &API{

--- a/mantle/platform/api/gcloud/compute.go
+++ b/mantle/platform/api/gcloud/compute.go
@@ -94,6 +94,13 @@ func (a *API) mkinstance(userdata, name string, keys []*agent.Key) *compute.Inst
 				Network: instancePrefix + "/global/networks/" + a.options.Network,
 			},
 		},
+		// allow the instance to perform authenticated GCS fetches
+		ServiceAccounts: []*compute.ServiceAccount{
+			&compute.ServiceAccount{
+				Email:  a.options.ServiceAcct,
+				Scopes: []string{"https://www.googleapis.com/auth/devstorage.read_only"},
+			},
+		},
 	}
 	// add cloud config
 	if userdata != "" {

--- a/mantle/platform/api/gcloud/pending.go
+++ b/mantle/platform/api/gcloud/pending.go
@@ -71,7 +71,11 @@ func (p *Pending) Wait() error {
 	}
 	if op.Error != nil {
 		if len(op.Error.Errors) > 0 {
-			return fmt.Errorf("Operation %q failed: %+v", p.desc, op.Error.Errors)
+			var messages []string
+			for _, err := range op.Error.Errors {
+				messages = append(messages, err.Message)
+			}
+			return fmt.Errorf("Operation %q failed: %+v", p.desc, messages)
 		}
 		return fmt.Errorf("Operation %q failed to start", p.desc)
 	}

--- a/mantle/platform/machine/aws/cluster.go
+++ b/mantle/platform/machine/aws/cluster.go
@@ -83,7 +83,7 @@ func (ac *cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 			fmt.Printf("WARNING: compressed userdata exceeds expected limit of %d\n", MaxUserDataSize)
 		}
 	}
-	instances, err := ac.flight.api.CreateInstances(ac.Name(), keyname, ud, 1, int64(options.MinDiskSize))
+	instances, err := ac.flight.api.CreateInstances(ac.Name(), keyname, ud, 1, int64(options.MinDiskSize), !ac.RuntimeConf().NoInstanceCreds)
 	if err != nil {
 		return nil, err
 	}

--- a/mantle/platform/machine/gcloud/cluster.go
+++ b/mantle/platform/machine/gcloud/cluster.go
@@ -69,7 +69,7 @@ func (gc *cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 		}
 	}
 
-	instance, err := gc.flight.api.CreateInstance(conf.String(), keys)
+	instance, err := gc.flight.api.CreateInstance(conf.String(), keys, !gc.RuntimeConf().NoInstanceCreds)
 	if err != nil {
 		return nil, err
 	}

--- a/mantle/platform/platform.go
+++ b/mantle/platform/platform.go
@@ -199,6 +199,7 @@ type RuntimeConfig struct {
 
 	NoSSHKeyInUserData bool                // don't inject SSH key into Ignition/cloud-config
 	NoSSHKeyInMetadata bool                // don't add SSH key to platform metadata
+	NoInstanceCreds    bool                // don't grant credentials (AWS instance profile, GCP service account) to the instance
 	AllowFailedUnits   bool                // don't fail CheckMachine if a systemd unit has failed
 	WarningsAction     conf.WarningsAction // what to do on Ignition or Butane validation warnings
 


### PR DESCRIPTION
In order to test authenticated GCS fetches from instances, we need to attach some service account with GCS read access to each instance.  Use the project's default service account unless the command line specifies otherwise.

Also allow tests to disable service account attachment in GCE and instance profile attachment in EC2, so that we can verify that anonymous fetches S3 -> EC2 and GCS -> GCE work without credentials.  (This has been a [problem in the past](https://github.com/coreos/ignition/pull/1363).)

This change requires kola's GCP service account to have Service Account User permission for the instance service account.  Otherwise, the GCP SDK will fail with a helpful error message.