### PR TITLE
build: Make v1 chunked opt-in via config git

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -406,10 +406,9 @@ else
         # Note rpm-ostree always copies the rpmostree.inputhash key
         oci-chunked)
             cmd=(rpm-ostree container-encapsulate --max-layers="$MAX_OSTREECONTAINER_LAYERS") 
-            # rpm-ostree currently conservatively defaults to format-version=0, but we want 1
-            if rpm-ostree container-encapsulate --help 2>&1 |grep -qFe '--format-version'; then
-                cmd+=(--format-version=1)
-            fi
+        ;;
+        oci-chunked-v1)
+            cmd=(rpm-ostree container-encapsulate --max-layers="$MAX_OSTREECONTAINER_LAYERS" --format-version=1)
         ;;
         *) fatal "Unknown ostree-format: ${ostree_format}"
     esac


### PR DESCRIPTION
https://github.com/coreos/coreos-assembler/pull/2970 was in
retrospect a bit aggressive and we discovered some things were
still using too-old rpm-ostree.

Let's make this opt-in until the new rpm-ostree has time to propagate.