### PR TITLE
supermin: double disk space of supermin vm and use cgroups2

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -699,7 +699,7 @@ EOF
     chmod a+x "${vmpreparedir}"/init
     (cd "${vmpreparedir}" && tar -czf init.tar.gz --remove-files init)
     # put the supermin output in a separate file since it's noisy
-    if ! supermin --build "${vmpreparedir}" --size 5G -f ext2 -o "${vmbuilddir}" \
+    if ! supermin --build "${vmpreparedir}" --size 10G -f ext2 -o "${vmbuilddir}" \
             &> "${tmp_builddir}/supermin.out"; then
         cat "${tmp_builddir}/supermin.out"
         fatal "Failed to run: supermin --build"

--- a/src/supermin-init-prelude.sh
+++ b/src/supermin-init-prelude.sh
@@ -5,6 +5,7 @@
 
 mount -t proc /proc /proc
 mount -t sysfs /sys /sys
+mount -t cgroup2 cgroup2 -o rw,nosuid,nodev,noexec,relatime,seclabel,nsdelegate,memory_recursiveprot /sys/fs/cgroup
 mount -t devtmpfs devtmpfs /dev
 
 # need /dev/shm for podman


### PR DESCRIPTION
As part of https://issues.redhat.com/browse/COS-1646 podman is
going to be running inside the supermin vm, we run out of disk
quickly with 5G when loading the rhcos image in the FROM line.
Podman also needs /sys/fs/cgroup properly mounted as cgroup2.