### PR TITLE
kola/tests/files: Drop filesystem/sgid and filesystem/suid

### DIFF
--- a/mantle/kola/tests/misc/files.go
+++ b/mantle/kola/tests/misc/files.go
@@ -33,88 +33,10 @@ func init() {
 }
 
 func Filesystem(c cluster.TestCluster) {
-	c.Run("suid", SUIDFiles)
-	c.Run("sgid", SGIDFiles)
 	c.Run("writablefiles", WritableFiles)
 	c.Run("writabledirs", WritableDirs)
 	c.Run("stickydirs", StickyDirs)
 	c.Run("denylist", Denylist)
-}
-
-func sugidFiles(c cluster.TestCluster, validfiles []string, mode string) {
-	m := c.Machines()[0]
-	badfiles := make([]string, 0)
-
-	output := c.MustSSH(m, fmt.Sprintf("sudo find / -ignore_readdir_race -path /sys -prune -o -path /proc -prune -o -path /sysroot/ostree -prune -o -type f -perm -%v -print", mode))
-
-	if string(output) == "" {
-		return
-	}
-
-	files := strings.Split(string(output), "\n")
-	for _, file := range files {
-		var valid bool
-
-		for _, validfile := range validfiles {
-			if file == validfile {
-				valid = true
-			}
-		}
-		if !valid {
-			badfiles = append(badfiles, file)
-		}
-	}
-
-	if len(badfiles) != 0 {
-		c.Fatalf("Unknown SUID or SGID files found: %v", badfiles)
-	}
-}
-
-func SUIDFiles(c cluster.TestCluster) {
-	validfiles := []string{
-		"/usr/bin/chage",
-		"/usr/bin/chfn",
-		"/usr/bin/chsh",
-		"/usr/bin/expiry",
-		"/usr/bin/fusermount",
-		"/usr/bin/fusermount3",
-		"/usr/bin/gpasswd",
-		"/usr/bin/ksu",
-		"/usr/bin/man",
-		"/usr/bin/mandb",
-		"/usr/bin/mount",
-		"/usr/bin/newgidmap",
-		"/usr/bin/newgrp",
-		"/usr/bin/newuidmap",
-		"/usr/bin/passwd",
-		"/usr/bin/pkexec",
-		"/usr/bin/umount",
-		"/usr/bin/su",
-		"/usr/bin/sudo",
-		"/usr/lib/polkit-1/polkit-agent-helper-1",
-		"/usr/lib64/polkit-1/polkit-agent-helper-1",
-		"/usr/libexec/dbus-daemon-launch-helper",
-		"/usr/libexec/sssd/krb5_child",
-		"/usr/libexec/sssd/ldap_child",
-		"/usr/libexec/sssd/selinux_child",
-		"/usr/sbin/mount.nfs",
-		"/usr/sbin/unix_chkpwd",
-		"/usr/sbin/grub2-set-bootflag",
-		"/usr/sbin/mount.nfs",
-		"/usr/sbin/pam_timestamp_check",
-	}
-
-	sugidFiles(c, validfiles, "4000")
-}
-
-func SGIDFiles(c cluster.TestCluster) {
-	validfiles := []string{
-		"/usr/bin/write",
-		"/usr/libexec/openssh/ssh-keysign",
-		"/usr/libexec/utempter/utempter",
-	}
-
-	sugidFiles(c, validfiles, "2000")
 }
 
 func WritableFiles(c cluster.TestCluster) {


### PR DESCRIPTION
Since [ext.config.files.setgid](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/tests/kola/files/setgid) and [ext.config.files.setuid](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/tests/kola/files/setuid)  test the same thing as filesystem/sgid and filesystem/suid respectively, we can drop them from here