### PR TITLE
[rhcos-4.11] support being initiated from a `cosa remote-session`

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -139,11 +139,15 @@ prepare_build
 ostree --version
 rpm-ostree --version
 
-previous_build=$(get_latest_build)
+previous_build=$(get_latest_build_for_arch "$basearch")
+echo "Previous build: ${previous_build:-none}"
 if [ -n "${previous_build}" ]; then
     previous_builddir=$(get_build_dir "${previous_build}")
+    if [ ! -d "${previous_builddir}" ]; then
+        echo "Previous build directory doesn't exist locally. Ignoring..."
+        previous_build=""
+    fi
 fi
-echo "Previous build: ${previous_build:-none}"
 
 previous_commit=
 previous_ostree_tarfile_path=

--- a/src/cmd-buildfetch
+++ b/src/cmd-buildfetch
@@ -22,7 +22,7 @@ from cosalib.cmdlib import (
     retry_stop,
     rm_allow_noent,
     sha256sum_file)
-from cosalib.s3 import download_file, head_bucket, head_object
+from cosalib.s3 import S3
 
 retry_requests_exception = (retry_if_exception_type(requests.Timeout) |
                             retry_if_exception_type(requests.ReadTimeout) |
@@ -34,6 +34,8 @@ FCOS_STREAMS_URL = "https://builds.coreos.fedoraproject.org/prod/streams"
 
 def main():
     args = parse_args()
+    if args.aws_config_file:
+        os.environ["AWS_CONFIG_FILE"] = args.aws_config_file
 
     url = args.url or f'{FCOS_STREAMS_URL}/{args.stream}/builds'
     if url.startswith("s3://"):
@@ -157,6 +159,8 @@ def parse_args():
                         help="the target architecture(s)")
     parser.add_argument("--artifact", default=[], action='append',
                         help="Fetch given image artifact(s)", metavar="ARTIFACT")
+    parser.add_argument("--aws-config-file", metavar='CONFIG', default="",
+                        help="Path to AWS config file")
     return parser.parse_args()
 
 
@@ -221,20 +225,23 @@ class HTTPFetcher(Fetcher):
 
 
 class S3Fetcher(Fetcher):
+    def __init__(self, url_base):
+        super().__init__(url_base)
+        self.s3_client = S3()
 
     def fetch_impl(self, url, dest):
         assert url.startswith("s3://")
         bucket, key = url[len("s3://"):].split('/', 1)
         # this function does not need to be retried with the decorator as download_file would
         # retry automatically based on s3config settings
-        download_file(bucket, key, dest)
+        self.s3_client.download_file(bucket, key, dest)
 
     def exists_impl(self, url):
         assert url.startswith("s3://")
         bucket, key = url[len("s3://"):].split('/', 1)
         # sanity check that the bucket exists and we have access to it
-        head_bucket(bucket=bucket)
-        return head_object(bucket=bucket, key=key)
+        self.s3_client.head_bucket(bucket=bucket)
+        return self.s3_client.head_object(bucket=bucket, key=key)
 
 
 class LocalFetcher(Fetcher):

--- a/src/cmd-buildupload
+++ b/src/cmd-buildupload
@@ -57,6 +57,8 @@ def parse_args():
                     "and set Content-Disposition names", action='store_true')
     s3.add_argument("--endpoint-url", help="URL of S3-compatible server",
                     action="store", metavar="URL")
+    s3.add_argument("--aws-config-file", metavar='CONFIG', default="",
+                    help="Path to AWS config file")
     s3.set_defaults(func=cmd_upload_s3)
 
     return parser.parse_args()
@@ -65,6 +67,8 @@ def parse_args():
 def cmd_upload_s3(args):
     bucket, prefix = args.url.split('/', 1)
     builds = Builds()
+    if args.aws_config_file:
+        os.environ["AWS_CONFIG_FILE"] = args.aws_config_file
     s3_client = boto3.client('s3', endpoint_url=args.endpoint_url)
     # This can't be an error for backcompat reasons, but let's print something
     if not os.path.isfile(BUILDFILES['sourceurl']):

--- a/src/cmd-generate-hashlist
+++ b/src/cmd-generate-hashlist
@@ -82,8 +82,7 @@ class HashListV1(dict):
         import_ostree_commit(
             os.getcwd(),
             self._metadata.build_dir,
-            self._metadata,
-            force=True)
+            self._metadata)
         subprocess.check_call([
             'ostree', 'checkout',
             '--repo=tmp/repo', '-U',

--- a/src/cmd-meta
+++ b/src/cmd-meta
@@ -65,7 +65,7 @@ def new_cli():
 
     def pather(val):
         path = val.split('.')
-        if val.startswith("coreos-assembler."):
+        if val.startswith("coreos-assembler.") or val.startswith("fedora-coreos."):
             new_path = [f"{path[0]}.{path[1]}"]
             new_path.extend(path[2:])
             return ".".join(new_path)

--- a/src/cmd-sign
+++ b/src/cmd-sign
@@ -53,6 +53,8 @@ def parse_args():
                                     'RoboSignatory via fedora-messaging')
     robosig.add_argument("--s3", metavar='<BUCKET>[/PREFIX]', required=True,
                          help="bucket and prefix to S3 builds/ dir")
+    robosig.add_argument("--aws-config-file", metavar='CONFIG', default="",
+                         help="Path to AWS config file")
     group = robosig.add_mutually_exclusive_group(required=True)
     group.add_argument("--ostree", help="sign commit", action='store_true')
     group.add_argument("--images", help="sign images", action='store_true')
@@ -72,6 +74,8 @@ def parse_args():
 
 
 def cmd_robosignatory(args):
+    if args.aws_config_file:
+        os.environ["AWS_CONFIG_FILE"] = args.aws_config_file
     s3 = boto3.client('s3')
     args.bucket, args.prefix = get_bucket_and_prefix(args.s3)
 

--- a/src/cmd-sign
+++ b/src/cmd-sign
@@ -138,7 +138,7 @@ def robosign_ostree(args, s3, build, gpgkey):
     # Ensure we have an unpacked repo with the ostree content
     if not os.path.exists('tmp/repo'):
         subprocess.check_call(['ostree', '--repo=tmp/repo', 'init', '--mode=archive'])
-    import_ostree_commit(os.getcwd(), builddir, build, force=True)
+    import_ostree_commit(os.getcwd(), builddir, build)
     repo = OSTree.Repo.new(Gio.File.new_for_path('tmp/repo'))
     repo.open(None)
 

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -884,6 +884,18 @@ get_latest_build() {
     fi
 }
 
+get_latest_build_for_arch() {
+    local arch=$1; shift
+    # yup, this is happening
+    (python3 -c "
+import sys
+sys.path.insert(0, '${DIR}')
+from cosalib.builds import Builds
+buildid = Builds('${workdir:-$(pwd)}').get_latest_for_arch('${arch}')
+if buildid:
+    print(buildid)")
+}
+
 get_build_dir() {
     local buildid=$1; shift
     # yup, this is happening

--- a/src/cosalib/aws.py
+++ b/src/cosalib/aws.py
@@ -1,5 +1,6 @@
 import boto3
 import json
+import os
 import subprocess
 import sys
 
@@ -113,6 +114,9 @@ def aws_run_ore(build, args):
     if args.force:
         ore_args.extend(['--force'])
 
+    if args.credentials_file:
+        ore_args.extend(['--credentials-file', args.credentials_file])
+
     region = "us-east-1"
     if args.region is not None and len(args.region) > 0:
         region = args.region[0]
@@ -159,6 +163,8 @@ def aws_run_ore(build, args):
 
 def aws_cli(parser):
     parser.add_argument("--bucket", help="S3 Bucket")
+    parser.add_argument("--credentials-file", help="AWS config file",
+                        default=os.environ.get("AWS_CONFIG_FILE"))
     parser.add_argument("--name-suffix", help="Suffix for name")
     parser.add_argument("--grant-user", help="Grant user launch permission",
                         nargs="*", default=[])

--- a/src/cosalib/builds.py
+++ b/src/cosalib/builds.py
@@ -69,6 +69,12 @@ class Builds:  # pragma: nocover
         # just let throw if there are none
         return self._data['builds'][0]['id']
 
+    def get_latest_for_arch(self, basearch):
+        for build in self._data['builds']:
+            if basearch in build['arches']:
+                return build['id']
+        return None
+
     def get_build_arches(self, build_id):
         for build in self._data['builds']:
             if build['id'] == build_id:

--- a/src/cosalib/builds.py
+++ b/src/cosalib/builds.py
@@ -136,14 +136,15 @@ class Builds:  # pragma: nocover
         genver_key = 'coreos-assembler.image-genver'
         if not self.is_empty():
             previous_buildid = parent_build or self.get_latest()
-            metapath = self.get_build_dir(previous_buildid) + '/meta.json'
-            with open(metapath) as f:
-                previous_buildmeta = json.load(f)
-            previous_commit = previous_buildmeta['ostree-commit']
-            previous_image_genver = int(previous_buildmeta[genver_key])
-            if previous_commit == ostree_commit:
-                image_genver = previous_image_genver + 1
-                buildid = f"{version}-{image_genver}"
+            if get_basearch() in self.get_build_arches(previous_buildid):
+                metapath = self.get_build_dir(previous_buildid) + '/meta.json'
+                with open(metapath) as f:
+                    previous_buildmeta = json.load(f)
+                previous_commit = previous_buildmeta['ostree-commit']
+                previous_image_genver = int(previous_buildmeta[genver_key])
+                if previous_commit == ostree_commit:
+                    image_genver = previous_image_genver + 1
+                    buildid = f"{version}-{image_genver}"
         meta = {
             'buildid': buildid,
             genver_key: image_genver

--- a/src/cosalib/cmdlib.py
+++ b/src/cosalib/cmdlib.py
@@ -265,8 +265,9 @@ def extract_image_json(workdir, commit):
 #
 # Call this function to ensure that the ostree commit for a given build is in tmp/repo.
 def import_ostree_commit(workdir, buildpath, buildmeta, force=False):
+    tmpdir = os.path.join(workdir, 'tmp')
     with Lock(os.path.join(workdir, 'tmp/repo.import.lock')):
-        repo = os.path.join(workdir, 'tmp/repo')
+        repo = os.path.join(tmpdir, 'repo')
         commit = buildmeta['ostree-commit']
         tarfile = os.path.join(buildpath, buildmeta['images']['ostree']['path'])
         # create repo in case e.g. tmp/ was cleared out; idempotent
@@ -298,7 +299,7 @@ def import_ostree_commit(workdir, buildpath, buildmeta, force=False):
             gid = os.getgid()
             subprocess.check_call(['sudo', 'chown', '-hR', f"{uid}:{gid}", repo])
         else:
-            with tempfile.TemporaryDirectory() as tmpd:
+            with tempfile.TemporaryDirectory(dir=tmpdir) as tmpd:
                 subprocess.check_call(['ostree', 'init', '--repo', tmpd, '--mode=bare-user'])
                 subprocess.check_call(['ostree', 'container', 'import', '--repo', tmpd,
                                        '--write-ref', buildmeta['buildid'],

--- a/src/cosalib/cmdlib.py
+++ b/src/cosalib/cmdlib.py
@@ -264,7 +264,7 @@ def extract_image_json(workdir, commit):
 # a metal image, we may not have preserved that cache.
 #
 # Call this function to ensure that the ostree commit for a given build is in tmp/repo.
-def import_ostree_commit(workdir, buildpath, buildmeta, force=False):
+def import_ostree_commit(workdir, buildpath, buildmeta):
     tmpdir = os.path.join(workdir, 'tmp')
     with Lock(os.path.join(workdir, 'tmp/repo.import.lock')):
         repo = os.path.join(tmpdir, 'repo')
@@ -279,8 +279,7 @@ def import_ostree_commit(workdir, buildpath, buildmeta, force=False):
         if (subprocess.call(['ostree', 'show', '--repo', repo, commit],
                             stdout=subprocess.DEVNULL,
                             stderr=subprocess.DEVNULL) == 0
-                and not os.path.isfile(commitpartial)
-                and not force):
+                and not os.path.isfile(commitpartial)):
             extract_image_json(workdir, commit)
             return
 

--- a/src/cosalib/cmdlib.py
+++ b/src/cosalib/cmdlib.py
@@ -27,7 +27,7 @@ from tenacity import (
 gi.require_version("RpmOstree", "1.0")
 from gi.repository import RpmOstree
 
-from datetime import datetime, timezone
+import datetime
 
 retry_stop = (stop_after_delay(10) | stop_after_attempt(5))
 retry_boto_exception = (retry_if_exception_type(ConnectionClosedError) |
@@ -212,7 +212,7 @@ def rfc3339_time(t=None):
     :rtype: str
     """
     if t is None:
-        t = datetime.utcnow()
+        t = datetime.datetime.utcnow()
     else:
         # if the need arises, we can convert to UTC, but let's just enforce
         # this doesn't slip by for now
@@ -327,8 +327,8 @@ def parse_date_string(date_string):
     :rtype: datetime.datetime
     :raises: ValueError, TypeError
     """
-    dt = datetime.strptime(date_string, '%Y-%m-%dT%H:%M:%SZ')
-    return dt.replace(tzinfo=timezone.utc)
+    dt = datetime.datetime.strptime(date_string, '%Y-%m-%dT%H:%M:%SZ')
+    return dt.replace(tzinfo=datetime.timezone.utc)
 
 
 def get_timestamp(entry):

--- a/src/cosalib/prune.py
+++ b/src/cosalib/prune.py
@@ -2,12 +2,7 @@ import collections
 import json
 import os
 
-from cosalib.s3 import (
-    head_object,
-    list_objects,
-    download_file,
-    delete_object
-)
+from cosalib.s3 import S3
 
 from cosalib.aws import (
     deregister_ami,
@@ -30,7 +25,7 @@ def get_unreferenced_s3_builds(active_build_set, bucket, prefix):
     :type active_build_set: list
     """
     print(f"Looking for unreferenced builds in s3://{bucket}/{prefix}")
-    s3_subdirs = list_objects(bucket, f"{prefix}/", result_key='CommonPrefixes')
+    s3_subdirs = S3().list_objects(bucket, f"{prefix}/", result_key='CommonPrefixes')
     s3_matched = set()
     s3_unmatched = set()
     for prefixKey in s3_subdirs:
@@ -58,10 +53,10 @@ def fetch_build_meta(builds, buildid, arch, bucket, prefix):
         os.makedirs(build_dir, exist_ok=True)
         s3_key = f"{prefix}/{buildid}/{arch}/meta.json"
         print(f"Fetching meta.json for '{buildid}' from s3://{bucket}/{prefix} to {meta_json_path}")
-        head_result = head_object(bucket, s3_key)
+        head_result = S3().head_object(bucket, s3_key)
         if head_result:
             print(f"Found s3 key at {s3_key}")
-            download_file(bucket, s3_key, meta_json_path)
+            S3().download_file(bucket, s3_key, meta_json_path)
         else:
             print(f"Failed to find object at {s3_key}")
             return None
@@ -143,4 +138,4 @@ def delete_build(build, bucket, prefix, cloud_config, force=False):
 
     # Delete s3 bucket
     print(f"Deleting key {prefix}{build.id} from bucket {bucket}")
-    delete_object(bucket, f"{prefix}{str(build.id)}")
+    S3().delete_object(bucket, f"{prefix}{str(build.id)}")

--- a/src/cosalib/s3.py
+++ b/src/cosalib/s3.py
@@ -9,51 +9,46 @@ from cosalib.cmdlib import (
 from tenacity import retry
 
 
-S3 = boto3.client('s3')
-S3CONFIG = boto3.s3.transfer.TransferConfig(
-    num_download_attempts=5
-)
+class S3(object):
+    def __init__(self):
+        self.client = boto3.client('s3')
 
+    def download_file(self, bucket, key, dest):
+        self.client.download_file(bucket, key, dest,
+            Config=boto3.s3.transfer.TransferConfig(num_download_attempts=5))
 
-def download_file(bucket, key, dest):
-    S3.download_file(bucket, key, dest, Config=S3CONFIG)
+    @retry(stop=retry_stop, retry=retry_boto_exception, before_sleep=retry_callback)
+    def head_bucket(self, bucket):
+        self.client.head_bucket(Bucket=bucket)
 
+    @retry(stop=retry_stop, retry=retry_boto_exception, before_sleep=retry_callback)
+    def head_object(self, bucket, key):
+        try:
+            self.client.head_object(Bucket=bucket, Key=key)
+        except ClientError as e:
+            if e.response['Error']['Code'] == '404':
+                return False
+            raise e
+        return True
 
-@retry(stop=retry_stop, retry=retry_boto_exception, before_sleep=retry_callback)
-def head_bucket(bucket):
-    S3.head_bucket(Bucket=bucket)
+    @retry(stop=retry_stop, retry=retry_boto_exception, before_sleep=retry_callback)
+    def list_objects(self, bucket, prefix, delimiter="/", result_key='Contents'):
+        kwargs = {
+            'Bucket': bucket,
+            'Delimiter': delimiter,
+            'Prefix': prefix,
+        }
+        isTruncated = True
+        while isTruncated:
+            batch = self.client.list_objects_v2(**kwargs)
+            yield from batch.get(result_key) or []
+            kwargs['ContinuationToken'] = batch.get('NextContinuationToken')
+            isTruncated = batch['IsTruncated']
 
-
-@retry(stop=retry_stop, retry=retry_boto_exception, before_sleep=retry_callback)
-def head_object(bucket, key):
-    try:
-        S3.head_object(Bucket=bucket, Key=key)
-    except ClientError as e:
-        if e.response['Error']['Code'] == '404':
-            return False
-        raise e
-    return True
-
-
-@retry(stop=retry_stop, retry=retry_boto_exception, before_sleep=retry_callback)
-def list_objects(bucket, prefix, delimiter="/", result_key='Contents'):
-    kwargs = {
-        'Bucket': bucket,
-        'Delimiter': delimiter,
-        'Prefix': prefix,
-    }
-    isTruncated = True
-    while isTruncated:
-        batch = S3.list_objects_v2(**kwargs)
-        yield from batch.get(result_key) or []
-        kwargs['ContinuationToken'] = batch.get('NextContinuationToken')
-        isTruncated = batch['IsTruncated']
-
-
-@retry(stop=retry_stop, retry=retry_boto_exception, before_sleep=retry_callback)
-def delete_object(bucket, key):
-    sub_objects = list(list_objects(bucket, key))
-    if sub_objects != []:
-        print("S3: deleting {sub_objects}")
-        S3.delete_objects(Bucket=bucket, Delete=sub_objects)
-    S3.delete_object(Bucket=bucket, Key=key)
+    @retry(stop=retry_stop, retry=retry_boto_exception, before_sleep=retry_callback)
+    def delete_object(self, bucket, key):
+        sub_objects = list(self.list_objects(bucket, key))
+        if sub_objects != []:
+            print("S3: deleting {sub_objects}")
+            self.client.delete_objects(Bucket=bucket, Delete=sub_objects)
+        self.client.delete_object(Bucket=bucket, Key=key)


### PR DESCRIPTION
We recently did some golang migration [1] and happened to add the
`cosa remote-session` pieces [2] after that migration. This makes
it not easy to backport to other branches. For a period of time
let's use the latest COSA for our COSA pod for multi-arch builds
instead of the versioned COSA. We will still use the versioned COSA
on the remote so the actual building will happened with the correctly
versioned COSA (substituted below and passed as an argument to
`cosa remote-session create --image=`). However we still need to support
some of the new command line flags that were added to aid in the transition
to `cosa remote-session`. This PR backports various pieces needed.

[1] https://github.com/coreos/coreos-assembler/pull/2919
[2] https://github.com/coreos/coreos-assembler/pull/2979
