### PR TITLE
buildextend-live: add coreos-installer config directives to feature map

### DIFF
--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -15,6 +15,7 @@ import sys
 import tarfile
 import tempfile
 import time
+import yaml
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from cosalib.builds import Builds
@@ -141,6 +142,21 @@ def get_os_features():
         # coreos/fedora-coreos-config@3edd2f28
         'live-initrd-network': True,
     }
+
+    # coreos-installer >= 0.16.0
+    try:
+        f = runcmd(['/usr/bin/ostree', 'cat', '--repo', repo, buildmeta_commit,
+                    '/usr/share/coreos-installer/example-config.yaml'],
+                   capture_output=True).stdout.decode()
+        features['installer-config-directives'] = {
+            k: True for k in yaml.safe_load(f)
+        }
+    except subprocess.CalledProcessError as e:
+        if e.returncode == 1:
+            print('coreos-installer example-config.yaml not found.  Not setting feature.')
+        else:
+            raise
+
     return features
 
 

--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -135,25 +135,12 @@ def align_initrd_for_uncompressed_append(destf):
 # Return OS features table for features.json, which is read by
 # coreos-installer {iso|pxe} customize
 def get_os_features():
-    features = {}
-
-    f = runcmd(['/usr/bin/ostree', 'cat', '--repo', repo,
-               buildmeta_commit, '/usr/libexec/coreos-installer-service'],
-               capture_output=True).stdout.decode()
-    # eventually we can assume coreos-installer >= 0.12.0, delete this check,
-    # and hardcode the feature flag
-    if '--config-file' in f:
-        features['installer-config'] = True
-
-    f = runcmd(['/usr/bin/ostree', 'cat', '--repo', repo,
-               buildmeta_commit,
-               '/usr/lib/dracut/modules.d/35coreos-network/coreos-copy-firstboot-network.sh'],
-               capture_output=True).stdout.decode()
-    # eventually we can assume /etc/coreos-firstboot-network support and
-    # hardcode the feature flag
-    if 'etc_firstboot_network_dir' in f:
-        features['live-initrd-network'] = True
-
+    features = {
+        # coreos-installer >= 0.12.0
+        'installer-config': True,
+        # coreos/fedora-coreos-config@3edd2f28
+        'live-initrd-network': True,
+    }
     return features
 
 


### PR DESCRIPTION
On a coreos-installer new enough to ship `example-config.yaml` (coreos/coreos-installer#976), parse that file from the image and convert it to a map of supported directives in `features.json`.  `coreos-installer iso/pxe customize` can use this to decide whether it can safely use a directive, without us having to manually add a new feature flag every time.

While we're here, drop checks for older features and assume they always exist now.