### PR TITLE
cmd/build-extensions-container: set SkipCompression to true for artifact

### DIFF
--- a/cmd/build-extensions-container.go
+++ b/cmd/build-extensions-container.go
@@ -82,7 +82,7 @@ func buildExtensionContainer() error {
 		Path:            targetname,
 		Sha256:          sha256sum,
 		SizeInBytes:     float64(stat.Size()),
-		SkipCompression: false,
+		SkipCompression: true,
 	}
 
 	newBytes, err := json.MarshalIndent(cosaBuild, "", "    ")


### PR DESCRIPTION
We don't want to compress an ociarchive (already a compressed format). Let's set it up to skip compression in the archive stage.