### PR TITLE
platform: add an early release callback

### DIFF
--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -1357,6 +1357,7 @@ func runTest(h *harness.H, t *register.Test, pltfrm string, flight platform.Flig
 		OutputDir:          h.OutputDir(),
 		SSHOnTestFailure:   Options.SSHOnTestFailure,
 		WarningsAction:     conf.FailWarnings,
+		EarlyRelease:       h.Release,
 	}
 	if t.HasFlag(register.AllowConfigWarnings) {
 		rconf.WarningsAction = conf.IgnoreWarnings

--- a/mantle/platform/machine/aws/machine.go
+++ b/mantle/platform/machine/aws/machine.go
@@ -94,6 +94,7 @@ func (am *machine) Destroy() {
 		am.journal.Destroy()
 	}
 
+	am.cluster.EarlyRelease()
 	if err := am.saveConsole(origConsole); err != nil {
 		plog.Errorf("Error saving console for instance %v: %v", am.ID(), err)
 	}

--- a/mantle/platform/platform.go
+++ b/mantle/platform/platform.go
@@ -205,6 +205,7 @@ type RuntimeConfig struct {
 
 	// InternetAccess is true if the cluster should be Internet connected
 	InternetAccess bool
+	EarlyRelease   func()
 
 	// whether a Manhole into a machine should be created on detected failure
 	SSHOnTestFailure bool


### PR DESCRIPTION
Some platforms (particularly AWS) take a long time to perform
post-termination tasks. AWS sometimes takes 5 minutes to retrieve
console logs. This is a bottle neck to how fast our tests can run.

Let's add a callback that will allow us to release a test early before
post-termination tasks, so that the next tests waiting in queue may begin.