### PR TITLE
schema/cosa/build: check http response codes in http.Get

### DIFF
--- a/gangplank/vendor/github.com/coreos/coreos-assembler-schema/cosa/build.go
+++ b/gangplank/vendor/github.com/coreos/coreos-assembler-schema/cosa/build.go
@@ -305,6 +305,10 @@ func FetchAndParseBuild(url string) (*Build, error) {
 		return nil, err
 	}
 	defer res.Body.Close()
+    if res.StatusCode != 200 {
+        return nil, fmt.Errorf(
+            "Received a %d error in http response for: %s", res.StatusCode, url)
+    }
 	return buildParser(res.Body)
 }
 

--- a/mantle/vendor/github.com/coreos/coreos-assembler-schema/cosa/build.go
+++ b/mantle/vendor/github.com/coreos/coreos-assembler-schema/cosa/build.go
@@ -305,6 +305,10 @@ func FetchAndParseBuild(url string) (*Build, error) {
 		return nil, err
 	}
 	defer res.Body.Close()
+    if res.StatusCode != 200 {
+        return nil, fmt.Errorf(
+            "Received a %d error in http response for: %s", res.StatusCode, url)
+    }
 	return buildParser(res.Body)
 }
 

--- a/schema/cosa/build.go
+++ b/schema/cosa/build.go
@@ -305,6 +305,10 @@ func FetchAndParseBuild(url string) (*Build, error) {
 		return nil, err
 	}
 	defer res.Body.Close()
+    if res.StatusCode != 200 {
+        return nil, fmt.Errorf(
+            "Received a %d error in http response for: %s", res.StatusCode, url)
+    }
 	return buildParser(res.Body)
 }
 


### PR DESCRIPTION
This will make the error more clear when trying to run
an upgrade test where the fedora-coreos.parent-version`
is not actually a real version in the stream history.

I'm running a separate pipeline right now and so I'm
pushing dev builds into s3 and my parent version is
`36.20220716.dev.1`. That doesn't exist in the real
testing-devel stream so the code barfs like this:

```
$ cosa kola --rerun --upgrades --no-test-exit-error
kola -p qemu-unpriv --output-dir tmp/kola-upgrade run-upgrade --rerun --no-test-exit-error --qemu-image-dir tmp/kola-qemu-cache -v --find-parent-image
2022-07-16T21:52:14Z cli: Started logging at level INFO
2022-07-16T21:52:14Z cli: Started logging at level INFO
Error: failed to parse build: invalid character '<' looking for beginning of value
```

This will improve that error message.