### PR TITLE
kola/harness: support excluding tests by tag

### DIFF
--- a/docs/kola.md
+++ b/docs/kola.md
@@ -55,6 +55,11 @@ and can also be used with glob patterns:
 Tests specified in `src/config/kola-denylist.yaml` will also be skipped
 regardless of whether the switch `--denylist-test` was provided.
 
+It's also possible to skip tests based on tags by prefixing
+the tag by `!`:
+
+`kola run --tag '!reprovision'`
+
 Example format of the file:
 
 ```yaml

--- a/mantle/kola/tests/ignition/luks.go
+++ b/mantle/kola/tests/ignition/luks.go
@@ -24,7 +24,7 @@ func init() {
 		Name:        `luks.tang`,
 		Flags:       []register.Flag{},
 		Distros:     []string{"rhcos"},
-		Tags:        []string{"luks", "tang", kola.NeedsInternetTag},
+		Tags:        []string{"luks", "tang", kola.NeedsInternetTag, "reprovision"},
 	})
 	register.RegisterTest(&register.Test{
 		Run:                  luksSSST1Test,
@@ -34,7 +34,7 @@ func init() {
 		Distros:              []string{"rhcos"},
 		Platforms:            []string{"qemu-unpriv"},
 		ExcludeArchitectures: []string{"s390x"}, // no TPM backend support for s390x
-		Tags:                 []string{"luks", "tpm", "tang", "sss", kola.NeedsInternetTag},
+		Tags:                 []string{"luks", "tpm", "tang", "sss", kola.NeedsInternetTag, "reprovision"},
 	})
 	register.RegisterTest(&register.Test{
 		Run:                  luksSSST2Test,
@@ -44,7 +44,7 @@ func init() {
 		Distros:              []string{"rhcos"},
 		Platforms:            []string{"qemu-unpriv"},
 		ExcludeArchitectures: []string{"s390x"}, // no TPM backend support for s390x
-		Tags:                 []string{"luks", "tpm", "tang", "sss", kola.NeedsInternetTag},
+		Tags:                 []string{"luks", "tpm", "tang", "sss", kola.NeedsInternetTag, "reprovision"},
 	})
 }
 

--- a/mantle/kola/tests/misc/boot-mirror.go
+++ b/mantle/kola/tests/misc/boot-mirror.go
@@ -65,7 +65,7 @@ func init() {
 		// skipping this test on UEFI until https://github.com/coreos/coreos-assembler/issues/2039
 		// gets resolved.
 		ExcludeFirmwares: []string{"uefi"},
-		Tags:             []string{"boot-mirror", "raid1"},
+		Tags:             []string{"boot-mirror", "raid1", "reprovision"},
 		FailFast:         true,
 		Timeout:          15 * time.Minute,
 	})
@@ -80,7 +80,7 @@ func init() {
 		// skipping this test on UEFI until https://github.com/coreos/coreos-assembler/issues/2039
 		// gets resolved.
 		ExcludeFirmwares: []string{"uefi"},
-		Tags:             []string{"boot-mirror", "luks", "raid1", "tpm2", kola.NeedsInternetTag},
+		Tags:             []string{"boot-mirror", "luks", "raid1", "tpm2", kola.NeedsInternetTag, "reprovision"},
 		FailFast:         true,
 		Timeout:          15 * time.Minute,
 	})


### PR DESCRIPTION
Support passing e.g. `--tag !foo` to exclude all tests with tag `foo`.