### PR TITLE
tools: freeze minio on RELEASE.2022-05-26T05-48-41Z

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ endif
 .%.shellchecked: %
 	./tests/check_one.sh $< $@
 
-check: ${src_checked} ${tests_checked} ${cwd_checked} flake8 pycheck schema-check mantle-check
+check: ${src_checked} ${tests_checked} ${cwd_checked} flake8 pycheck schema-check mantle-check gangplank-check
 	echo OK
 
 pycheck:

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -14,8 +14,10 @@ build:
 		go install github.com/idubinskiy/schematyper@latest
 	test -e bin/gomarkdoc || \
 		go install github.com/princjef/gomarkdoc/cmd/gomarkdoc@latest
+	# Freeze on 2022-05-26 release of minio for now.
+	# https://github.com/coreos/coreos-assembler/pull/2895#issuecomment-1145558105
 	test -e bin/minio || \
-		curl -sSfLO --output-dir $(GOPATH)/bin https://dl.min.io/server/minio/release/linux-$(GOARCH)/minio && chmod +x $(GOPATH)/bin/minio
+		curl -sSfL --output minio --output-dir $(GOPATH)/bin https://dl.min.io/server/minio/release/linux-$(GOARCH)/archive/minio.RELEASE.2022-05-26T05-48-41Z && chmod +x $(GOPATH)/bin/minio
 	rm -rf pkg
 
 clean:


### PR DESCRIPTION


The new version is causing issues with files being transferred back
being directories and not files and other general issues.

See https://github.com/coreos/coreos-assembler/pull/2895#issuecomment-1145558105
