### PR TITLE
src/create_disk.sh: change bls-append-except-default seperator

### DIFF
--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -427,7 +427,7 @@ ostree config --repo $rootfs/ostree/repo set sysroot.bootloader "${bootloader_ba
 ostree config --repo $rootfs/ostree/repo set sysroot.readonly true
 # enable support for GRUB password
 if [ "${bootloader_backend}" = "none" ]; then
-    ostree config --repo $rootfs/ostree/repo set sysroot.bls-append-except-default 'grub_users,""'
+    ostree config --repo $rootfs/ostree/repo set sysroot.bls-append-except-default 'grub_users=""'
 fi
 
 touch $rootfs/boot/ignition.firstboot


### PR DESCRIPTION
We have decided to change the seperator used in the
bls-append-except-default-key. We want to add to the changes
in https://github.com/coreos/coreos-assembler/pull/2854.