### PR TITLE
cmd-buildextend-live: update `kargs_json` when moving EFI `grub.cfg`

### DIFF
--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -551,6 +551,11 @@ def generate_iso():
             os.rename(srcpath, f"EFI/{vendor_id}", src_dir_fd=dfd, dst_dir_fd=dfd)
             os.close(dfd)
 
+            # And update kargs.json
+            for file in kargs_json['files']:
+                if file['path'] == grubfilepath[0]:
+                    file['path'] = f'EFI/{vendor_id}/grub.cfg'
+
             # Delete fallback and its CSV file.  Its purpose is to create
             # EFI boot variables, which we don't want when booting from
             # removable media.

--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -625,10 +625,11 @@ boot
                        '-efi-boot', 'images/efiboot.img',
                        '-no-emul-boot']
 
-    # We've done everything that might affect kargs, so filter out any files
-    # that no longer exist and write out the kargs JSON if it lists any files
-    kargs_json['files'] = [f for f in kargs_json['files']
-            if os.path.exists(os.path.join(tmpisoroot, f['path']))]
+    # Sanity-check that all kargs files that we found earlier still exist. This
+    # ensures that any modifications made also updated kargs_json as needed.
+    for f in kargs_json['files']:
+        fn = os.path.join(tmpisoroot, f['path'])
+        assert os.path.exists(fn), f"{fn} no longer exists"
     kargs_json['files'].sort(key=lambda f: f['path'])
     if kargs_json['files']:
         # Store the location of "karg embed areas" for use by

--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -543,11 +543,13 @@ def generate_iso():
 
             # Always replace live/EFI/{vendor} to actual live/EFI/{vendor_id}
             # https://github.com/openshift/os/issues/954
-            grubfilepath = ensure_glob(os.path.join(tmpdir, 'live/EFI/*/grub.cfg'))
+            dfd = os.open(tmpisoroot, os.O_RDONLY)
+            grubfilepath = ensure_glob('EFI/*/grub.cfg', dir_fd=dfd)
             if len(grubfilepath) != 1:
                 raise Exception(f'Found != 1 grub.cfg files: {grubfilepath}')
             srcpath = os.path.dirname(grubfilepath[0])
-            os.renames(srcpath, os.path.join(os.path.dirname(srcpath), vendor_id))
+            os.rename(srcpath, f"EFI/{vendor_id}", src_dir_fd=dfd, dst_dir_fd=dfd)
+            os.close(dfd)
 
             # Delete fallback and its CSV file.  Its purpose is to create
             # EFI boot variables, which we don't want when booting from

--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -548,13 +548,14 @@ def generate_iso():
             if len(grubfilepath) != 1:
                 raise Exception(f'Found != 1 grub.cfg files: {grubfilepath}')
             srcpath = os.path.dirname(grubfilepath[0])
-            os.rename(srcpath, f"EFI/{vendor_id}", src_dir_fd=dfd, dst_dir_fd=dfd)
+            if srcpath != f'EFI/{vendor_id}':
+                print(f"Renaming '{srcpath}' to 'EFI/{vendor_id}'")
+                os.rename(srcpath, f"EFI/{vendor_id}", src_dir_fd=dfd, dst_dir_fd=dfd)
+                # And update kargs.json
+                for file in kargs_json['files']:
+                    if file['path'] == grubfilepath[0]:
+                        file['path'] = f'EFI/{vendor_id}/grub.cfg'
             os.close(dfd)
-
-            # And update kargs.json
-            for file in kargs_json['files']:
-                if file['path'] == grubfilepath[0]:
-                    file['path'] = f'EFI/{vendor_id}/grub.cfg'
 
             # Delete fallback and its CSV file.  Its purpose is to create
             # EFI boot variables, which we don't want when booting from

--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -539,14 +539,15 @@ def generate_iso():
             vendor_ids = [n for n in os.listdir(tmpimageefidir) if n != "BOOT"]
             if len(vendor_ids) != 1:
                 raise Exception(f"did not find exactly one EFI vendor ID: {vendor_ids}")
+            vendor_id = vendor_ids[0]
 
-            # Always replace live/EFI/{vendor} to actual live/EFI/{vendor_id[0]}
+            # Always replace live/EFI/{vendor} to actual live/EFI/{vendor_id}
             # https://github.com/openshift/os/issues/954
             grubfilepath = ensure_glob(os.path.join(tmpdir, 'live/EFI/*/grub.cfg'))
             if len(grubfilepath) != 1:
                 raise Exception(f'Found != 1 grub.cfg files: {grubfilepath}')
             srcpath = os.path.dirname(grubfilepath[0])
-            os.renames(srcpath, os.path.join(os.path.dirname(srcpath), vendor_ids[0]))
+            os.renames(srcpath, os.path.join(os.path.dirname(srcpath), vendor_id))
 
             # Delete fallback and its CSV file.  Its purpose is to create
             # EFI boot variables, which we don't want when booting from
@@ -557,19 +558,19 @@ def generate_iso():
             # exists.  But for now, fail if fallback.efi is missing.
             for path in ensure_glob(os.path.join(tmpimageefidir, "BOOT", "fb*.efi")):
                 os.unlink(path)
-            for path in ensure_glob(os.path.join(tmpimageefidir, vendor_ids[0], "BOOT*.CSV")):
+            for path in ensure_glob(os.path.join(tmpimageefidir, vendor_id, "BOOT*.CSV")):
                 os.unlink(path)
 
             # Drop vendor copies of shim; we already have it in BOOT*.EFI in
             # BOOT
-            for path in ensure_glob(os.path.join(tmpimageefidir, vendor_ids[0], "shim*.efi")):
+            for path in ensure_glob(os.path.join(tmpimageefidir, vendor_id, "shim*.efi")):
                 os.unlink(path)
 
             # Consolidate remaining files into BOOT.  shim needs GRUB to be
             # there, and the rest doesn't hurt.
-            for path in ensure_glob(os.path.join(tmpimageefidir, vendor_ids[0], "*")):
+            for path in ensure_glob(os.path.join(tmpimageefidir, vendor_id, "*")):
                 shutil.move(path, os.path.join(tmpimageefidir, "BOOT"))
-            os.rmdir(os.path.join(tmpimageefidir, vendor_ids[0]))
+            os.rmdir(os.path.join(tmpimageefidir, vendor_id))
 
             # Inject a stub grub.cfg pointing to the one in the main ISO image.
             #
@@ -587,7 +588,7 @@ def generate_iso():
             # pointing to efiboot.img) and needs a grub.cfg there.
             with open(os.path.join(tmpimageefidir, "BOOT", "grub.cfg"), "w") as fh:
                 fh.write(f'''search --label "{volid}" --set root --no-floppy
-set prefix=($root)/EFI/{vendor_ids[0]}
+set prefix=($root)/EFI/{vendor_id}
 echo "Booting via ESP..."
 configfile $prefix/grub.cfg
 boot


### PR DESCRIPTION
Otherwise, code lower down will remove the that `grub.cfg` from the list
of kargs files. This in turn will prevent `coreos-installer iso kargs`
from affecting kargs on UEFI boots.

Fixes https://github.com/coreos/coreos-assembler/commit/3991e6f066e47cf185bc214361de8a8e092b6e7f ("cmd-buildextend-live: always change dir
`EFI/{vendor}/` to correct vendor id").