### PR TITLE
main: Stop setting `COSA_META_SCHEMA`

### DIFF
--- a/src/cmd-meta
+++ b/src/cmd-meta
@@ -29,7 +29,7 @@ def new_cli():
                         action='store_true')
     parser.add_argument('--schema', help='location of meta.json schema',
                         default=os.environ.get("COSA_META_SCHEMA",
-                                               f'{COSA_PATH}/v1.json.json'))
+                                               f'{COSA_PATH}/v1.json'))
     parser.add_argument('--true', dest='bool', default=None,
                         help='set a field', action='store_true')
     parser.add_argument('--false', dest='bool', default=None,

--- a/src/cmd-oc-adm-release
+++ b/src/cmd-oc-adm-release
@@ -80,7 +80,7 @@ if __name__ == '__main__':
     parser.add_argument('--build', default='latest')
     parser.add_argument('--schema', help='location of meta.json schema',
                         default=os.environ.get("COSA_META_SCHEMA",
-                                               f'{COSA_PATH}/v1.json.json'))
+                                               f'{COSA_PATH}/v1.json'))
     parser.add_argument("--authfile", action="store", required=True,
                         help="Pull secret")
     parser.add_argument("--arch", action='store',

--- a/src/coreos-assembler
+++ b/src/coreos-assembler
@@ -74,14 +74,6 @@ if [ -z "${cmd}" ]; then
 fi
 shift
 
-COSA_META_SCHEMA="${COSA_META_SCHEMA:-/usr/lib/coreos-assembler/v1.json}"
-schema_override="${PWD}/src/config/schema.json"
-if [ -e "${schema_override}" ]; then
-    COSA_META_SCHEMA=$(realpath "${schema_override}")
-fi
-export COSA_META_SCHEMA
-
-
 target=/usr/lib/coreos-assembler/cmd-${cmd}
 if test -x "${target}"; then
     exec "${target}" "$@"


### PR DESCRIPTION
We already have fallback defaults in the code.  Avoiding global
environment variables is good on general principle; but this
is specifically prep for making the entrypoint a Go program.