### PR TITLE
[rhcos-4.8] .cci.Jenkinsfile: drop Fedora CoreOS testing

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -1,53 +1,6 @@
-// Documentation: https://github.com/coreos/coreos-ci/blob/master/README-upstream-ci.md
+// Documentation: https://github.com/coreos/coreos-ci/blob/main/README-upstream-ci.md
 
 // Build coreos-assembler image and create
 // an imageStream for it
-def imageName = buildImage()
-
-pod(image: imageName + ":latest", kvm: true, memory: "10Gi") {
-    checkout scm
-
-    shwrap("rpm -qa | sort > rpmdb.txt")
-    archiveArtifacts artifacts: 'rpmdb.txt'
-
-    // Run stage Build FCOS (init, fetch and build)
-    fcosBuild(skipKola: 1, cosaDir: "/srv", noForce: true)
-
-    // Run stage Kola QEMU (basic-qemu-scenarios, upgrade and self tests)
-    fcosKola(basicScenarios: true, cosaDir: "/srv", addExtTests: ["${env.WORKSPACE}/ci/run-kola-self-tests"])
-
-    stage("Build Metal") {
-        cosaParallelCmds(cosaDir: "/srv", commands: ["metal", "metal4k"])
-    }
-
-    stage("Build Live Images") {
-        utils.cosaCmd(cosaDir: "/srv", args: "buildextend-live --fast")
-    }
-
-    fcosKolaTestIso(cosaDir: "/srv", extraArgs4k: "--no-pxe")
-
-    stage("Build Cloud Images") {
-        cosaParallelCmds(cosaDir: "/srv", commands: ["Aliyun", "AWS", "Azure", "DigitalOcean", "Exoscale", "GCP",
-                                                     "IBMCloud", "OpenStack", "VMware", "Vultr"])
-
-        // quick schema validation
-        utils.cosaCmd(cosaDir: "/srv", args: "meta --get name")
-    }
-
-    stage("Compress") {
-        utils.cosaCmd(cosaDir: "/srv", args: "compress --fast")
-    }
-
-    stage("Upload Dry Run") {
-        utils.cosaCmd(cosaDir: "/srv", args: "buildupload --dry-run s3 --acl=public-read my-nonexistent-bucket/my/prefix")
-    }
-
-    // Random other tests that aren't about building. XXX: These should be part of `make
-    // check` or something and use dummy cosa builds.
-    stage("CLI Tests") {
-        shwrap("""
-            cd /srv
-            sudo -u builder ${env.WORKSPACE}/tests/test_pruning.sh
-        """)
-    }
-}
+def cpuCount = "8".toString()
+buildImage(env: [ENABLE_GO_RACE_DETECTOR: "1", GOMAXPROCS: cpuCount], cpu: cpuCount)


### PR DESCRIPTION
It doesn't work properly against these rhcos- branches anyway. Let's just limit the testing to building the container and running check and unittest tests.