### PR TITLE
tests: add `--cache-only` option for `rpm-ostree install` in scos testing as workaround

### DIFF
--- a/mantle/kola/tests/rpmostree/deployments.go
+++ b/mantle/kola/tests/rpmostree/deployments.go
@@ -214,7 +214,9 @@ func rpmOstreeInstallUninstall(c cluster.TestCluster) {
 
 	c.Run("install", func(c cluster.TestCluster) {
 		// install package and reboot
-		c.RunCmdSync(m, "sudo rpm-ostree install "+ahtRpmPath)
+		// add workaround for scos
+		// https://bugzilla.redhat.com/show_bug.cgi?id=2113042
+		c.RunCmdSync(m, "sudo rpm-ostree install --cache-only "+ahtRpmPath)
 
 		installRebootErr := m.Reboot()
 		if installRebootErr != nil {


### PR DESCRIPTION
See:
- https://bugzilla.redhat.com/show_bug.cgi?id=2113042
- https://github.com/coreos/rpm-ostree/issues/3241