### PR TITLE
ci: Move ShellCheck to GH actions

### DIFF
--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -1,0 +1,27 @@
+name: lints
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches:
+      - main
+      - rhcos-*
+
+permissions:
+  contents: read
+
+jobs:
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    container: registry.ci.openshift.org/coreos/fcos-buildroot:testing-devel
+    steps:
+      - name: Install deps
+        run: yum -y install ShellCheck
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      # https://github.com/actions/checkout/issues/760
+      - name: Mark git checkout as safe
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - run: make shellcheck

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ bin/coreos-assembler:
 
 shellcheck: ${src_checked} ${tests_checked} ${cwd_checked}
 
-check: shellcheck flake8 pycheck schema-check mantle-check gangplank-check cosa-go-check
+check: flake8 pycheck schema-check mantle-check gangplank-check cosa-go-check
 	echo OK
 
 pycheck:

--- a/src/deps.txt
+++ b/src/deps.txt
@@ -55,8 +55,6 @@ python3-tenacity
 # For ignition file validation in cmd-run
 /usr/bin/ignition-validate
 
-# shellcheck for test
-ShellCheck
 
 # For python testing
 python3-flake8 python3-pytest python3-pytest-cov pylint


### PR DESCRIPTION
This is similar to
https://github.com/coreos/coreos-assembler/pull/2977
https://github.com/coreos/coreos-assembler/pull/2978

Today we're shipping code linting tools for shell and python
as part of the coreos-assembler image, which makes little sense.

Move `ShellCheck` to a separate CI flow run via GH actions.  For local
development, this are now manual instead of run as part of
`make check`.

(I tried to move python too but `pylint` depends on half the world
 being installed)