### PR TITLE
main: Change `/sys/fs/selinux` handling to be a hard error

### DIFF
--- a/src/coreos-assembler
+++ b/src/coreos-assembler
@@ -27,16 +27,10 @@ if ! whoami &> /dev/null; then
   fi
 fi
 
-# Ensure we've unshared our mount namespace so
-# the later umount doesn't affect the host potentially
+# https://github.com/containers/libpod/issues/1448
 if [ -e /sys/fs/selinux/status ]; then
-    if [ -z "${coreos_assembler_unshared:-}" ]; then
-        exec sudo -E -- env coreos_assembler_unshared=1 unshare -m -- runuser -u "${USER}" -- "$0" "$@"
-    else
-        # Work around https://github.com/containers/libpod/issues/1448
-        # https://github.com/cgwalters/coretoolbox/blob/04e36894cdb912cd4d4c91b26436c57a2d96707d/src/coretoolbox.rs#L616
-        sudo mount --bind /usr/share/empty /sys/fs/selinux
-    fi
+    echo "error: /sys/fs/selinux appears to be mounted but should not be" 1>&2
+    exit 1
 fi
 
 cmd=${1:-}


### PR DESCRIPTION


Prep for reworking this in Go, where re-exec'ing ourself is
a bit more hairy.

Also I think this code should really, finally be dead.  We shouldn't
be seeing the host selinuxfs mount in any container setup.

---

