### PR TITLE
cmdlib: make locks use long lifetimes

### DIFF
--- a/src/cmd-generate-hashlist
+++ b/src/cmd-generate-hashlist
@@ -82,8 +82,7 @@ class HashListV1(dict):
         import_ostree_commit(
             os.getcwd(),
             self._metadata.build_dir,
-            self._metadata,
-            force=True)
+            self._metadata)
         subprocess.check_call([
             'ostree', 'checkout',
             '--repo=tmp/repo', '-U',

--- a/src/cmd-sign
+++ b/src/cmd-sign
@@ -134,7 +134,7 @@ def robosign_ostree(args, s3, build, gpgkey):
     # Ensure we have an unpacked repo with the ostree content
     if not os.path.exists('tmp/repo'):
         subprocess.check_call(['ostree', '--repo=tmp/repo', 'init', '--mode=archive'])
-    import_ostree_commit(os.getcwd(), builddir, build, force=True)
+    import_ostree_commit(os.getcwd(), builddir, build)
     repo = OSTree.Repo.new(Gio.File.new_for_path('tmp/repo'))
     repo.open(None)
 

--- a/src/cosalib/cmdlib.py
+++ b/src/cosalib/cmdlib.py
@@ -264,7 +264,7 @@ def extract_image_json(workdir, commit):
 # a metal image, we may not have preserved that cache.
 #
 # Call this function to ensure that the ostree commit for a given build is in tmp/repo.
-def import_ostree_commit(workdir, buildpath, buildmeta, force=False):
+def import_ostree_commit(workdir, buildpath, buildmeta):
     tmpdir = os.path.join(workdir, 'tmp')
     with Lock(os.path.join(workdir, 'tmp/repo.import.lock')):
         repo = os.path.join(tmpdir, 'repo')
@@ -279,8 +279,7 @@ def import_ostree_commit(workdir, buildpath, buildmeta, force=False):
         if (subprocess.call(['ostree', 'show', '--repo', repo, commit],
                             stdout=subprocess.DEVNULL,
                             stderr=subprocess.DEVNULL) == 0
-                and not os.path.isfile(commitpartial)
-                and not force):
+                and not os.path.isfile(commitpartial)):
             extract_image_json(workdir, commit)
             return
 

--- a/src/cosalib/cmdlib.py
+++ b/src/cosalib/cmdlib.py
@@ -27,7 +27,7 @@ from tenacity import (
 gi.require_version("RpmOstree", "1.0")
 from gi.repository import RpmOstree
 
-from datetime import datetime, timezone
+import datetime
 
 retry_stop = (stop_after_delay(10) | stop_after_attempt(5))
 retry_boto_exception = (retry_if_exception_type(ConnectionClosedError) |
@@ -212,7 +212,7 @@ def rfc3339_time(t=None):
     :rtype: str
     """
     if t is None:
-        t = datetime.utcnow()
+        t = datetime.datetime.utcnow()
     else:
         # if the need arises, we can convert to UTC, but let's just enforce
         # this doesn't slip by for now
@@ -327,8 +327,8 @@ def parse_date_string(date_string):
     :rtype: datetime.datetime
     :raises: ValueError, TypeError
     """
-    dt = datetime.strptime(date_string, '%Y-%m-%dT%H:%M:%SZ')
-    return dt.replace(tzinfo=timezone.utc)
+    dt = datetime.datetime.strptime(date_string, '%Y-%m-%dT%H:%M:%SZ')
+    return dt.replace(tzinfo=datetime.timezone.utc)
 
 
 def get_timestamp(entry):


### PR DESCRIPTION
`flufl` requires specifying lock lifetimes, i.e. how long the lock
should be considered valid before others can also lock it. The default
is 15s. This surprisingly means that a critical section could in fact be
run concurrently if one of the locks takes more than 15s.

I don't think we want to use lock lifetimes here, so let's make sure we
always pass in a large number. The intended use case is that your
program doesn't deadlock, but I'd prefer we deadlock and have pipelines
fail instead after timing out at the Jenkins level.

This should fix the `NotLockedError: Already unlocked` error messages
we've had in the FCOS pipeline after parallelizing
`cosa generate-hashlist` and `cosa buildextend-qemu` (related:
https://github.com/coreos/fedora-coreos-pipeline/pull/554).

What would be interesting would be lock timeouts instead: e.g. have
`with Lock(...)` automatically throw if it still hasn't acquired the
lock after X duration. That'd allow us to error out earlier than the
Jenkins timeout in case of something taking much longer than it really
should.

We could do this now but it'd require creating the lock separately from
using it in a context. Latest upstream `flufl` supports specifying this
as part of the constructor so let's wait for that instead:

https://gitlab.com/warsaw/flufl.lock/-/merge_requests/47