### PR TITLE
build: Restore summary value

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -446,7 +446,7 @@ fi
 cat > tmp/buildmeta.json <<EOF
 {
  "name": "${name}",
- "summary": "This field is unused",
+ "summary": "${summary//\"/\\\"}",
  "coreos-assembler.build-timestamp": "${build_timestamp}",
  "coreos-assembler.image-config-checksum": "${image_config_checksum}",
  "coreos-assembler.image-input-checksum": "${image_input_checksum}",

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -251,8 +251,9 @@ prepare_build() {
     # Abuse the rojig/name as the name of the VM images
     # Also grab rojig summary for image upload descriptions
     name=$(jq -r '.rojig.name' < "${flattened_manifest}")
+    summary=$(jq -r '.rojig.summary' < "${flattened_manifest}")
     ref=$(jq -r '.ref//""' < "${flattened_manifest}")
-    export name ref
+    export name ref summary
     # And validate fields coreos-assembler requires, but not rpm-ostree
     required_fields=("automatic-version-prefix")
     for field in "${required_fields[@]}"; do


### PR DESCRIPTION
I somehow completely missed that the value is used on AWS.

This should address https://github.com/coreos/fedora-coreos-tracker/issues/1300