### PR TITLE
cmdlib: Explain to people they can set `COSA_NO_KVM`

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -105,7 +105,7 @@ preflight_kvm() {
 
     if test -z "${COSA_NO_KVM:-}"; then
         if ! test -c /dev/kvm; then
-            fatal "Missing /dev/kvm"
+            fatal "Missing /dev/kvm; you can set COSA_NO_KVM=1 to bypass this at the cost of performance."
         fi
         if ! [ -w /dev/kvm ]; then
             if ! has_privileges; then


### PR DESCRIPTION
It's OK, it will just be slow.  In some cases e.g. "I just want
to inject some kernel arguments in a custom AMI building from a Mac",
the performance hit is OK.