### PR TITLE
build-extensions-container: use `finalize-artifact`

### DIFF
--- a/cmd/build-extensions-container.go
+++ b/cmd/build-extensions-container.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"fmt"
+	"os/exec"
+
 	"github.com/coreos/coreos-assembler-schema/cosa"
 	"github.com/coreos/coreos-assembler/internal/pkg/cosash"
 
@@ -40,8 +42,7 @@ func buildExtensionContainer() error {
 		return err
 	}
 	targetPath := filepath.Join(buildPath, targetname)
-	err = os.Rename(filepath.Join(tmpdir, targetname), targetPath)
-	if err != nil {
+	if err := exec.Command("/usr/lib/coreos-assembler/finalize-artifact", filepath.Join(tmpdir, targetname), targetPath).Run(); err != nil {
 		return err
 	}
 	// Gather metadata of the OCI archive (sha256, size)


### PR DESCRIPTION
We hit on the problem that current RHCOS pipeline uses a separate volume for `builds/`, and we can't use `rename()` across that. One thing the `finalize-artifact` wrapper does today is use `mv` which will use an efficient `rename()` if possible, otherwise fall back to a copy.

(We also now more consistently make the artifact read-only)