### PR TITLE
kola: Add a `platform-independent` tag

### DIFF
--- a/docs/kola/external-tests.md
+++ b/docs/kola/external-tests.md
@@ -221,6 +221,7 @@ with `kola run --tag`, but some tags have semantic meaning.
 Tags with semantic meaning:
 
  - `needs-internet`: Taken from the Autopkgtest (linked above).  Currently only the `qemu` platform enforces this restriction.
+ - `platform-independent`: This test should pass or fail on all platforms (clouds and hardware architectures); it may be run less often.
  - `skip-base-checks`: Skip built-in checks for e.g. kernel warnings on the console or systemd unit failures.
 
 If a test has a `requiredTag`, it is run only if the required tag is specified.

--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -59,6 +59,7 @@ func init() {
 	ss("debug-systemd-unit", []string{}, "full-unit-name.service to enable SYSTEMD_LOG_LEVEL=debug on. Can be specified multiple times.")
 	ssv(&kola.DenylistedTests, "denylist-test", []string{}, "Test pattern to add to denylist. Can be specified multiple times.")
 	bv(&kola.NoNet, "no-net", false, "Don't run tests that require an Internet connection")
+	bv(&kola.ForceRunPlatformIndependent, "run-platform-independent", false, "Run tests that claim platform independence")
 	ssv(&kola.Tags, "tag", []string{}, "Test tag to run. Can be specified multiple times.")
 	bv(&kola.Options.SSHOnTestFailure, "ssh-on-test-failure", false, "SSH into a machine when tests fail")
 	sv(&kola.Options.Stream, "stream", "", "CoreOS stream ID (e.g. for Fedora CoreOS: stable, testing, next)")


### PR DESCRIPTION
So in fedora-coreos-config we grew this "standard" for documenting
the tags for tests:
https://github.com/coreos/fedora-coreos-config/blob/50ee01a89075d8ef204f1f40c5d89ab060748aac/README.md#tests-layout

And we've semi-standardized on the idiom `platforms: qemu` with
a manual documentation flag.  But just look at the level
of duplication:

```
$ git grep 'This test should pass everywhere'
tests/kola/binfmt/qemu:#   - This test should pass everywhere if it passes anywhere.
tests/kola/clhm/ignition-warnings/test.sh:#   - This test should pass everywhere if it passes anywhere.
tests/kola/content-origins/test.sh:#   - This test should pass everywhere if it passes anywhere.
tests/kola/extensions/module:#   - This test should pass everywhere if it passes anywhere.
tests/kola/extensions/package:#   - This test should pass everywhere if it passes anywhere.
tests/kola/files/validate-symlinks:#   - This test should pass everywhere if it passes anywhere.
tests/kola/networking/force-persist-ip/test.sh:#   - This test should pass everywhere if it passes anywhere.
tests/kola/networking/hostname/fallback-hostname/test.sh:#   - This test should pass everywhere if it passes anywhere.
tests/kola/networking/kargs-rd-net:#   - This test should pass everywhere if it passes anywhere.
tests/kola/networking/mtu-on-bond-ignition/test.sh:#   - This test should pass everywhere if it passes anywhere.
tests/kola/networking/mtu-on-bond-kargs:#   - This test should pass everywhere if it passes anywhere.
tests/kola/networking/no-default-initramfs-net-propagation/bootif:#   - This test should pass everywhere if it passes anywhere.
tests/kola/networking/prefer-ignition-networking/test.sh:#   - This test should pass everywhere if it passes anywhere.
tests/kola/podman/dns/test.sh:#   - This test should pass everywhere if it passes anywhere.
tests/kola/root-reprovision/filesystem-only/test.sh:#   - This test should pass everywhere if it passes anywhere.
tests/kola/root-reprovision/linear/test.sh:#   - This test should pass everywhere if it passes anywhere.
tests/kola/root-reprovision/luks/test.sh:#   - This test should pass everywhere if it passes anywhere.
tests/kola/root-reprovision/raid1/test.sh:#   - This test should pass everywhere if it passes anywhere.
tests/kola/root-reprovision/swap-before-root/test.sh:#   - This test should pass everywhere if it passes anywhere.
$
```

Instead, we can entirely avoid the need for copy-pasting lots of
comments with a *self-describing* tag that's documented here - *once*.

Further, as the code here mentions, I think what we really want to
do is e.g. *sometimes* (at least) run tests that claim they're
platform independent *not* on qemu to verify that's really true.

With a semantic tag, we can clearly distinguish these tests
from tests that *actually* only run on qemu.