### PR TITLE
cmdlib: Ensure bare-user tmpdir is in $workdir/tmp

### DIFF
--- a/src/cosalib/cmdlib.py
+++ b/src/cosalib/cmdlib.py
@@ -265,8 +265,9 @@ def extract_image_json(workdir, commit):
 #
 # Call this function to ensure that the ostree commit for a given build is in tmp/repo.
 def import_ostree_commit(workdir, buildpath, buildmeta, force=False):
+    tmpdir = os.path.join(workdir, 'tmp')
     with Lock(os.path.join(workdir, 'tmp/repo.import.lock')):
-        repo = os.path.join(workdir, 'tmp/repo')
+        repo = os.path.join(tmpdir, 'repo')
         commit = buildmeta['ostree-commit']
         tarfile = os.path.join(buildpath, buildmeta['images']['ostree']['path'])
         # create repo in case e.g. tmp/ was cleared out; idempotent
@@ -298,7 +299,7 @@ def import_ostree_commit(workdir, buildpath, buildmeta, force=False):
             gid = os.getgid()
             subprocess.check_call(['sudo', 'chown', '-hR', f"{uid}:{gid}", repo])
         else:
-            with tempfile.TemporaryDirectory() as tmpd:
+            with tempfile.TemporaryDirectory(dir=tmpdir) as tmpd:
                 subprocess.check_call(['ostree', 'init', '--repo', tmpd, '--mode=bare-user'])
                 subprocess.check_call(['ostree', 'container', 'import', '--repo', tmpd,
                                        '--write-ref', buildmeta['buildid'],


### PR DESCRIPTION
Linux `tmpfs` still doesn't support `user.` xattrs, and so for
toolbox-like containers that use a (proper!) `tmpfs` for `/tmp`
instead of having it be `overlayfs`, we need to ensure that
we create our tempdir in `$workdir/tmp` - the workdir must have
`user.` xattr support for the `cache/repo-build` anyways.

Closes: https://github.com/coreos/coreos-assembler/issues/2904