### PR TITLE
build: Default to new ostree chunked v1 (with new rpm-ostree)

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -392,7 +392,13 @@ else
     case "${ostree_format}" in
         oci) ;;
         # Note rpm-ostree always copies the rpmostree.inputhash key
-        oci-chunked) cmd=(rpm-ostree container-encapsulate --max-layers="$MAX_OSTREECONTAINER_LAYERS") ;;
+        oci-chunked)
+            cmd=(rpm-ostree container-encapsulate --max-layers="$MAX_OSTREECONTAINER_LAYERS") 
+            # rpm-ostree currently conservatively defaults to format-version=0, but we want 1
+            if rpm-ostree container-encapsulate --help 2>&1 |grep -qFe '--format-version'; then
+                cmd+=(--format-version=1)
+            fi
+        ;;
         *) fatal "Unknown ostree-format: ${ostree_format}"
     esac
     runv "${cmd[@]}" --repo="${tmprepo}" \


### PR DESCRIPTION
This will have us start making use of
https://github.com/ostreedev/ostree-rs-ext/pull/331

(Arguably rpm-ostree should default to the new one, but...eh,
 at some point not too long from now we'll be ripping out support
 for all the old things and just making this the default)