### PR TITLE
Default to UEFI (non-SB) on x86_64

### DIFF
--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -202,17 +202,7 @@ func syncOptionsImpl(useCosa bool) error {
 
 	// native 4k requires a UEFI bootloader
 	if kola.QEMUOptions.Native4k && kola.QEMUOptions.Firmware == "bios" {
-		return fmt.Errorf("native 4k requires uefi firmware")
-	}
-	// default to BIOS, UEFI for aarch64 and x86(only for 4k)
-	if kola.QEMUOptions.Firmware == "" {
-		if kola.Options.CosaBuildArch == "aarch64" {
-			kola.QEMUOptions.Firmware = "uefi"
-		} else if kola.Options.CosaBuildArch == "x86_64" && kola.QEMUOptions.Native4k {
-			kola.QEMUOptions.Firmware = "uefi"
-		} else {
-			kola.QEMUOptions.Firmware = "bios"
-		}
+		kola.QEMUOptions.Firmware = platform.UefiFirmwareDefault
 	}
 
 	if err := validateOption("platform", kolaPlatform, kolaPlatforms); err != nil {

--- a/mantle/cmd/kola/qemuexec.go
+++ b/mantle/cmd/kola/qemuexec.go
@@ -268,7 +268,9 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 		builder.AppendFirstbootKernelArgs = firstbootkargs
 	}
 	builder.AppendKernelArgs = strings.Join(kargs, " ")
-	builder.Firmware = kola.QEMUOptions.Firmware
+	if kola.QEMUOptions.Firmware != "" {
+		builder.Firmware = kola.QEMUOptions.Firmware
+	}
 	if kola.QEMUOptions.DiskImage != "" {
 		channel := "virtio"
 		if kola.QEMUOptions.Nvme {

--- a/mantle/platform/machine/unprivqemu/cluster.go
+++ b/mantle/platform/machine/unprivqemu/cluster.go
@@ -101,7 +101,9 @@ func (qc *Cluster) NewMachineWithQemuOptions(userdata *conf.UserData, options pl
 	builder.ConfigFile = confPath
 	defer builder.Close()
 	builder.UUID = qm.id
-	builder.Firmware = qc.flight.opts.Firmware
+	if qc.flight.opts.Firmware != "" {
+		builder.Firmware = qc.flight.opts.Firmware
+	}
 	builder.Swtpm = qc.flight.opts.Swtpm
 	builder.Hostname = fmt.Sprintf("qemu%d", qc.BaseCluster.AllocateMachineSerial())
 	builder.ConsoleFile = qm.consolePath

--- a/src/cmd-kola
+++ b/src/cmd-kola
@@ -10,7 +10,7 @@ import sys
 # Just test these boot to start with.  In the future we should at least
 # do ostree upgrades with uefi etc.  But we don't really need the *full*
 # suite...if podman somehow broke with nvme or uefi I'd be amazed and impressed.
-BASIC_SCENARIOS = ["nvme=true", "firmware=uefi"]
+BASIC_SCENARIOS = ["nvme=true", "firmware=bios"]
 BASIC_SCENARIOS_SECURE_BOOT = ["firmware=uefi-secure"]
 arch = platform.machine()
 


### PR DESCRIPTION
There's some momentum around e.g. UKI
https://github.com/uapi-group/specifications/blob/main/specs/unified_kernel_image.md

I think it's about time to flip our default to be UEFI instead of BIOS.

(But, we obviously still do need to care about bios...and
 we should e.g. be running at least a subset of our tests
 acrosss that too)

Also while we're here, make the implementation here have the default for firmware be the empty string `""` instead of `bios`, which doesn't really apply on e.g. ppc64le/s390x.