### PR TITLE
tests/rhcos/upgrade: Switch to `ostree container`

### DIFF
--- a/mantle/kola/tests/rhcos/upgrade.go
+++ b/mantle/kola/tests/rhcos/upgrade.go
@@ -120,7 +120,7 @@ func setup(c cluster.TestCluster) {
 			outputname="%s"
 			commit="%s"
 			ostree --repo=tmp/repo-cache init --mode=bare-user
-			rpm-ostree ex-container import --repo=tmp/repo ostree-unverified-image:oci-archive:$tarname:latest
+			ostree container unencapsulate --repo=tmp/repo ostree-unverified-image:oci-archive:$tarname:latest
 			ostree --repo=tmp/repo pull-local tmp/repo-cache "$commit"
 			tar -cf "$outputname" -C tmp/repo .
 			rm tmp/repo-cache -rf


### PR DESCRIPTION
This is how we want to expose it to users, the `ex-container` CLI
is deprecated and will be removed.