### PR TITLE
Drop golangci-lint from image build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,9 +75,6 @@ gangplank:
 gangplank-check:
 	cd gangplank && $(MAKE) test
 
-staticanalysis:
-	cd gangplank && $(MAKE) staticanalysis
-
 tools:
 	cd tools && $(MAKE)
 

--- a/ci/prow.sh
+++ b/ci/prow.sh
@@ -2,4 +2,3 @@
 set -xeuo pipefail
 make -j 4
 make check
-make staticanalysis

--- a/gangplank/Makefile
+++ b/gangplank/Makefile
@@ -26,11 +26,6 @@ docs:
 fmt:
 	gofmt -d -e -l $(shell find . -iname "*.go"  -not -path "./vendor/*")
 
-.PHONY: staticanalysis
-staticanalysis:
-	golangci-lint run -v --build-tags ${buildtags},gangway ./...
-	env CGO_ENABLED=0 golangci-lint run -v --build-tags ${buildtags},gangway ./...
-
 .PHONY: test
 test: miniotag ?= ",!minio"
 test: fmt

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -8,8 +8,6 @@ export GOPATH=$(shell readlink -f .)
 GOARCH := $(shell go env GOARCH)
 build:
 	mkdir -p bin
-	test -e bin/golangci-lint || \
-		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin
 	test -f bin/schematyper || \
 		go install github.com/idubinskiy/schematyper@latest
 	test -e bin/gomarkdoc || \
@@ -24,5 +22,5 @@ clean:
 	rm -rfv bin
 	rm -rfv pkg
 
-install: bin/golangci-lint bin/gomarkdoc bin/minio bin/schematyper
-	install -v -D -t $(DESTDIR)$(PREFIX)/bin bin/{golangci-lint,gomarkdoc,minio,schematyper}
+install: bin/gomarkdoc bin/minio bin/schematyper
+	install -v -D -t $(DESTDIR)$(PREFIX)/bin bin/{gomarkdoc,minio,schematyper}

--- a/tools/README.md
+++ b/tools/README.md
@@ -3,7 +3,6 @@
 This directory contains Golang Tools that are needed for building/using
 `gangplank`, generating schemas, or generating Markdown documentation.
 
-- golangci-lint
 - gomarkdoc
 - minio
 - schematyper


### PR DESCRIPTION
Installing it is flaky and regularly breaks Prow and/or CoreOS CI. I
think the main issue for Prow is that the install script uses the GitHub
API anonymously and we get rate limited.

Looking at the official docs, they recommend using the GitHub Action
instead so let's do that in a follow-up (and have it run over the whole
repo instead of just the gangplank code).