### PR TITLE
src/cmd-remote-build-container: support building from subdirectories in git repos

### DIFF
--- a/src/cmd-remote-build-container
+++ b/src/cmd-remote-build-container
@@ -15,15 +15,16 @@ logging.basicConfig(level=logging.INFO,
                     format="%(asctime)s %(levelname)s - %(message)s")
 
 
-def build_container_image(labels, buildDir, repo, tag):
+def build_container_image(labels, buildDir, cacheTTL, repo, tag):
     '''
     Build the image  using podman remote and push to the registry
     @param labels list labels to add to image
     @param buildDir str the location of the directory to build from
+    @param cacheTTL str value to pass to `podman build --cache-ttl=`
     @param repo str registry repository
     @param tag  str image tag
     '''
-    cmd = ["podman", "build", "--no-cache", f"--tag={repo}:{tag}", buildDir]
+    cmd = ["podman", "build", f"--cache-ttl={cacheTTL}", f"--tag={repo}:{tag}", buildDir]
     for label in labels:
         cmd.extend([f"--label={label}"])
     # Long running command. Send output to stdout for logging
@@ -136,7 +137,8 @@ def main():
         if needbuild:
             logging.info("Building container via podman")
             builddir = os.path.join(gitdir, args.git_sub_dir)
-            build_container_image(args.label, builddir, args.repo, args.tag)
+            build_container_image(args.label, builddir,
+                                  args.cache_ttl, args.repo, args.tag)
 
     # Push to the registry if needed
     if args.push_to_registry:
@@ -168,6 +170,10 @@ Examples:
     parser.add_argument(
         '--authfile', required=False,
         help='A file to use for registry auth')
+    parser.add_argument(
+        '--cache-ttl', default="0.1s", required=False,
+        help="""Pass along --cache-ttl=<value> to `podman build`.
+                Defaults to 0.1s, which is effectively `--no-cache`""")
     parser.add_argument(
         '--label', default=[], action='append',
         required=False, help='Add image label(s)')

--- a/src/cmd-remote-build-container
+++ b/src/cmd-remote-build-container
@@ -91,9 +91,13 @@ def main():
     if environ.get('CONTAINER_HOST') is None or environ.get('CONTAINER_SSHKEY') is None:
         sys.exit('You must have CONTAINER_HOST and CONTAINER_SSHKEY environment variables setup')
 
-    # Podman doesn't seem to support building from a specific commit:
-    # https://github.com/containers/buildah/issues/4148
-    # Create a tmpdir to use for the git repo to build from.
+    # Podman supports building from a specific commit
+    # (https://github.com/containers/buildah/issues/4148), but the way
+    # we've set this up we don't know if the argument the user is
+    # passing to --git-ref is a commit or a ref. If we knew it was a
+    # ref then we could use `git ls-remote` to remotely determine
+    # the commit we wanted to build, but we don't. Just fetch the code
+    # into a tmpdir for now and use that as the git repo to build from.
     with tempfile.TemporaryDirectory() as gitdir:
         # fetch the git repo contents for the build and determine commit/shortcommit
         cmd = ["git", "-C", gitdir, "init", "."]

--- a/src/cmd-remote-build-container
+++ b/src/cmd-remote-build-container
@@ -15,15 +15,15 @@ logging.basicConfig(level=logging.INFO,
                     format="%(asctime)s %(levelname)s - %(message)s")
 
 
-def build_container_image(labels, gitDir, repo, tag):
+def build_container_image(labels, buildDir, repo, tag):
     '''
     Build the image  using podman remote and push to the registry
     @param labels list labels to add to image
-    @param gitDir the location of the directory to build from
+    @param buildDir str the location of the directory to build from
     @param repo str registry repository
     @param tag  str image tag
     '''
-    cmd = ["podman", "build", "--no-cache", f"--tag={repo}:{tag}", gitDir]
+    cmd = ["podman", "build", "--no-cache", f"--tag={repo}:{tag}", buildDir]
     for label in labels:
         cmd.extend([f"--label={label}"])
     # Long running command. Send output to stdout for logging
@@ -135,7 +135,8 @@ def main():
         # Build the container if needed.
         if needbuild:
             logging.info("Building container via podman")
-            build_container_image(args.label, gitdir, args.repo, args.tag)
+            builddir = os.path.join(gitdir, args.git_sub_dir)
+            build_container_image(args.label, builddir, args.repo, args.tag)
 
     # Push to the registry if needed
     if args.push_to_registry:
@@ -179,6 +180,9 @@ Examples:
     parser.add_argument(
         '--git-url', required=True,
         help='Git URL')
+    parser.add_argument(
+        '--git-sub-dir', default='', required=False,
+        help='Git sub directory to use for container build')
     parser.add_argument(
         '--push-to-registry', required=False, action='store_true',
         help='Push image to registry. You must be logged in before pushing images')


### PR DESCRIPTION
This should allow us to build the fcos-buildroot container from
https://github.com/coreos/fedora-coreos-config/tree/testing-devel/ci/buildroot
