### PR TITLE
metal.go: remove optional rom pxe-rtl8139 

### DIFF
--- a/mantle/platform/metal.go
+++ b/mantle/platform/metal.go
@@ -467,7 +467,7 @@ func (t *installerRun) run() (*QemuInstance, error) {
 	builder := t.builder
 	netdev := fmt.Sprintf("%s,netdev=mynet0,mac=52:54:00:12:34:56", t.pxe.networkdevice)
 	if t.pxe.bootindex == "" {
-		builder.Append("-boot", "once=n", "-option-rom", "/usr/share/qemu/pxe-rtl8139.rom")
+		builder.Append("-boot", "once=n")
 	} else {
 		netdev += fmt.Sprintf(",bootindex=%s", t.pxe.bootindex)
 	}


### PR DESCRIPTION
The `-option-rom .../pxe-rtl8139.rom` used to be required but is no
longer needed because according to [1] "If no rom bar is specified,
the qemu default will be used (older versions of qemu used a default
of "off", while newer qemus have a default of "on")".

The attribute `file` which is used to pass  an [1] 
`alternative boot ROM for a network device` is optional and thus 
assumed to have a default in QEMU.

So now qemu will default to loading the option rom for the given NIC
device model.

[1] https://gitlab.com/libvirt/libvirt/-/blob/3547875f3a8cf286a03b62f5e7bdb8e4b0eeee29/docs/formatdomain.rst#interface-rom-bios-configuration

fixes: https://github.com/coreos/coreos-assembler/issues/2918