### PR TITLE
cmd-generate-hashlist: use `lsinitrd --unpack` to unpack initrd

### DIFF
--- a/src/cmd-generate-hashlist
+++ b/src/cmd-generate-hashlist
@@ -90,6 +90,10 @@ class HashListV1(dict):
             'ostree', 'checkout',
             '--repo=tmp/repo', '-U',
             self._metadata['ostree-commit'], checkout])
+        # Force all dirs to be owner writable so that we can delete the
+        # checkout at the end. XXX: Lower into a new `ostree checkout` flag.
+        subprocess.check_call(['find', checkout, '-type', 'd', '-exec',
+                               'chmod', 'u+w', '{}', '+'])
         self.hash_from_path(checkout)
 
         # Extract initramfs contents

--- a/src/cmd-generate-hashlist
+++ b/src/cmd-generate-hashlist
@@ -103,18 +103,8 @@ class HashListV1(dict):
         initramfs_path = os.path.realpath(initramfs_path)
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            skipcpio = subprocess.Popen(
-                ['/usr/lib/dracut/skipcpio', initramfs_path],
-                stdout=subprocess.PIPE)
-            gunzip = subprocess.Popen(
-                ['gunzip', '-c'],
-                stdin=skipcpio.stdout,
-                stdout=subprocess.PIPE)
-            cpio = subprocess.Popen(
-                ['cpio', '-idmv'],
-                stdin=gunzip.stdout,
-                cwd=tmpdir)
-            cpio.wait(timeout=300)  # timeout of 5 minutes
+            subprocess.check_call(['lsinitrd', '--unpack', initramfs_path],
+                                  cwd=tmpdir)
             self.hash_from_path(tmpdir)
 
         shutil.rmtree(checkout)

--- a/src/cmd-generate-hashlist
+++ b/src/cmd-generate-hashlist
@@ -9,6 +9,7 @@ import argparse
 import datetime
 import json
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -78,6 +79,8 @@ class HashListV1(dict):
         :raises: IndexError
         """
         checkout = 'tmp/repo/tmp/keylime-checkout'
+        if os.path.isdir(checkout):
+            shutil.rmtree(checkout)
 
         import_ostree_commit(
             os.getcwd(),
@@ -109,6 +112,8 @@ class HashListV1(dict):
                 cwd=tmpdir)
             cpio.wait(timeout=300)  # timeout of 5 minutes
             self.hash_from_path(tmpdir)
+
+        shutil.rmtree(checkout)
 
     def hash_from_path(self, toppath):
         """


### PR DESCRIPTION
Rather than a custom `skipcpio | gunzip | cpio` pipeline, we can just
use `lsinitrd --unpack` here. It's simpler, but it also fixes the
command on systems that no longer use gzip for initramfs compression. It
also provides better error-handling (e.g. note that this command wasn't
failing when FCOS switched to zstd). Finally, this also fixes the fact
that `cpio` was run with `-v` which generated a lot of output in
pipeline logs.

For keylime, I'm actually not sure if this makes sense. The list of
initramfs files are hashed and included in the same JSON object keyed by
file path. This means that an initrd file could clash with a real root
file. The schema supports multiple hashes per keys, but the code isn't
appending, just replacing. To be investigated whether keylime really
wants the digests of files inside initramfses.