### PR TITLE
Move some fedora-coreos-releng-automation scripts here

### DIFF
--- a/src/fcos-versionary
+++ b/src/fcos-versionary
@@ -91,8 +91,8 @@ def get_y(manifest):
                 lockfile = yaml.safe_load(f)
                 generated = lockfile.get('metadata', {}).get('generated')
                 if not generated:
-                    raise Exception(f"Missing 'metadata.generated' key "
-                                    "from {lockfile}")
+                    raise Exception("Missing 'metadata.generated' key "
+                                    f"from {lockfile}")
                 dt = datetime.strptime(generated, '%Y-%m-%dT%H:%M:%SZ')
                 assert stream not in UNLOCKED_STREAMS
                 msg_src = "from lockfile"
@@ -129,7 +129,7 @@ def get_next_iteration(x, y, z):
         builds = {'builds': []}
 
     if len(builds['builds']) == 0:
-        eprint(f"n: 0 (no previous builds)")
+        eprint("n: 0 (no previous builds)")
         return 0
 
     last_buildid = builds['builds'][0]['id']

--- a/src/fcos-versionary
+++ b/src/fcos-versionary
@@ -1,0 +1,173 @@
+#!/usr/bin/python3 -u
+
+# This file originally lived in
+# https://github.com/coreos/fedora-coreos-releng-automation. See that repo for
+# archeological git research.
+
+'''
+    Implements the Fedora CoreOS versioning scheme as per:
+        https://github.com/coreos/fedora-coreos-tracker/issues/81
+        https://github.com/coreos/fedora-coreos-tracker/issues/211
+'''
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+import yaml
+
+from datetime import datetime
+
+# streams which don't use lockfiles
+UNLOCKED_STREAMS = [
+    'rawhide',
+    'branched',
+    'bodhi-updates-testing',
+    'bodhi-updates',
+]
+
+# https://github.com/coreos/fedora-coreos-tracker/issues/211#issuecomment-543547587
+STREAM_TO_NUM = {
+    'next': 1,
+    'testing': 2,
+    'stable': 3,
+    'next-devel': 10,
+    'testing-devel': 20,
+    'rawhide': 91,
+    'branched': 92,
+    'bodhi-updates-testing': 93,
+    'bodhi-updates': 94,
+}
+
+
+def main():
+    args = parse_args()
+    if args.workdir is not None:
+        os.chdir(args.workdir)
+    assert os.path.isdir('builds'), 'Missing builds/ dir'
+
+    manifest = get_flattened_manifest()
+    x, y, z = (get_x(manifest), get_y(manifest), get_z(manifest))
+    n = get_next_iteration(x, y, z)
+    new_version = f'{x}.{y}.{z}.{n}'
+
+    # sanity check the new version by trying to re-parse it
+    assert parse_version(new_version) is not None
+    print(new_version)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--workdir', help="path to cosa workdir")
+    return parser.parse_args()
+
+
+def get_x(manifest):
+    """
+        X is the Fedora release version on which we're based.
+    """
+    releasever = manifest['releasever']
+    eprint(f"x: {releasever} (from manifest)")
+    return int(releasever)
+
+
+def get_y(manifest):
+    """
+        Y is the base snapshot date in YYYYMMDD format of Fedora. We derive
+        this using the timestamp in the base lockfile.
+    """
+
+    stream = manifest['add-commit-metadata']['fedora-coreos.stream']
+
+    # XXX: should sanity check that the lockfiles for all the basearches have
+    # matching timestamps
+    exts = ['json', 'yaml']
+    for ext in exts:
+        try:
+            with open(f"src/config/manifest-lock.x86_64.{ext}") as f:
+                lockfile = yaml.safe_load(f)
+                generated = lockfile.get('metadata', {}).get('generated')
+                if not generated:
+                    raise Exception(f"Missing 'metadata.generated' key "
+                                    "from {lockfile}")
+                dt = datetime.strptime(generated, '%Y-%m-%dT%H:%M:%SZ')
+                assert stream not in UNLOCKED_STREAMS
+                msg_src = "from lockfile"
+                break
+        except FileNotFoundError:
+            continue
+    else:
+        # must be an unlocked stream
+        assert stream in UNLOCKED_STREAMS
+        msg_src = "unlocked stream"
+        dt = datetime.now()
+
+    ymd = dt.strftime('%Y%m%d')
+    eprint(f"y: {ymd} ({msg_src})")
+    return int(ymd)
+
+
+def get_z(manifest):
+    """
+        Z is the stream indicator.
+    """
+    stream = manifest['add-commit-metadata']['fedora-coreos.stream']
+    assert stream in STREAM_TO_NUM, f"Unknown stream: {stream}"
+    mapped = STREAM_TO_NUM[stream]
+    eprint(f"z: {mapped} (mapped from stream {stream})")
+    return mapped
+
+
+def get_next_iteration(x, y, z):
+    try:
+        with open('builds/builds.json') as f:
+            builds = json.load(f)
+    except FileNotFoundError:
+        builds = {'builds': []}
+
+    if len(builds['builds']) == 0:
+        eprint(f"n: 0 (no previous builds)")
+        return 0
+
+    last_buildid = builds['builds'][0]['id']
+    last_version = parse_version(last_buildid)
+    if not last_version:
+        eprint(f"n: 0 (previous version {last_buildid} does not match scheme)")
+        return 0
+
+    if (x, y, z) != last_version[:3]:
+        eprint(f"n: 0 (previous version {last_buildid} x.y.z does not match)")
+        return 0
+
+    n = last_version[3] + 1
+    eprint(f"n: {n} (incremented from previous version {last_buildid})")
+    return n
+
+
+def get_flattened_manifest():
+    return yaml.safe_load(
+        subprocess.check_output(['rpm-ostree', 'compose', 'tree',
+                                 '--print-only', 'src/config/manifest.yaml']))
+
+
+def parse_version(version):
+    m = re.match(r'^([0-9]{2})\.([0-9]{8})\.([0-9]+)\.([0-9]+)$', version)
+    if m is None:
+        return None
+    # sanity-check date
+    try:
+        time.strptime(m.group(2), '%Y%m%d')
+    except ValueError:
+        return None
+    return tuple(map(int, m.groups()))
+
+
+def eprint(*args):
+    print(*args, file=sys.stderr)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/fedmsg-broadcast
+++ b/src/fedmsg-broadcast
@@ -10,12 +10,10 @@
 '''
 
 import argparse
-import os
 import sys
 
 # Pick up libraries we use that are delivered along with COSA
 sys.path.insert(0, '/usr/lib/coreos-assembler')
-from cosalib.meta import GenericBuildMeta
 from cosalib.fedora_messaging_request import broadcast_fedmsg
 
 

--- a/src/fedmsg-broadcast
+++ b/src/fedmsg-broadcast
@@ -1,0 +1,117 @@
+#!/usr/bin/python3
+
+# This file originally lived in
+# https://github.com/coreos/fedora-coreos-releng-automation. See that repo for
+# archeological git research.
+
+'''
+    This script is used by the pipeline to send informational messages. It is a
+    thin wrapper around cosa's broadcast_fedmsg().
+'''
+
+import argparse
+import os
+import sys
+
+# Pick up libraries we use that are delivered along with COSA
+sys.path.insert(0, '/usr/lib/coreos-assembler')
+from cosalib.meta import GenericBuildMeta
+from cosalib.fedora_messaging_request import broadcast_fedmsg
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--fedmsg-conf",
+        metavar="CONFIG.TOML",
+        required=True,
+        help="fedora-messaging config file for publishing",
+    )
+    parser.add_argument(
+        "--stg",
+        action="store_true",
+        help="target the stg infra rather than prod",
+    )
+    parser.add_argument(
+        "--extra-fedmsg-keys",
+        action='append',
+        metavar='KEY=VAL',
+        default=[],
+        help="extra keys to inject into messages",
+    )
+
+    subparsers = parser.add_subparsers(dest='cmd', title='subcommands')
+    subparsers.required = True
+
+    build_state_change = subparsers.add_parser('build.state.change')
+    build_state_change.add_argument("--build", required=True)
+    build_state_change.add_argument("--basearch", required=True)
+    build_state_change.add_argument("--stream", required=True)
+    build_state_change.add_argument("--state", required=True)
+    build_state_change.add_argument("--build-dir")
+    build_state_change.add_argument("--result")
+    build_state_change.set_defaults(func=msg_build_state_change)
+
+    stream_release = subparsers.add_parser('stream.release')
+    stream_release.add_argument("--build", required=True)
+    stream_release.add_argument("--basearch", required=True)
+    stream_release.add_argument("--stream", required=True)
+    stream_release.set_defaults(func=msg_stream_release)
+
+    stream_metadata_update = subparsers.add_parser('stream.metadata.update')
+    stream_metadata_update.add_argument("--stream", required=True)
+    stream_metadata_update.set_defaults(func=msg_stream_metadata_update)
+
+    return parser.parse_args()
+
+
+def msg_build_state_change(args):
+    body = {
+        "build_id": args.build,
+        "basearch": args.basearch,
+        "stream": args.stream,
+        "state": args.state,
+        "build_dir": args.build_dir,
+    }
+    if args.result:
+        body['result'] = args.result
+    broadcast_fedmsg(
+        broadcast_type='build.state.change',
+        config=args.fedmsg_conf,
+        environment=args.environment,
+        body=body,
+    )
+
+
+def msg_stream_release(args):
+    broadcast_fedmsg(
+        broadcast_type='stream.release',
+        config=args.fedmsg_conf,
+        environment=args.environment,
+        body={
+            "build_id": args.build,
+            "basearch": args.basearch,
+            "stream": args.stream,
+        },
+    )
+
+
+def msg_stream_metadata_update(args):
+    broadcast_fedmsg(
+        broadcast_type='stream.metadata.update',
+        config=args.fedmsg_conf,
+        environment=args.environment,
+        body={
+            "stream": args.stream,
+        },
+    )
+
+
+def main():
+    args = parse_args()
+    args.environment = "stg" if args.stg else "prod"
+    args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/fedmsg-send-ostree-import-request
+++ b/src/fedmsg-send-ostree-import-request
@@ -1,0 +1,116 @@
+#!/usr/bin/python3
+
+# This file originally lived in
+# https://github.com/coreos/fedora-coreos-releng-automation. See that repo for
+# archeological git research.
+
+"""
+    This script is meant to be run from the Fedora CoreOS build
+    pipeline (see https://github.com/coreos/fedora-coreos-pipeline.git)
+    It makes an OSTree import request to the coreos-ostree-importer
+    running in Fedora's Infra OpenShift cluster.
+"""
+
+import argparse
+import os
+import sys
+
+# Pick up libraries we use that are delivered along with COSA
+sys.path.insert(0, '/usr/lib/coreos-assembler')
+from cosalib.meta import GenericBuildMeta
+from cosalib.fedora_messaging_request import send_request_and_wait_for_response
+from cosalib.cmdlib import get_basearch
+
+# Example datagrepper URLs to inspect sent messages:
+# https://apps.fedoraproject.org/datagrepper/raw?topic=org.fedoraproject.prod.coreos.build.request.ostree-import&delta=100000
+# https://apps.stg.fedoraproject.org/datagrepper/raw?topic=org.fedoraproject.stg.coreos.build.request.ostree-import&delta=100000
+# https://apps.fedoraproject.org/datagrepper/raw?topic=org.fedoraproject.prod.coreos.build.request.ostree-import.finished&delta=100000
+# https://apps.stg.fedoraproject.org/datagrepper/raw?topic=org.fedoraproject.stg.coreos.build.request.ostree-import.finished&delta=100000
+
+# Give the importer some time to do the import
+OSTREE_IMPORTER_REQUEST_TIMEOUT_SEC = 15 * 60
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--build", help="Build ID", required=True)
+    parser.add_argument(
+        "--arch", help="target architecture", default=get_basearch()
+    )
+    parser.add_argument(
+        "--fedmsg-conf",
+        metavar="CONFIG.TOML",
+        required=True,
+        help="fedora-messaging config file for publishing",
+    )
+    parser.add_argument(
+        "--stg", action="store_true", help="target the stg infra rather than prod"
+    )
+    parser.add_argument(
+        "--s3",
+        metavar="<BUCKET>[/PREFIX]",
+        required=True,
+        help="bucket and prefix to S3 builds/ dir",
+    )
+    parser.add_argument(
+        "--repo",
+        choices=["prod", "compose"],
+        required=True,
+        help="the name of the OSTree repo within Fedora to import into",
+    )
+    return parser.parse_args()
+
+
+def send_ostree_import_request(args):
+    if args.build == 'latest':
+        raise Exception("Refusing to ostree import generic 'latest' build ID")
+    build = GenericBuildMeta(build=args.build, basearch=args.arch)
+
+    bucket, prefix = get_bucket_and_prefix(args.s3)
+    environment = "prod"
+    if args.stg:
+        environment = "stg"
+
+    # Example: https://fcos-builds.s3.amazonaws.com/prod/streams/stable/builds/31.20200127.3.0/x86_64/fedora-coreos-31.20200127.3.0-ostree.x86_64.tar
+    commit_url = f"https://{bucket}.s3.amazonaws.com/{prefix}/builds/{args.build}/{args.arch}/{build['images']['ostree']['path']}"
+
+    response = send_request_and_wait_for_response(
+        request_type="ostree-import",
+        config=args.fedmsg_conf,
+        environment=environment,
+        request_timeout=OSTREE_IMPORTER_REQUEST_TIMEOUT_SEC,
+        body={
+            "build_id": args.build,
+            "basearch": args.arch,
+            "commit_url": commit_url,
+            "checksum": "sha256:" + build["images"]["ostree"]["sha256"],
+            "ostree_ref": build["ref"],
+            "ostree_checksum": build["ostree-commit"],
+            "target_repo": args.repo,
+        },
+    )
+    validate_response(response)
+
+
+def get_bucket_and_prefix(path):
+    split = path.split("/", 1)
+    if len(split) == 1:
+        return (split[0], "")
+    return split
+
+
+def validate_response(response):
+    if response["status"].lower() == "failure":
+        # https://pagure.io/robosignatory/pull-request/38
+        if "failure-message" not in response:
+            raise Exception("Importing failed")
+        raise Exception(f"Importing failed: {response['failure-message']}")
+    assert response["status"].lower() == "success", str(response)
+
+
+def main():
+    args = parse_args()
+    send_ostree_import_request(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/fedmsg-send-ostree-import-request
+++ b/src/fedmsg-send-ostree-import-request
@@ -12,7 +12,6 @@
 """
 
 import argparse
-import os
 import sys
 
 # Pick up libraries we use that are delivered along with COSA
@@ -29,6 +28,7 @@ from cosalib.cmdlib import get_basearch
 
 # Give the importer some time to do the import
 OSTREE_IMPORTER_REQUEST_TIMEOUT_SEC = 15 * 60
+
 
 def parse_args():
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
We have some loose scripts in the fedora-coreos-releng-automation repo used by the FCOS pipeline. It's always been awkward however: some of the scripts import cosa Python/shell APIs, and the pipeline has to clone the repo just to use the standalone scripts.

Initially I had thought we'd eventually find a way to have a sort of sidecar container to make that cleaner, but... that never happened. Another idea was a layered cosa image, but experience since then has shown deriving the cosa image has many downsides.

Purely for practical purposes, let's just have them in cosa directly. It's not an ideal fit but OTOH we already have a lot of FCOS-specific things in here. This will allow us to clean up the pipeline code and the automation repo.

I've renamed the scripts from their original names so that they're no longer suffixed by `.py` since that's an implementation detail, and prefixed by `fcos` or `fedmsg` to make clearer their scopes.