### PR TITLE
kola: Change `--oscontainer` to use new ostree native containers

### DIFF
--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -289,10 +289,6 @@ func syncOptionsImpl(useCosa bool) error {
 		})
 	}
 
-	if kola.Options.OSContainer != "" && kola.Options.Distribution != "rhcos" {
-		return fmt.Errorf("oscontainer is only supported on rhcos")
-	}
-
 	if kola.Options.Distribution == "" {
 		kola.Options.Distribution = kolaDistros[0]
 	} else if kola.Options.Distribution == "scos" {


### PR DESCRIPTION
Quite a while ago we added this special case code to kola
which learned how to do in-place updates to the weird bespoke
"ostree repo in container" OCP/RHCOS-specific container image.

A huge benefit of the change to use ostree-native containers
is that this approach can now be shared across FCOS/RHCOS.

(Also, rpm-ostree natively understands this, so it's much much
 more efficient and less awkward than the wrappers we had in `pivot` around
 rpm-ostree)

But the benefits get even larger: this issue:
https://github.com/coreos/coreos-assembler/issues/2685
proposes rethinking of our pipeline to more cleanly split up
"build OS update container" from "build disk images".

With this, it becomes extra convenient to do a flow of:

- build OS update container, push to registry
- `kola run -p stable --oscontainer quay.io/fcos-devel/testos@sha256...`

IOW we're not generating a disk image to test the OS update - we're
using the *stable* disk image and doing an in-place update before
we run tests.

Now...as of right now nothing in the pipeline passes this flag,
so the code won't be used (except for manual testing).

Suddenly with this, the number of tests we can run roughly *doubles*.
For example, we can run e.g.
`kola run rpm-ostree` both with and without `--oscontainer`.

In most cases, things should be the same.  But, I think it will
be interesting to try to explictly use this for at least some tests;
it's almost a full generalization of the `kola run-upgrades` bits.