### PR TITLE
create_disk: fix literal `$ignition_firstboot` karg on s390x

### DIFF
--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -259,9 +259,12 @@ if [ "${rootfs_type}" = "ext4verity" ]; then
 fi
 
 # Compute kargs
-# Note that $ignition_firstboot is interpreted by grub at boot time,
-# *not* the shell here.  Hence the backslash escape.
-allkargs="$extrakargs \$ignition_firstboot"
+allkargs="$extrakargs"
+if [ "$arch" != s390x ]; then
+    # Note that $ignition_firstboot is interpreted by grub at boot time,
+    # *not* the shell here.  Hence the backslash escape.
+    allkargs+=" \$ignition_firstboot"
+fi
 
 if test -n "${deploy_via_container}"; then
     kargsargs=""


### PR DESCRIPTION
While reviewing some related code, I realized that `$ignition_firstboot`
was literally being embedded into the kernel command-line on s390x. We
don't use GRUB there, so it will never get evaluated. Having it there
doesn't break anything but it's useless and can cause confusion, so
remove it.

We already handle the `ignition.firstboot` karg in all the places we
need to for s390x.