### PR TITLE
network: disable `interface=lo` when start dnsmasq for `bond-with-dhcp`

### DIFF
--- a/mantle/kola/tests/misc/network.go
+++ b/mantle/kola/tests/misc/network.go
@@ -316,7 +316,8 @@ var (
 
           # Run a dnsmasq service on the network_namespace, to set the host-side veth ends a ip via their MAC addresses
           echo -e "dhcp-range=192.168.0.50,192.168.0.60,255.255.255.0,12h\ndhcp-host=${primary_mac},${primary_ip}\ndhcp-host=${secondary_mac},${secondary_ip}" > /etc/dnsmasq.d/dhcp
-          ip netns exec ${network_namespace} dnsmasq &
+          # Disable interface=lo as new dnsmasq version has it by default
+          ip netns exec ${network_namespace} dnsmasq --except-interface=lo --bind-interfaces -u dnsmasq -g dnsmasq --conf-dir=/etc/dnsmasq.d,.rpmnew,.rpmsave,.rpmorig --conf-file=/dev/null &
 
           # Tell NM to manage the "veth-host" interface and bring it up (will attempt DHCP).
           # Do this after we start dnsmasq so we don't have to deal with DHCP timeouts.


### PR DESCRIPTION
Make the update according to the default config in `/etc/dnsmasq.conf`

- Check dnsmasq config on c9s:

```
[root@cosa-devsh ~]# rpm -q dnsmasq
dnsmasq-2.85-4.el9.x86_64
[root@cosa-devsh ~]# grep "^[^#;]" /etc/dnsmasq.conf
user=dnsmasq
group=dnsmasq
interface=lo
bind-interfaces
conf-dir=/etc/dnsmasq.d,.rpmnew,.rpmsave,.rpmorig
```

- Check dnsmasq config on rhcos8:
```
[core@cosa-devsh ~]$ rpm -q dnsmasq
dnsmasq-2.79-21.el8.x86_64
[core@cosa-devsh ~]$ grep "^[^#;]" /etc/dnsmasq.conf
user=dnsmasq
group=dnsmasq
conf-dir=/etc/dnsmasq.d,.rpmnew,.rpmsave,.rpmorig
```
Build scos locally with PR and run `rhcos.network.bond-with-dhcp` PASSED
```
[coreos-assembler]$ kola run rhcos.network.bond-with-dhcp
=== RUN   rhcos.network.bond-with-dhcp
--- PASS: rhcos.network.bond-with-dhcp (100.60s)
PASS, output in tmp/kola/qemu-unpriv-2022-09-07-0338-56878
```