### PR TITLE
kola: Also support inline YAML for metadata

### DIFF
--- a/docs/kola/external-tests.md
+++ b/docs/kola/external-tests.md
@@ -281,6 +281,22 @@ test code here
 
 This metadata stanza must start with `# kola: ` and have a single line of JSON.
 
+Even more recently, you can write the test metadata as YAML inline; this is signified
+by using `## kola: `.  The lines after it starting with `## ` will be parsed as metadata YAML.
+For example:
+
+```
+#!/bin/bash
+set -xeuo pipefail
+## kola:
+##   architectures: x86_64
+##   platforms: "aws gcp"  # azure support is pending
+##   tags: needs-internet
+test code here
+```
+
+A notable advantage of YAML here is support for inline comments.
+
 ## Quick Start
 
 1. In your project's upstream repository, create the `tests/kola` directory, if


### PR DESCRIPTION
The *third* salvo in my battle against the duplicative and verbose
required comment metadata we've grown in fedora-coreos-config.

A key objection I have to it is that it requires specifying
the option *twice* - meaning it's easy for the actual options and
the comments to get out of date, etc.

Add support for YAML for metadata, which is just nicer to write:

- We support comments inline
- The data can span multiple Lines

So if we have comments to add, we can now do it in a better way.