### PR TITLE
kola/tests: account for ipv6 in `fcos.network.listeners`

### DIFF
--- a/mantle/kola/tests/misc/network.go
+++ b/mantle/kola/tests/misc/network.go
@@ -165,6 +165,9 @@ func NetworkListeners(c cluster.TestCluster) {
 		// https://serverfault.com/a/929642
 		{"tcp", "5355", "systemd-resolve"},
 		{"udp", "5355", "systemd-resolve"},
+		// DHCPv6 from NetworkManager (when IPv6 network available)
+		// https://github.com/coreos/fedora-coreos-tracker/issues/1216
+		{"udp", "546", "NetworkManager"},
 	}
 	checkList := func() error {
 		return checkListeners(c, expectedListeners)


### PR DESCRIPTION
Now that we have an ipv6 enabled VPC in AWS we need to update our
test to account for Networkmanager listening on port 546 for DHCPv6.

Fixes https://github.com/coreos/fedora-coreos-tracker/issues/1216