### PR TITLE
mantle/platform/qemu: use non-debug UEFI firmware for aarch64

### DIFF
--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -1150,7 +1150,7 @@ func (builder *QemuBuilder) setupUefi(secureBoot bool) error {
 		}
 
 		fdset := builder.AddFd(vars)
-		builder.Append("-drive", "file=/usr/share/edk2/aarch64/QEMU_EFI-pflash.raw,if=pflash,format=raw,unit=0,readonly=on,auto-read-only=off")
+		builder.Append("-drive", "file=/usr/share/edk2/aarch64/QEMU_EFI-silent-pflash.raw,if=pflash,format=raw,unit=0,readonly=on,auto-read-only=off")
 		builder.Append("-drive", fmt.Sprintf("file=%s,if=pflash,format=raw,unit=1,readonly=off,auto-read-only=off", fdset))
 	default:
 		panic(fmt.Sprintf("Architecture %s doesn't have support for UEFI in qemu.", system.RpmArch()))


### PR DESCRIPTION
We get a ton of output on the serial console of the machines because
the we're using the UEFI firmware with debug output. Let's use the
"silent" version instead.

I suspect this will also speed up our testing on qemu/aarch64.