### PR TITLE
Drop references to fedora-coreos-pinger

### DIFF
--- a/mantle/kola/tests/misc/users.go
+++ b/mantle/kola/tests/misc/users.go
@@ -36,12 +36,10 @@ func CheckUserShells(c cluster.TestCluster) {
 	var badusers []string
 
 	ValidUsers := map[string]string{
-		"sync":                 "/bin/sync",
-		"shutdown":             "/sbin/shutdown",
-		"halt":                 "/sbin/halt",
-		"core":                 "/bin/bash",
-		"fedora-coreos-pinger": "/usr/sbin/nologin",
-		"zincati":              "/usr/sbin/nologin",
+		"sync":     "/bin/sync",
+		"shutdown": "/sbin/shutdown",
+		"halt":     "/sbin/halt",
+		"core":     "/bin/bash",
 	}
 
 	output := c.MustSSH(m, "getent passwd")

--- a/mantle/platform/cluster.go
+++ b/mantle/platform/cluster.go
@@ -207,10 +207,8 @@ func (bc *BaseCluster) RenderUserData(userdata *platformConf.UserData, ignitionV
 		conf.CopyKeys(keys)
 	}
 
-	// disable Zincati & Pinger by default
+	// disable Zincati by default
 	if bc.Distribution() == "fcos" {
-		conf.AddFile("/etc/fedora-coreos-pinger/config.d/90-disable-reporting.toml", `[reporting]
-enabled = false`, 0644)
 		conf.AddFile("/etc/zincati/config.d/90-disable-auto-updates.toml", `[updates]
 enabled = false`, 0644)
 	}


### PR DESCRIPTION
We're removing it from FCOS (https://github.com/coreos/fedora-coreos-tracker/issues/770).

Nothing in this PR should cause a behavior change with OS images that still include the pinger.