### PR TITLE
cmd/remote-session: specify --pull=always when creating container

### DIFF
--- a/cmd/remote-session.go
+++ b/cmd/remote-session.go
@@ -241,7 +241,7 @@ func init() {
 	// cmdRemoteSessionCreate options
 	cmdRemoteSessionCreate.Flags().StringVarP(
 		&remoteSessionOpts.CreateImage, "image", "",
-		"quay.io/coreos-assembler/coreos-assembler:latest",
+		"quay.io/coreos-assembler/coreos-assembler:main",
 		"The COSA container image to use on the remote")
 	cmdRemoteSessionCreate.Flags().StringVarP(
 		&remoteSessionOpts.CreateExpiration, "expiration", "", "infinity",

--- a/cmd/remote-session.go
+++ b/cmd/remote-session.go
@@ -133,8 +133,8 @@ func preRunCheckEnv(c *cobra.Command, args []string) error {
 // The user is then expected to store this ID in the
 // COREOS_ASSEMBLER_REMOTE_SESSION environment variable.
 func runCreate(c *cobra.Command, args []string) error {
-	podmanargs := []string{"--remote", "run", "--rm", "-d", "--privileged",
-		"--security-opt=label=disable", "--volume=/srv/",
+	podmanargs := []string{"--remote", "run", "--rm", "-d", "--pull=always",
+		"--privileged", "--security-opt=label=disable", "--volume=/srv/",
 		"--uidmap=1000:0:1", "--uidmap=0:1:1000", "--uidmap=1001:1001:64536",
 		"--device=/dev/kvm", "--device=/dev/fuse", "--tmpfs=/tmp",
 		"--entrypoint=/usr/bin/dumb-init", remoteSessionOpts.CreateImage,


### PR DESCRIPTION
```
commit 1041c620276950f44554e9d57317090fcbbb7a2e
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Fri Aug 5 16:41:46 2022 -0400

    cmd/remote-session: update to use `main` tag from quay.io
    
    Both tags work but `main` maps to the branch name we use and we've
    been trying to use that in more places so let's use it here too.

commit dde9d09e133a4aaa4e5b331645260353dd312acf
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Fri Aug 5 16:40:05 2022 -0400

    cmd/remote-session: specify --pull=always when creating container
    
    Otherwise our remotes use their local copy of the remote container
    image and it never gets updated from the first time it was pulled.
    
    With --pull=always no work is done if the container latest version
    of the container is already local (i.e. it uses the cached local
    copy), but the container image is fetched if there is a newer version.
    This is what we want.
```