### PR TITLE
build: Downgrade edk2-ovmf to f35

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -66,6 +66,9 @@ install_rpms() {
     # as we want to enable fast iteration there.
     yum -y --enablerepo=updates-testing upgrade rpm-ostree
 
+    # https://github.com/openshift/os/issues/862
+    yum -y --setopt=releasever=35 distro-sync edk2-ovmf
+
     # Delete file that only exists on ppc64le because it is causing
     # sudo to not work.
     # https://bugzilla.redhat.com/show_bug.cgi?id=2082149


### PR DESCRIPTION
Something changed here to cause older host kernels (e.g. rhel8)
to break but only when emulated on an even older (rhel7) host.

See https://github.com/openshift/os/issues/862

Will try to file a proper bug soon, but for now...