### PR TITLE
kola: Add support for `injectContainer`

### DIFF
--- a/docs/kola/external-tests.md
+++ b/docs/kola/external-tests.md
@@ -229,6 +229,12 @@ In the example above, the test would only run if `--tag special` was provided.
 The `additionalDisks` key has the same semantics as the `--add-disk` argument
 to `qemuexec`. It is currently only supported on `qemu-unpriv`.
 
+The `injectContainer` boolean if set will cause the framework to inject
+the ostree base image container into the target system; the path can be
+found in the environment variable `KOLA_OSTREE_OCIARCHIVE`.  This will be
+an `.ociarchive` file that can be e.g. loaded into the containers storage
+via `skopeo copy oci-archive:$KOLA_OSTREE_OCIARCHIVE containers-storage:localhost/os`.
+
 The `minDisk` key takes a size in GB and ensures that an instance type with at
 least the specified amount of primary disk space is used. On QEMU, this is
 equivalent to the `--qemu-size` argument to `qemuexec`. This is currently only

--- a/mantle/kola/register/register.go
+++ b/mantle/kola/register/register.go
@@ -78,6 +78,9 @@ type Test struct {
 	// "5G:mpath,foo,bar"]) -- defaults to none.
 	AdditionalDisks []string
 
+	// InjectContainer will cause the ostree base image to be injected into the target
+	InjectContainer bool
+
 	// Minimum amount of memory in MB required for test.
 	MinMemory int
 


### PR DESCRIPTION
Closes: https://github.com/coreos/coreos-assembler/issues/2952

For quite a while we've been generating a "base image" container
as part of our builds, but it has basically been entirely untested
outside of its processing and use by the ostree stack.

This adds a base framework such that external tests can request
the injection of the container (`.ociarchive`).

Now, we can (and *definitely* should) also pursue "natively" testing
this container image outside of kola, which is very virtual-machine
focused.

However, that will also require a lot of pipeline changes; this
approach allows us to natively "bridge" the worlds of cosa/kola
to test the container image.