### PR TITLE
cosash: Ensure we always inject trailing newline into commands

### DIFF
--- a/internal/pkg/cosash/cosash.go
+++ b/internal/pkg/cosash/cosash.go
@@ -137,6 +137,11 @@ func (r *CosaSh) ProcessWithReply(buf string) (string, error) {
 	if _, err := io.WriteString(r.input, buf); err != nil {
 		return "", err
 	}
+	if !strings.HasSuffix(buf, "\n") {
+		if _, err := io.WriteString(r.input, "\n"); err != nil {
+			return "", err
+		}
+	}
 
 	select {
 	case reply := <-r.replychan:


### PR DESCRIPTION
The `HasPrivileges()` API would hang forever because it didn't have a trailing newline in the command emitted.  This took me some time to figure out.  Let's fix this by auto-injecting a trailing newline automatically to entirely avoid the problem.