### PR TITLE
build: Always pass `--format-version` to rpm-ostree

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -405,7 +405,7 @@ else
         oci) ;;
         # Note rpm-ostree always copies the rpmostree.inputhash key
         oci-chunked)
-            cmd=(rpm-ostree container-encapsulate --max-layers="$MAX_OSTREECONTAINER_LAYERS") 
+            cmd=(rpm-ostree container-encapsulate --max-layers="$MAX_OSTREECONTAINER_LAYERS" --format-version=0)
         ;;
         oci-chunked-v1)
             cmd=(rpm-ostree container-encapsulate --max-layers="$MAX_OSTREECONTAINER_LAYERS" --format-version=1)


### PR DESCRIPTION
It was intended to be optional, but our dynamic detection
of the availability of the option masked that bug.

This now bites us with the new rpm-ostree.