### PR TITLE
mantle/util: replace `.cosa` by const `fastBuildCosaDir`

### DIFF
--- a/mantle/util/repo.go
+++ b/mantle/util/repo.go
@@ -72,7 +72,7 @@ func GetLocalFastBuildQemu() (string, error) {
 	}
 	for _, ent := range ents {
 		if strings.HasSuffix(ent.Name(), ".qcow2") {
-			return filepath.Join(".cosa", ent.Name()), nil
+			return filepath.Join(fastBuildCosaDir, ent.Name()), nil
 		}
 	}
 	return "", nil


### PR DESCRIPTION
This is the only bit in that function that didn't use the const.