### PR TITLE
[rhcos-4.11] Dockerfile: allow root group to add root certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,9 @@ RUN rm -rf /root/containerbuild /go
 # https://docs.openshift.com/container-platform/4.8/openshift_images/create-images.html
 RUN chmod g=u /etc/passwd
 
+# also allow adding certificates
+RUN chmod -R g=u /etc/pki/ca-trust
+
 # run as `builder` user
 USER builder
 ENTRYPOINT ["/usr/bin/dumb-init", "/usr/bin/coreos-assembler"]

--- a/src/add-root-cas
+++ b/src/add-root-cas
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euo pipefail
+
+# This runs a subset of what `update-ca-trust` does. Unlike the latter, it runs
+# fine unprivileged as long as it has write access to /etc/pki/ca-trust/.
+
+root_ca_dir=$1; shift
+
+cp -t /etc/pki/ca-trust/source/anchors/ "${root_ca_dir}"/*.crt
+
+# Compare to:
+# https://src.fedoraproject.org/rpms/ca-certificates/blob/3e2443900394/f/update-ca-trust
+
+DEST=/etc/pki/ca-trust/extracted
+
+# Prevent p11-kit from reading user configuration files.
+export P11_KIT_NO_USER_CONFIG=1
+
+# OpenSSL PEM bundle that includes trust flags
+/usr/bin/p11-kit extract --format=openssl-bundle --filter=certificates --overwrite --comment $DEST/openssl/ca-bundle.trust.crt
+/usr/bin/p11-kit extract --format=pem-bundle --filter=ca-anchors --overwrite --comment --purpose server-auth $DEST/pem/tls-ca-bundle.pem


### PR DESCRIPTION
Similarly to the familiar `/etc/passwd` OpenShift hack, loosen up restrictions on `/etc/pki/ca-trust` so that the unprivileged UID can add root certificates to the platform.

This allows cosa to be used as is to build in environments where additional root certificates may be necessary to fetch build inputs.

Add a script which can be used instead of `update-ca-trust` (which assumes root with `CAP_DAC_OVERRIDE`) to update the primary bundles we really care about for our stacks.