### PR TITLE
s390x: use full path to default secex-hostkey

### DIFF
--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -34,7 +34,7 @@ EOF
 }
 
 # Parse options
-hostkey=src/config/secex-hostkey
+hostkey=/srv/src/config/secex-hostkey
 genprotimgvm=
 rc=0
 build=


### PR DESCRIPTION
Fix an issue introduced by https://github.com/coreos/coreos-assembler/pull/3025:
```
qemu-system-s390x: -drive if=none,id=hostkey,format=raw,file=src/config/secex-hostkey,readonly=on: Could not open 'src/config/secex-hostkey': No such file or directory
```