### PR TITLE
kola: Add `isolation=readonly|dynamicuser`

### DIFF
--- a/docs/kola/external-tests.md
+++ b/docs/kola/external-tests.md
@@ -264,6 +264,13 @@ is simple and is not expected to conflict with other tests, it should be marked
 `exclusive: false`. When the `exclusive` key is not provided, tests are marked
 `exclusive: true` by default.
 
+The `isolation` key can take two values: `readonly` and `dynamicuser`.  These
+are thin wrappers for the equivalent systemd options; `readonly` equals `ProtectSystem=strict`,
+and `dynamicuser` means `DynamicUser=yes`.  Setting either of these options
+also implies `exclusive: false`.  Use these for tests that are mostly about
+read-only system inspection.  If specified, the test *cannot* provide
+an Ignition (or butane) config either.
+
 The `conflicts` key takes a list of test names that conflict with this test.
 This key can only be specified if `exclusive` is marked `false` since
 `exclusive: true` tests are run exclusively in their own VM.  At runtime,

--- a/tests/kola-ci-self/tests/kola/exclusive-readonly
+++ b/tests/kola-ci-self/tests/kola/exclusive-readonly
@@ -1,0 +1,9 @@
+#!/bin/bash
+# This verifies that isolation=dynamicuser maps to systemd DynamicUser=yes and
+# (unlike the default kola model) runs as non-root.
+# kola: { "isolation": "dynamicuser" }
+set -xeuo pipefail
+
+id=$(id -u)
+test "$id" '!=' 0
+echo "ok dynamicuser"


### PR DESCRIPTION
EDIT: I apologize for the tone in this PR that started from me; it was absolutely unnecessary.  Again, I apologize.  


----

Part of my battle against duplicative comments in our kola tests.
We have a few tests that write a comment like this:

```
 # - exclusive: false
 #   - This test doesn't make meaningful changes to the system and
 #     should be able to be combined with other tests.
```
Of course, this comment is already redundant because the
meaning of the `exclusive` tag is defined canonically in coreos-assembler
(here) and copy-pasting that into every test that uses it would
be pointlessly verbose.

But - we can do one better.  Instead of having a test flag which
is mainly an "I promise not to mutate the system in a way which could
interfere with other tests", let's add a field that *enforces* this.
Then it doesn't need to be commented; we have a variety of
tests which are just "system inspection" (e.g. query rpmdb) and
run just fine with `DynamicUser=yes` and hence *cannot* affect
the system, and hence are inherently isolated from other concurrent
tests.

---

