### PR TITLE
workflows: fix bump-nocache-line with current Git

### DIFF
--- a/.github/workflows/bump-nocache-line.yml
+++ b/.github/workflows/bump-nocache-line.yml
@@ -26,6 +26,9 @@ jobs:
           # in case the fork is out of date and we need to bring it up
           # to date.
           fetch-depth: 0
+      # https://github.com/actions/checkout/issues/766
+      - name: Mark git checkout as safe
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: bump nocache line
         run: |
           datestr=$(date +%D)


### PR DESCRIPTION
When running Git in a containerized job, we need to tell it that repos not owned by the current user are safe.

[Sample failing run](https://github.com/coreos/coreos-assembler/actions/runs/2312652823).