### PR TITLE
cmdlib: mount `src/config-git` into supermin instead of `src/config` if present

### DIFF
--- a/src/cmd-init
+++ b/src/cmd-init
@@ -112,7 +112,7 @@ mkdir -p src
 (cd src
  if ! test -e config; then
      case "${source}" in
-         /*) ln -s "${source}/${subdir}" config;;
+         /*) ln -s "${source}" config;;
          *) git clone ${BRANCH:+--branch=${BRANCH}} --depth=1 --shallow-submodules --recurse-submodules "${source}" config
             # If a commit was specified then we'll fetch and reset
             # the specified branch to that commit. This is useful when
@@ -124,13 +124,13 @@ mkdir -p src
                 git -C ./config fetch origin "$COMMIT"
                 git -C ./config reset --hard "$COMMIT"
             fi
-            if [ -n "${subdir}" ]; then
-                mv config config-git
-                ln -sr config-git/"${subdir}" config
-            fi
             (set +x; cd config && echo -n "Config commit: " && git describe --tags --always --abbrev=42)
             ;;
      esac
+     if [ -n "${subdir}" ]; then
+         mv config config-git
+         ln -s config-git/"${subdir}" config
+     fi
      manifest=config/manifest.yaml
      if ! [ -f "${manifest}" ]; then
          echo 1>&2 "Failed to find src/${manifest}"

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -673,7 +673,10 @@ EOF
 
     # support local dev cases where src/config is a symlink.  Note if you change or extend to this set,
     # you also need to update supermin-init-prelude.sh to mount it inside the VM.
-    if [ -L "${workdir}/src/config" ]; then
+    if [ -L "${workdir}/src/config-git" ]; then
+        # qemu follows symlinks
+        base_qemu_args+=("-virtfs" 'local,id=source,path='"${workdir}"'/src/config-git,security_model=none,mount_tag=source')
+    elif [ -L "${workdir}/src/config" ]; then
         # qemu follows symlinks
         base_qemu_args+=("-virtfs" 'local,id=source,path='"${workdir}"'/src/config,security_model=none,mount_tag=source')
     fi

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -198,7 +198,7 @@ prepare_build() {
     echo "Using manifest: ${manifest}"
 
     # backcompat for local setups that initialized with `ln -sr`
-    if [ -L "${configdir}" ]; then
+    if [ -L "${configdir}" ] && [ ! -e "${workdir}/src/config-git" ]; then
         if [[ $(readlink "${configdir}") != /* ]]; then
             ln -sfn "$(realpath "${configdir}")" "${configdir}"
         fi

--- a/src/supermin-init-prelude.sh
+++ b/src/supermin-init-prelude.sh
@@ -37,8 +37,11 @@ umask 002
 # https://github.com/coreos/coreos-assembler/issues/2171
 mkdir -p "${workdir:?}"
 mount -t 9p -o rw,trans=virtio,version=9p2000.L,msize=10485760 workdir "${workdir}"
-# These two invocations pair with virtfs setups for qemu in cmdlib.sh.  Keep them in sync.
-if [ -L "${workdir}"/src/config ]; then
+# These invocations pair with virtfs setups for qemu in cmdlib.sh.  Keep them in sync.
+if [ -L "${workdir}"/src/config-git ]; then
+    mkdir -p "$(readlink "${workdir}"/src/config-git)"
+    mount -t 9p -o rw,trans=virtio,version=9p2000.L,msize=10485760 source "${workdir}"/src/config-git
+elif [ -L "${workdir}"/src/config ]; then
     mkdir -p "$(readlink "${workdir}"/src/config)"
     mount -t 9p -o rw,trans=virtio,version=9p2000.L,msize=10485760 source "${workdir}"/src/config
 fi


### PR DESCRIPTION
The real repo is in `src/config-git` in a subdir setup and `src/config`
is just a relative symlink to the subdir in question.

This should allow us to use subdirs in the CI of openshift/os for
different RHEL/CentOS versions.

Long-term, we should probably move away from subdirs into something more
structured that doesn't require symlinking everything into the subdirs.