### PR TITLE
platform/azure: delete storage group on failure

### DIFF
--- a/mantle/platform/machine/azure/flight.go
+++ b/mantle/platform/machine/azure/flight.go
@@ -93,11 +93,17 @@ func (af *flight) NewCluster(rconf *platform.RuntimeConfig) (platform.Cluster, e
 
 	ac.StorageAccount, err = af.api.CreateStorageAccount(ac.ResourceGroup)
 	if err != nil {
+		if e := af.api.TerminateResourceGroup(ac.ResourceGroup); e != nil {
+			plog.Errorf("Deleting resource group %v: %v", ac.ResourceGroup, e)
+		}
 		return nil, err
 	}
 
 	_, err = af.api.PrepareNetworkResources(ac.ResourceGroup)
 	if err != nil {
+		if e := af.api.TerminateResourceGroup(ac.ResourceGroup); e != nil {
+			plog.Errorf("Deleting resource group %v: %v", ac.ResourceGroup, e)
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
If e.g. we fail to create the storage account, we need to make sure we
delete the resource group.

Leaking is not a big deal if you also regularly run `ore azure gc`, but
combined with #2956, it was causing us issues because the same resource
group name was being reused. If an initial run failed to delete the
resource group due to a network flake, subsequent runs could also fail
trying to e.g. create storage resources because they already existed.
Not deleting the resource group there meant that later jobs could keep
failing the same way.