### PR TITLE
testiso: Check local iso image and live kernel existence

### DIFF
--- a/mantle/vendor/github.com/coreos/coreos-assembler-schema/cosa/build.go
+++ b/mantle/vendor/github.com/coreos/coreos-assembler-schema/cosa/build.go
@@ -178,7 +178,7 @@ func (build *Build) GetArtifact(artifact string) (*Artifact, error) {
 	if ok && r.Path != "" {
 		return r, nil
 	}
-	return nil, errors.New("artifact not defined")
+	return nil, errors.New("artifact " + artifact + " not defined")
 }
 
 // IsArtifact takes a path and returns the artifact type and a bool if
@@ -305,10 +305,10 @@ func FetchAndParseBuild(url string) (*Build, error) {
 		return nil, err
 	}
 	defer res.Body.Close()
-    if res.StatusCode != 200 {
-        return nil, fmt.Errorf(
-            "Received a %d error in http response for: %s", res.StatusCode, url)
-    }
+	if res.StatusCode != 200 {
+		return nil, fmt.Errorf(
+			"Received a %d error in http response for: %s", res.StatusCode, url)
+	}
 	return buildParser(res.Body)
 }
 

--- a/schema/cosa/build.go
+++ b/schema/cosa/build.go
@@ -178,7 +178,7 @@ func (build *Build) GetArtifact(artifact string) (*Artifact, error) {
 	if ok && r.Path != "" {
 		return r, nil
 	}
-	return nil, errors.New("artifact not defined")
+	return nil, errors.New("artifact " + artifact + " not defined")
 }
 
 // IsArtifact takes a path and returns the artifact type and a bool if
@@ -305,10 +305,10 @@ func FetchAndParseBuild(url string) (*Build, error) {
 		return nil, err
 	}
 	defer res.Body.Close()
-    if res.StatusCode != 200 {
-        return nil, fmt.Errorf(
-            "Received a %d error in http response for: %s", res.StatusCode, url)
-    }
+	if res.StatusCode != 200 {
+		return nil, fmt.Errorf(
+			"Received a %d error in http response for: %s", res.StatusCode, url)
+	}
 	return buildParser(res.Body)
 }
 


### PR DESCRIPTION
We should not continue with any testiso scenario if we don't have the relevant local images to run it on. When we `cosa buildfetch` we end up with a `meta.json` which specifies that we have a live kernel and iso image and run the tests regardless of the actual local existence of those images. Added an additional check for those images in addition to the check that we already do with `meta.json` to give an appropriate error earlier

Fixes: https://github.com/coreos/coreos-assembler/issues/2991