### PR TITLE
cmd-buildextend-live: use virtio-serial for osmet

### DIFF
--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -311,16 +311,17 @@ def generate_iso():
         fast_arg = ['--fast']
     print('Generating osmet file for 512b metal image')
     runcmd(['/usr/lib/coreos-assembler/runvm-coreos-installer', img_metal,
-            'pack', 'osmet', '/dev/disk/by-id/virtio-coreos', '--description',
-            pretty_name, '--checksum', img_metal_checksum, '--output',
-            tmp_osmet] + fast_arg)
+            tmp_osmet, 'pack', 'osmet', '/dev/disk/by-id/virtio-coreos',
+            '--description', pretty_name, '--checksum', img_metal_checksum,
+            '--output', '/var/tmp/coreos-installer-output'] + fast_arg)
     if img_metal4k_obj:
         tmp_osmet4k = os.path.join(tmpinitrd_rootfs, img_metal4k_obj['path'] + '.osmet')
         print('Generating osmet file for 4k metal image')
         runcmd(['/usr/lib/coreos-assembler/runvm-coreos-installer',
-                img_metal4k, 'pack', 'osmet', '/dev/disk/by-id/virtio-coreos',
-                '--description', pretty_name, '--checksum',
-                img_metal4k_checksum, '--output', tmp_osmet4k] + fast_arg)
+                img_metal4k, tmp_osmet4k, 'pack', 'osmet',
+                '/dev/disk/by-id/virtio-coreos', '--description', pretty_name,
+                '--checksum', img_metal4k_checksum, '--output',
+                '/var/tmp/coreos-installer-output'] + fast_arg)
 
     # Generate root squashfs
     print(f'Compressing squashfs with {squashfs_compression}')
@@ -676,7 +677,7 @@ boot
     if basearch == "x86_64":
         runcmd(['/usr/bin/isohybrid', '--uefi', f'{tmpisofile}.minimal'])
     # this consumes the minimal image
-    runcmd(['/usr/lib/coreos-assembler/runvm-coreos-installer', img_metal,
+    runcmd(['/usr/lib/coreos-assembler/runvm-coreos-installer', img_metal, '',
             'pack', 'minimal-iso', tmpisofile, f'{tmpisofile}.minimal',
             '--consume'])
 

--- a/src/runvm-coreos-installer
+++ b/src/runvm-coreos-installer
@@ -3,8 +3,10 @@ set -euo pipefail
 
 # This script runs the coreos-installer found in the compose itself inside a
 # chroot inside a supermin VM. The first argument is the path to the metal
-# image. All following arguments are passed as is to coreos-installer.
-# The metal image is available as /dev/disk/by-id/virtio-coreos.
+# image. It will be available as /dev/disk/by-id/virtio-coreos. The second
+# argument is an optional path to an output file. It will be available as
+# /var/tmp/coreos-installer-output. All following arguments are passed as is to
+# coreos-installer.
 
 if [ ! -f /etc/cosa-supermin ]; then
     dn=$(dirname "$0")
@@ -12,6 +14,8 @@ if [ ! -f /etc/cosa-supermin ]; then
     . "${dn}"/cmdlib.sh
 
     img_src=$1; shift
+    output_path=$1; shift
+
     if [[ $img_src == *.gz || $img_src == *.xz ]]; then
         img="$(basename "$img_src")"
         fatal "Cannot pack osmet from $img; not an uncompressed image"
@@ -24,9 +28,15 @@ if [ ! -f /etc/cosa-supermin ]; then
         device_opts=",physical_block_size=4096,logical_block_size=4096"
     fi
 
-    # stamp it with "coreos" serial so we find it easily in the VM
+    virtioserial_args=()
+    if [ -n "${output_path}" ]; then
+        virtioserial_args+=(-chardev "file,id=coreosout,path=${output_path}" \
+                            -device "virtserialport,chardev=coreosout,name=coreosout")
+    fi
+
     runvm -drive "if=none,id=coreos,format=raw,readonly=on,file=${img_src}" \
-        -device "virtio-blk,serial=coreos,drive=coreos${device_opts}" -- \
+        -device "virtio-blk,serial=coreos,drive=coreos${device_opts}" \
+        "${virtioserial_args[@]}" -- \
         /usr/lib/coreos-assembler/runvm-coreos-installer "$@"
 
     exit 0
@@ -58,3 +68,8 @@ mount --bind "${workdir}" "${deploydir}/${workdir}"
 set -x
 
 RUST_BACKTRACE=full chroot "${deploydir}" env -C "${workdir}" coreos-installer "$@"
+
+# and now transfer out the output file if provided (see header)
+if [ -f /var/tmp/coreos-installer-output ]; then
+    cp /var/tmp/coreos-installer-output /dev/virtio-ports/coreosout
+fi

--- a/src/runvm-coreos-installer
+++ b/src/runvm-coreos-installer
@@ -34,8 +34,6 @@ fi
 
 # This runs inside supermin
 
-set -x
-
 mkdir -p /sysroot
 rootfs=/dev/disk/by-id/virtio-coreos-part4
 mount -o ro "${rootfs}" /sysroot
@@ -55,5 +53,8 @@ mkdir -p "${deploydir}/var/"{home,mnt,opt,roothome,srv}
 workdir=$(pwd)
 mkdir -p "${deploydir}/${workdir}/"
 mount --bind "${workdir}" "${deploydir}/${workdir}"
+
+# echo back the invocation
+set -x
 
 RUST_BACKTRACE=full chroot "${deploydir}" env -C "${workdir}" coreos-installer "$@"


### PR DESCRIPTION
We keep hitting issues in the pipeline with osmet packing triggering the
9p bug. Rework it so that we use virtio-serial instead.

For some reason, the miniso packing step doesn't trigger that same
issue. Possibly because it's only modifying an existing file over 9p
rather than creating a new one? Not sure. Hopefully, we can get off 9p
soon (https://github.com/coreos/coreos-assembler/issues/1812).

Closes: https://github.com/coreos/fedora-coreos-tracker/issues/1294