### PR TITLE
create_disk.sh: use /bin/bash interpreter and address ShellCheck lints

### DIFF
--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -1,4 +1,6 @@
-#!/bin/sh
+#!/bin/bash
+set -euo pipefail
+
 # This script is run in supermin to create a Fedora CoreOS style
 # disk image, very much in the spirit of the original
 # Container Linux (orig CoreOS) disk layout, although adapted
@@ -8,7 +10,6 @@
 # although see also https://github.com/coreos/coreos-assembler/pull/298
 # For people building "derived"/custom FCOS-like systems, feel free to file
 # an issue and we can discuss configuration needs.
-set -euo pipefail
 
 # This fixed UUID is detected in ignition-dracut and changed
 # on firstboot:


### PR DESCRIPTION
```
commit d4225adc39dad9b0a774057b01218fd27d8cd4c2
Date:   Tue Jul 12 17:18:12 2022 -0400

    create_disk.sh: use /bin/bash interpreter

    We're already using bashisms in this script, so this is just reflecting
    reality.

    As a plus, this makes the script no longer ignored by ShellCheck.
```
```
commit 9330b89f4368b2e9f24f859a8fd64bfe91c09eea
Date:   Tue Jul 12 17:19:32 2022 -0400

    create_disk.sh: address ShellCheck lints

    Nothing major here. Mostly quoting arguments where needed.
```