### PR TITLE
create_disk: use -p when creating grub2 directory

### DIFF
--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -471,7 +471,8 @@ EOF
 install_grub_cfg() {
     # 0700 to match the RPM permissions which I think are mainly in case someone has
     # manually set a grub password
-    mkdir -m 0700 $rootfs/boot/grub2
+    mkdir -p $rootfs/boot/grub2
+    chmod 0700 $rootfs/boot/grub2
     printf "%s\n" "$grub_script" | \
         sed -E 's@(^# CONSOLE-SETTINGS-START$)@\1'"${platform_grub_cmds:+\\n${platform_grub_cmds}}"'@' \
         > $rootfs/boot/grub2/grub.cfg


### PR DESCRIPTION
The use of `-p` was dropped in
9330b89f4368b2e9f24f859a8fd64bfe91c09eea to appease some ShellCheck
errors.  (Notably https://www.shellcheck.net/wiki/SC2174)

But dropping the use of `-p` causes a fatal error when the directory
already exists.

This reintroduces the use of the `-p` flag and splits out setting the
permissions on the directory as a separate operation.

Closes openshift/os#896