### PR TITLE
[rhcos-4.10] cmdlib.sh: bump supermin VM to 8G of RAM on ppc64le

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -56,6 +56,11 @@ install_rpms() {
     # Process our base dependencies + build dependencies and install
     (echo "${builddeps}" && "${srcdir}"/src/print-dependencies.sh) | xargs yum -y install
 
+    # Delete file that only exists on ppc64le because it is causing
+    # sudo to not work.
+    # https://bugzilla.redhat.com/show_bug.cgi?id=2082149
+    rm -f /etc/security/limits.d/95-kvm-memlock.conf
+
     # Commented out for now, see above
     #dnf remove -y ${builddeps}
     # can't remove grubby on el7 because libguestfs-tools depends on it

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -637,7 +637,7 @@ EOF
     case $arch in
     # Power 8 page faults with 2G of memory in rpm-ostree
     # Most probably due to radix and 64k overhead.
-    "ppc64le") memory_default=4096 ;;
+    "ppc64le") memory_default=8192 ;;
     esac
 
     kola_args=(kola qemuexec -m "${COSA_SUPERMIN_MEMORY:-${memory_default}}" --auto-cpus -U --workdir none \


### PR DESCRIPTION
The RHCOS 4.10 Power pipeline is hitting the second variant in
openshift/os#594 (comment).

This is worked around in more recent pipelines by the move to OCI
containers, but 4.10 doesn't have this code and it seems risky to
backport. So let's just bump the memory there for that release.