### PR TITLE
[rhcos-4.10] tests: fix /var race in multipath.partition part 2

### DIFF
--- a/mantle/kola/tests/misc/multipath.go
+++ b/mantle/kola/tests/misc/multipath.go
@@ -61,6 +61,9 @@ systemd:
         ConditionFirstBoot=true
         Requires=dev-mapper-mpatha.device
         After=dev-mapper-mpatha.device
+        # See https://github.com/coreos/coreos-assembler/pull/2457
+        # and https://github.com/openshift/os/issues/743
+        After=ostree-remount.service
         Before=kubelet.service
         DefaultDependencies=no
 
@@ -77,8 +80,6 @@ systemd:
       contents: |
         [Unit]
         Description=Mount /var/lib/containers
-        # See https://github.com/coreos/coreos-assembler/pull/2457
-        After=ostree-remount.service
         After=mpath-var-lib-containers.service
         Before=kubelet.service
 


### PR DESCRIPTION
This fixes the same race condition in a previous PR #2457 [0]. The
difference is that in PR #2758 [1], `mpath-var-lib-containers.service`
uses mkdir to create `/var/lib/containers` and in some cases it will race
against `ostree-remount.service` during the short window `/var` is
read-only. Have `mpath-var-lib-containers.service` run after
`ostree-remount.service` to resolve this.

[0] https://github.com/coreos/coreos-assembler/pull/2457
[1] https://github.com/coreos/coreos-assembler/pull/2758

(cherry picked from commit 46e7d0c)