### PR TITLE
[4.11] Backports for RHCOS CI (--transient option & test entrypoint)

### DIFF
--- a/ci/prow-rhcos.sh
+++ b/ci/prow-rhcos.sh
@@ -17,5 +17,5 @@ esac
 export COSA_SKIP_OVERLAY=1
 # Create a temporary cosa workdir
 cd "$(mktemp -d)"
-cosa init -b "${RHCOS_BRANCH}" https://github.com/openshift/os
+cosa init --transient -b "${RHCOS_BRANCH}" https://github.com/openshift/os
 exec src/config/ci/prow-build-test-qemu.sh

--- a/ci/prow-rhcos.sh
+++ b/ci/prow-rhcos.sh
@@ -18,4 +18,5 @@ export COSA_SKIP_OVERLAY=1
 # Create a temporary cosa workdir
 cd "$(mktemp -d)"
 cosa init --transient -b "${RHCOS_BRANCH}" https://github.com/openshift/os
-exec src/config/ci/prow-entrypoint.sh rhcos-86-build-test-qemu
+# Use a COSA specifc test entry point to focus on tests relevant for COSA
+exec src/config/ci/prow-entrypoint.sh rhcos-cosa-prow-pr-ci

--- a/ci/prow-rhcos.sh
+++ b/ci/prow-rhcos.sh
@@ -18,4 +18,4 @@ export COSA_SKIP_OVERLAY=1
 # Create a temporary cosa workdir
 cd "$(mktemp -d)"
 cosa init --transient -b "${RHCOS_BRANCH}" https://github.com/openshift/os
-exec src/config/ci/prow-build-test-qemu.sh
+exec src/config/ci/prow-entrypoint.sh rhcos-86-build-test-qemu

--- a/src/cmd-build
+++ b/src/cmd-build
@@ -175,6 +175,9 @@ if [ -n "${previous_commit}" ]; then
         ostree refs --repo="${tmprepo}" --create "${ref}" "${previous_commit}"
     fi
 
+    # also make sure the previous build ref exists
+    ostree refs --repo="${tmprepo}" --create "${previous_build}" "${previous_commit}" --force
+
     # Corner-case here: if the previous build was for a different ref, then we
     # want to make sure rpm-ostree doesn't select the same version. Do this by
     # pretending the ref is currently pointing at the last commit on the

--- a/src/cmd-build
+++ b/src/cmd-build
@@ -258,8 +258,6 @@ if [ -n "${PARENT}" ]; then
 fi
 extra_compose_args+=("$parent_arg")
 
-# These need to be absolute paths right now for rpm-ostree
-composejson="$(readlink -f "${workdir}"/tmp/compose.json)"
 # Put this under tmprepo so it gets automatically chown'ed if needed
 lockfile_out=${tmprepo}/tmp/manifest-lock.generated.${basearch}.json
 # shellcheck disable=SC2119

--- a/src/cmd-build
+++ b/src/cmd-build
@@ -277,7 +277,6 @@ if test -n "${previous_commit}"; then
 fi
 RUNVM_NONET=1 runcompose_tree --cache-only ${FORCE} \
            --add-metadata-from-json "${commitmeta_input_json}" \
-           --write-composejson-to "${composejson}" \
            --ex-write-lockfile-to "${lockfile_out}".tmp \
            "${extra_compose_args[@]}"
 strip_out_lockfile_digests "$lockfile_out".tmp

--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -18,7 +18,7 @@ import time
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from cosalib.builds import Builds
-from cosalib.cmdlib import run_verbose, sha256sum_file, generate_image_json
+from cosalib.cmdlib import run_verbose, sha256sum_file
 from cosalib.cmdlib import import_ostree_commit, get_basearch, ensure_glob
 from cosalib.meta import GenericBuildMeta
 
@@ -46,9 +46,6 @@ if not args.build:
     args.build = builds.get_latest()
 print(f"Targeting build: {args.build}")
 
-image_json = generate_image_json('src/config/image.yaml')
-squashfs_compression = 'lz4' if args.fast else image_json['squashfs-compression']
-
 srcdir_prefix = "src/config/live/"
 
 if not os.path.isdir(srcdir_prefix):
@@ -58,6 +55,15 @@ workdir = os.path.abspath(os.getcwd())
 builddir = builds.get_build_dir(args.build)
 buildmeta_path = os.path.join(builddir, 'meta.json')
 buildmeta = GenericBuildMeta(workdir=workdir, build=args.build)
+repo = os.path.join(workdir, 'tmp/repo')
+
+# Grab the commit hash for this build
+buildmeta_commit = buildmeta['ostree-commit']
+
+import_ostree_commit(workdir, builddir, buildmeta)
+with open(os.path.join(workdir, 'tmp/image.json')) as f:
+    image_json = json.load(f)
+squashfs_compression = 'lz4' if args.fast else image_json['squashfs-compression']
 
 base_name = buildmeta['name']
 if base_name == "rhcos" and args.fast:
@@ -70,12 +76,6 @@ build_semaphore = os.path.join(buildmeta.build_dir, ".live.building")
 if os.path.exists(build_semaphore):
     raise Exception(
         f"{build_semaphore} exists: another process is building live")
-
-
-# Grab the commit hash for this build
-buildmeta_commit = buildmeta['ostree-commit']
-
-repo = os.path.join(workdir, 'tmp/repo')
 
 # Don't run if it's already been done, unless forced
 if 'live-iso' in buildmeta['images'] and not args.force:
@@ -695,8 +695,6 @@ boot
     buildmeta.write(artifact_name='live')
     print(f"Updated: {buildmeta_path}")
 
-
-import_ostree_commit(repo, builddir, buildmeta)
 
 # lock and build
 with open(build_semaphore, 'w') as f:

--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -117,6 +117,11 @@ commit=$(meta_key ostree-commit)
 ostree_repo=${tmprepo}
 # Ensure that we have the cached unpacked commit
 import_ostree_commit_for_build "${build}"
+# Note this overwrote the bits generated in prepare_build
+# for image_json.  In the future we expect to split prepare_build
+# into prepare_ostree_build and prepare_diskimage_build; the
+# latter path would only run this.
+image_json=${workdir}/tmp/image.json
 
 image_format=raw
 if [[ $image_type == qemu ]]; then

--- a/src/cmd-fetch
+++ b/src/cmd-fetch
@@ -115,8 +115,10 @@ fi
 # shellcheck disable=SC2086
 prepare_compose_overlays ${IGNORE_COSA_OVERRIDES_ARG}
 
+# Use --force-nocache to ensure we always download packages, regardless of
+# whether the package set didn't changed since the last build.
 # shellcheck disable=SC2086
-runcompose_tree --download-only ${args}
+runcompose_tree --download-only ${args} --force-nocache
 # This stamp file signifies we successfully fetched once; it's
 # validated in cmd-build.
 touch "${fetch_stamp}"

--- a/src/cmd-generate-hashlist
+++ b/src/cmd-generate-hashlist
@@ -80,7 +80,7 @@ class HashListV1(dict):
         checkout = 'tmp/repo/tmp/keylime-checkout'
 
         import_ostree_commit(
-            'tmp/repo',
+            os.getcwd(),
             self._metadata.build_dir,
             self._metadata,
             force=True)

--- a/src/cmd-init
+++ b/src/cmd-init
@@ -147,3 +147,6 @@ mkdir -p overrides/rootfs
 if test "${TRANSIENT}" = 1; then
     touch tmp/cosa-transient
 fi
+
+set +x
+echo "Initialized $PWD as coreos-assembler working directory."

--- a/src/cmd-init
+++ b/src/cmd-init
@@ -9,11 +9,12 @@ dn=$(dirname "$0")
 FORCE=0
 BRANCH=""
 COMMIT=""
+TRANSIENT=0
 
 print_help() {
     cat 1>&2 <<'EOF'
 Usage: coreos-assembler init --help
-       coreos-assembler init [--force] [--branch BRANCH] 
+       coreos-assembler init [--force] [--transient] [--branch BRANCH] 
                              [--commit COMMIT] GITCONFIG [SUBDIR]
 
   For example, you can use https://github.com/coreos/fedora-coreos-config
@@ -24,12 +25,15 @@ Usage: coreos-assembler init --help
 
   If specified, SUBDIR is a subdirectory of the git repository that should
   contain manifest.yaml and image.yaml (or image.ks).
+
+  Use `--transient` for builds that will throw away all cached data on success/failure,
+  and should hence not invoke `fsync()` for example.
 EOF
 }
 
 # Call getopt to validate the provided input.
 rc=0
-options=$(getopt --options hfb:c: --longoptions help,force,branch:,commit: -- "$@") || rc=$?
+options=$(getopt --options hfb:c: --longoptions help,force,transient,branch:,commit: -- "$@") || rc=$?
 [ $rc -eq 0 ] || {
     print_help
     exit 1
@@ -43,6 +47,9 @@ while true; do
         ;;
     -f | --force)
         FORCE=1
+        ;;
+    --transient)
+        TRANSIENT=1
         ;;
     -b | --branch)
         case "$2" in
@@ -136,3 +143,7 @@ mkdir -p builds
 mkdir -p tmp
 mkdir -p overrides/rpm
 mkdir -p overrides/rootfs
+
+if test "${TRANSIENT}" = 1; then
+    touch tmp/cosa-transient
+fi

--- a/src/cmd-sign
+++ b/src/cmd-sign
@@ -134,7 +134,7 @@ def robosign_ostree(args, s3, build, gpgkey):
     # Ensure we have an unpacked repo with the ostree content
     if not os.path.exists('tmp/repo'):
         subprocess.check_call(['ostree', '--repo=tmp/repo', 'init', '--mode=archive'])
-    import_ostree_commit('tmp/repo', builddir, build, force=True)
+    import_ostree_commit(os.getcwd(), builddir, build, force=True)
     repo = OSTree.Repo.new(Gio.File.new_for_path('tmp/repo'))
     repo.open(None)
 

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -184,6 +184,9 @@ prepare_build() {
 
     export image_json="${workdir}/tmp/image.json"
     write_image_json "${configdir}/image.yaml" "${image_json}"
+    # These need to be absolute paths right now for rpm-ostree
+    composejson="$(readlink -f "${workdir}"/tmp/compose.json)"
+    export composejson
 
     export workdir configdir manifest manifest_lock manifest_lock_overrides manifest_lock_arch_overrides
     export fetch_stamp

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -207,6 +207,11 @@ prepare_build() {
         else
             ostree init --repo="${tmprepo}" --mode=archive
         fi
+
+        # No need to fsync for transient flows
+        if test -f "${workdir}/tmp/cosa-transient"; then
+            ostree --repo="${tmprepo}" config set 'core.fsync' 'false'
+        fi
     fi
 
     configdir_gitrepo=${configdir}

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -484,30 +484,15 @@ runcompose_tree() {
         # we need our overrides to be at the end of the list
         set - "$@" --ex-lockfile="${tmp_overridesdir}/local-overrides.json"
     fi
-    impl_rpmostree_compose tree --unified-core "${manifest}" "$@"
-    if has_privileges; then
-        sudo chown -R -h "${USER}":"${USER}" "${tmprepo}"
-    fi
-}
 
-runcompose_extensions() {
-    local outputdir=$1; shift
-    impl_rpmostree_compose extensions "$@" --output-dir "$outputdir"
-    if has_privileges; then
-        sudo chown -R -h "${USER}":"${USER}" "${outputdir}"
-    fi
-}
-
-impl_rpmostree_compose() {
-    local cmd=$1; shift
     local workdir=${workdir:-$(pwd)}
     local repo=${tmprepo:-${workdir}/tmp/repo}
 
     rm -f "${changed_stamp}"
     # shellcheck disable=SC2086
-    set - ${COSA_RPMOSTREE_GDB:-} rpm-ostree compose "${cmd}" --repo="${repo}" \
+    set - ${COSA_RPMOSTREE_GDB:-} rpm-ostree compose tree --repo="${repo}" \
             --touch-if-changed "${changed_stamp}" --cachedir="${workdir}"/cache \
-            ${COSA_RPMOSTREE_ARGS:-} "$@"
+            ${COSA_RPMOSTREE_ARGS:-} --unified-core "${manifest}" "$@"
 
     echo "Running: $*"
 
@@ -516,6 +501,31 @@ impl_rpmostree_compose() {
         # we hardcode a umask of 0022 here to make sure that composes are run
         # with a consistent value, regardless of the environment
         (umask 0022 && sudo -E "$@")
+        sudo chown -R -h "${USER}":"${USER}" "${tmprepo}"
+    else
+        runvm_with_cache "$@"
+    fi
+}
+
+runcompose_extensions() {
+    local outputdir=$1; shift
+    local workdir=${workdir:-$(pwd)}
+    local repo=${tmprepo:-${workdir}/tmp/repo}
+
+    rm -f "${changed_stamp}"
+    # shellcheck disable=SC2086
+    set - ${COSA_RPMOSTREE_GDB:-} rpm-ostree compose extensions --repo="${repo}" \
+            --touch-if-changed "${changed_stamp}" --cachedir="${workdir}"/cache \
+            ${COSA_RPMOSTREE_ARGS:-} "$@" --output-dir "$outputdir"
+
+    echo "Running: $*"
+
+    # this is the heart of the privs vs no privs dual path
+    if has_privileges; then
+        # we hardcode a umask of 0022 here to make sure that composes are run
+        # with a consistent value, regardless of the environment
+        (umask 0022 && sudo -E "$@")
+        sudo chown -R -h "${USER}":"${USER}" "${outputdir}"
     else
         runvm_with_cache "$@"
     fi

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -398,6 +398,16 @@ EOF
         done
     fi
 
+    # Store the fully rendered disk image config (image.json) inside
+    # the ostree commit, so it can later be extracted by disk image
+    # builds.
+    local imagejsondir="${tmp_overridesdir}/imagejson"
+    export ostree_image_json="/usr/share/coreos-assembler/image.json"
+    mkdir -p "${imagejsondir}/usr/share/coreos-assembler/"
+    cp "${image_json}" "${imagejsondir}${ostree_image_json}"
+    commit_overlay cosa-image-json "${imagejsondir}"
+    layers="${layers} cosa-image-json"
+
     local_overrides_lockfile="${tmp_overridesdir}/local-overrides.json"
     if [ -n "${with_cosa_overrides}" ] && [[ -n $(ls "${overridesdir}/rpm/"*.rpm 2> /dev/null) ]]; then
         (cd "${overridesdir}"/rpm && rm -rf .repodata && createrepo_c .)
@@ -884,6 +894,7 @@ builds.bump_timestamp()
 print('Build ${buildid} was inserted ${arch:+for $arch}')")
 }
 
+# Prepare the image.json as part of an ostree image build
 write_image_json() {
     local srcfile=$1; shift
     local outfile=$1; shift
@@ -894,7 +905,9 @@ from cosalib import cmdlib
 cmdlib.write_image_json('${srcfile}', '${outfile}')")
 }
 
-# Shell wrapper for the Python import_ostree_commit
+# API to prepare image builds.
+# Ensures that the tmp/repo ostree repo is initialized,
+# and also writes tmp/image.json.
 import_ostree_commit_for_build() {
     local buildid=$1; shift
     (python3 -c "
@@ -902,9 +915,10 @@ import sys
 sys.path.insert(0, '${DIR}')
 from cosalib import cmdlib
 from cosalib.builds import Builds
-builds = Builds('${workdir:-$(pwd)}')
+workdir = '${workdir:-$(pwd)}'
+builds = Builds(workdir)
 builddir = builds.get_build_dir('${buildid}')
 buildmeta = builds.get_build_meta('${buildid}')
-cmdlib.import_ostree_commit('${workdir:-$(pwd)}/tmp/repo', builddir, buildmeta)
+cmdlib.import_ostree_commit(workdir, builddir, buildmeta)
 ")
 }

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -494,6 +494,7 @@ runcompose_tree() {
     rm -f "${changed_stamp}"
     # shellcheck disable=SC2086
     set - ${COSA_RPMOSTREE_GDB:-} rpm-ostree compose tree --repo="${repo}" \
+            --write-composejson-to "${composejson}" \
             --touch-if-changed "${changed_stamp}" --cachedir="${workdir}"/cache \
             ${COSA_RPMOSTREE_ARGS:-} --unified-core "${manifest}" "$@"
 

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -408,8 +408,8 @@ EOF
     export ostree_image_json="/usr/share/coreos-assembler/image.json"
     mkdir -p "${imagejsondir}/usr/share/coreos-assembler/"
     cp "${image_json}" "${imagejsondir}${ostree_image_json}"
-    commit_overlay cosa-image-json "${imagejsondir}"
-    layers="${layers} cosa-image-json"
+    commit_overlay overlay/cosa-image-json "${imagejsondir}"
+    layers="${layers} overlay/cosa-image-json"
 
     local_overrides_lockfile="${tmp_overridesdir}/local-overrides.json"
     if [ -n "${with_cosa_overrides}" ] && [[ -n $(ls "${overridesdir}/rpm/"*.rpm 2> /dev/null) ]]; then

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -493,8 +493,7 @@ runcompose_tree() {
 
     rm -f "${changed_stamp}"
     # shellcheck disable=SC2086
-    set - ${COSA_RPMOSTREE_GDB:-} rpm-ostree compose tree --repo="${repo}" \
-            --write-composejson-to "${composejson}" \
+    set - ${COSA_RPMOSTREE_GDB:-} rpm-ostree compose tree \
             --touch-if-changed "${changed_stamp}" --cachedir="${workdir}"/cache \
             ${COSA_RPMOSTREE_ARGS:-} --unified-core "${manifest}" "$@"
 
@@ -502,12 +501,30 @@ runcompose_tree() {
 
     # this is the heart of the privs vs no privs dual path
     if has_privileges; then
+        set - "$@" --repo "${repo}" --write-composejson-to "${composejson}"
         # we hardcode a umask of 0022 here to make sure that composes are run
         # with a consistent value, regardless of the environment
         (umask 0022 && sudo -E "$@")
         sudo chown -R -h "${USER}":"${USER}" "${tmprepo}"
     else
-        runvm_with_cache "$@"
+        local tarball="${workdir}/tmp/repo/commit.tar"
+        rm -f "${tarball}"
+        runvm_with_cache /usr/lib/coreos-assembler/compose.sh \
+            "${tarball}" "${composejson}" "$@"
+        if [ ! -f "${tarball}" ]; then
+            return
+        fi
+        local commit
+        commit=$(jq -r '.["ostree-commit"]' < "${composejson}")
+        local import_repo="${workdir}/tmp/repo-import"
+        rm -rf "${import_repo}" && mkdir "${import_repo}"
+        tar -C "${import_repo}" -xf "${tarball}" && rm -f "${tarball}"
+        # this is archive to archive so will hardlink
+        ostree pull-local --repo "${repo}" "${import_repo}" "${commit}"
+        if [ -n "${ref}" ]; then
+            ostree refs --repo "${repo}" "${commit}" --create "${ref}" --force
+        fi
+        rm -rf "${import_repo}"
     fi
 }
 

--- a/src/compose.sh
+++ b/src/compose.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -euo pipefail
+
+output_tarball=$1; shift
+output_composejson=$1; shift
+
+tarball=cache/output.tar
+composejson=cache/compose.json
+
+repo=cache/repo
+rm -rf "${repo}" "${composejson}"
+ostree init --repo="${repo}" --mode=archive-z2
+
+# we do need to pull at least the overlay bits over 9p, but it shouldn't be that
+# many files
+ostree refs --repo tmp/repo overlay --list | \
+    xargs -r ostree pull-local --repo "${repo}" tmp/repo
+# And import commit metadata for all refs; this will bring in the previous
+# build if there is one. Ideally, we'd import the SELinux policy too to take
+# advantage of https://github.com/coreos/rpm-ostree/pull/1704 but that's yet
+# more files over 9p and our pipelines don't have cache anyway (and devs likely
+# use the privileged path).
+ostree refs --repo tmp/repo | \
+    xargs -r ostree pull-local --commit-metadata-only --repo "${repo}" tmp/repo
+
+# run rpm-ostree
+"$@" --repo "${repo}" --write-composejson-to "${composejson}"
+
+if [ ! -f "${composejson}" ]; then
+    # no commit was produced; we're done
+    exit 0
+fi
+
+tar -f "${tarball}" -C "${repo}" -c .
+
+# this is key bit where we move the OSTree content over 9p
+mv "${tarball}" "${output_tarball}"
+mv "${composejson}" "${output_composejson}"

--- a/src/cosalib/ova.py
+++ b/src/cosalib/ova.py
@@ -5,12 +5,13 @@
 import logging as log
 import os.path
 import sys
+import json
 
 cosa_dir = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, f"{cosa_dir}/cosalib")
 sys.path.insert(0, cosa_dir)
 
-from cosalib.cmdlib import generate_image_json, image_info
+from cosalib.cmdlib import image_info
 from cosalib.qemuvariants import QemuVariantImage
 
 
@@ -86,7 +87,8 @@ class OVA(QemuVariantImage):
         Returns a dictionary with the parameters needed to create an OVF file
         based on the qemu, vmdk, image.yaml, and info from the build metadata
         """
-        image_json = generate_image_json('src/config/image.yaml')
+        with open(os.path.join(self._workdir, 'tmp/image.json')) as f:
+            image_json = json.load(f)
 
         system_type = 'vmx-{}'.format(image_json['vmware-hw-version'])
         os_type = image_json['vmware-os-type']

--- a/src/cosalib/qemuvariants.py
+++ b/src/cosalib/qemuvariants.py
@@ -20,7 +20,8 @@ from cosalib.cmdlib import (
     get_basearch,
     image_info,
     run_verbose,
-    sha256sum_file
+    sha256sum_file,
+    import_ostree_commit
 )
 
 # BASEARCH is the current machine architecture
@@ -236,6 +237,10 @@ class QemuVariantImage(_Build):
         :param callback: callback function for extra processing image
         :type callback: function
         """
+
+        # Disk image builds may require an unpacked ostree repo and tmp/image.json in general.
+        import_ostree_commit(self._workdir, self.build_dir, self.meta)
+
         work_img = os.path.join(self._tmpdir,
                                 f"{self.image_name_base}.{self.image_format}")
         final_img = os.path.join(os.path.abspath(self.build_dir),

--- a/src/vmdeps.txt
+++ b/src/vmdeps.txt
@@ -27,3 +27,5 @@ gdisk xfsprogs e2fsprogs dosfstools btrfs-progs
 
 # needed for basic CA support
 ca-certificates
+
+tar


### PR DESCRIPTION
Backports for 4.11:
- https://github.com/coreos/coreos-assembler/pull/2889
- https://github.com/coreos/coreos-assembler/pull/2922
- https://github.com/coreos/coreos-assembler/pull/2930
- https://github.com/coreos/coreos-assembler/pull/2839
- https://github.com/coreos/coreos-assembler/pull/2886
- https://github.com/coreos/coreos-assembler/pull/2946

Revealed by: https://github.com/openshift/release/pull/29949