### PR TITLE
create_disk.sh: go back to using --kargs for `rdcore zipl`

### DIFF
--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -486,7 +486,9 @@ ppc64le)
     ;;
 s390x)
     bootloader_backend=zipl
-    rdcore_zipl_args=("--boot-mount=$rootfs/boot" "--append-karg=ignition.firstboot")
+    # XXX: switch to using --append-karg once we have new enough rdcore
+    # https://github.com/coreos/coreos-installer/pull/950
+    rdcore_zipl_args=("--boot-mount=$rootfs/boot" "--kargs=ignition.firstboot")
     # in the secex case, we run zipl at the end; in the non-secex case, we need
     # to run it now because zipl wants rw access to the bootfs
     if [[ ${secure_execution} -ne 1 ]]; then


### PR DESCRIPTION
The new switch requires a new coreos-installer in the target systems.
Keep using the old switch for now until that happens.

The Secure Execution bit at the bottom still uses the newer
`--append-karg` because it needs latest coreos-installer anyway and no
pipeline is currently building the secex image.

Fixes 3246b72cb ("Protect s390x secex filesystems using dm-verity
instead of LUKS").