### PR TITLE
cmdlib: use `repo-packages` for `overrides/rpm` only as necessary

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -425,21 +425,21 @@ for line in sys.stdin:
     lockfile["packages"][name] = {"evra": f"{evr}.{arch}"}
 json.dump(lockfile, sys.stdout)' > "${local_overrides_lockfile}"
 
-        < "${tmp_overridesdir}/pkgs.txt" python3 -c '
+        < "${tmp_overridesdir}/pkgs.txt" python3 -c "
 import sys, yaml
 manifest = {
-    "repos": ["coreos-assembler-local-overrides"],
-    "repo-packages": [
+    'repos': ['coreos-assembler-local-overrides'],
+    'repo-packages': [
         {
-            "repo": "coreos-assembler-local-overrides",
-            "packages": []
+            'repo': 'coreos-assembler-local-overrides',
+            'packages': []
         }
     ]
 }
 for line in sys.stdin:
-    name, evr, arch = line.strip().split("\t")
-    manifest["repo-packages"][0]["packages"] += [name]
-yaml.dump(manifest, sys.stdout)' >> "${override_manifest}"
+    name, evr, arch = line.strip().split('\t')
+    manifest['repo-packages'][0]['packages'] += [name]
+yaml.dump(manifest, sys.stdout)" >> "${override_manifest}"
         rm "${tmp_overridesdir}/pkgs.txt"
 
         echo "Using RPM overrides from: ${overridesdir}/rpm"

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -417,7 +417,8 @@ EOF
             --exclude '*.src' --qf '%{NAME}\t%{EVR}\t%{ARCH}' \
             --quiet > "${tmp_overridesdir}/pkgs.txt"
 
-        < "${tmp_overridesdir}/pkgs.txt" python3 -c '
+        # shellcheck disable=SC2002
+        cat "${tmp_overridesdir}/pkgs.txt" | python3 -c '
 import sys, json
 lockfile = {"packages": {}}
 for line in sys.stdin:
@@ -428,7 +429,8 @@ json.dump(lockfile, sys.stdout)' > "${local_overrides_lockfile}"
         # for all the repo packages in the manifest for which we have an
         # override, create a new repo-packages entry to make sure our overrides
         # win.
-        < "${tmp_overridesdir}/pkgs.txt" python3 -c "
+        # shellcheck disable=SC2002
+        cat "${tmp_overridesdir}/pkgs.txt" | python3 -c "
 import sys, yaml
 flattened = yaml.safe_load(open('${flattened_manifest}'))
 all_overrides = set()


### PR DESCRIPTION
This is follow-up to https://github.com/coreos/coreos-assembler/commit/8c8b7338af5e1395604498cab47227cd7c47a011 ("cmdlib: use `repo-packages` for
`overrides/rpm`").

That commit changed semantics of `overrides/rpm` such that all packages
found are forced to be installed rather than only "preferred".

This revert the semantics back to what it used to be while still
allowing `repo-packages` to be overridden.

We do this by simply only adding a `repo-packages` override for the
packages which are found in the flattened manifest.