### PR TITLE
cmd-buildextend-legacy-oscontainer: don't directly write `meta.json`

### DIFF
--- a/src/cmd-buildextend-legacy-oscontainer
+++ b/src/cmd-buildextend-legacy-oscontainer
@@ -20,6 +20,17 @@ sys.path.insert(0, cosa_dir)
 from cosalib import cmdlib
 
 
+parser = argparse.ArgumentParser()
+parser.add_argument("--arch-tag", help="append arch name to push tag",
+                    action='store_true')
+parser.add_argument("--from", help="Base image", default='scratch',
+                    dest='from_image')
+parser.add_argument("--format", help="Format to use for push")
+parser.add_argument("--add-directory", help="Copy in all content from referenced directory DIR",
+                    metavar='DIR', action='append', default=[])
+
+args = parser.parse_args()
+
 with open('builds/builds.json') as f:
     builds = json.load(f)['builds']
 if len(builds) == 0:
@@ -33,16 +44,6 @@ with open(metapath) as f:
     meta = json.load(f)
 
 name = meta['name'] + '-' + meta['buildid'] + '-legacy-oscontainer.' + arch + '.ociarchive'
-parser = argparse.ArgumentParser()
-parser.add_argument("--arch-tag", help="append arch name to push tag",
-                    action='store_true')
-parser.add_argument("--from", help="Base image", default='scratch',
-                    dest='from_image')
-parser.add_argument("--format", help="Format to use for push")
-parser.add_argument("--add-directory", help="Copy in all content from referenced directory DIR",
-                    metavar='DIR', action='append', default=[])
-
-args = parser.parse_args()
 
 # for backcompat, we auto-build extensions if they're missing
 if os.path.exists('src/config/extensions.yaml'):

--- a/src/cmd-buildextend-legacy-oscontainer
+++ b/src/cmd-buildextend-legacy-oscontainer
@@ -36,8 +36,6 @@ name = meta['name'] + '-' + meta['buildid'] + '-legacy-oscontainer.' + arch + '.
 parser = argparse.ArgumentParser()
 parser.add_argument("--arch-tag", help="append arch name to push tag",
                     action='store_true')
-parser.add_argument("--name", help="oscontainer name",
-                    action='store', default=f'{name}')
 parser.add_argument("--from", help="Base image", default='scratch',
                     dest='from_image')
 parser.add_argument("--format", help="Format to use for push")
@@ -95,17 +93,17 @@ if display_name == "":
     raise SystemExit(f"Failed to find NAME= in /usr/lib/os-release in commit {ostree_commit}")
 shutil.rmtree(tmp_osreleasedir)
 
-osc_name_and_tag = f"{args.name}:{latest_build}"
+osc_name_and_tag = f"{name}:{latest_build}"
 if args.arch_tag:
     arch = meta.get("coreos-assembler.basearch", cmdlib.get_basearch)
-    osc_name_and_tag = f"{args.name}:{latest_build}-{arch}"
+    osc_name_and_tag = f"{name}:{latest_build}-{arch}"
 
 # TODO: Use labels for the build hash and avoid pulling the oscontainer
 # every time we want to poll.
 # TODO: Remove --from
 print("Entering vm to build oscontainer for build: {}".format(latest_build))
 
-oci_archive = f"{latest_build_path}/{args.name}"
+oci_archive = f"{latest_build_path}/{name}"
 cosa_argv = (['/usr/lib/coreos-assembler/buildextend-legacy-oscontainer.sh', oci_archive, 'build', f'--from={args.from_image}'])
 for d in args.add_directory:
     cosa_argv.append(f'--add-directory="{d}"')
@@ -118,7 +116,7 @@ if args.format is not None:
 subprocess.check_call(cosa_argv + [tmprepo, meta['ostree-commit'], osc_name_and_tag])
 
 # Inject the oscontainer with SHA256 into the build metadata
-meta['images']['legacy-oscontainer'] = {'path': args.name,
+meta['images']['legacy-oscontainer'] = {'path': name,
                                         'sha256': sha256sum_file(oci_archive),
                                         'size': os.path.getsize(oci_archive),
                                         "skip-compression": True}

--- a/src/cmd-buildextend-legacy-oscontainer
+++ b/src/cmd-buildextend-legacy-oscontainer
@@ -26,6 +26,7 @@ parser.add_argument("--arch-tag", help="append arch name to push tag",
 parser.add_argument("--from", help="Base image", default='scratch',
                     dest='from_image')
 parser.add_argument("--format", help="Format to use for push")
+parser.add_argument("--build", help="Build ID")
 parser.add_argument("--add-directory", help="Copy in all content from referenced directory DIR",
                     metavar='DIR', action='append', default=[])
 
@@ -35,11 +36,12 @@ with open('builds/builds.json') as f:
     builds = json.load(f)['builds']
 if len(builds) == 0:
     cmdlib.fatal("No builds found")
-latest_build = builds[0]['id']
+if not args.build:
+    args.build = builds[0]['id']
 arch = cmdlib.get_basearch()
-latest_build_path = f"builds/{latest_build}/{arch}"
+build_path = f"builds/{args.build}/{arch}"
 
-metapath = f"{latest_build_path}/meta.json"
+metapath = f"{build_path}/meta.json"
 with open(metapath) as f:
     meta = json.load(f)
 
@@ -64,7 +66,7 @@ if os.path.exists(oscconfigpath):
 if 'base' in configyaml:
     args.from_image = configyaml['base']
 
-print("Preparing to upload oscontainer for build: {}".format(latest_build))
+print("Preparing to upload oscontainer for build: {}".format(args.build))
 ostree_commit = meta['ostree-commit']
 
 tmprepo = "{}/tmp/repo".format(os.getcwd())
@@ -79,7 +81,7 @@ if not os.path.exists(tmprepo):
     os.makedirs(tmprepo, exist_ok=True)
     ostree_commit_tar = meta['images']['ostree']['path']
     subprocess.check_call(['tar', '-xf',
-                           f'{latest_build_path}/{ostree_commit_tar}',
+                           f'{build_path}/{ostree_commit_tar}',
                            '-C', tmprepo])
 
 tmp_osreleasedir = 'tmp/usrlib-osrelease'
@@ -94,17 +96,17 @@ if display_name == "":
     raise SystemExit(f"Failed to find NAME= in /usr/lib/os-release in commit {ostree_commit}")
 shutil.rmtree(tmp_osreleasedir)
 
-osc_name_and_tag = f"{name}:{latest_build}"
+osc_name_and_tag = f"{name}:{args.build}"
 if args.arch_tag:
     arch = meta.get("coreos-assembler.basearch", cmdlib.get_basearch)
-    osc_name_and_tag = f"{name}:{latest_build}-{arch}"
+    osc_name_and_tag = f"{name}:{args.build}-{arch}"
 
 # TODO: Use labels for the build hash and avoid pulling the oscontainer
 # every time we want to poll.
 # TODO: Remove --from
-print("Entering vm to build oscontainer for build: {}".format(latest_build))
+print("Entering vm to build oscontainer for build: {}".format(args.build))
 
-oci_archive = f"{latest_build_path}/{name}"
+oci_archive = f"{build_path}/{name}"
 cosa_argv = (['/usr/lib/coreos-assembler/buildextend-legacy-oscontainer.sh', oci_archive, 'build', f'--from={args.from_image}'])
 for d in args.add_directory:
     cosa_argv.append(f'--add-directory="{d}"')

--- a/src/cmd-buildextend-legacy-oscontainer
+++ b/src/cmd-buildextend-legacy-oscontainer
@@ -61,7 +61,7 @@ if os.path.exists(oscconfigpath):
 if 'base' in configyaml:
     args.from_image = configyaml['base']
 
-print("Preparing to upload oscontainer for build: {}".format(args.build))
+print(f"Building legacy-oscontainer for build {args.build}")
 ostree_commit = meta['ostree-commit']
 
 tmprepo = "{}/tmp/repo".format(os.getcwd())

--- a/src/cmd-buildextend-legacy-oscontainer
+++ b/src/cmd-buildextend-legacy-oscontainer
@@ -6,7 +6,6 @@
 # command.
 
 import argparse
-import json
 import yaml
 import os
 import shutil
@@ -18,6 +17,8 @@ cosa_dir = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, cosa_dir)
 
 from cosalib import cmdlib
+from cosalib.builds import Builds
+from cosalib.meta import GenericBuildMeta
 
 
 parser = argparse.ArgumentParser()
@@ -32,18 +33,13 @@ parser.add_argument("--add-directory", help="Copy in all content from referenced
 
 args = parser.parse_args()
 
-with open('builds/builds.json') as f:
-    builds = json.load(f)['builds']
-if len(builds) == 0:
-    cmdlib.fatal("No builds found")
+builds = Builds()
 if not args.build:
-    args.build = builds[0]['id']
+    args.build = builds.get_latest()
 arch = cmdlib.get_basearch()
 build_path = f"builds/{args.build}/{arch}"
 
-metapath = f"{build_path}/meta.json"
-with open(metapath) as f:
-    meta = json.load(f)
+meta = GenericBuildMeta(build=args.build)
 
 name = meta['name'] + '-' + meta['buildid'] + '-legacy-oscontainer.' + arch + '.ociarchive'
 
@@ -51,8 +47,7 @@ name = meta['name'] + '-' + meta['buildid'] + '-legacy-oscontainer.' + arch + '.
 if os.path.exists('src/config/extensions.yaml'):
     if 'extensions' not in meta:
         cmdlib.runcmd(['coreos-assembler', 'buildextend-extensions'])
-        with open(metapath) as f:
-            meta = json.load(f)
+        meta = GenericBuildMeta(build=args.build)
     assert 'extensions' in meta
 
 configdir = os.path.abspath('src/config')
@@ -123,8 +118,5 @@ meta['images']['legacy-oscontainer'] = {'path': name,
                                         'sha256': sha256sum_file(oci_archive),
                                         'size': os.path.getsize(oci_archive),
                                         "skip-compression": True}
-metapath_new = f"{metapath}.new"
-with open(metapath_new, 'w') as f:
-    json.dump(meta, f, sort_keys=True)
-shutil.move(metapath_new, metapath)
-print(f"Updated {metapath}")
+meta.write(artifact_name='legacy-oscontainer')
+print("Updated meta.json")


### PR DESCRIPTION
All `meta.json` updates must use the `GenericBuildMeta` API to make sure
that concurrent writes don't race.
