### PR TITLE
mantle/kola: machine check enhancements

### DIFF
--- a/docs/kola/external-tests.md
+++ b/docs/kola/external-tests.md
@@ -221,7 +221,7 @@ with `kola run --tag`, but some tags have semantic meaning.
 Tags with semantic meaning:
 
  - `needs-internet`: Taken from the Autopkgtest (linked above).  Currently only the `qemu` platform enforces this restriction.
- - `skip-base-checks`: Skip built-in checks for e.g. kernel warnings on the console.
+ - `skip-base-checks`: Skip built-in checks for e.g. kernel warnings on the console or systemd unit failures.
 
 If a test has a `requiredTag`, it is run only if the required tag is specified.
 In the example above, the test would only run if `--tag special` was provided.

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -1340,12 +1340,12 @@ func runTest(h *harness.H, t *register.Test, pltfrm string, flight platform.Flig
 	h.SetSubtests(t.Subtests)
 
 	rconf := &platform.RuntimeConfig{
-		OutputDir:          h.OutputDir(),
-		NoSSHKeyInUserData: t.HasFlag(register.NoSSHKeyInUserData),
-		NoSSHKeyInMetadata: t.HasFlag(register.NoSSHKeyInMetadata),
-		NoInstanceCreds:    t.HasFlag(register.NoInstanceCreds),
-		WarningsAction:     conf.FailWarnings,
 		InternetAccess:     testRequiresInternet(t),
+		NoInstanceCreds:    t.HasFlag(register.NoInstanceCreds),
+		NoSSHKeyInMetadata: t.HasFlag(register.NoSSHKeyInMetadata),
+		NoSSHKeyInUserData: t.HasFlag(register.NoSSHKeyInUserData),
+		OutputDir:          h.OutputDir(),
+		WarningsAction:     conf.FailWarnings,
 	}
 	if t.HasFlag(register.AllowConfigWarnings) {
 		rconf.WarningsAction = conf.IgnoreWarnings

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -966,7 +966,7 @@ ExecStart=%s
 				} else {
 					fmt.Printf("Fetching status failed: %v\n", suberr)
 				}
-				if Options.SSHOnTestFailure {
+				if mach.RuntimeConf().SSHOnTestFailure {
 					plog.Errorf("dropping to shell: kolet failed: %v: %s", err, stderr)
 					if err := platform.Manhole(mach); err != nil {
 						plog.Errorf("failed to get terminal via ssh: %v", err)
@@ -1355,6 +1355,7 @@ func runTest(h *harness.H, t *register.Test, pltfrm string, flight platform.Flig
 		NoSSHKeyInMetadata: t.HasFlag(register.NoSSHKeyInMetadata),
 		NoSSHKeyInUserData: t.HasFlag(register.NoSSHKeyInUserData),
 		OutputDir:          h.OutputDir(),
+		SSHOnTestFailure:   Options.SSHOnTestFailure,
 		WarningsAction:     conf.FailWarnings,
 	}
 	if t.HasFlag(register.AllowConfigWarnings) {

--- a/mantle/platform/platform.go
+++ b/mantle/platform/platform.go
@@ -432,7 +432,7 @@ func checkSystemdUnitFailures(output string, distribution string) error {
 		}
 	}
 	if len(failedUnits) > 0 {
-		return fmt.Errorf("some systemd units failed:\n%s", output)
+		return fmt.Errorf("some systemd units failed: %s", failedUnits)
 	}
 
 	return nil


### PR DESCRIPTION
```
commit 0a7f0ce3a15376078ccc331de898f5f2facb9705
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Fri Jul 8 10:59:44 2022 -0400

    mantle/kola: extend --ssh-on-test-failure to work when systemd unit failrues are detected
    
    It's frustrating when systemd unit failures are detected but you can't
    just get a shell on the machine to investigate. This patch plumbs
    through the SSHOnTestFailure information into the RuntimeConfig for the
    machine object so we can use that information within CheckMachine to
    dropt into a shell if desired by the user.

commit 9483eb704d8e49f850a702d6ff54cdae71edc51e
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Fri Jul 8 10:30:58 2022 -0400

    mantle/kola: extend the "skip-base-checks" tag to cover systemd unit failures
    
    This will mean that if someone adds the "skip-base-checks" tag to their
    test systemd unit failures won't cause a failure.

commit e6560685fb93287bd9e2001f2514fd571b365fa1
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Fri Jul 8 10:24:51 2022 -0400

    mantle/kola: sort RuntimeConfig options alphabetically

commit aa585866459dbb60c34ecdeea2bad842e0630910
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Fri Jul 8 10:52:59 2022 -0400

    mantle/platform: always run systemd unit checks
    
    In this way we'll always run the unit checks (a change) but we'll continue to
    only fail if we are not allowing failed units.

commit 124fe8d1926c61e352f570308fdccab27be758df
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Fri Jul 8 10:28:10 2022 -0400

    mantle/platform: enhance failed units check output
    
    Right now the output is on multiple lines if there are multiple failed
    units. Let's make it print on a single line.

```
