### PR TITLE
buildextend-metal: fix --build to take an argument

### DIFF
--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -35,7 +35,7 @@ EOF
 hostkey=src/config/secex-hostkey
 rc=0
 build=
-options=$(getopt --options h --longoptions help,build,hostkey: -- "$@") || rc=$?
+options=$(getopt --options h --longoptions help,build:,hostkey: -- "$@") || rc=$?
 [ $rc -eq 0 ] || {
     print_help
     exit 1


### PR DESCRIPTION
It looks like the support for an argument passed to `--build` was
erroneously removed as part of 1d33f5bf4