### PR TITLE
[rhcos-4.11] vmware: add image.yaml toggle for secure boot

### DIFF
--- a/src/cosalib/ova.py
+++ b/src/cosalib/ova.py
@@ -90,6 +90,7 @@ class OVA(QemuVariantImage):
         with open(os.path.join(self._workdir, 'tmp/image.json')) as f:
             image_json = json.load(f)
 
+        secure_boot = 'true' if image_json['vmware-secure-boot'] else 'false'
         system_type = 'vmx-{}'.format(image_json['vmware-hw-version'])
         os_type = image_json['vmware-os-type']
         disk_info = image_info(vmdk)
@@ -102,6 +103,7 @@ class OVA(QemuVariantImage):
         params = {
             'ovf_cpu_count':                    cpu,
             'ovf_memory_mb':                    memory,
+            'secure_boot':                      secure_boot,
             'vsphere_image_name':               image,
             'vsphere_product_name':             product,
             'vsphere_product_vendor_name':      vendor,

--- a/src/image-default.yaml
+++ b/src/image-default.yaml
@@ -22,3 +22,4 @@ squashfs-compression: zstd
 # Defaults for VMware OVA, matching historical behavior
 vmware-hw-version: 13
 vmware-os-type: rhel7_64Guest
+vmware-secure-boot: true

--- a/src/vmware-template.xml
+++ b/src/vmware-template.xml
@@ -80,7 +80,7 @@
         <vmw:Config ovf:required="false" vmw:key="connectable.allowGuestControl" vmw:value="true"/>
         <vmw:Config ovf:required="false" vmw:key="wakeOnLanEnabled" vmw:value="false"/>
       </Item>
-      <vmw:Config ovf:required="false" vmw:key="bootOptions.efiSecureBootEnabled" vmw:value="true"/>
+      <vmw:Config ovf:required="false" vmw:key="bootOptions.efiSecureBootEnabled" vmw:value="{secure_boot}"/>
       <vmw:Config ovf:required="false" vmw:key="firmware" vmw:value="efi"/>
     </VirtualHardwareSection>
     <ProductSection>


### PR DESCRIPTION
Add toggle for secure boot in the OVA. This is a cherry-pick of two
commits that added the toggle for secure boot.

ref: https://bugzilla.redhat.com/show_bug.cgi?id=2106055
(cherry picked from commit 37df48675f350539bff4bd8205f89e5ec5dc5e78)
(cherry picked from commit 27fa455d3c1925e478171ef38e3d618f015ef453)