### PR TITLE
kola/harness.go: fix kola conflicts bug

### DIFF
--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -1190,7 +1190,7 @@ func createTestBuckets(tests []*register.Test) [][]*register.Test {
 			if _, found := testMap[conflict]; found {
 				testMap[conflict].Conflicts = append(testMap[conflict].Conflicts, test.Name)
 			} else {
-				plog.Fatalf("%v specified %v as a conflict but %v was not found. Double-check that it is marked as non-exclusive.",
+				plog.Debugf("%v specified %v as a conflict but %v was not found. If you are running both tests, verify that both are marked as non-exclusive.",
 					test.Name, conflict, conflict)
 			}
 		}


### PR DESCRIPTION
If only one of two conflicting tests is ran an error will occur.
Let convert this error to a debugging message.