### PR TITLE
Don't `pull-local` over 9p during rpm-ostree compose

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -175,6 +175,9 @@ if [ -n "${previous_commit}" ]; then
         ostree refs --repo="${tmprepo}" --create "${ref}" "${previous_commit}"
     fi
 
+    # also make sure the previous build ref exists
+    ostree refs --repo="${tmprepo}" --create "${previous_build}" "${previous_commit}" --force
+
     # Corner-case here: if the previous build was for a different ref, then we
     # want to make sure rpm-ostree doesn't select the same version. Do this by
     # pretending the ref is currently pointing at the last commit on the

--- a/src/cmd-build
+++ b/src/cmd-build
@@ -258,8 +258,6 @@ if [ -n "${PARENT}" ]; then
 fi
 extra_compose_args+=("$parent_arg")
 
-# These need to be absolute paths right now for rpm-ostree
-composejson="$(readlink -f "${workdir}"/tmp/compose.json)"
 # Put this under tmprepo so it gets automatically chown'ed if needed
 lockfile_out=${tmprepo}/tmp/manifest-lock.generated.${basearch}.json
 # shellcheck disable=SC2119

--- a/src/cmd-build
+++ b/src/cmd-build
@@ -277,7 +277,6 @@ if test -n "${previous_commit}"; then
 fi
 RUNVM_NONET=1 runcompose_tree --cache-only ${FORCE} \
            --add-metadata-from-json "${commitmeta_input_json}" \
-           --write-composejson-to "${composejson}" \
            --ex-write-lockfile-to "${lockfile_out}".tmp \
            "${extra_compose_args[@]}"
 strip_out_lockfile_digests "$lockfile_out".tmp

--- a/src/cmd-fetch
+++ b/src/cmd-fetch
@@ -115,8 +115,10 @@ fi
 # shellcheck disable=SC2086
 prepare_compose_overlays ${IGNORE_COSA_OVERRIDES_ARG}
 
+# Use --force-nocache to ensure we always download packages, regardless of
+# whether the package set didn't changed since the last build.
 # shellcheck disable=SC2086
-runcompose_tree --download-only ${args}
+runcompose_tree --download-only ${args} --force-nocache
 # This stamp file signifies we successfully fetched once; it's
 # validated in cmd-build.
 touch "${fetch_stamp}"

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -411,8 +411,8 @@ EOF
     export ostree_image_json="/usr/share/coreos-assembler/image.json"
     mkdir -p "${imagejsondir}/usr/share/coreos-assembler/"
     cp "${image_json}" "${imagejsondir}${ostree_image_json}"
-    commit_overlay cosa-image-json "${imagejsondir}"
-    layers="${layers} cosa-image-json"
+    commit_overlay overlay/cosa-image-json "${imagejsondir}"
+    layers="${layers} overlay/cosa-image-json"
 
     local_overrides_lockfile="${tmp_overridesdir}/local-overrides.json"
     if [ -n "${with_cosa_overrides}" ] && [[ -n $(ls "${overridesdir}/rpm/"*.rpm 2> /dev/null) ]]; then

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -497,6 +497,7 @@ runcompose_tree() {
     rm -f "${changed_stamp}"
     # shellcheck disable=SC2086
     set - ${COSA_RPMOSTREE_GDB:-} rpm-ostree compose tree --repo="${repo}" \
+            --write-composejson-to "${composejson}" \
             --touch-if-changed "${changed_stamp}" --cachedir="${workdir}"/cache \
             ${COSA_RPMOSTREE_ARGS:-} --unified-core "${manifest}" "$@"
 

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -184,6 +184,9 @@ prepare_build() {
 
     export image_json="${workdir}/tmp/image.json"
     write_image_json "${configdir}/image.yaml" "${image_json}"
+    # These need to be absolute paths right now for rpm-ostree
+    composejson="$(readlink -f "${workdir}"/tmp/compose.json)"
+    export composejson
 
     export workdir configdir manifest manifest_lock manifest_lock_overrides manifest_lock_arch_overrides
     export fetch_stamp

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -520,25 +520,29 @@ impl_rpmostree_compose() {
         # with a consistent value, regardless of the environment
         (umask 0022 && sudo -E "$@")
     else
-        # "cache2" has an explicit label so we can find it in qemu easily
-        if [ ! -f "${workdir}"/cache/cache2.qcow2 ]; then
-            qemu-img create -f qcow2 cache2.qcow2.tmp 10G
-            (
-             # shellcheck source=src/libguestfish.sh
-             source /usr/lib/coreos-assembler/libguestfish.sh
-             virt-format --filesystem=xfs --label=cosa-cache -a cache2.qcow2.tmp)
-            mv -T cache2.qcow2.tmp "${workdir}"/cache/cache2.qcow2
-        fi
-        # And remove the old one
-        rm -vf "${workdir}"/cache/cache.qcow2
-        local cachedriveargs="discard=unmap"
-        if is_transient; then
-            cachedriveargs="cache=unsafe,discard=ignore"
-        fi
-        compose_qemu_args+=("-drive" "if=none,id=cache,$cachedriveargs,file=${workdir}/cache/cache2.qcow2" \
-                            "-device" "virtio-blk,drive=cache")
-        runvm "${compose_qemu_args[@]}" -- "$@"
+        runvm_with_cache "$@"
     fi
+}
+
+runvm_with_cache() {
+    # "cache2" has an explicit label so we can find it in qemu easily
+    if [ ! -f "${workdir}"/cache/cache2.qcow2 ]; then
+        qemu-img create -f qcow2 cache2.qcow2.tmp 10G
+        (
+         # shellcheck source=src/libguestfish.sh
+         source /usr/lib/coreos-assembler/libguestfish.sh
+         virt-format --filesystem=xfs --label=cosa-cache -a cache2.qcow2.tmp)
+        mv -T cache2.qcow2.tmp "${workdir}"/cache/cache2.qcow2
+    fi
+    # And remove the old one
+    rm -vf "${workdir}"/cache/cache.qcow2
+    local cachedriveargs="discard=unmap"
+    if is_transient; then
+        cachedriveargs="cache=unsafe,discard=ignore"
+    fi
+    cache_args+=("-drive" "if=none,id=cache,$cachedriveargs,file=${workdir}/cache/cache2.qcow2" \
+                        "-device" "virtio-blk,drive=cache")
+    runvm "${cache_args[@]}" -- "$@"
 }
 
 # Strips out the digest field from lockfiles since they subtly conflict with

--- a/src/compose.sh
+++ b/src/compose.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -euo pipefail
+
+output_tarball=$1; shift
+output_composejson=$1; shift
+
+tarball=cache/output.tar
+composejson=cache/compose.json
+
+repo=cache/repo
+rm -rf "${repo}" "${composejson}"
+ostree init --repo="${repo}" --mode=archive-z2
+
+# we do need to pull at least the overlay bits over 9p, but it shouldn't be that
+# many files
+ostree refs --repo tmp/repo overlay --list | \
+    xargs -r ostree pull-local --repo "${repo}" tmp/repo
+# And import commit metadata for all refs; this will bring in the previous
+# build if there is one. Ideally, we'd import the SELinux policy too to take
+# advantage of https://github.com/coreos/rpm-ostree/pull/1704 but that's yet
+# more files over 9p and our pipelines don't have cache anyway (and devs likely
+# use the privileged path).
+ostree refs --repo tmp/repo | \
+    xargs -r ostree pull-local --commit-metadata-only --repo "${repo}" tmp/repo
+
+# run rpm-ostree
+"$@" --repo "${repo}" --write-composejson-to "${composejson}"
+
+if [ ! -f "${composejson}" ]; then
+    # no commit was produced; we're done
+    exit 0
+fi
+
+tar -f "${tarball}" -C "${repo}" -c .
+
+# this is key bit where we move the OSTree content over 9p
+mv "${tarball}" "${output_tarball}"
+mv "${composejson}" "${output_composejson}"

--- a/src/vmdeps.txt
+++ b/src/vmdeps.txt
@@ -27,3 +27,5 @@ gdisk xfsprogs e2fsprogs dosfstools btrfs-progs
 
 # needed for basic CA support
 ca-certificates
+
+tar


### PR DESCRIPTION
Instead of having rpm-ostree effectively doing a `pull-local` under the
hood over 9p, change things so we compose in a local repo, export the
commit to an archive and only copy *that* over 9p.

This should greatly help with pipelines hitting ENOMEM due to
transferring many small files over 9p:

https://github.com/openshift/os/issues/594

An initial approach exported to OCI archive instead, but encapsulating
and unencapsulating are more expensive operations. Unfortunately, we
still need to unpack into `tmp/repo` given that many follow-up commands
expect the commit to be available in `tmp/repo`. If we can drop that
assumption (and get rid of `tmp/repo` entirely), we could refactor
things further so that `compose.sh` creates the final chunked OCI
artifact upfront.

In local testing, this adds about 30s to `cosa build`. We still compress
just once, and we get hardlinks pulling out of the tarball.
