### PR TITLE
build-extensions-container: add more logging

### DIFF
--- a/cmd/build-extensions-container.go
+++ b/cmd/build-extensions-container.go
@@ -45,6 +45,9 @@ func buildExtensionContainer() error {
 	if err := exec.Command("/usr/lib/coreos-assembler/finalize-artifact", filepath.Join(tmpdir, targetname), targetPath).Run(); err != nil {
 		return err
 	}
+
+	fmt.Printf("Built %s\n", targetPath)
+
 	// Gather metadata of the OCI archive (sha256, size)
 	file, err := os.Open(targetPath)
 	if err != nil {
@@ -94,5 +97,7 @@ func buildExtensionContainer() error {
 	if err != nil {
 		return err
 	}
+
+	fmt.Printf("Updated %s\n", metapath)
 	return nil
 }

--- a/src/cmd-buildextend-legacy-oscontainer
+++ b/src/cmd-buildextend-legacy-oscontainer
@@ -131,3 +131,4 @@ metapath_new = f"{metapath}.new"
 with open(metapath_new, 'w') as f:
     json.dump(meta, f, sort_keys=True)
 shutil.move(metapath_new, metapath)
+print(f"Updated {metapath}")


### PR DESCRIPTION
Log when the `extensions-container` artifact was built, and at the very end when `meta.json` was updated. This makes it easier to tell when looking at pipeline output that the command successfully finished.

While we're here, do the same for `cmd-buildextend-legacy-oscontainer`.