### PR TITLE
cmd-push-container: clean up name and tag logic

### DIFF
--- a/src/cmd-push-container
+++ b/src/cmd-push-container
@@ -46,18 +46,19 @@ if args.authfile is not None:
     skopeoargs.extend(['--authfile', args.authfile])
 if args.format is not None:
     skopeoargs.extend(['--format', args.format])
-container_name = container_name_and_tag = args.name
-if args.base_image_name:
-    container_name = f"{container_name}-base-image"
-if ":" not in container_name_and_tag:
+if ":" not in args.name:
+    container_name = args.name
     # If a specific tag wasn't requested, add a default one
-    container_name_and_tag = f"{container_name}:{latest_build}-{arch}"
+    container_tag = f"{latest_build}-{arch}"
 else:
     # Strip the tag out, as we will be injecting the digest below
-    container_name = container_name.rsplit(':')[0]
+    # Note this implicitly errors out if there's more than one ':'
+    container_name, container_tag = args.name.rsplit(':')
+if args.base_image_name:
+    container_name = f"{container_name}-base-image"
 with tempfile.NamedTemporaryFile(dir='tmp', prefix='push-container-digestfile') as df:
     skopeoargs.append(f"--digestfile={df.name}")
-    skopeoargs.extend([f"oci-archive:{ociarchive}", f"docker://{container_name_and_tag}"])
+    skopeoargs.extend([f"oci-archive:{ociarchive}", f"docker://{container_name}:{container_tag}"])
     print(subprocess.list2cmdline(skopeoargs))
     subprocess.check_call(skopeoargs)
     df.seek(0)


### PR DESCRIPTION
This reworks how we parse the container name and tag from the cmdline to
make it easier to follow and I think also fixes a bug in handling of
`--base-image-name`.