### PR TITLE
Consolidate and reimplement CPU-count logic; enable SMP mksquashfs

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -5,7 +5,7 @@
 def cpuCount = "8".toString()
 def imageName = buildImage(env: [ENABLE_GO_RACE_DETECTOR: "1", GOMAXPROCS: cpuCount], cpu: cpuCount)
 
-pod(image: imageName + ":latest", kvm: true, memory: "10Gi") {
+pod(image: imageName + ":latest", kvm: true, cpu: cpuCount, memory: "10Gi") {
     checkout scm
 
     stage("Unit tests") {

--- a/mantle/cmd/kola/kola.go
+++ b/mantle/cmd/kola/kola.go
@@ -107,6 +107,14 @@ This can be useful for e.g. serving locally built OSTree repos to qemu.
 		SilenceUsage: true,
 	}
 
+	cmdNcpu = &cobra.Command{
+		Use:   "ncpu",
+		Short: "Report the number of available CPUs for parallelism",
+		RunE:  runNcpu,
+
+		SilenceUsage: true,
+	}
+
 	listJSON           bool
 	listPlatform       string
 	listDistro         string
@@ -145,6 +153,8 @@ func init() {
 	cmdRunUpgrade.Flags().BoolVar(&runRerunFlag, "rerun", false, "re-run failed tests once")
 
 	root.AddCommand(cmdRerun)
+
+	root.AddCommand(cmdNcpu)
 }
 
 func main() {
@@ -665,4 +675,13 @@ func runRunUpgrade(cmd *cobra.Command, args []string) error {
 	}
 
 	return runErr
+}
+
+func runNcpu(cmd *cobra.Command, args []string) error {
+	count, err := system.GetProcessors()
+	if err != nil {
+		return err
+	}
+	fmt.Println(count)
+	return nil
 }

--- a/src/cmd-compress
+++ b/src/cmd-compress
@@ -4,9 +4,7 @@
 # Compresses all images in a build.
 
 import os
-import re
 import sys
-import math
 import json
 import shutil
 import argparse
@@ -14,6 +12,7 @@ import argparse
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from cosalib.builds import Builds
 from cosalib.cmdlib import (
+    ncpu,
     rm_allow_noent,
     run_verbose,
     sha256sum_file,
@@ -73,21 +72,6 @@ def strip_ext(path):
     return path.rsplit(".", 1)[0]
 
 
-# XXX: should dedupe this with logic in cmdlib and put in the shared lib
-def xz_threads():
-    with open("/proc/1/cgroup") as f:
-        in_k8s = re.search(r'.*kubepods.*', f.read())
-    if in_k8s:
-        # see similar code in OpenJKD HotSpot:
-        # https://hg.openjdk.java.net/jdk/jdk/file/7b671e6b0d5b/src/hotspot/os/linux/osContainer_linux.cpp#l595
-        quota = get_cpu_param('cfs_quota_us')
-        period = get_cpu_param('cfs_period_us')
-        # are k8s limits enforced?
-        if quota != -1 and period > 0:
-            return math.ceil(quota / period)
-    return 0  # no limits, let xz choose what it wants
-
-
 def compress_one_builddir(builddir):
     print(f"Compressing: {builddir}")
     buildmeta_path = os.path.join(builddir, 'meta.json')
@@ -136,7 +120,7 @@ def compress_one_builddir(builddir):
             img['uncompressed-size'] = img['size']
             with open(tmpfile, 'wb') as f:
                 if args.compressor == 'xz':
-                    t = xz_threads()
+                    t = ncpu()
                     run_verbose(['xz', '-c9', f'-T{t}', filepath], stdout=f)
                 else:
                     run_verbose(['gzip', f'-{gzip_level}', '-c', filepath], stdout=f)
@@ -214,7 +198,7 @@ def uncompress_one_builddir(builddir):
             # during 'build'
             with open(tmpfile, 'wb') as f:
                 if file.endswith('xz'):
-                    t = xz_threads()
+                    t = ncpu()
                     run_verbose(['xz', '-dc', f'-T{t}', filepath], stdout=f)
                 elif file.endswith('gz'):
                     run_verbose(['gzip', '-dc', filepath], stdout=f)

--- a/src/cosalib/cmdlib.py
+++ b/src/cosalib/cmdlib.py
@@ -436,3 +436,8 @@ def ensure_glob(pathname, **kwargs):
     if not ret:
         raise Exception(f'No matches for {pathname}')
     return ret
+
+
+def ncpu():
+    '''Return the number of usable CPUs we have for parallelism.'''
+    return int(subprocess.check_output(['kola', 'ncpu']))

--- a/src/libguestfish.sh
+++ b/src/libguestfish.sh
@@ -43,6 +43,8 @@ coreos_gf_run() {
         return
     fi
     coreos_gf_launch "$@"
+    # Allow mksquashfs to parallelize
+    coreos_gf set-smp "$(kola ncpu)"
     coreos_gf run
     GUESTFISH_RUNNING=1
 }


### PR DESCRIPTION
The existing Go CPU-count code doesn't even attempt to report multiple CPUs if it detects Kubernetes, and the existing Python code in `cmd-compress` doesn't attempt to determine cgroup quotas unless it detects Kubernetes specifically.  Consolidate the CPU count detection into Go code, and always factor in any CPU quotas from either cgroups v1 or v2.

Use the new code to give the libguestfs VM the same number of vCPUs as the host, so mksquashfs can use all of them.  On my 6-core system, this reduces FCOS `buildextend-live` without `--fast` from 4m9s to 2m23s.

Request 8 CPUs in CoreOS CI to avoid the new default of 2 in https://github.com/coreos/coreos-ci-lib/pull/112.