### PR TITLE
remote-build-container: add remote for origin

### DIFF
--- a/src/cmd-remote-build-container
+++ b/src/cmd-remote-build-container
@@ -118,7 +118,9 @@ def main():
         # fetch the git repo contents for the build and determine commit/shortcommit
         cmd = ["git", "-C", gitdir, "init", "."]
         runcmd(cmd, quiet=True, capture_output=True)
-        cmd = ["git", "-C", gitdir, "fetch", "--depth=1", args.git_url, args.git_ref]
+        cmd = ["git", "-C", gitdir, "remote", "add", "origin", args.git_url]
+        runcmd(cmd, quiet=True, capture_output=True)
+        cmd = ["git", "-C", gitdir, "fetch", "--depth=1", "origin", args.git_ref]
         runcmd(cmd, quiet=True, capture_output=True)
         cmd = ["git", "-C", gitdir, "checkout", "FETCH_HEAD"]
         runcmd(cmd, quiet=True, capture_output=True)


### PR DESCRIPTION
meta.json had `unknown` for `coreos-assembler.container-image-git.origin` because remote-build-container uses `git fetch <commit>` which does not setup a remote called `origin`. This is fixed by setting up the `origin` remote first then fetching the commit.

This was affecting all cosa branch builds because the jenkins job that builds multi-arch cosa uses the coreos-assembler:main container to remotely build cosa on all the architectures.

Closes: #3095