### PR TITLE
build.sh: Remove Go cache after build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -102,6 +102,9 @@ install_ocp_tools() {
 
 make_and_makeinstall() {
     make && make install
+    # Remove go build cache
+    # https://github.com/coreos/coreos-assembler/issues/2872
+    rm -rf /root/.cache/go-build
 }
 
 configure_user(){


### PR DESCRIPTION
Clean up Go cache to keep the COSA image as small as possible.

Fixes: https://github.com/coreos/coreos-assembler/issues/2872

From top to bottom: build with this, build without, image from quay:
```
localhost/coreos-assembler                 latest      3ca60570e4ac  46 minutes ago  4.38 GB
<none>                                     <none>      c6ebb222c0ba  2 hours ago     6.84 GB
quay.io/coreos-assembler/coreos-assembler  latest      2e56de22ca96  5 days ago      5.76 GB
```