### PR TITLE
cmd-buildextend-legacy-oscontainer: hack around broken 9p

### DIFF
--- a/cmd/build-extensions-container.go
+++ b/cmd/build-extensions-container.go
@@ -31,7 +31,7 @@ func buildExtensionContainer() error {
 	if _, err := sh.PrepareBuild(); err != nil {
 		return err
 	}
-	targetname := "extensions-container-" + buildID + "." + arch + ".ociarchive"
+	targetname := lastBuild.Name + "-" + buildID + "-extensions-container" + "." + arch + ".ociarchive"
 	process := "runvm -- /usr/lib/coreos-assembler/build-extensions-container.sh " + arch + " $tmp_builddir/" + targetname + " " + buildID
 	if err := sh.Process(process); err != nil {
 		return err

--- a/src/buildextend-legacy-oscontainer.py
+++ b/src/buildextend-legacy-oscontainer.py
@@ -90,9 +90,9 @@ def oscontainer_extract(containers_storage, tmpdir, src, dest,
 # Given an OSTree repository at src (and exactly one ref) generate an
 # oscontainer with it.
 def oscontainer_build(containers_storage, tmpdir, src, ref, image_name_and_tag,
-                      base_image, push=False, tls_verify=True, pushformat=None,
+                      base_image, tls_verify=True, pushformat=None,
                       add_directories=[], cert_dir="", authfile="", digestfile=None,
-                      display_name=None, labeled_pkgs=[]):
+                      ociarchive=None, display_name=None, labeled_pkgs=[]):
     r = OSTree.Repo.new(Gio.File.new_for_path(src))
     r.open(None)
 
@@ -206,7 +206,7 @@ def oscontainer_build(containers_storage, tmpdir, src, ref, image_name_and_tag,
         subprocess.call(buildah_base_argv + ['umount', bid], stdout=subprocess.DEVNULL)
         subprocess.call(buildah_base_argv + ['rm', bid], stdout=subprocess.DEVNULL)
 
-    if push:
+    if ociarchive:
         print("Saving container to oci-archive")
         podCmd = buildah_base_argv + ['push']
 
@@ -224,7 +224,7 @@ def oscontainer_build(containers_storage, tmpdir, src, ref, image_name_and_tag,
 
         podCmd.append(image_name_and_tag)
 
-        podCmd.append(f'oci-archive:{builddir}/{image_name_and_tag}')
+        podCmd.append(f'oci-archive:{ociarchive}')
 
         cmdlib.runcmd(podCmd)
     elif digestfile is not None:
@@ -271,10 +271,7 @@ def main():
         help="Write image digest to file",
         action='store',
         metavar='FILE')
-    parser_build.add_argument(
-        "--push",
-        help="Push to registry",
-        action='store_true')
+    parser.add_argument("--ociarchive", help="Write image as OCI archive to file")
     args = parser.parse_args()
 
     labeled_pkgs = []
@@ -306,8 +303,8 @@ def main():
                 getattr(args, 'from'),
                 display_name=args.display_name,
                 digestfile=args.digestfile,
+                ociarchive=args.ociarchive,
                 add_directories=args.add_directory,
-                push=args.push,
                 pushformat=args.format,
                 tls_verify=not args.disable_tls_verify,
                 cert_dir=args.cert_dir,

--- a/src/buildextend-legacy-oscontainer.sh
+++ b/src/buildextend-legacy-oscontainer.sh
@@ -3,5 +3,12 @@
 set -euo pipefail
 # Start VM and call buildah
 . /usr/lib/coreos-assembler/cmdlib.sh
+final_outfile=$(realpath "$1"); shift
 prepare_build
-runvm -- /usr/lib/coreos-assembler/buildextend-legacy-oscontainer.py "$@"
+# shellcheck disable=SC2154
+tmp_outfile=${tmp_builddir}/legacy-oscontainer.ociarchive
+runvm -chardev "file,id=ociarchiveout,path=${tmp_outfile}" \
+    -device "virtserialport,chardev=ociarchiveout,name=ociarchiveout" -- \
+    /usr/lib/coreos-assembler/buildextend-legacy-oscontainer.py \
+        --ociarchive "/dev/virtio-ports/ociarchiveout" "$@"
+/usr/lib/coreos-assembler/finalize-artifact "${tmp_outfile}" "${final_outfile}"

--- a/src/cmd-buildextend-legacy-oscontainer
+++ b/src/cmd-buildextend-legacy-oscontainer
@@ -32,7 +32,7 @@ metapath = f"{latest_build_path}/meta.json"
 with open(metapath) as f:
     meta = json.load(f)
 
-name = meta['name'] + '-' + meta['buildid'] + '-oscontainer.' + arch + '.ociarchive'
+name = meta['name'] + '-' + meta['buildid'] + '-legacy-oscontainer.' + arch + '.ociarchive'
 parser = argparse.ArgumentParser()
 parser.add_argument("--arch-tag", help="append arch name to push tag",
                     action='store_true')

--- a/src/cmd-buildextend-legacy-oscontainer
+++ b/src/cmd-buildextend-legacy-oscontainer
@@ -105,6 +105,7 @@ if args.arch_tag:
 # TODO: Remove --from
 print("Entering vm to build oscontainer for build: {}".format(latest_build))
 
+oci_archive = f"{latest_build_path}/{args.name}"
 cosa_argv = (['/usr/lib/coreos-assembler/buildextend-legacy-oscontainer.sh', '--workdir=./tmp', 'build', f'--from={args.from_image}'])
 for d in args.add_directory:
     cosa_argv.append(f'--add-directory="{d}"')
@@ -115,12 +116,11 @@ if 'labeled-packages' in configyaml:
 if args.format is not None:
     cosa_argv.append(f'--format={args.format}')
 subprocess.check_call(cosa_argv +
-    ['--push', tmprepo,
+    ['--ociarchive', oci_archive, tmprepo,
         meta['ostree-commit'],
         osc_name_and_tag])
 
 # Inject the oscontainer with SHA256 into the build metadata
-oci_archive = f"{latest_build_path}/{args.name}"
 meta['images']['legacy-oscontainer'] = {'path': args.name,
                                         'sha256': sha256sum_file(oci_archive),
                                         'size': os.path.getsize(oci_archive),

--- a/src/cmd-buildextend-legacy-oscontainer
+++ b/src/cmd-buildextend-legacy-oscontainer
@@ -106,7 +106,7 @@ if args.arch_tag:
 print("Entering vm to build oscontainer for build: {}".format(latest_build))
 
 oci_archive = f"{latest_build_path}/{args.name}"
-cosa_argv = (['/usr/lib/coreos-assembler/buildextend-legacy-oscontainer.sh', '--workdir=./tmp', 'build', f'--from={args.from_image}'])
+cosa_argv = (['/usr/lib/coreos-assembler/buildextend-legacy-oscontainer.sh', oci_archive, '--workdir=./tmp', 'build', f'--from={args.from_image}'])
 for d in args.add_directory:
     cosa_argv.append(f'--add-directory="{d}"')
 cosa_argv.append(f'--display-name="{display_name}"')
@@ -115,10 +115,7 @@ if 'labeled-packages' in configyaml:
     cosa_argv.append(f'--labeled-packages="{pkgs}"')
 if args.format is not None:
     cosa_argv.append(f'--format={args.format}')
-subprocess.check_call(cosa_argv +
-    ['--ociarchive', oci_archive, tmprepo,
-        meta['ostree-commit'],
-        osc_name_and_tag])
+subprocess.check_call(cosa_argv + [tmprepo, meta['ostree-commit'], osc_name_and_tag])
 
 # Inject the oscontainer with SHA256 into the build metadata
 meta['images']['legacy-oscontainer'] = {'path': args.name,

--- a/src/cmd-buildextend-legacy-oscontainer
+++ b/src/cmd-buildextend-legacy-oscontainer
@@ -106,7 +106,7 @@ if args.arch_tag:
 print("Entering vm to build oscontainer for build: {}".format(latest_build))
 
 oci_archive = f"{latest_build_path}/{args.name}"
-cosa_argv = (['/usr/lib/coreos-assembler/buildextend-legacy-oscontainer.sh', oci_archive, '--workdir=./tmp', 'build', f'--from={args.from_image}'])
+cosa_argv = (['/usr/lib/coreos-assembler/buildextend-legacy-oscontainer.sh', oci_archive, 'build', f'--from={args.from_image}'])
 for d in args.add_directory:
     cosa_argv.append(f'--add-directory="{d}"')
 cosa_argv.append(f'--display-name="{display_name}"')

--- a/src/cmd-buildextend-legacy-oscontainer
+++ b/src/cmd-buildextend-legacy-oscontainer
@@ -103,7 +103,6 @@ if args.arch_tag:
 # TODO: Use labels for the build hash and avoid pulling the oscontainer
 # every time we want to poll.
 # TODO: Remove --from
-digestfile = "tmp/oscontainer-digest"
 print("Entering vm to build oscontainer for build: {}".format(latest_build))
 
 cosa_argv = (['/usr/lib/coreos-assembler/buildextend-legacy-oscontainer.sh', '--workdir=./tmp', 'build', f'--from={args.from_image}'])
@@ -116,8 +115,7 @@ if 'labeled-packages' in configyaml:
 if args.format is not None:
     cosa_argv.append(f'--format={args.format}')
 subprocess.check_call(cosa_argv +
-    [f'--digestfile={digestfile}',
-        '--push', tmprepo,
+    ['--push', tmprepo,
         meta['ostree-commit'],
         osc_name_and_tag])
 


### PR DESCRIPTION
We're seeing the classic ENOMEM error from `cosa
buildextend-legacy-oscontainer` when trying to write back the legacy
oscontainer over 9p. Instead, have the supermin VM output the final OCI
archive over virtio-serial.