### PR TITLE
build: don't fail if edk2-ovmf couldn't be found (s390x)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -67,7 +67,8 @@ install_rpms() {
     yum -y --enablerepo=updates-testing upgrade rpm-ostree
 
     # https://github.com/openshift/os/issues/862
-    yum -y --setopt=releasever=35 distro-sync edk2-ovmf
+    # On arches others than x86 this package is not available, just ignore the error
+    yum -y --setopt=releasever=35 distro-sync edk2-ovmf || :
 
     # Delete file that only exists on ppc64le because it is causing
     # sudo to not work.


### PR DESCRIPTION
After https://github.com/coreos/coreos-assembler/pull/2943, build on s390x fails with:
```
yum -y --setopt=releasever=35 distro-sync edk2-ovmf
Fedora 35 - s390x                                18 MB/s |  72 MB     00:04
Fedora 35 openh264 (From Cisco) - s390x         1.7 kB/s | 2.5 kB     00:01
Fedora Modular 35 - s390x                       1.3 MB/s | 3.2 MB     00:02
Fedora 35 - s390x - Updates                     7.8 MB/s |  27 MB     00:03
Fedora Modular 35 - s390x - Updates             1.4 MB/s | 3.1 MB     00:02
No package edk2-ovmf installed.
Error: No packages marked for distribution synchronization.
```
Ignore the error.