### PR TITLE
Revert "create_disk.sh: go back to using --kargs for `rdcore zipl`"

### DIFF
--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -488,9 +488,7 @@ ppc64le)
     ;;
 s390x)
     ostree config --repo $rootfs/ostree/repo set sysroot.bootloader zipl
-    # XXX: switch to using --append-karg once we have new enough rdcore
-    # https://github.com/coreos/coreos-installer/pull/950
-    rdcore_zipl_args=("--boot-mount=$rootfs/boot" "--kargs=ignition.firstboot")
+    rdcore_zipl_args=("--boot-mount=$rootfs/boot" "--append-karg=ignition.firstboot")
     # in the secex case, we run zipl at the end; in the non-secex case, we need
     # to run it now because zipl wants rw access to the bootfs
     if [[ ${secure_execution} -ne 1 ]]; then


### PR DESCRIPTION
Now that `rdcore zipl` supports `--append-karg` in all streams, use it.

Reverts #3051.