### PR TITLE
build: Add image.yaml option to inject OpenShift CVO annotations

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -407,6 +407,7 @@ else
     ostree_tarfile_path="${name}-${buildid}-ostree.${basearch}.ociarchive"
     gitsrc=$(jq -r .git.origin < "${PWD}/coreos-assembler-config-git.json")
     cmd=(ostree container encapsulate --copymeta="rpmostree.inputhash")
+    openshift_cvo_labels=$(jq -r '.["ostree-container-inject-openshift-cvo-labels"]' < "${image_json}")
 
     # The ostree-ext default is 64, but this is still too much apparently
     # for (older?) versions of podman AKA containers/storage (or maybe)
@@ -419,11 +420,18 @@ else
         ;;
         *) fatal "Unknown ostree-format: ${ostree_format}"
     esac
+    labels=()
+    if test "${openshift_cvo_labels}" = "true"; then
+        labels+=("--label=io.openshift.build.version-display-names=machine-os=$(extract_osrelease_name "$buildid")" \
+                 "--label=io.openshift.build.versions=machine-os=${buildid}"
+                )
+    fi
     runv "${cmd[@]}" --repo="${tmprepo}" \
         --label="coreos-assembler.image-config-checksum=${image_config_checksum}" \
         --label="coreos-assembler.image-input-checksum=${image_input_checksum}" \
         --label="org.opencontainers.image.source=${gitsrc}" \
         --label="org.opencontainers.image.revision=${config_gitrev}" \
+        "${labels[@]}" \
         "${buildid}" \
         oci-archive:"${ostree_tarfile_path}".tmp:latest
     /usr/lib/coreos-assembler/finalize-artifact "${ostree_tarfile_path}"{.tmp,}

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -1038,3 +1038,13 @@ buildmeta = builds.get_build_meta('${buildid}')
 cmdlib.import_ostree_commit(workdir, builddir, buildmeta)
 ")
 }
+
+# Extract the value of NAME from os-release
+extract_osrelease_name() {
+    local buildid=$1; shift
+    local out="$workdir/tmp/osrelease"
+    rm "${out}" -rf
+    ostree checkout --repo "${tmprepo}" --user-mode --subpath=/usr/lib/os-release "${buildid}" "$out"
+    # shellcheck disable=SC1091,SC2153
+    (. "$out/os-release" && echo "${NAME}")
+}

--- a/src/image-default.yaml
+++ b/src/image-default.yaml
@@ -10,6 +10,8 @@ extra-kargs: []
 
 # Can also be oci-chunked
 ostree-format: oci-chunked-v1
+# Inject io.openshift.build.version-display-names for OpenShift CVO
+ostree-container-inject-openshift-cvo-labels: false
 # True if we should use `ostree container image deploy`
 deploy-via-container: false
 


### PR DESCRIPTION
We had these in the legacy oscontainer for RHCOS, and OKD today hacks them in via a Dockerfile:
https://github.com/openshift/okd-machine-os/blob/0e9fbabbd3363bfc46d9d657bc173666e83e5d18/Dockerfile#L34

We need to carry support for this forward into the new format image, as it's what is used to display the OS version as part of the release image.