### PR TITLE
mantle: use `os.ReadDir` for lightweight directory reading

### DIFF
--- a/mantle/cmd/kola/switchkernel.go
+++ b/mantle/cmd/kola/switchkernel.go
@@ -17,7 +17,6 @@ package main
 import (
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"strings"
@@ -151,7 +150,7 @@ func runSwitchKernel(cmd *cobra.Command, args []string) error {
 func dropRpmFilesAll(m platform.Machine, localPath string) error {
 	fmt.Println("Dropping RT Kernel RPMs...")
 	re := regexp.MustCompile(`^kernel-rt-.*\.rpm$`)
-	files, err := ioutil.ReadDir(localPath)
+	files, err := os.ReadDir(localPath)
 	if err != nil {
 		return err
 	}

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -1138,23 +1138,28 @@ func testIsDenyListed(testname string) (bool, error) {
 }
 
 // registerTestDir parses one test directory and registers it as a test
-func registerTestDir(dir, testprefix string, children []os.FileInfo) error {
+func registerTestDir(dir, testprefix string, children []os.DirEntry) error {
 	var dependencydir string
 	var meta externalTestMeta
-	var err error
 	userdata := conf.EmptyIgnition()
 	executables := []string{}
 	for _, c := range children {
 		fpath := filepath.Join(dir, c.Name())
+
+		info, err := c.Info()
+		if err != nil {
+			return errors.Wrapf(err, "c.Info %s", c.Name())
+		}
+
 		// follow symlinks; oddly, there's no IsSymlink()
-		if c.Mode()&os.ModeSymlink != 0 {
-			c, err = os.Stat(fpath)
+		if info.Mode()&os.ModeSymlink != 0 {
+			info, err = os.Stat(fpath)
 			if err != nil {
 				return errors.Wrapf(err, "stat %s", fpath)
 			}
 		}
-		isreg := c.Mode().IsRegular()
-		if isreg && (c.Mode().Perm()&0001) > 0 {
+		isreg := info.Mode().IsRegular()
+		if isreg && (info.Mode().Perm()&0001) > 0 {
 			executables = append(executables, filepath.Join(dir, c.Name()))
 		} else if isreg && c.Name() == "config.ign" {
 			v, err := ioutil.ReadFile(filepath.Join(dir, c.Name()))
@@ -1183,7 +1188,7 @@ func registerTestDir(dir, testprefix string, children []os.FileInfo) error {
 			}
 		} else if c.IsDir() && c.Name() == kolaExtBinDataName {
 			dependencydir = filepath.Join(dir, c.Name())
-		} else if c.Mode()&os.ModeSymlink != 0 && c.Name() == kolaExtBinDataName {
+		} else if info.Mode()&os.ModeSymlink != 0 && c.Name() == kolaExtBinDataName {
 			target, err := filepath.EvalSymlinks(filepath.Join(dir, c.Name()))
 			if err != nil {
 				return err
@@ -1191,7 +1196,7 @@ func registerTestDir(dir, testprefix string, children []os.FileInfo) error {
 			dependencydir = target
 		} else if c.IsDir() {
 			subdir := filepath.Join(dir, c.Name())
-			subchildren, err := ioutil.ReadDir(subdir)
+			subchildren, err := os.ReadDir(subdir)
 			if err != nil {
 				return err
 			}
@@ -1199,7 +1204,7 @@ func registerTestDir(dir, testprefix string, children []os.FileInfo) error {
 			if err := registerTestDir(subdir, subprefix, subchildren); err != nil {
 				return err
 			}
-		} else if isreg && (c.Mode().Perm()&0001) == 0 {
+		} else if isreg && (info.Mode().Perm()&0001) == 0 {
 			file, err := os.Open(filepath.Join(dir, c.Name()))
 			if err != nil {
 				return errors.Wrapf(err, "opening %s", c.Name())
@@ -1238,7 +1243,7 @@ func registerTestDir(dir, testprefix string, children []os.FileInfo) error {
 
 func RegisterExternalTestsWithPrefix(dir, prefix string) error {
 	testsdir := filepath.Join(dir, "tests/kola")
-	children, err := ioutil.ReadDir(testsdir)
+	children, err := os.ReadDir(testsdir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			// The directory doesn't exist.. Skip registering tests

--- a/mantle/util/repo.go
+++ b/mantle/util/repo.go
@@ -16,7 +16,6 @@ package util
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -67,7 +66,7 @@ func GetLocalFastBuildQemu() (string, error) {
 		}
 		return "", err
 	}
-	ents, err := ioutil.ReadDir(fastBuildCosaDir)
+	ents, err := os.ReadDir(fastBuildCosaDir)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
`ioutil.ReadDir` has been deprecated in Go 1.16. The new `os.ReadDir` is a more efficient implementation than `ioutil.ReadDir` as stated here https://pkg.go.dev/io/ioutil#ReadDir.

The full proposal can be read here: https://<!---->github.com<!---->/<!---->golang<!---->/go/issues/41467