### PR TITLE
[rhcos-4.11] cmd-push-container: replace --base-image-name by --name-suffix

### DIFF
--- a/src/cmd-push-container
+++ b/src/cmd-push-container
@@ -19,7 +19,7 @@ parser = argparse.ArgumentParser()
 parser.add_argument("--authfile", help="Authentication file",
                     action='store')
 parser.add_argument("--format", help="Image format for destination", choices=['oci', 'v2s2'], action='store')
-parser.add_argument("--base-image-name", help="Append extra 'base-image' to the name of the container image", action='store_true')
+parser.add_argument("--name-suffix", metavar='SUFFIX', help="Append SUFFIX to container name")
 parser.add_argument("name", help="destination image reference")
 
 args = parser.parse_args()
@@ -44,11 +44,15 @@ if args.authfile is not None:
     skopeoargs.extend(['--authfile', args.authfile])
 if args.format is not None:
     skopeoargs.extend(['--format', args.format])
-container_name = args.name
-if ":" not in container_name:
-    container_name = f"{container_name}:{latest_build}-{arch}"
-if args.base_image_name:
-    container_name = f"{container_name}-base-image"
-skopeoargs.extend([f"oci-archive:{ociarchive}", f"docker://{container_name}"])
+if ":" not in args.name:
+    container_name = args.name
+    # If a specific tag wasn't requested, add a default one
+    container_tag = f"{latest_build}-{arch}"
+else:
+    # Note this implicitly errors out if there's more than one ':'
+    container_name, container_tag = args.name.rsplit(':')
+if args.name_suffix:
+    container_name = f"{container_name}-{args.name_suffix}"
+skopeoargs.extend([f"oci-archive:{ociarchive}", f"docker://{container_name}:{container_tag}"])
 print(subprocess.list2cmdline(skopeoargs))
 os.execvp('skopeo', skopeoargs)


### PR DESCRIPTION
The latter takes the suffix as a parameter so that we don't have to
hardcode any suffix in the codebase itself.

Addresses review comment:
https://github.com/coreos/coreos-assembler/pull/2837#pullrequestreview-959395787

(cherry picked from commit c462739e1a15cd428c865511ffa3a46434580301)