### PR TITLE
buildextend-secex: Make genprotimgvm the default path

### DIFF
--- a/cmd/remote-session.go
+++ b/cmd/remote-session.go
@@ -138,6 +138,7 @@ func runCreate(c *cobra.Command, args []string) error {
 		"--pull=always", "--privileged", "--security-opt=label=disable",
 		"--volume", remoteSessionOpts.CreateWorkdir,
 		"--workdir", remoteSessionOpts.CreateWorkdir,
+		"--volume=secex-data:/data.secex:ro",
 		"--uidmap=1000:0:1", "--uidmap=0:1:1000", "--uidmap=1001:1001:64536",
 		"--device=/dev/kvm", "--device=/dev/fuse", "--tmpfs=/tmp",
 		"--entrypoint=/usr/bin/dumb-init", remoteSessionOpts.CreateImage,

--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -34,8 +34,8 @@ EOF
 }
 
 # Parse options
-hostkey=/srv/src/config/secex-hostkey
-genprotimgvm=
+hostkey=
+genprotimgvm=/data.secex/genprotimgvm.qcow2
 rc=0
 build=
 force=
@@ -187,15 +187,18 @@ qemu_args=()
 # SecureExecution extra stuff
 if [[ $secure_execution -eq "1" ]]; then
     disk_args+=("--with-secure-execution")
-    if [ -z "${genprotimgvm}" ]; then
-        qemu_args+=("-drive" "if=none,id=hostkey,format=raw,file=$hostkey,readonly=on" \
-                            "-device" "virtio-blk,serial=hostkey,drive=hostkey")
-    else
+    if [ -z "${hostkey}" ]; then
+        if [ ! -f "${genprotimgvm}" ]; then
+            fatal "No genprotimgvm provided at ${genprotimgvm}"
+        fi
         genprotimg_img="${PWD}/secex-genprotimg.img"
         qemu-img create -f raw "${genprotimg_img}" 512M
         mkfs.ext4 "${genprotimg_img}"
         qemu_args+=("-drive" "if=none,id=genprotimg,format=raw,file=${genprotimg_img}" \
                             "-device" "virtio-blk,serial=genprotimg,drive=genprotimg")
+    else
+        qemu_args+=("-drive" "if=none,id=hostkey,format=raw,file=$hostkey,readonly=on" \
+                            "-device" "virtio-blk,serial=hostkey,drive=hostkey")
     fi
 fi
 
@@ -268,7 +271,7 @@ runvm "${qemu_args[@]}" -- \
             ${platforms_json:+--platforms-json "${platforms_json}"} \
             "${disk_args[@]}"
 
-if [[ $secure_execution -eq "1" && -n "${genprotimgvm}" ]]; then
+if [[ $secure_execution -eq "1" && -z "${hostkey}" ]]; then
     /usr/lib/coreos-assembler/secex-genprotimgvm-scripts/runvm.sh \
         --genprotimgvm "${genprotimgvm}" -- "${qemu_args[@]}"
 fi


### PR DESCRIPTION
Enable buildextend-secex to run without arguments by making genprotimgvm the default path and adding a default location for the genprotimgvm qcow2 file.

Always mount the volume secex-data in cosa remote sessions.

These changes enable buildextend-secex to be run in the fcos pipeline without changes to the pipeline code.

Signed-off-by: Jan Schintag <jan.schintag@de.ibm.com>