### PR TITLE
cmdlib: consistently use `overlay/` prefix for injected overlays

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -457,7 +457,7 @@ EOF
         chmod 0644 "${tmp_overridesdir}/contentsetrootfs/usr/share/buildinfo/content_manifest.json"
 
         echo -n "Committing ${tmp_overridesdir}/contentsetrootfs... "
-        commit_ostree_layer "${tmp_overridesdir}/contentsetrootfs" overlay/contentset
+        commit_overlay overlay/contentset "${tmp_overridesdir}/contentsetrootfs"
         layers="${layers} overlay/contentset"
     fi
 
@@ -470,9 +470,8 @@ EOF
 
     rootfs_overrides="${overridesdir}/rootfs"
     if [[ -d "${rootfs_overrides}" && -n $(ls -A "${rootfs_overrides}") ]]; then
-        echo -n "Committing ${rootfs_overrides}... "
         touch "${overrides_active_stamp}"
-        commit_ostree_layer "${rootfs_overrides}" "overlay/cosa-overrides-rootfs"
+        commit_overlay "overlay/cosa-overrides-rootfs" "${rootfs_overrides}"
           cat >> "${override_manifest}" << EOF
 ostree-override-layers:
   - overlay/cosa-overrides-rootfs

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -457,8 +457,8 @@ EOF
         chmod 0644 "${tmp_overridesdir}/contentsetrootfs/usr/share/buildinfo/content_manifest.json"
 
         echo -n "Committing ${tmp_overridesdir}/contentsetrootfs... "
-        commit_ostree_layer "${tmp_overridesdir}/contentsetrootfs" contentset
-        layers="${layers} contentset"
+        commit_ostree_layer "${tmp_overridesdir}/contentsetrootfs" overlay/contentset
+        layers="${layers} overlay/contentset"
     fi
 
     if [ -n "${layers}" ]; then
@@ -472,10 +472,10 @@ EOF
     if [[ -d "${rootfs_overrides}" && -n $(ls -A "${rootfs_overrides}") ]]; then
         echo -n "Committing ${rootfs_overrides}... "
         touch "${overrides_active_stamp}"
-        commit_ostree_layer "${rootfs_overrides}" "cosa-overrides-rootfs"
+        commit_ostree_layer "${rootfs_overrides}" "overlay/cosa-overrides-rootfs"
           cat >> "${override_manifest}" << EOF
 ostree-override-layers:
-  - cosa-overrides-rootfs
+  - overlay/cosa-overrides-rootfs
 EOF
     fi
 }

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -301,7 +301,7 @@ commit_overlay() {
     # files, but we do.
     touch "${TMPDIR}/overlay/statoverride"
     echo -n "Committing ${name}: ${path} ... "
-    commit_ostree_layer "${TMPDIR}/overlay" "${name}" \
+    commit_ostree_layer "${TMPDIR}/overlay" "overlay/${name}" \
         --statoverride <(sed -e '/^#/d' "${TMPDIR}/overlay/statoverride") \
         --skip-list <(echo /statoverride)
 }
@@ -397,10 +397,7 @@ EOF
             if ! [ -d "${n}" ]; then
                 continue
             fi
-            local bn ovlname
-            bn=$(basename "${n}")
-            ovlname="overlay/${bn}"
-            commit_overlay "${ovlname}" "${n}"
+            commit_overlay "$(basename "${n}")" "${n}"
         done
     fi
 
@@ -411,7 +408,7 @@ EOF
     export ostree_image_json="/usr/share/coreos-assembler/image.json"
     mkdir -p "${imagejsondir}/usr/share/coreos-assembler/"
     cp "${image_json}" "${imagejsondir}${ostree_image_json}"
-    commit_overlay overlay/cosa-image-json "${imagejsondir}"
+    commit_overlay cosa-image-json "${imagejsondir}"
     layers="${layers} overlay/cosa-image-json"
 
     local_overrides_lockfile="${tmp_overridesdir}/local-overrides.json"
@@ -457,7 +454,7 @@ EOF
         chmod 0644 "${tmp_overridesdir}/contentsetrootfs/usr/share/buildinfo/content_manifest.json"
 
         echo -n "Committing ${tmp_overridesdir}/contentsetrootfs... "
-        commit_overlay overlay/contentset "${tmp_overridesdir}/contentsetrootfs"
+        commit_overlay contentset "${tmp_overridesdir}/contentsetrootfs"
         layers="${layers} overlay/contentset"
     fi
 
@@ -471,7 +468,7 @@ EOF
     rootfs_overrides="${overridesdir}/rootfs"
     if [[ -d "${rootfs_overrides}" && -n $(ls -A "${rootfs_overrides}") ]]; then
         touch "${overrides_active_stamp}"
-        commit_overlay "overlay/cosa-overrides-rootfs" "${rootfs_overrides}"
+        commit_overlay cosa-overrides-rootfs "${rootfs_overrides}"
           cat >> "${override_manifest}" << EOF
 ostree-override-layers:
   - overlay/cosa-overrides-rootfs

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -275,14 +275,6 @@ prepare_build() {
     export overrides_active_stamp
 }
 
-commit_ostree_layer() {
-    local rootfs=$1; shift
-    local branch=$1; shift
-    ostree commit --repo="${tmprepo}" --tree=dir="${rootfs}" -b "${branch}" \
-        --owner-uid 0 --owner-gid 0 --no-xattrs --no-bindings --parent=none \
-        --mode-ro-executables --timestamp "${git_timestamp}" "$@"
-}
-
 commit_overlay() {
     local name path respath
     name=$1
@@ -301,7 +293,10 @@ commit_overlay() {
     # files, but we do.
     touch "${TMPDIR}/overlay/statoverride"
     echo -n "Committing ${name}: ${path} ... "
-    commit_ostree_layer "${TMPDIR}/overlay" "overlay/${name}" \
+    ostree commit --repo="${tmprepo}" \
+        --tree=dir="${TMPDIR}/overlay" -b "overlay/${name}" \
+        --owner-uid 0 --owner-gid 0 --no-xattrs --no-bindings --parent=none \
+        --mode-ro-executables --timestamp "${git_timestamp}" \
         --statoverride <(sed -e '/^#/d' "${TMPDIR}/overlay/statoverride") \
         --skip-list <(echo /statoverride)
 }


### PR DESCRIPTION
Like in e6b07ffb2 ("cmdlib: rename `cosa-image-json` ostree overlay"),
we need the content set overlay and the `overrides/rootfs` overlay to
use that prefix. That's how `compose.sh` knows to pull it over 9p.

Fixes: #2949