### PR TITLE
kola: seed `math/rand` earlier

### DIFF
--- a/mantle/cmd/kola/kola.go
+++ b/mantle/cmd/kola/kola.go
@@ -18,12 +18,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"net/http"
 	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
 	"text/tabwriter"
+	"time"
 
 	"github.com/coreos/pkg/capnslog"
 	"github.com/pkg/errors"
@@ -146,6 +148,8 @@ func init() {
 }
 
 func main() {
+	// initialize global state
+	rand.Seed(time.Now().UnixNano())
 	cli.Execute(root)
 }
 

--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -930,7 +930,6 @@ func (builder *QemuBuilder) addDiskImpl(disk *Disk, primary bool) error {
 		// Each disk is presented on its own controller.
 
 		// The WWN needs to be a unique uint64 number
-		rand.Seed(time.Now().UnixNano())
 		wwn := rand.Uint64()
 
 		var bus string


### PR DESCRIPTION
There's a bunch of other places that use `math/rand`. None of them rely
on the default seed of 1 and some cases may cause issues if the same
sequence is used. One example is creating temporary cloud resources:
we're currently investigating Azure tests failing with

```
Cluster failed: creating storage account: storage.AccountsClient#Create:
Failure responding to request: StatusCode=409 -- Original Error:
autorest/azure: Service returned an error. Status=409
Code="StorageAccountAlreadyExists" Message="The storage account named
kolasa94cb3c7856 already exists under the subscription."
```

and we think this is part of the issue.

Let's just seed the generator early during startup so that lower levels
don't have to think about whether to re-seed or not.