### PR TITLE
Revert "mantle: use `os.ReadDir` for lightweight directory reading"

### DIFF
--- a/mantle/cmd/kola/switchkernel.go
+++ b/mantle/cmd/kola/switchkernel.go
@@ -17,6 +17,7 @@ package main
 import (
 	"encoding/base64"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"regexp"
 	"strings"
@@ -150,7 +151,7 @@ func runSwitchKernel(cmd *cobra.Command, args []string) error {
 func dropRpmFilesAll(m platform.Machine, localPath string) error {
 	fmt.Println("Dropping RT Kernel RPMs...")
 	re := regexp.MustCompile(`^kernel-rt-.*\.rpm$`)
-	files, err := os.ReadDir(localPath)
+	files, err := ioutil.ReadDir(localPath)
 	if err != nil {
 		return err
 	}

--- a/mantle/util/repo.go
+++ b/mantle/util/repo.go
@@ -16,6 +16,7 @@ package util
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -66,7 +67,7 @@ func GetLocalFastBuildQemu() (string, error) {
 		}
 		return "", err
 	}
-	ents, err := os.ReadDir(fastBuildCosaDir)
+	ents, err := ioutil.ReadDir(fastBuildCosaDir)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Reverts coreos/coreos-assembler#3082

See https://github.com/coreos/coreos-assembler/issues/3135

I'm working on a fix for the underlying issue but revert this until it's ready.