### PR TITLE
src/cmd-push-container-manifest: make sure all meta.json files get updated

### DIFF
--- a/src/cmd-push-container-manifest
+++ b/src/cmd-push-container-manifest
@@ -69,7 +69,7 @@ def main():
         # Update the meta.json in each build/arch metadata
         for _, buildmeta in buildmetas.items():
             buildmeta[args.metajsonname] = {'image': f"{args.repo}@{digest}"}
-        buildmeta.write(artifact_name=args.metajsonname)
+            buildmeta.write(artifact_name=args.metajsonname)
 
 
 def parse_args():


### PR DESCRIPTION
I needed to include the `buildmeta.write` inside the for loop so that all meta.json files for each arch would get updated with the reference to the manifest list.

Fixes a8259fe