### PR TITLE
mantle/kola: detect when systemd-generators fail

### DIFF
--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -198,6 +198,11 @@ var (
 			desc:  "oom killer",
 			match: regexp.MustCompile("invoked oom-killer"),
 		},
+		{
+			// https://github.com/coreos/fedora-coreos-config/pull/1797
+			desc:  "systemd generator failure",
+			match: regexp.MustCompile(`systemd\[[0-9]+\]: (.*) failed with exit status`),
+		},
 	}
 )
 


### PR DESCRIPTION
For example, this ugly failure has been hanging around in our
console logs for some time:

```
[    5.733962] ln:
[    5.733968] failed to create symbolic link '/run/udev/rules.d/80-coreos-boot-disk.rules'
[    5.734511] : File exists
[    5.737931] systemd[1023]: /usr/lib/systemd/system-generators/coreos-diskful-generator failed with exit status 1.
```

Let's detect these when they pop up.