### PR TITLE
Generalize osmet-pack and use it for miniso packing

### DIFF
--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -301,13 +301,13 @@ def generate_iso():
     tmp_osmet = os.path.join(tmpinitrd_rootfs, img_metal_obj['path'] + '.osmet')
     print('Generating osmet file for 512b metal image')
     runcmd(['/usr/lib/coreos-assembler/osmet-pack',
-           img_metal, '512', tmp_osmet, img_metal_checksum,
+           img_metal, tmp_osmet, img_metal_checksum,
            'fast' if args.fast else 'normal'])
     if img_metal4k_obj:
         tmp_osmet4k = os.path.join(tmpinitrd_rootfs, img_metal4k_obj['path'] + '.osmet')
         print('Generating osmet file for 4k metal image')
         runcmd(['/usr/lib/coreos-assembler/osmet-pack',
-               img_metal4k, '4096', tmp_osmet4k, img_metal4k_checksum,
+               img_metal4k, tmp_osmet4k, img_metal4k_checksum,
                'fast' if args.fast else 'normal'])
 
     # Generate root squashfs

--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -676,8 +676,9 @@ boot
     if basearch == "x86_64":
         runcmd(['/usr/bin/isohybrid', '--uefi', f'{tmpisofile}.minimal'])
     # this consumes the minimal image
-    runcmd(['coreos-installer', 'pack', 'minimal-iso',
-           tmpisofile, f'{tmpisofile}.minimal', "--consume"])
+    runcmd(['/usr/lib/coreos-assembler/runvm-coreos-installer', img_metal,
+            'pack', 'minimal-iso', tmpisofile, f'{tmpisofile}.minimal',
+            '--consume'])
 
     buildmeta['images'].update({
         'live-iso': {

--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -297,18 +297,30 @@ def generate_iso():
     with open(os.path.join(tmpisocoreos, 'features.json'), 'w') as fh:
         fh.write(features)
 
+    # Get PRETTY_NAME
+    with tempfile.TemporaryDirectory() as tmpd:
+        runcmd(['/usr/bin/ostree', 'checkout', '--repo', repo, '--user-mode',
+                '--subpath', "/usr/lib/os-release", buildmeta_commit, tmpd])
+        pretty_name = subprocess.check_output(['sh', '-euc', '. ./os-release; echo -n $PRETTY_NAME'],
+                                              encoding='utf-8', cwd=tmpd)
+
     # Add osmet files
     tmp_osmet = os.path.join(tmpinitrd_rootfs, img_metal_obj['path'] + '.osmet')
+    fast_arg = []
+    if args.fast:
+        fast_arg = ['--fast']
     print('Generating osmet file for 512b metal image')
-    runcmd(['/usr/lib/coreos-assembler/osmet-pack',
-           img_metal, tmp_osmet, img_metal_checksum,
-           'fast' if args.fast else 'normal'])
+    runcmd(['/usr/lib/coreos-assembler/osmet-pack', img_metal, 'pack', 'osmet',
+            '/dev/disk/by-id/virtio-coreos', '--description', pretty_name,
+            '--checksum', img_metal_checksum, '--output', tmp_osmet] +
+           fast_arg)
     if img_metal4k_obj:
         tmp_osmet4k = os.path.join(tmpinitrd_rootfs, img_metal4k_obj['path'] + '.osmet')
         print('Generating osmet file for 4k metal image')
-        runcmd(['/usr/lib/coreos-assembler/osmet-pack',
-               img_metal4k, tmp_osmet4k, img_metal4k_checksum,
-               'fast' if args.fast else 'normal'])
+        runcmd(['/usr/lib/coreos-assembler/osmet-pack', img_metal4k, 'pack',
+                'osmet', '/dev/disk/by-id/virtio-coreos', '--description',
+                pretty_name, '--checksum', img_metal4k_checksum, '--output',
+                tmp_osmet4k] + fast_arg)
 
     # Generate root squashfs
     print(f'Compressing squashfs with {squashfs_compression}')

--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -310,17 +310,17 @@ def generate_iso():
     if args.fast:
         fast_arg = ['--fast']
     print('Generating osmet file for 512b metal image')
-    runcmd(['/usr/lib/coreos-assembler/osmet-pack', img_metal, 'pack', 'osmet',
-            '/dev/disk/by-id/virtio-coreos', '--description', pretty_name,
-            '--checksum', img_metal_checksum, '--output', tmp_osmet] +
-           fast_arg)
+    runcmd(['/usr/lib/coreos-assembler/runvm-coreos-installer', img_metal,
+            'pack', 'osmet', '/dev/disk/by-id/virtio-coreos', '--description',
+            pretty_name, '--checksum', img_metal_checksum, '--output',
+            tmp_osmet] + fast_arg)
     if img_metal4k_obj:
         tmp_osmet4k = os.path.join(tmpinitrd_rootfs, img_metal4k_obj['path'] + '.osmet')
         print('Generating osmet file for 4k metal image')
-        runcmd(['/usr/lib/coreos-assembler/osmet-pack', img_metal4k, 'pack',
-                'osmet', '/dev/disk/by-id/virtio-coreos', '--description',
-                pretty_name, '--checksum', img_metal4k_checksum, '--output',
-                tmp_osmet4k] + fast_arg)
+        runcmd(['/usr/lib/coreos-assembler/runvm-coreos-installer',
+                img_metal4k, 'pack', 'osmet', '/dev/disk/by-id/virtio-coreos',
+                '--description', pretty_name, '--checksum',
+                img_metal4k_checksum, '--output', tmp_osmet4k] + fast_arg)
 
     # Generate root squashfs
     print(f'Compressing squashfs with {squashfs_compression}')

--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -263,7 +263,7 @@ fi
 runvm "${qemu_args[@]}" -- \
         /usr/lib/coreos-assembler/create_disk.sh \
             --config "$(pwd)"/image-for-disk.json \
-            --kargs "\"${kargs}\"" \
+            --kargs "${kargs}" \
             --platform "${ignition_platform_id}" \
             ${platforms_json:+--platforms-json "${platforms_json}"} \
             "${disk_args[@]}"

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -722,7 +722,10 @@ EOF
     # we hardcode a umask of 0022 here to make sure that composes are run
     # with a consistent value, regardless of the environment
     echo "umask 0022" > "${tmp_builddir}"/cmd.sh
-    echo "$@" >> "${tmp_builddir}"/cmd.sh
+    for arg in "$@"; do
+        # escape it appropriately so that spaces in args survive
+        printf '%q ' "$arg" >> "${tmp_builddir}"/cmd.sh
+    done
 
     touch "${runvm_console}"
 

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -656,7 +656,11 @@ runvm() {
     # tmp_builddir is set in prepare_build, but some stages may not
     # know that it exists.
     # shellcheck disable=SC2086
-    export tmp_builddir="${tmp_builddir:-$(mktemp -p ${workdir}/tmp -d supermin.XXXX)}"
+    if [ -z "${tmp_builddir:-}" ]; then
+        tmp_builddir="$(mktemp -p ${workdir}/tmp -d supermin.XXXX)"
+        export tmp_builddir
+        local cleanup_tmpdir=1
+    fi
 
     # shellcheck disable=SC2155
     local vmpreparedir="${tmp_builddir}/supermin.prepare"
@@ -784,6 +788,12 @@ EOF
         fatal "Couldn't find rc file; failure inside supermin init?"
     fi
     rc="$(cat "${rc_file}")"
+
+    if [ -n "${cleanup_tmpdir:-}" ]; then
+        rm -rf "${tmp_builddir}"
+        unset tmp_builddir
+    fi
+
     return "${rc}"
 }
 

--- a/src/osmet-pack
+++ b/src/osmet-pack
@@ -12,7 +12,6 @@ if [ ! -f /etc/cosa-supermin ]; then
         fatal "Cannot pack osmet from $img; not an uncompressed image"
     fi
 
-    sector_size=$1; shift
     osmet_dest=$1; shift
     checksum=$1; shift
     speed=$1; shift
@@ -30,8 +29,8 @@ if [ ! -f /etc/cosa-supermin ]; then
     fi
 
     device_opts=
-    if [ "$sector_size" != 512 ]; then
-        device_opts=",physical_block_size=${sector_size},logical_block_size=${sector_size}"
+    if [[ "${img_src}" == *metal4k* ]]; then
+        device_opts=",physical_block_size=4096,logical_block_size=4096"
     fi
 
     # stamp it with "osmet" serial so we find it easily in the VM

--- a/src/osmet-pack
+++ b/src/osmet-pack
@@ -12,16 +12,7 @@ if [ ! -f /etc/cosa-supermin ]; then
         fatal "Cannot pack osmet from $img; not an uncompressed image"
     fi
 
-    osmet_dest=$1; shift
-    checksum=$1; shift
-    speed=$1; shift
-
     workdir=$(pwd)
-    TMPDIR=$(readlink -f tmp/tmp-osmet-pack)
-    rm -rf "${TMPDIR}"
-    mkdir -p "${TMPDIR}"
-
-    set -- "${TMPDIR}/osmet.bin" "${checksum}" "${speed}"
 
     device_opts=
     if [[ "${img_src}" == *metal4k* ]]; then
@@ -32,9 +23,6 @@ if [ ! -f /etc/cosa-supermin ]; then
     runvm -drive "if=none,id=coreos,format=raw,readonly=on,file=${img_src}" \
         -device "virtio-blk,serial=coreos,drive=coreos${device_opts}" -- \
         /usr/lib/coreos-assembler/osmet-pack "$@"
-
-    mv "${TMPDIR}/osmet.bin" "${osmet_dest}"
-    rm -rf "${TMPDIR}"
 
     exit 0
 fi
@@ -73,6 +61,4 @@ RUST_BACKTRACE=full chroot "${deploydir}" coreos-installer pack osmet \
     /dev/disk/by-id/virtio-coreos \
     --description "${description}" \
     --checksum "${checksum}" \
-    --output /tmp/osmet.bin $fast
-
-mv /tmp/osmet.bin "${osmet_dest}"
+    --output "${osmet_dest}" $fast

--- a/src/osmet-pack
+++ b/src/osmet-pack
@@ -15,7 +15,6 @@ if [ ! -f /etc/cosa-supermin ]; then
     osmet_dest=$1; shift
     checksum=$1; shift
     speed=$1; shift
-    coreinst=${1:-${OSMET_PACK_COREOS_INSTALLER:-}}
 
     workdir=$(pwd)
     TMPDIR=$(readlink -f tmp/tmp-osmet-pack)
@@ -23,10 +22,6 @@ if [ ! -f /etc/cosa-supermin ]; then
     mkdir -p "${TMPDIR}"
 
     set -- "${TMPDIR}/osmet.bin" "${checksum}" "${speed}"
-    if [ -n "${coreinst:-}" ]; then
-        cp "${coreinst}" "${TMPDIR}/coreos-installer"
-        set -- "$@" "${TMPDIR}/coreos-installer"
-    fi
 
     device_opts=
     if [[ "${img_src}" == *metal4k* ]]; then
@@ -49,7 +44,6 @@ fi
 osmet_dest=$1; shift
 checksum=$1; shift
 speed=$1; shift
-coreinst=${1:-}
 
 set -x
 
@@ -61,14 +55,11 @@ deploydir=$(find "/sysroot/ostree/deploy/$osname/deploy" -mindepth 1 -maxdepth 1
 # shellcheck disable=SC1090,SC1091
 description=$(. "${deploydir}/etc/os-release" && echo "${PRETTY_NAME}")
 
-if [ -z "${coreinst}" ]; then
-    # if we weren't given a custom coreos-installer, then we want to use the one
-    # from the target system itself; chroot into it to avoid linking issues
-    for mnt in dev proc sys run var tmp; do
-        mount --rbind /$mnt "${deploydir}/$mnt"
-    done
-    coreinst="chroot ${deploydir} coreos-installer"
-fi
+# we want to use the coreos-installer from the target system but we need to
+# chroot into it to avoid linking issues
+for mnt in dev proc sys run var tmp; do
+    mount --rbind /$mnt "${deploydir}/$mnt"
+done
 
 case "$speed" in
     fast)      fast=--fast ;;
@@ -76,9 +67,10 @@ case "$speed" in
     *)         exit 1      ;;
 esac
 
-# We don't want double quotes (for both `coreinst` and `fast`, which may be '')
+# We don't want double quotes for `fast`, which may be ''
 # shellcheck disable=SC2086
-RUST_BACKTRACE=full ${coreinst} pack osmet /dev/disk/by-id/virtio-osmet \
+RUST_BACKTRACE=full chroot "${deploydir}" coreos-installer pack osmet \
+    /dev/disk/by-id/virtio-osmet \
     --description "${description}" \
     --checksum "${checksum}" \
     --output /tmp/osmet.bin $fast

--- a/src/osmet-pack
+++ b/src/osmet-pack
@@ -28,9 +28,9 @@ if [ ! -f /etc/cosa-supermin ]; then
         device_opts=",physical_block_size=4096,logical_block_size=4096"
     fi
 
-    # stamp it with "osmet" serial so we find it easily in the VM
-    runvm -drive "if=none,id=osmet,format=raw,readonly=on,file=${img_src}" \
-        -device "virtio-blk,serial=osmet,drive=osmet${device_opts}" -- \
+    # stamp it with "coreos" serial so we find it easily in the VM
+    runvm -drive "if=none,id=coreos,format=raw,readonly=on,file=${img_src}" \
+        -device "virtio-blk,serial=coreos,drive=coreos${device_opts}" -- \
         /usr/lib/coreos-assembler/osmet-pack "$@"
 
     mv "${TMPDIR}/osmet.bin" "${osmet_dest}"
@@ -48,7 +48,7 @@ speed=$1; shift
 set -x
 
 mkdir -p /sysroot
-rootfs=/dev/disk/by-id/virtio-osmet-part4
+rootfs=/dev/disk/by-id/virtio-coreos-part4
 mount -o ro "${rootfs}" /sysroot
 osname=$(ls /sysroot/ostree/deploy)
 deploydir=$(find "/sysroot/ostree/deploy/$osname/deploy" -mindepth 1 -maxdepth 1 -type d)
@@ -70,7 +70,7 @@ esac
 # We don't want double quotes for `fast`, which may be ''
 # shellcheck disable=SC2086
 RUST_BACKTRACE=full chroot "${deploydir}" coreos-installer pack osmet \
-    /dev/disk/by-id/virtio-osmet \
+    /dev/disk/by-id/virtio-coreos \
     --description "${description}" \
     --checksum "${checksum}" \
     --output /tmp/osmet.bin $fast

--- a/src/osmet-pack
+++ b/src/osmet-pack
@@ -7,6 +7,11 @@ if [ ! -f /etc/cosa-supermin ]; then
     . "${dn}"/cmdlib.sh
 
     img_src=$1; shift
+    if [[ $img_src == *.gz || $img_src == *.xz ]]; then
+        img="$(basename "$img_src")"
+        fatal "Cannot pack osmet from $img; not an uncompressed image"
+    fi
+
     sector_size=$1; shift
     osmet_dest=$1; shift
     checksum=$1; shift
@@ -17,11 +22,6 @@ if [ ! -f /etc/cosa-supermin ]; then
     TMPDIR=$(readlink -f tmp/tmp-osmet-pack)
     rm -rf "${TMPDIR}"
     mkdir -p "${TMPDIR}"
-
-    if [[ $img_src == *.gz || $img_src == *.xz ]]; then
-        img="$(basename "$img_src")"
-        fatal "Cannot pack osmet from $img; not an uncompressed image"
-    fi
 
     set -- "${TMPDIR}/osmet.bin" "${checksum}" "${speed}"
     if [ -n "${coreinst:-}" ]; then

--- a/src/osmet-pack
+++ b/src/osmet-pack
@@ -29,10 +29,6 @@ fi
 
 # This runs inside supermin
 
-osmet_dest=$1; shift
-checksum=$1; shift
-speed=$1; shift
-
 set -x
 
 mkdir -p /sysroot
@@ -40,8 +36,6 @@ rootfs=/dev/disk/by-id/virtio-coreos-part4
 mount -o ro "${rootfs}" /sysroot
 osname=$(ls /sysroot/ostree/deploy)
 deploydir=$(find "/sysroot/ostree/deploy/$osname/deploy" -mindepth 1 -maxdepth 1 -type d)
-# shellcheck disable=SC1090,SC1091
-description=$(. "${deploydir}/etc/os-release" && echo "${PRETTY_NAME}")
 
 # we want to use the coreos-installer from the target system but we need to
 # chroot into it to avoid linking issues
@@ -49,16 +43,4 @@ for mnt in dev proc sys run var tmp; do
     mount --rbind /$mnt "${deploydir}/$mnt"
 done
 
-case "$speed" in
-    fast)      fast=--fast ;;
-    normal)    fast=       ;;
-    *)         exit 1      ;;
-esac
-
-# We don't want double quotes for `fast`, which may be ''
-# shellcheck disable=SC2086
-RUST_BACKTRACE=full chroot "${deploydir}" coreos-installer pack osmet \
-    /dev/disk/by-id/virtio-coreos \
-    --description "${description}" \
-    --checksum "${checksum}" \
-    --output "${osmet_dest}" $fast
+RUST_BACKTRACE=full chroot "${deploydir}" coreos-installer "$@"

--- a/src/runvm-coreos-installer
+++ b/src/runvm-coreos-installer
@@ -48,4 +48,12 @@ for mnt in dev proc sys run var tmp; do
     mount --rbind /$mnt "${deploydir}/$mnt"
 done
 
-RUST_BACKTRACE=full chroot "${deploydir}" coreos-installer "$@"
+# some dirs which we expect to exist already
+mkdir -p "${deploydir}/var/"{home,mnt,opt,roothome,srv}
+
+# and pass through the workdir itself
+workdir=$(pwd)
+mkdir -p "${deploydir}/${workdir}/"
+mount --bind "${workdir}" "${deploydir}/${workdir}"
+
+RUST_BACKTRACE=full chroot "${deploydir}" env -C "${workdir}" coreos-installer "$@"

--- a/src/runvm-coreos-installer
+++ b/src/runvm-coreos-installer
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
+# This script runs the coreos-installer found in the compose itself inside a
+# chroot inside a supermin VM. The first argument is the path to the metal
+# image. All following arguments are passed as is to coreos-installer.
+# The metal image is available as /dev/disk/by-id/virtio-coreos.
+
 if [ ! -f /etc/cosa-supermin ]; then
     dn=$(dirname "$0")
     # shellcheck source=src/cmdlib.sh
@@ -22,7 +27,7 @@ if [ ! -f /etc/cosa-supermin ]; then
     # stamp it with "coreos" serial so we find it easily in the VM
     runvm -drive "if=none,id=coreos,format=raw,readonly=on,file=${img_src}" \
         -device "virtio-blk,serial=coreos,drive=coreos${device_opts}" -- \
-        /usr/lib/coreos-assembler/osmet-pack "$@"
+        /usr/lib/coreos-assembler/runvm-coreos-installer "$@"
 
     exit 0
 fi


### PR DESCRIPTION
The first commits work towards generalizing `osmet-pack` to support just running the matched `coreos-installer` in a supermin VM. The final patch makes the miniso packing step use it. Its commit message follows.

---

cmd-buildextend-live: pack miniso with composed coreos-installer

Currently, we're packing the miniso using the coreos-installer from the
cosa image. This is not ideal however, because it introduces skew
between the packing side and the unpacking side, which may be older.

Fix this by using the new `runvm-coreos-installer` to pack with the
composed coreos-installer.

For more information, see:
https://github.com/coreos/coreos-assembler/pull/3009