### PR TITLE
cmdlib: bump supermin VM memory to 3G

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -651,7 +651,9 @@ EOF
 
     # There seems to be some false positives in shellcheck
     # https://github.com/koalaman/shellcheck/issues/2217
-    memory_default=2048
+    # If this is too low, we can hit ENOMEM issues in the guest kernel related
+    # to a 9p memory bug: https://github.com/openshift/os/issues/594
+    memory_default=4096
     # shellcheck disable=2031
     case $arch in
     # Power 8 page faults with 2G of memory in rpm-ostree


### PR DESCRIPTION
Something has changed recently which causes us to hit the ENOMEM issue
more easily now:

https://github.com/openshift/os/issues/594#issuecomment-1163549882

Mid-term, we could rework the compose so that only the OCI archive is
pulled through 9p rather than a full `pull-local`. Long-term, the fix is
to stop using 9p.

But for now to unblock CI, let's just bump the VM memory to 3G which
should help.