### PR TITLE
Add `hack/Dockerfile`, drop `COREOS_ASSEMBLER_GIT`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 # kola_temp can include socket files that the build process does not like
 /mantle/_kola_temp
+/bin

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ else ifeq ($(GOARCH),aarch64)
 endif
 
 bin/coreos-assembler:
-	cd cmd && go build -mod vendor -o ../$@
+	cd cmd && go build $(GOFLAGS) -mod vendor -o ../$@
 .PHONY: bin/coreos-assembler
 
 .%.shellchecked: %

--- a/docs/building-fcos.md
+++ b/docs/building-fcos.md
@@ -101,7 +101,6 @@ cosa() {
               -v ${PWD}:/srv/ --device /dev/kvm --device /dev/fuse                                  \
               --tmpfs /tmp -v /var/tmp:/var/tmp --name cosa                                         \
               ${COREOS_ASSEMBLER_CONFIG_GIT:+-v $COREOS_ASSEMBLER_CONFIG_GIT:/srv/src/config/:ro}   \
-              ${COREOS_ASSEMBLER_GIT:+-v $COREOS_ASSEMBLER_GIT/src/:/usr/lib/coreos-assembler/:ro}  \
               ${COREOS_ASSEMBLER_CONTAINER_RUNTIME_ARGS}                                            \
               ${COREOS_ASSEMBLER_CONTAINER:-$COREOS_ASSEMBLER_CONTAINER_LATEST} "$@"
    rc=$?; set +x; return $rc
@@ -127,9 +126,6 @@ The environment variables are special purpose:
 
 - `COREOS_ASSEMBLER_CONFIG_GIT`: Allows you to specifiy a local directory that
   contains the configs for the ostree you are trying to compose.
-- `COREOS_ASSEMBLER_GIT`: Allows you to specify a local directory that contains
-  the CoreOS Assembler scripts. This allows for quick hacking on the assembler
-  itself.
 - `COREOS_ASSEMBLER_CONTAINER_RUNTIME_ARGS`: Allows for adding arbitrary mounts
   or args to the container runtime.
 - `COREOS_ASSEMBLER_CONTAINER`: Allows for overriding the default assembler

--- a/docs/devel.md
+++ b/docs/devel.md
@@ -12,18 +12,18 @@ guides if you are looking for how to use the CoreOS Assembler.
 1. TOC
 {:toc}
 
-## Hacking on CoreOS Assembler Scripts
+## Hacking on CoreOS Assembler 
 
-If you find yourself wanting to hack on CoreOS Assembler itself then you can
-easily mount the scripts into the container and prevent rebuilding the
-container to test every change. This can be done using the
-`COREOS_ASSEMBLER_GIT` env var.
+You could rerun `podman build -t localhost/cosa` every time you make
+a change, but it'd be very expensive to do so. 
 
-```
-$ export COREOS_ASSEMBLER_GIT=/path/to/github.com/coreos/coreos-assembler/
-$ cosa init https://github.com/coreos/fedora-coreos-config.git
-$ cosa fetch && cosa build
-```
+Instead, you can use [hack/Dockerfile].  There are instructions in that
+file.  This avoids redownloading and reinstalling all of the
+dependency RPMs.
+
+For even faster workflow, you can just bind mount in binaries from
+your host or from another container by adding additional bind mounts,
+and then copy files into your coreos-assembler container more manually.
 
 ## Installing cosa inside an existing container
 

--- a/hack/Dockerfile
+++ b/hack/Dockerfile
@@ -1,0 +1,8 @@
+# Use this for quicker iteration on coros-assembler; from the toplevel run e.g.:
+# podman build -t localhost/cosa -f hack/Dockerfile .
+FROM quay.io/coreos-assembler/coreos-assembler:latest
+WORKDIR /src
+COPY . .
+USER root
+RUN env GOFLAGS="-buildvcs=false" make && make install
+USER builder

--- a/mantle/build
+++ b/mantle/build
@@ -26,7 +26,7 @@ ldflags="-X ${REPO_PATH}/version.Version=${version}"
 host_build() {
     local cmd=$1; shift
     echo "Building $cmd"
-    go build \
+    go build ${GOFLAGS:-} \
         -ldflags "${ldflags}" \
         -mod vendor \
         -o "bin/$cmd" \
@@ -41,7 +41,7 @@ cross_static_build() {
         mkdir -p "bin/$a"
         echo "Building $a/$cmd (static)"
         CGO_ENABLED=0 GOARCH=${BASEARCH_TO_GOARCH[$a]} \
-        go build \
+        go build ${GOFLAGS:-} \
             -ldflags "${ldflags} -extldflags=-static" \
             -mod vendor \
             -o "bin/$a/$cmd" \


### PR DESCRIPTION
With the move to using even more Go, the workflow of just bind mounting the source code will break more and more.

(It has never worked for anything in mantle/)

Let's document a more robust workflow that ensures that the Go code is recompiled.