### PR TITLE
build.sh: fix sudo on ppc64le

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -66,6 +66,11 @@ install_rpms() {
     # as we want to enable fast iteration there.
     yum -y --enablerepo=updates-testing upgrade rpm-ostree
 
+    # Delete file that only exists on ppc64le because it is causing
+    # sudo to not work.
+    # https://bugzilla.redhat.com/show_bug.cgi?id=2082149
+    rm -f /etc/security/limits.d/95-kvm-memlock.conf
+
     # Commented out for now, see above
     #dnf remove -y ${builddeps}
     # can't remove grubby on el7 because libguestfs-tools depends on it


### PR DESCRIPTION
The existence of /etc/security/limits.d/95-kvm-memlock.conf
causes sudo not to work on ppc64le which means we will never
execute our "privileged" path.

Let's delete the file so sudo can work on ppc64le while we discuss
in the bug our options.

https://bugzilla.redhat.com/show_bug.cgi?id=2082149