### PR TITLE
cmd-generate-hashlist: don't print symlinks skipped

### DIFF
--- a/src/cmd-generate-hashlist
+++ b/src/cmd-generate-hashlist
@@ -127,7 +127,6 @@ class HashListV1(dict):
                 filepath = os.path.join(dirpath, fname)
                 # Skip symlinks
                 if os.path.islink(filepath):
-                    print(f'Skipping symlink {filepath}')
                     continue
                 try:
                     filehash = sha256sum_file(filepath)


### PR DESCRIPTION
There are a lot of symlinks in the OSTree compose and initrd. Listing
them all adds noise to pipeline outputs.