### PR TITLE
Protect s390x secex filesystems using dm-verity instead of LUKS

### DIFF
--- a/src/deps-s390x.txt
+++ b/src/deps-s390x.txt
@@ -3,3 +3,6 @@ lorax xorriso
 
 # Deps needed by supermin
 s390utils-base
+
+# for Secure Execution
+veritysetup

--- a/src/vmdeps-s390x.txt
+++ b/src/vmdeps-s390x.txt
@@ -1,1 +1,4 @@
 s390utils-base
+
+# for Secure Execution
+veritysetup


### PR DESCRIPTION
LUKS with `--integrity` provided us with integrity protection so that we
were sure a malicious sysadmin couldn't have tampered with the disk
image. The problem however is that then we have to think about
protecting the generic per-cosa build LUKS keys.

We don't need confidentiality here, just integrity. Switch to using
dm-verity, which is made for this. Add new partitions to store the
hashes. Run `cryptsetup format` to populate them. Put the root and boot
partition root hashes in the kernel command line. Delete code related to
the previous LUKS approach.

On first boot, we will delete the hash partitions, and reprovision the
rootfs and bootfs on top of LUKS.