### PR TITLE
[rhcos-4.11]build: Add BZ comment and tweak error handling for `edk2-ovmf`

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -66,9 +66,10 @@ install_rpms() {
     # as we want to enable fast iteration there.
     yum -y --enablerepo=updates-testing upgrade rpm-ostree
 
+    # Downgrade edk2-ovmf to work around crazy bug with (rhel7 host, rhel8 guest, fedora userspace)
     # https://github.com/openshift/os/issues/862
-    # On arches others than x86 this package is not available, just ignore the error
-    yum -y --setopt=releasever=35 distro-sync edk2-ovmf || :
+    # https://bugzilla.redhat.com/show_bug.cgi?id=2101573
+    if rpm -q edk2-ovmf 2>/dev/null; then yum -y --setopt=releasever=35 distro-sync edk2-ovmf; fi
 
     # Delete file that only exists on ppc64le because it is causing
     # sudo to not work.

--- a/build.sh
+++ b/build.sh
@@ -66,6 +66,9 @@ install_rpms() {
     # as we want to enable fast iteration there.
     yum -y --enablerepo=updates-testing upgrade rpm-ostree
 
+    # https://github.com/openshift/os/issues/862
+    yum -y --setopt=releasever=35 distro-sync edk2-ovmf
+
     # Delete file that only exists on ppc64le because it is causing
     # sudo to not work.
     # https://bugzilla.redhat.com/show_bug.cgi?id=2082149

--- a/build.sh
+++ b/build.sh
@@ -67,7 +67,8 @@ install_rpms() {
     yum -y --enablerepo=updates-testing upgrade rpm-ostree
 
     # https://github.com/openshift/os/issues/862
-    yum -y --setopt=releasever=35 distro-sync edk2-ovmf
+    # On arches others than x86 this package is not available, just ignore the error
+    yum -y --setopt=releasever=35 distro-sync edk2-ovmf || :
 
     # Delete file that only exists on ppc64le because it is causing
     # sudo to not work.


### PR DESCRIPTION
Backport https://github.com/coreos/coreos-assembler/pull/2951 to rhcos-4.11