### PR TITLE
mantle/kola/harness: disallow AppendKernelArgs for non-Exclusive tests

### DIFF
--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -1267,6 +1267,9 @@ func makeNonExclusiveTest(bucket int, tests []*register.Test, flight platform.Fl
 		if test.HasFlag(register.AllowConfigWarnings) {
 			plog.Fatalf("Non-exclusive test %v cannot have AllowConfigWarnings flag", test.Name)
 		}
+		if test.AppendKernelArgs != "" {
+			plog.Fatalf("Non-exclusive test %v cannot have AppendKernelArgs", test.Name)
+		}
 		if !internetAccess && testRequiresInternet(test) {
 			flags = append(flags, register.RequiresInternetAccess)
 			internetAccess = true


### PR DESCRIPTION
If a test is modifying kernel arguments it's almost by defnition not
friendly to other tests. Let's detect this and error out.

This would have saved me some time as I was hacking around locally.