### PR TITLE
init: Add `--transient` flag for ephemeral builds

### DIFF
--- a/ci/prow-rhcos.sh
+++ b/ci/prow-rhcos.sh
@@ -17,5 +17,5 @@ esac
 export COSA_SKIP_OVERLAY=1
 # Create a temporary cosa workdir
 cd "$(mktemp -d)"
-cosa init -b "${RHCOS_BRANCH}" https://github.com/openshift/os
+cosa init --transient -b "${RHCOS_BRANCH}" https://github.com/openshift/os
 exec src/config/ci/prow-build-test-qemu.sh

--- a/src/cmd-init
+++ b/src/cmd-init
@@ -147,3 +147,6 @@ mkdir -p overrides/rootfs
 if test "${TRANSIENT}" = 1; then
     touch tmp/cosa-transient
 fi
+
+set +x
+echo "Initialized $PWD as coreos-assembler working directory."

--- a/src/cmd-init
+++ b/src/cmd-init
@@ -9,11 +9,12 @@ dn=$(dirname "$0")
 FORCE=0
 BRANCH=""
 COMMIT=""
+TRANSIENT=0
 
 print_help() {
     cat 1>&2 <<'EOF'
 Usage: coreos-assembler init --help
-       coreos-assembler init [--force] [--branch BRANCH] 
+       coreos-assembler init [--force] [--transient] [--branch BRANCH] 
                              [--commit COMMIT] GITCONFIG [SUBDIR]
 
   For example, you can use https://github.com/coreos/fedora-coreos-config
@@ -24,12 +25,15 @@ Usage: coreos-assembler init --help
 
   If specified, SUBDIR is a subdirectory of the git repository that should
   contain manifest.yaml and image.yaml (or image.ks).
+
+  Use `--transient` for builds that will throw away all cached data on success/failure,
+  and should hence not invoke `fsync()` for example.
 EOF
 }
 
 # Call getopt to validate the provided input.
 rc=0
-options=$(getopt --options hfb:c: --longoptions help,force,branch:,commit: -- "$@") || rc=$?
+options=$(getopt --options hfb:c: --longoptions help,force,transient,branch:,commit: -- "$@") || rc=$?
 [ $rc -eq 0 ] || {
     print_help
     exit 1
@@ -43,6 +47,9 @@ while true; do
         ;;
     -f | --force)
         FORCE=1
+        ;;
+    --transient)
+        TRANSIENT=1
         ;;
     -b | --branch)
         case "$2" in
@@ -136,3 +143,7 @@ mkdir -p builds
 mkdir -p tmp
 mkdir -p overrides/rpm
 mkdir -p overrides/rootfs
+
+if test "${TRANSIENT}" = 1; then
+    touch tmp/cosa-transient
+fi

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -119,6 +119,12 @@ preflight_kvm() {
     fi
 }
 
+# Use this for things like disabling fsync.
+# For more information, see the docs of `cosa init --transient`.
+is_transient() {
+    test -f "${workdir}"/tmp/cosa-transient
+}
+
 # Picks between yaml or json based on which version exists. Errors out if both
 # exists. If neither exist, prefers the extension in ${2}, or otherwise YAML.
 pick_yaml_or_else_json() {
@@ -525,7 +531,11 @@ impl_rpmostree_compose() {
         fi
         # And remove the old one
         rm -vf "${workdir}"/cache/cache.qcow2
-        compose_qemu_args+=("-drive" "if=none,id=cache,discard=unmap,file=${workdir}/cache/cache2.qcow2" \
+        local cachedriveargs="discard=unmap"
+        if is_transient; then
+            cachedriveargs="cache=unsafe,discard=ignore"
+        fi
+        compose_qemu_args+=("-drive" "if=none,id=cache,$cachedriveargs,file=${workdir}/cache/cache2.qcow2" \
                             "-device" "virtio-blk,drive=cache")
         runvm "${compose_qemu_args[@]}" -- "$@"
     fi

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -210,6 +210,11 @@ prepare_build() {
             # level to avoid burning excessive CPU.
             ostree --repo="${tmprepo}" config set archive.zlib-level 2
         fi
+
+        # No need to fsync for transient flows
+        if test -f "${workdir}/tmp/cosa-transient"; then
+            ostree --repo="${tmprepo}" config set 'core.fsync' 'false'
+        fi
     fi
 
     configdir_gitrepo=${configdir}


### PR DESCRIPTION
init: Add `--transient` flag for ephemeral builds

We go to a lot of effort to create various caches of builds, and this
is very useful for local incremental development to avoid re-downloading
RPMs and rewriting data.

Conversely, it is useless for CI builds that discard everything when they're done, and actually slows things down.

Add a `cosa init --transient` flag that for now just disables `fsync()`
on `tmp/repo`.

There's more we can do here in the future, for example we need to
propagate this too into `cache/repo-build` and `cache/pkgcache-repo`,
and actually in general we don't need the pkgcache repo at all here.

---

init: Add a success message

To make it clearer that things worked.

---

