### PR TITLE
cmd-init: support `--yumrepos` being a local checkout

### DIFF
--- a/src/cmd-init
+++ b/src/cmd-init
@@ -30,7 +30,7 @@ Usage: coreos-assembler init --help
   Use --yumrepos for builds that need .repo files and a content_sets.yaml which
   are not in GITCONFIG. For example: files need to be hidden behind a firewall
   in GITREPO. Using this option will clone GITREPO alongside GITCONFIG, thus you
-  may need to configure certificates.
+  may need to configure certificates. Local paths are also supported.
 
   Use `--transient` for builds that will throw away all cached data on success/failure,
   and should hence not invoke `fsync()` for example.
@@ -163,10 +163,11 @@ if test "${TRANSIENT}" = 1; then
     touch tmp/cosa-transient
 fi
 
-if [ -n "${YUMREPOS}" ]; then
-    mkdir -p src/yumrepos
-    git clone --depth=1 "${YUMREPOS}" src/yumrepos
-fi
+case "${YUMREPOS}" in
+    "");;
+    /*) ln -s "${YUMREPOS}" src/yumrepos;;
+    *) git clone --depth=1 "${YUMREPOS}" src/yumrepos;;
+esac
 
 set +x
 echo "Initialized $PWD as coreos-assembler working directory."

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -738,7 +738,7 @@ EOF
 
     # support local dev cases where src/config is a symlink.  Note if you change or extend to this set,
     # you also need to update supermin-init-prelude.sh to mount it inside the VM.
-    for maybe_symlink in "${workdir}"/{src/config,builds}; do
+    for maybe_symlink in "${workdir}"/{src/config,src/yumrepos,builds}; do
         if [ -L "${maybe_symlink}" ]; then
             # qemu follows symlinks
             local bn

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -738,14 +738,14 @@ EOF
 
     # support local dev cases where src/config is a symlink.  Note if you change or extend to this set,
     # you also need to update supermin-init-prelude.sh to mount it inside the VM.
-    if [ -L "${workdir}/src/config" ]; then
-        # qemu follows symlinks
-        base_qemu_args+=("-virtfs" 'local,id=source,path='"${workdir}"'/src/config,security_model=none,mount_tag=source')
-    fi
-    # Current RHCOS pipeline makes builds/ a PVC
-    if [ -L "${workdir}/builds" ]; then
-        base_qemu_args+=("-virtfs" 'local,id=builds,path='"${workdir}"'/builds,security_model=none,mount_tag=builds')
-    fi
+    for maybe_symlink in "${workdir}"/{src/config,builds}; do
+        if [ -L "${maybe_symlink}" ]; then
+            # qemu follows symlinks
+            local bn
+            bn=$(basename "${maybe_symlink}")
+            base_qemu_args+=("-virtfs" "local,id=${bn},path=${maybe_symlink},security_model=none,mount_tag=${bn}")
+        fi
+    done
 
     if [ -z "${RUNVM_SHELL:-}" ]; then
         if ! "${kola_args[@]}" -- "${base_qemu_args[@]}" \

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -383,9 +383,9 @@ EOF
         # Because right now rpm-ostree doesn't look for .repo files in
         # each included dir.
         # https://github.com/projectatomic/rpm-ostree/issues/1628
-        find "${configdir}" -name '*.repo' -exec cp -t "${tmp_overridesdir}" {} +
+        find "${configdir}/" -name '*.repo' -maxdepth 1 -type f -exec cp -t "${tmp_overridesdir}" {} +
         if [ -d "${workdir}/src/yumrepos" ]; then
-            find "${workdir}/src/yumrepos" -name '*.repo' -exec cp -t "${tmp_overridesdir}" {} +
+            find "${workdir}/src/yumrepos/" -maxdepth 1 -type f -name '*.repo' -exec cp -t "${tmp_overridesdir}" {} +
         fi
         if ! ls "${tmp_overridesdir}"/*.repo; then
             echo "ERROR: no yum repo files were found"

--- a/src/supermin-init-prelude.sh
+++ b/src/supermin-init-prelude.sh
@@ -37,15 +37,16 @@ umask 002
 # https://github.com/coreos/coreos-assembler/issues/2171
 mkdir -p "${workdir:?}"
 mount -t 9p -o rw,trans=virtio,version=9p2000.L,msize=10485760 workdir "${workdir}"
-# These two invocations pair with virtfs setups for qemu in cmdlib.sh.  Keep them in sync.
-if [ -L "${workdir}"/src/config ]; then
-    mkdir -p "$(readlink "${workdir}"/src/config)"
-    mount -t 9p -o rw,trans=virtio,version=9p2000.L,msize=10485760 source "${workdir}"/src/config
-fi
-if [ -L "${workdir}"/builds ]; then
-    mkdir -p "$(readlink "${workdir}"/builds)"
-    mount -t 9p -o rw,trans=virtio,version=9p2000.L,msize=10485760 builds "${workdir}"/builds
-fi
+
+# This loop pairs with virtfs setups for qemu in cmdlib.sh.  Keep them in sync.
+for maybe_symlink in "${workdir}"/{src/config,builds}; do
+    if [ -L "${maybe_symlink}" ]; then
+        bn=$(basename "${maybe_symlink}")
+        mkdir -p "$(readlink "${maybe_symlink}")"
+        mount -t 9p -o rw,trans=virtio,version=9p2000.L,msize=10485760 "${bn}" "${maybe_symlink}"
+    fi
+done
+
 mkdir -p "${workdir}"/cache
 cachedev=$(blkid -lt LABEL=cosa-cache -o device || true)
 if [ -n "${cachedev}" ]; then

--- a/src/supermin-init-prelude.sh
+++ b/src/supermin-init-prelude.sh
@@ -39,7 +39,7 @@ mkdir -p "${workdir:?}"
 mount -t 9p -o rw,trans=virtio,version=9p2000.L,msize=10485760 workdir "${workdir}"
 
 # This loop pairs with virtfs setups for qemu in cmdlib.sh.  Keep them in sync.
-for maybe_symlink in "${workdir}"/{src/config,builds}; do
+for maybe_symlink in "${workdir}"/{src/config,src/yumrepos,builds}; do
     if [ -L "${maybe_symlink}" ]; then
         bn=$(basename "${maybe_symlink}")
         mkdir -p "$(readlink "${maybe_symlink}")"


### PR DESCRIPTION
Just like the main source config, support passing an existing git
checkout to `--yumrepos` for a better local dev experience.