### PR TITLE
src/cmd-buildfetch: dedupe --artifact list

### DIFF
--- a/src/cmd-buildfetch
+++ b/src/cmd-buildfetch
@@ -128,8 +128,11 @@ def main():
 
         buildmeta = load_json(f'builds/{builddir}/meta.json')
 
-        if args.artifact == ['all']:
-            artifacts = buildmeta['images']
+        # dedupe any possible duplicates in the list
+        args.artifact = set(args.artifact)
+
+        if 'all' in args.artifact:
+            artifacts = buildmeta['images'].keys()
         else:
             artifacts = args.artifact
 


### PR DESCRIPTION
I accidentally typed `--artifact qemu --artifact qemu` and buildfetch
downloaded it twice. Let's dedupe here.

Also, let's apply "all" even if the user passed more than one argument
to `--artifact`.