### PR TITLE
ci: lower CPU requests and allocate 1.5G per CPU

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -2,10 +2,12 @@
 
 // Build coreos-assembler image and create
 // an imageStream for it
-def cpuCount = "8".toString()
-def imageName = buildImage(env: [ENABLE_GO_RACE_DETECTOR: "1", GOMAXPROCS: cpuCount], cpu: cpuCount)
+def cpuCount = 6
+def cpuCount_s = cpuCount.toString()
+def imageName = buildImage(env: [ENABLE_GO_RACE_DETECTOR: "1", GOMAXPROCS: cpuCount_s], cpu: cpuCount_s)
 
-pod(image: imageName + ":latest", kvm: true, cpu: cpuCount, memory: "10Gi") {
+def memory = (cpuCount * 1536) as Integer
+pod(image: imageName + ":latest", kvm: true, cpu: "${cpuCount}", memory: "${memory}Mi") {
     checkout scm
 
     stage("Unit tests") {


### PR DESCRIPTION
This roughly matches what we do now in e.g. the FCOS pipeline and a few other places. Otherwise, we may hit against our memory limit and get evicted.

See https://github.com/coreos/coreos-assembler/issues/3118 for more background info.