### PR TITLE
mantle/platform/aws: add IPv6 support

### DIFF
--- a/mantle/platform/api/aws/api.go
+++ b/mantle/platform/api/aws/api.go
@@ -113,7 +113,7 @@ func (a *API) PreflightCheck() error {
 	return err
 }
 
-func tagSpecCreatedByMantle(resourceType string) []*ec2.TagSpecification {
+func tagSpecCreatedByMantle(name, resourceType string) []*ec2.TagSpecification {
 	return []*ec2.TagSpecification{
 		{
 			ResourceType: aws.String(resourceType),
@@ -121,6 +121,10 @@ func tagSpecCreatedByMantle(resourceType string) []*ec2.TagSpecification {
 				&ec2.Tag{
 					Key:   aws.String("CreatedBy"),
 					Value: aws.String("mantle"),
+				},
+				&ec2.Tag{
+					Key:   aws.String("Name"),
+					Value: aws.String(name),
 				},
 			},
 		},


### PR DESCRIPTION
When we go in and create the VPC and various other networking resources
let's make them IPv6 capable.

Also, let's add Name tags to resources we create.
