### PR TITLE
cmd-fetch: make `--force-nocache` optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ DESTDIR ?=
 # W504 line break after binary operator
 PYIGNORE ?= E128,E241,E402,E501,E722,W503,W504
 
-.PHONY: all check flake8 pycheck unittest clean mantle mantle-check install gangplank gangplank-check tools
+.PHONY: all check shellcheck flake8 pycheck unittest clean mantle mantle-check install gangplank gangplank-check tools
 
 MANTLE_BINARIES := ore kola plume
 
@@ -33,7 +33,9 @@ endif
 .%.shellchecked: %
 	./tests/check_one.sh $< $@
 
-check: ${src_checked} ${tests_checked} ${cwd_checked} flake8 pycheck schema-check mantle-check gangplank-check
+shellcheck: ${src_checked} ${tests_checked} ${cwd_checked}
+
+check: shellcheck flake8 pycheck schema-check mantle-check gangplank-check
 	echo OK
 
 pycheck:

--- a/src/cmd-fetch
+++ b/src/cmd-fetch
@@ -20,7 +20,7 @@ fi
 print_help() {
     cat 1>&2 <<'EOF'
 Usage: coreos-assembler fetch --help
-       coreos-assembler fetch [--update-lockfile] [--write-lockfile-to=file] [--with-cosa-overrides] [--strict]
+       coreos-assembler fetch [--update-lockfile] [--write-lockfile-to=file] [--with-cosa-overrides] [--strict] [--force]
 
   Fetch and import the latest packages.
 EOF
@@ -30,9 +30,10 @@ UPDATE_LOCKFILE=
 OUTPUT_LOCKFILE=
 IGNORE_COSA_OVERRIDES_ARG=--ignore-cosa-overrides
 DRY_RUN=
+FORCE_ARG=
 STRICT=
 rc=0
-options=$(getopt --options h --longoptions help,update-lockfile,dry-run,with-cosa-overrides,write-lockfile-to:,strict -- "$@") || rc=$?
+options=$(getopt --options h --longoptions help,update-lockfile,dry-run,with-cosa-overrides,write-lockfile-to:,strict,force -- "$@") || rc=$?
 [ $rc -eq 0 ] || {
     print_help
     exit 1
@@ -60,6 +61,9 @@ while true; do
             ;;
         --strict)
             STRICT=1
+            ;;
+        --force)
+            FORCE_ARG=--force-nocache
             ;;
         --)
             shift
@@ -115,10 +119,8 @@ fi
 # shellcheck disable=SC2086
 prepare_compose_overlays ${IGNORE_COSA_OVERRIDES_ARG}
 
-# Use --force-nocache to ensure we always download packages, regardless of
-# whether the package set didn't changed since the last build.
 # shellcheck disable=SC2086
-runcompose_tree --download-only ${args} --force-nocache
+runcompose_tree --download-only ${args} ${FORCE_ARG}
 # This stamp file signifies we successfully fetched once; it's
 # validated in cmd-build.
 touch "${fetch_stamp}"


### PR DESCRIPTION
This is a rework of https://github.com/coreos/coreos-assembler/commit/0ea19847cde4a6f524913c6b31e8d808556c8b72 ("cmd-fetch: pass --force-nocache").

It's wasteful to do this by default because pipelines don't have cache
and we don't want them to always fetch packages if it's going to no-op
anyway.

Let's make it a `--force` option instead to match `cosa build`.