### PR TITLE
create_disk: correctly configure BLS `grub_users` setting (CVE-2022-3675)

### DIFF
--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -501,7 +501,7 @@ esac
 
 # enable support for GRUB password
 # shellcheck disable=SC2031
-if "$arch" != "s390x"; then
+if [ "$arch" != s390x ]; then
     ostree config --repo $rootfs/ostree/repo set sysroot.bls-append-except-default 'grub_users=""'
 fi
 

--- a/tests/check_one.sh
+++ b/tests/check_one.sh
@@ -27,6 +27,10 @@ if [[ ${HASSHELLCHECK} == 1 ]]; then
     if [[ $shebang =~ ^#!/.*/bash.* ]] || [[ $shebang =~ ^#!/.*/env\ bash ]]; then
         shellcheck -x "$f"
         bash -n "$f"
+        if grep -E '(^|[[:space:]])if[[:space:]]+"?\$' "$f"; then
+            echo "Possible unbracketed conditional in $f"
+            exit 1
+        fi
         echo "OK ${f}"
     fi
 fi


### PR DESCRIPTION
The conditional always failed since it's not a valid command without the brackets. So the `sysroot.bls-append-except-default` option was not set in builds created by affected cosa versions. This means that on systems provisioned from those releases with a GRUB password set, unprivileged GRUB users can boot non-default GRUB menu entries without entering a password.

To prevent a recurrence of this bug, have the shellcheck test fail if `if $` or `if "$` appears in a shell script.  This will generate false positives if a command is being run indirectly via a shell variable, but we can work around that later if needed.

Fixes coreos/coreos-assembler#3068.  For https://github.com/coreos/fedora-coreos-tracker/issues/1333.