### PR TITLE
cmd-compress: Clarify operation on Skipped artifacts output

### DIFF
--- a/src/cmd-compress
+++ b/src/cmd-compress
@@ -145,7 +145,7 @@ def compress_one_builddir(builddir):
             rm_allow_noent(filepath[:-3])
 
     if len(skipped) > 0:
-        print(f"Skipped artifacts: {' '.join(skipped)}")
+        print(f"Skipped compressing artifacts: {' '.join(skipped)}")
     if at_least_one:
         print(f"Updated: {buildmeta_path}")
     return at_least_one
@@ -235,7 +235,7 @@ def uncompress_one_builddir(builddir):
             rm_allow_noent(filepath[:-3])
 
     if len(skipped) > 0:
-        print(f"Skipped artifacts: {' '.join(skipped)}")
+        print(f"Skipped uncompressing artifacts: {' '.join(skipped)}")
     if len(skipped_missing) > 0:
         print(f"Skipped missing artifacts: {' '.join(skipped_missing)}")
     if at_least_one:


### PR DESCRIPTION
Trying to make it explicit that what was skipped was the compress/uncompress operations.