### PR TITLE
handle build with arch mismatch; support buildfetch --find-build-for-arch

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -151,11 +151,15 @@ prepare_build
 ostree --version
 rpm-ostree --version
 
-previous_build=$(get_latest_build)
+previous_build=$(get_latest_build_for_arch "$basearch")
+echo "Previous build: ${previous_build:-none}"
 if [ -n "${previous_build}" ]; then
     previous_builddir=$(get_build_dir "${previous_build}")
+    if [ ! -d "${previous_builddir}" ]; then
+        echo "Previous build directory doesn't exist locally. Ignoring..."
+        previous_build=""
+    fi
 fi
-echo "Previous build: ${previous_build:-none}"
 
 previous_commit=
 previous_ostree_tarfile_path=

--- a/src/cmd-buildfetch
+++ b/src/cmd-buildfetch
@@ -97,10 +97,10 @@ def main():
     for arch in arches:
         # If the architecture doesn't exist then assume there were
         # no builds for this architecture yet, which can only happen
-        # if someone passed in the architecture value. return early
+        # if someone passed in architecture value(s)
         if arch not in builds.get_build_arches(buildid):
             print(f"No {arch} artifacts for build {buildid}")
-            return
+            continue
 
         builddir = builds.get_build_dir(buildid, arch)
         os.makedirs(builddir, exist_ok=True)

--- a/src/cmd-buildfetch
+++ b/src/cmd-buildfetch
@@ -132,17 +132,17 @@ def main():
                 print(f"Expected  sha256sum: {img['sha256']}")
                 raise Exception(f"Downloaded checksum for {imgpath} does not match expected")
 
+        # also nuke the any local matching OStree ref, since we want to build on
+        # top of this new one
+        if 'ref' in buildmeta and os.path.isdir('tmp/repo'):
+            subprocess.check_call(['ostree', 'refs', '--repo', 'tmp/repo',
+                                   '--delete', buildmeta['ref']],
+                                  stdout=subprocess.DEVNULL)
+
     # and finally the symlink
     if args.build is None:
         rm_allow_noent('builds/latest')
         os.symlink(buildid, 'builds/latest')
-
-    # also nuke the any local matching OStree ref, since we want to build on
-    # top of this new one
-    if 'ref' in buildmeta and os.path.isdir('tmp/repo'):
-        subprocess.check_call(['ostree', 'refs', '--repo', 'tmp/repo',
-                               '--delete', buildmeta['ref']],
-                              stdout=subprocess.DEVNULL)
 
 
 def parse_args():

--- a/src/cmd-buildfetch
+++ b/src/cmd-buildfetch
@@ -94,6 +94,19 @@ def main():
     else:
         arches = args.arch
 
+    # If someone passed in --find-build-for-arch they want us to
+    # find the most recent build that was successful for $arch.
+    # Since this may be a different build ID for the different
+    # given possible architectures we'll limit the use of this option
+    # to a single given arch.
+    if args.find_build_for_arch:
+        if len(arches) != 1:
+            raise Exception("Must provide single arch when finding build for architecture")
+        buildid = builds.get_latest_for_arch(arches[0])
+        if buildid is None:
+            print(f"No builds for arch {arches[0]} found in the history")
+            return
+
     for arch in arches:
         # If the architecture doesn't exist then assume there were
         # no builds for this architecture yet, which can only happen
@@ -161,6 +174,8 @@ def parse_args():
                         help="Fetch given image artifact(s)", metavar="ARTIFACT")
     parser.add_argument("--aws-config-file", metavar='CONFIG', default="",
                         help="Path to AWS config file")
+    parser.add_argument("--find-build-for-arch", action='store_true',
+                        help="Traverse build history to find latest for given architecture")
     return parser.parse_args()
 
 

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -902,6 +902,18 @@ get_latest_build() {
     fi
 }
 
+get_latest_build_for_arch() {
+    local arch=$1; shift
+    # yup, this is happening
+    (python3 -c "
+import sys
+sys.path.insert(0, '${DIR}')
+from cosalib.builds import Builds
+buildid = Builds('${workdir:-$(pwd)}').get_latest_for_arch('${arch}')
+if buildid:
+    print(buildid)")
+}
+
 get_build_dir() {
     local buildid=$1; shift
     # yup, this is happening

--- a/src/cosalib/builds.py
+++ b/src/cosalib/builds.py
@@ -64,6 +64,12 @@ class Builds:  # pragma: nocover
         # just let throw if there are none
         return self._data['builds'][0]['id']
 
+    def get_latest_for_arch(self, basearch):
+        for build in self._data['builds']:
+            if basearch in build['arches']:
+                return build['id']
+        return None
+
     def get_build_arches(self, build_id):
         for build in self._data['builds']:
             if build['id'] == build_id:


### PR DESCRIPTION
```
commit a8896bc193774b2ead347e6ee75c89db187319b4
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Fri Jul 22 11:56:28 2022 -0400

    cmd-buildfetch: add --find-build-for-arch option
    
    This instructs buildfetch to traverse the builds.json history to
    find the most recent build for the given architecture.

commit 54cd68e0af7e796ac4cc4a30bcd1a43b6c45ac0a
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Fri Jul 22 11:55:42 2022 -0400

    cmd-buildfetch: bring the ostree ref delete into the loop
    
    There will be a ref per arch so we need to do it on each loop
    iteration.

commit 65e2d8b51c2bcc091803587967448347552aa435
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Fri Jul 22 11:54:40 2022 -0400

    cmd-buildfetch: continue loop if arch missing
    
    The user could have passed in multiple arches so we should continue
    the loop rather than returning.

commit 62064b21dbea936105efc48dbc95ea30147c8b30
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Fri Jul 22 11:45:26 2022 -0400

    cosalib/builds: add get_latest_for_arch function; use it in cmd-build
    
    Right now cmd-build will just pick up whatever the latest symlink points
    to and try to get previous build information from that, but what if
    the absolute latest build doesn't have a build for the architecture we
    are targetting? Currently cmd-build will fail with:
    
    ```
    /usr/lib/coreos-assembler/cmd-build: line 163: /srv/builds/36.20220720.20.5/aarch64/meta.json: No such file or directory
    error: failed to execute cmd-build: exit status 1
    ```
    
    What we really need is to get the latest build for the given
    architecture and use that in cmd-build instead.
```
