### PR TITLE
build: Switch to `rpm-ostree compose container-encapsulate`

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -412,10 +412,10 @@ else
         oci) ;;
         # Note rpm-ostree always copies the rpmostree.inputhash key
         oci-chunked)
-            cmd=(rpm-ostree container-encapsulate --max-layers="$MAX_OSTREECONTAINER_LAYERS" --format-version=0)
+            cmd=(rpm-ostree compose container-encapsulate --max-layers="$MAX_OSTREECONTAINER_LAYERS" --format-version=0)
         ;;
         oci-chunked-v1)
-            cmd=(rpm-ostree container-encapsulate --max-layers="$MAX_OSTREECONTAINER_LAYERS" --format-version=1)
+            cmd=(rpm-ostree compose container-encapsulate --max-layers="$MAX_OSTREECONTAINER_LAYERS" --format-version=1)
         ;;
         *) fatal "Unknown ostree-format: ${ostree_format}"
     esac


### PR DESCRIPTION
Following https://github.com/coreos/rpm-ostree/pull/3904/commits/60c8facfda1f79744a6a570613828772a7f93d93