### PR TITLE
build.sh: freeze on grub2-2.06-52.fc36

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -41,8 +41,11 @@ install_rpms() {
     local builddeps
     local frozendeps
 
-    # no frozen deps right now
+    # freeze grub2 due to https://github.com/coreos/coreos-assembler/issues/3148
     frozendeps=""
+    if [ "${arch}" != s390x ]; then
+        frozendeps=$(echo grub2{-common,-tools-extra}-2.06-52.fc36)
+    fi
 
     # First, a general update; this is best practice.  We also hit an issue recently
     # where qemu implicitly depended on an updated libusbx but didn't have a versioned


### PR DESCRIPTION
Build ova image for ppc64le with grub2 > 2.06-53 in cosa container, causes vm boot failed. See https://github.com/coreos/coreos-assembler/issues/3148