### PR TITLE
only set LIBGUESTFS_HV for ppc64le on el7

### DIFF
--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -660,7 +660,7 @@ func newGuestfish(diskImagePath string, diskSectorSize int) (*coreosGuestfish, e
 	cmd.Env = append(os.Environ(), "LIBGUESTFS_BACKEND=direct")
 	switch system.RpmArch() {
 	case "ppc64le":
-		cmd.Env = append(os.Environ(), "LIBGUESTFS_HV=/usr/lib/coreos-assembler/libguestfs-ppc64le-wrapper.sh")
+		cmd.Env = append(cmd.Env, "LIBGUESTFS_HV=/usr/lib/coreos-assembler/libguestfs-ppc64le-wrapper.sh")
 	}
 	// make sure it inherits stderr so we see any error message
 	cmd.Stderr = os.Stderr

--- a/src/libguestfish.sh
+++ b/src/libguestfish.sh
@@ -11,8 +11,12 @@ export LIBGUESTFS_BACKEND=direct
 
 arch=$(uname -m)
 
+
+# Hack to run with a wrapper on older P8 hardware running RHEL7
 if [ "$arch" = "ppc64le" ] ; then
-    export LIBGUESTFS_HV="/usr/lib/coreos-assembler/libguestfs-ppc64le-wrapper.sh"
+    if [[ "$(uname -r)" =~ "el7" ]]; then
+        export LIBGUESTFS_HV="/usr/lib/coreos-assembler/libguestfs-ppc64le-wrapper.sh"
+    fi
 fi
 
 # http://libguestfs.org/guestfish.1.html#using-remote-control-robustly-from-shell-scripts


### PR DESCRIPTION
```
commit 6c25ec0fd64b82dc70f31fa7262d656021cd4ccd
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Thu Aug 11 10:10:35 2022 -0400

    only set LIBGUESTFS_HV for ppc64le on el7
    
    It appears the newer P9 hardware that we are utilizing that is running
    a Fedora stack doesn't need this. Local testing seems to work fine.
    
    Let's hack around this for now while we still have el7 clusters.

commit 0eb38ebcad430c58e2e58fed5c069a638a07e73f
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon Aug 15 16:23:49 2022 -0400

    mantle/platform/qemu: fix seting of LIBGUESTFS env vars
    
    This setting of cmd.Env was overriding the LIBGUESTFS_BACKEND=direct
    that was being set just a few lines before. So the command was getting
    run with just LIBGUESTFS_HV being set, which happens to have no
    effect unless LIBGUESTFS_BACKEND=direct is set.
    
    Fix that by appending to cmd.Env on the second modification.

```
