### PR TITLE
[rhcos-4.10] build.sh: freeze coreos-installer to v0.12.0

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -38,6 +38,12 @@ configure_yum_repos() {
 }
 
 install_rpms() {
+    local builddeps
+    local frozendeps
+
+    # no frozen deps right now
+    frozendeps=""
+
     # First, a general update; this is best practice.  We also hit an issue recently
     # where qemu implicitly depended on an updated libusbx but didn't have a versioned
     # requires https://bugzilla.redhat.com/show_bug.cgi?id=1625641
@@ -54,7 +60,7 @@ install_rpms() {
     builddeps=$(grep -v '^#' "${srcdir}"/src/build-deps.txt)
 
     # Process our base dependencies + build dependencies and install
-    (echo "${builddeps}" && "${srcdir}"/src/print-dependencies.sh) | xargs yum -y install
+    (echo "${builddeps}" && echo "${frozendeps}" && "${srcdir}"/src/print-dependencies.sh) | xargs yum -y install
 
     # Delete file that only exists on ppc64le because it is causing
     # sudo to not work.

--- a/build.sh
+++ b/build.sh
@@ -41,8 +41,10 @@ install_rpms() {
     local builddeps
     local frozendeps
 
-    # no frozen deps right now
-    frozendeps=""
+    # freeze coreos-installer to 0.12.0 because newer releases dropped support
+    # for the legacy `iso extract pack-minimal-iso` alias:
+    # https://github.com/openshift/os/issues/916
+    frozendeps="coreos-installer-0.12.0-2.fc35"
 
     # First, a general update; this is best practice.  We also hit an issue recently
     # where qemu implicitly depended on an updated libusbx but didn't have a versioned


### PR DESCRIPTION
The latest coreos-installer dropped support for the legacy alias
`iso extract pack minimal-iso`, so this broke the 4.10 pipeline.

The core issue is that we run miniso packing using the coreos-installer
from cosa. We should fix this and make it use supermin to run the
packing step with the coreos-installer in the compose (like for osmet).

But for now, let's work around this by just freezing coreos-installer on
the version we're actually shipping in 4.10.

Closes: https://github.com/openshift/os/issues/916