### PR TITLE
Fix: error: Found argument 'pack' which wasn't expected, or isn't valid in this context

### DIFF
--- a/src/osmet-pack
+++ b/src/osmet-pack
@@ -79,7 +79,7 @@ esac
 
 # We don't want double quotes (for both `coreinst` and `fast`, which may be '')
 # shellcheck disable=SC2086
-RUST_BACKTRACE=full ${coreinst} pack osmet /dev/disk/by-id/virtio-osmet \
+RUST_BACKTRACE=full ${coreinst} osmet pack /dev/disk/by-id/virtio-osmet \
     --description "${description}" \
     --checksum "${checksum}" \
     --output /tmp/osmet.bin $fast


### PR DESCRIPTION
When buildextend-live:

```
    + chroot /sysroot/ostree/deploy/CeaOS/deploy/925bbb77377e20f3462744c901b660416defd914fd0b90e5eef64fd25e297052.0 coreos-installer pack osmet /dev/disk/by-id/virtio-osmet --description 'CeaOS 9' --checksum d20f55856d5b30bb372370bd53274a2876d88dd79dcadaf98cbc90d613a8afe1 --output /tmp/osmet.bin
    error: Found argument 'pack' which wasn't expected, or isn't valid in this context

    USAGE:
        coreos-installer
        coreos-installer <SUBCOMMAND>

    For more information try --help
    Error running command /usr/lib/coreos-assembler/osmet-pack
```

Link: https://github.com/coreos/coreos-assembler/issues/3116