### PR TITLE
build.sh: fix error-handling for `make`

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -101,7 +101,8 @@ install_ocp_tools() {
 }
 
 make_and_makeinstall() {
-    make && make install
+    make
+    make install
     # Remove go build cache
     # https://github.com/coreos/coreos-assembler/issues/2872
     rm -rf /root/.cache/go-build


### PR DESCRIPTION
We have `errexit` in `build.sh`, but that has no effect on `make` here
because it's part of a command list.

Closes: #2897