### PR TITLE
[rhcos-4.11] Bug 2107674: Add missing trailing newline in `grub.cfg`

### DIFF
--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -367,7 +367,7 @@ install_grub_cfg() {
     # 0700 to match the RPM permissions which I think are mainly in case someone has
     # manually set a grub password
     mkdir -p -m 0700 $rootfs/boot/grub2
-    printf "%s" "$grub_script" > $rootfs/boot/grub2/grub.cfg
+    printf "%s\n" "$grub_script" > $rootfs/boot/grub2/grub.cfg
 }
 
 # Other arch-specific bootloader changes


### PR DESCRIPTION
[Fixes petitboot on ppc64le](https://bugzilla.redhat.com/show_bug.cgi?id=2107674).  Backports 45fc1e7518e28834ecfa3c63e24bcfad0696bbfe from #2400.