### PR TITLE
Two docs patches

### DIFF
--- a/docs/cosa.md
+++ b/docs/cosa.md
@@ -67,7 +67,6 @@ Those less commonly used commands are listed here:
 | [offline-update](https://github.com/coreos/coreos-assembler/blob/main/src/cmd-offline-update) | Given a disk image and a coreos-assembler build, use supermin to update the disk image to the target OSTree commit "offline"
 | [prune](https://github.com/coreos/coreos-assembler/blob/main/src/cmd-prune) | This script removes previous builds. DO NOT USE on production pipelines
 | [remote-prune](https://github.com/coreos/coreos-assembler/blob/main/src/cmd-remote-prune) | Removes unreferenced builds from s3 bucket
-| [runc](https://github.com/coreos/coreos-assembler/blob/main/src/cmd-runc) | Spawn the current build as a container
 | [sign](https://github.com/coreos/coreos-assembler/blob/main/src/cmd-sign) | Implements signing with RoboSignatory via fedora-messaging
 | [supermin-shell](https://github.com/coreos/coreos-assembler/blob/main/src/cmd-supermin-shell) | Get a supermin shell
 | [tag](https://github.com/coreos/coreos-assembler/blob/main/src/cmd-tag) | Operate on the tags in `builds.json`

--- a/docs/working.md
+++ b/docs/working.md
@@ -111,17 +111,42 @@ In the future, it's likely coreos-assembler will also support something
 like `overrides/src` which could be a directory of symlinks to local
 git repositories.
 
-## Using cosa run --bind-ro for even faster iteration
+## Using cosa build-fast
 
 If you're working on e.g. the kernel or Ignition (things that go into the initramfs),
 then you probably need a `cosa build` workflow (or `cosa buildinitramfs-fast`, see below).
-However, let's say you want to test a change to something much later in the boot process - e.g. `podman`.  Rather
+However, let's say you want to test a change to something that runs purely in the real root,
+such as e.g. `rpm-ostree`, `podman`, or `console-login-helper-messages`.  Rather
 than doing a full image build each time, a fast way to test out changes is to use
-something like this:
+`cosa build-fast`.
+
+This command assumes you have a previous local coreos-assembler build.  From
+the git checkout of the project you want to add:
+
+```
+$ export COSA_DIR=/srv/builds/fcos
+$ cosa build-fast
+$ cosa run
+```
+
+The `cosa build-fast` command will run `make` and inject the resulting binaries
+on a qcow2 overlay file, which will appear in your project working directory.
+The `cosa run` command similarly knows to look for these `qcow2` files.
+
+This will not affect the "real" cosa build in `/srv/builds/fcos`, but will
+use it as a data source.
+
+## Using cosa run --bind-ro for even faster iteration
+
+This workflow can be used alongside `cosa build-fast`, or separate from it.
+If you invoke e.g.
 
 ```
 $ cosa run --bind-ro ~/src/github/containers/podman,/run/workdir
 ```
+
+The target VM will have the source directory bound in `/run/workdir`; then you
+can directly copy binaries from your development environment into the VM.
 
 If you are running cosa in a container, you will have to change your current
 working directory to a parent directory common to both project directories and


### PR DESCRIPTION
docs: Delete reference to `cosa runc`

Was gone in previous commit.

---

docs: Document `cosa build-fast`

I was surprised this was omitted.  Came up in chat.

---

