### PR TITLE
src/kola: Add '--skip-secure-boot' option to skip Secure Boot tests

### DIFF
--- a/src/cmd-kola
+++ b/src/cmd-kola
@@ -10,7 +10,8 @@ import sys
 # Just test these boot to start with.  In the future we should at least
 # do ostree upgrades with uefi etc.  But we don't really need the *full*
 # suite...if podman somehow broke with nvme or uefi I'd be amazed and impressed.
-BASIC_SCENARIOS = ["nvme=true", "firmware=uefi", "firmware=uefi-secure"]
+BASIC_SCENARIOS = ["nvme=true", "firmware=uefi"]
+BASIC_SCENARIOS_SECURE_BOOT = ["firmware=uefi-secure"]
 arch = platform.machine()
 
 cosa_dir = os.path.dirname(os.path.abspath(__file__))
@@ -25,6 +26,7 @@ parser = argparse.ArgumentParser()
 parser.add_argument("--build", help="Build ID")
 parser.add_argument("--basic-qemu-scenarios", help="Run the basic test across uefi-secure,nvme etc.", action='store_true')
 parser.add_argument("--output-dir", help="Output directory")
+parser.add_argument("--skip-secure-boot", help="Use with '--basic-qemu-scenarios' to skip the Secure Boot tests", action='store_true')
 parser.add_argument("--upgrades", help="Run upgrade tests", action='store_true')
 parser.add_argument("subargs", help="Remaining arguments for kola", nargs='*',
                     default=[])
@@ -63,6 +65,11 @@ if args.basic_qemu_scenarios:
             subargs = kolaargs + ['--qemu-' + scenario, 'basic']
             print(subprocess.list2cmdline(subargs), flush=True)
             subprocess.check_call(subargs)
+        if not args.skip_secure_boot:
+            for scenario in BASIC_SCENARIOS_SECURE_BOOT:
+                subargs = kolaargs + ['--qemu-' + scenario, 'basic']
+                print(subprocess.list2cmdline(subargs), flush=True)
+                subprocess.check_call(subargs)
     else:
         # Basic qemu scenarios using nvme and uefi
         # are not supported on multi-arch


### PR DESCRIPTION
This makes skipping those tests easier in downstream pipelines that call `cosa kola run --basic-qemu-scenarios`.