### PR TITLE
buildextend-extensions: Clean up temporary workdir when done

### DIFF
--- a/src/cmd-buildextend-extensions
+++ b/src/cmd-buildextend-extensions
@@ -63,6 +63,8 @@ def main():
     shutil.move(extensions_tarball, builddir)
     buildmeta.write(artifact_name='extensions')
 
+    shutil.rmtree(tmpworkdir)
+
 
 def parse_args():
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
This is what we should do in general, but specifically motivated
by trying to avoid out-of-space problems for RHCOS builds right now.