### PR TITLE
kola: denylist: Only display tracking issue when available

### DIFF
--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -424,7 +424,9 @@ func parseDenyListYaml(pltfrm string) error {
 			fmt.Printf("⚠️  Skipping kola test pattern \"%s\":\n", obj.Pattern)
 		}
 
-		fmt.Printf("  👉 %s\n", obj.Tracker)
+		if obj.Tracker != "" {
+			fmt.Printf("  👉 %s\n", obj.Tracker)
+		}
 		DenylistedTests = append(DenylistedTests, obj.Pattern)
 	}
 


### PR DESCRIPTION
We strongly prefer to have a tracking issue for each denylist entry, but
let's not display a mostly empty line when there isn't one.