### PR TITLE
prep patches for podman-remote work

### DIFF
--- a/src/cmd-sign
+++ b/src/cmd-sign
@@ -53,6 +53,8 @@ def parse_args():
                                     'RoboSignatory via fedora-messaging')
     robosig.add_argument("--s3", metavar='<BUCKET>[/PREFIX]', required=True,
                          help="bucket and prefix to S3 builds/ dir")
+    robosig.add_argument("--aws-config-file", metavar='CONFIG', default="",
+                         help="Path to AWS config file")
     group = robosig.add_mutually_exclusive_group(required=True)
     group.add_argument("--ostree", help="sign commit", action='store_true')
     group.add_argument("--images", help="sign images", action='store_true')
@@ -72,6 +74,8 @@ def parse_args():
 
 
 def cmd_robosignatory(args):
+    if args.aws_config_file:
+        os.environ["AWS_CONFIG_FILE"] = args.aws_config_file
     s3 = boto3.client('s3')
     args.bucket, args.prefix = get_bucket_and_prefix(args.s3)
 

--- a/src/cosalib/builds.py
+++ b/src/cosalib/builds.py
@@ -130,14 +130,15 @@ class Builds:  # pragma: nocover
         genver_key = 'coreos-assembler.image-genver'
         if not self.is_empty():
             previous_buildid = parent_build or self.get_latest()
-            metapath = self.get_build_dir(previous_buildid) + '/meta.json'
-            with open(metapath) as f:
-                previous_buildmeta = json.load(f)
-            previous_commit = previous_buildmeta['ostree-commit']
-            previous_image_genver = int(previous_buildmeta[genver_key])
-            if previous_commit == ostree_commit:
-                image_genver = previous_image_genver + 1
-                buildid = f"{version}-{image_genver}"
+            if get_basearch() in self.get_build_arches(previous_buildid):
+                metapath = self.get_build_dir(previous_buildid) + '/meta.json'
+                with open(metapath) as f:
+                    previous_buildmeta = json.load(f)
+                previous_commit = previous_buildmeta['ostree-commit']
+                previous_image_genver = int(previous_buildmeta[genver_key])
+                if previous_commit == ostree_commit:
+                    image_genver = previous_image_genver + 1
+                    buildid = f"{version}-{image_genver}"
         meta = {
             'buildid': buildid,
             genver_key: image_genver


### PR DESCRIPTION
```
commit 261331f642457f9cb3aa1c37a3d048a78e2614d0 (HEAD -> dusty-prep, origin/dusty-prep)
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Fri Jul 15 13:46:42 2022 -0400

    cmd-sign: add s3 --aws-config-file option
    
    This will allow us to specify the AWS_CONFIG_FILE from the command
    line without having to set it in the environment.

commit bb98107c1c87095ddef274ebcd9a2e2a592a724e
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Fri Jul 15 10:18:28 2022 -0400

    cosalib: fix init_build_meta_json for multi-arch
    
    If we are starting out a brand new stream and the x86_64 build
    has completed, but there was no build yet for $arch then the detected
    previous buildid:
    
    ```
    previous_buildid = parent_build or self.get_latest()
    ```
    
    Will just be the build ID of the x86_64 build from `get_latest()`,
    but this code tries to open a meta.json for it from $arch, which
    won't exist. Here's the error we see:
    
    ```
    Traceback (most recent call last):
      File "<string>", line 5, in <module>
      File "/usr/lib/coreos-assembler/cosalib/builds.py", line 134, in init_build_meta_json
        with open(metapath) as f:
    FileNotFoundError: [Errno 2] No such file or directory: '/srv/builds/36.20220714.dev.0/aarch64/meta.json'
    error: failed to execute cmd-build: exit status 1
    ```
    
    This should fix that error by verifying the detected buildid actually
    has a build for that architecture before continuing.

```