### PR TITLE
schema: Fix `make schema`

### DIFF
--- a/schema/generate-schema.sh
+++ b/schema/generate-schema.sh
@@ -27,10 +27,10 @@ cat > "${tdir}/schema_doc.go" <<EOM
 // Source hash: ${digest}
 // DO NOT EDIT
 
-package cosa
+package builds
 
 var generatedSchemaJSON = \`$(< ${schema_json})
 \`
 EOM
 
-cp -av ${tdir}/*go ${mydir}/cosa/
+cp -av ${tdir}/*go ${mydir}/../pkg/builds/


### PR DESCRIPTION
Fixes: https://github.com/coreos/coreos-assembler/pull/3069

I am pretty sure I had this working in some point in that PR, but in reworking for feedback I broke having `make schema` actually work.

Put the target files in the right place, and fix the namespace.