### PR TITLE
buildextend-legacy-oscontainer.py: various minor tweaks

### DIFF
--- a/src/buildextend-legacy-oscontainer.py
+++ b/src/buildextend-legacy-oscontainer.py
@@ -7,6 +7,9 @@
 #
 # This command manipulates those images.
 
+# This file was forked from src/oscontainer-deprecated-legacy-format.py and is
+# now only used to build the legacy oscontainer via supermin.
+
 import gi
 
 gi.require_version('OSTree', '1.0')

--- a/src/buildextend-legacy-oscontainer.py
+++ b/src/buildextend-legacy-oscontainer.py
@@ -94,7 +94,7 @@ def oscontainer_extract(containers_storage, tmpdir, src, dest,
 # oscontainer with it.
 def oscontainer_build(containers_storage, tmpdir, src, ref, image_name_and_tag,
                       base_image, tls_verify=True, pushformat=None,
-                      add_directories=[], cert_dir="", authfile="", digestfile=None,
+                      add_directories=[], cert_dir="", authfile="",
                       output=None, display_name=None, labeled_pkgs=[]):
     r = OSTree.Repo.new(Gio.File.new_for_path(src))
     r.open(None)
@@ -212,9 +212,6 @@ def oscontainer_build(containers_storage, tmpdir, src, ref, image_name_and_tag,
     print("Saving container to oci-archive")
     podCmd = buildah_base_argv + ['push']
 
-    if digestfile is not None:
-        podCmd.append(f'--digestfile={digestfile}')
-
     if pushformat is not None:
         podCmd.append(f'--format={pushformat}')
 
@@ -264,11 +261,6 @@ def main():
     parser_build.add_argument("--labeled-packages", help="Packages whose NEVRAs are included as labels on the image")
     # For now we forcibly override to v2s2 https://bugzilla.redhat.com/show_bug.cgi?id=2058421
     parser_build.add_argument("--format", help="Pass through push format to buildah", default="v2s2")
-    parser_build.add_argument(
-        "--digestfile",
-        help="Write image digest to file",
-        action='store',
-        metavar='FILE')
     parser.add_argument("--output", required=True, help="Write image as OCI archive to file")
     args = parser.parse_args()
 
@@ -300,7 +292,6 @@ def main():
                 containers_storage, tmpdir, args.src, args.rev, args.name,
                 getattr(args, 'from'),
                 display_name=args.display_name,
-                digestfile=args.digestfile,
                 output=args.output,
                 add_directories=args.add_directory,
                 pushformat=args.format,

--- a/src/buildextend-legacy-oscontainer.py
+++ b/src/buildextend-legacy-oscontainer.py
@@ -209,31 +209,26 @@ def oscontainer_build(containers_storage, tmpdir, src, ref, image_name_and_tag,
         subprocess.call(buildah_base_argv + ['umount', bid], stdout=subprocess.DEVNULL)
         subprocess.call(buildah_base_argv + ['rm', bid], stdout=subprocess.DEVNULL)
 
-    if output:
-        print("Saving container to oci-archive")
-        podCmd = buildah_base_argv + ['push']
+    print("Saving container to oci-archive")
+    podCmd = buildah_base_argv + ['push']
 
-        if digestfile is not None:
-            podCmd.append(f'--digestfile={digestfile}')
+    if digestfile is not None:
+        podCmd.append(f'--digestfile={digestfile}')
 
-        if pushformat is not None:
-            podCmd.append(f'--format={pushformat}')
+    if pushformat is not None:
+        podCmd.append(f'--format={pushformat}')
 
-        # Historically upload-oscontainer would require --name which was in our
-        # pipeline a repository URL. Going forward buildextend-legacy-oscontainer
-        # just creates an oci-archive and a url is not a valid name/tag combination.
-        if '/' in image_name_and_tag:
-            image_name_and_tag = image_name_and_tag.rsplit('/', 1)[1]
+    # Historically upload-oscontainer would require --name which was in our
+    # pipeline a repository URL. Going forward buildextend-legacy-oscontainer
+    # just creates an oci-archive and a url is not a valid name/tag combination.
+    if '/' in image_name_and_tag:
+        image_name_and_tag = image_name_and_tag.rsplit('/', 1)[1]
 
-        podCmd.append(image_name_and_tag)
+    podCmd.append(image_name_and_tag)
 
-        podCmd.append(f'oci-archive:{output}')
+    podCmd.append(f'oci-archive:{output}')
 
-        cmdlib.runcmd(podCmd)
-    elif digestfile is not None:
-        inspect = run_get_json(buildah_base_argv + ['inspect', image_name_and_tag])[0]
-        with open(digestfile, 'w') as f:
-            f.write(inspect['Digest'])
+    cmdlib.runcmd(podCmd)
 
 
 def main():
@@ -274,7 +269,7 @@ def main():
         help="Write image digest to file",
         action='store',
         metavar='FILE')
-    parser.add_argument("--output", help="Write image as OCI archive to file")
+    parser.add_argument("--output", required=True, help="Write image as OCI archive to file")
     args = parser.parse_args()
 
     labeled_pkgs = []

--- a/src/buildextend-legacy-oscontainer.py
+++ b/src/buildextend-legacy-oscontainer.py
@@ -95,7 +95,7 @@ def oscontainer_extract(containers_storage, tmpdir, src, dest,
 def oscontainer_build(containers_storage, tmpdir, src, ref, image_name_and_tag,
                       base_image, tls_verify=True, pushformat=None,
                       add_directories=[], cert_dir="", authfile="", digestfile=None,
-                      ociarchive=None, display_name=None, labeled_pkgs=[]):
+                      output=None, display_name=None, labeled_pkgs=[]):
     r = OSTree.Repo.new(Gio.File.new_for_path(src))
     r.open(None)
 
@@ -209,7 +209,7 @@ def oscontainer_build(containers_storage, tmpdir, src, ref, image_name_and_tag,
         subprocess.call(buildah_base_argv + ['umount', bid], stdout=subprocess.DEVNULL)
         subprocess.call(buildah_base_argv + ['rm', bid], stdout=subprocess.DEVNULL)
 
-    if ociarchive:
+    if output:
         print("Saving container to oci-archive")
         podCmd = buildah_base_argv + ['push']
 
@@ -227,7 +227,7 @@ def oscontainer_build(containers_storage, tmpdir, src, ref, image_name_and_tag,
 
         podCmd.append(image_name_and_tag)
 
-        podCmd.append(f'oci-archive:{ociarchive}')
+        podCmd.append(f'oci-archive:{output}')
 
         cmdlib.runcmd(podCmd)
     elif digestfile is not None:
@@ -274,7 +274,7 @@ def main():
         help="Write image digest to file",
         action='store',
         metavar='FILE')
-    parser.add_argument("--ociarchive", help="Write image as OCI archive to file")
+    parser.add_argument("--output", help="Write image as OCI archive to file")
     args = parser.parse_args()
 
     labeled_pkgs = []
@@ -306,7 +306,7 @@ def main():
                 getattr(args, 'from'),
                 display_name=args.display_name,
                 digestfile=args.digestfile,
-                ociarchive=args.ociarchive,
+                output=args.output,
                 add_directories=args.add_directory,
                 pushformat=args.format,
                 tls_verify=not args.disable_tls_verify,

--- a/src/buildextend-legacy-oscontainer.sh
+++ b/src/buildextend-legacy-oscontainer.sh
@@ -10,5 +10,5 @@ tmp_outfile=${tmp_builddir}/legacy-oscontainer.ociarchive
 runvm -chardev "file,id=ociarchiveout,path=${tmp_outfile}" \
     -device "virtserialport,chardev=ociarchiveout,name=ociarchiveout" -- \
     /usr/lib/coreos-assembler/buildextend-legacy-oscontainer.py \
-        --ociarchive "/dev/virtio-ports/ociarchiveout" "$@"
+        --output "/dev/virtio-ports/ociarchiveout" "$@"
 /usr/lib/coreos-assembler/finalize-artifact "${tmp_outfile}" "${final_outfile}"


### PR DESCRIPTION
A few things that came up in review in #3139. But most importantly, add a header at the top to provide more context on this file.