### PR TITLE
ci: Add Dockerfile.continuous

### DIFF
--- a/continuous/Dockerfile
+++ b/continuous/Dockerfile
@@ -1,0 +1,5 @@
+FROM registry.ci.openshift.org/coreos/coreos-assembler:latest
+USER root
+ADD fcos-continuous.repo /etc/yum.repos.d
+RUN yum -y update
+USER builder

--- a/continuous/fcos-continuous.repo
+++ b/continuous/fcos-continuous.repo
@@ -1,0 +1,10 @@
+[copr:copr.fedorainfracloud.org:group_CoreOS:continuous]
+name=Copr repo for continuous owned by @CoreOS
+baseurl=https://download.copr.fedorainfracloud.org/results/@CoreOS/continuous/fedora-$releasever-$basearch/
+type=rpm-md
+skip_if_unavailable=True
+gpgcheck=1
+gpgkey=https://download.copr.fedorainfracloud.org/results/@CoreOS/continuous/pubkey.gpg
+repo_gpgcheck=0
+enabled=1
+enabled_metadata=1


### PR DESCRIPTION
Right now, I want to test the new ostree code to inject signatures:
https://github.com/ostreedev/ostree-rs-ext/pull/301

And I want to do it *before* releasing a new rpm-ostree.

Add a new Dockerfile with pulls from our continuous COPR.
This is effectively the coreos-assembler dual of
https://github.com/coreos/fedora-coreos-config/pull/1710