### PR TITLE
Revert "build.sh: freeze on kernel-5.15.18-200.fc35.x86_64"

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -41,8 +41,8 @@ install_rpms() {
     local builddeps
     local frozendeps
 
-    # freeze kernel due to https://github.com/coreos/coreos-assembler/issues/2707
-    frozendeps=$(echo kernel{,-core,-modules}-5.15.18-200.fc35)
+    # no frozen deps right now
+    frozendeps=""
 
     # First, a general update; this is best practice.  We also hit an issue recently
     # where qemu implicitly depended on an updated libusbx but didn't have a versioned


### PR DESCRIPTION
This reverts commit d226eb2b07a3c522ab0f2225ab987000873f1bb7.

We've frozen on this long enough; f36 is about to be released. Let's
unpin and find out if the original issue causing this is still present.