### PR TITLE
Update centos distribution to scos as this prevents scos build testing

### DIFF
--- a/mantle/platform/platform.go
+++ b/mantle/platform/platform.go
@@ -497,7 +497,7 @@ func CheckMachine(ctx context.Context, m Machine) error {
 	switch string(out) {
 	case `fedora-coreos`:
 		distribution = "fcos"
-	case `centos-coreos`, `rhcos-`:
+	case `scos-`, `scos-coreos`, `rhcos-`, `rhcos-coreos`:
 		distribution = "rhcos"
 	default:
 		return fmt.Errorf("not a supported instance: %v", string(out))


### PR DESCRIPTION
See https://github.com/openshift/os/pull/901, when running kola test for scos, get error, this is to fix it
```
$ cosa kola run ostree.basic
kola -p qemu-unpriv --output-dir tmp/kola run ostree.basic
=== RUN   ostree.basic
--- FAIL: ostree.basic (57.14s)
        harness.go:1443: mach.Start() failed: machine "ea43750e-e04b-4632-b966-caff659a5214" failed basic checks: not a supported instance: scos-coreos
FAIL, output in tmp/kola
Error: harness: test suite failed
2022-06-10T09:12:23Z cli: harness: test suite failed
```