### PR TITLE
cmd/build-extensions-container.go: copy ociarchive over virtio-serial

### DIFF
--- a/cmd/build-extensions-container.go
+++ b/cmd/build-extensions-container.go
@@ -33,7 +33,10 @@ func buildExtensionContainer() error {
 		return err
 	}
 	targetname := cosaBuild.Name + "-" + buildID + "-extensions-container" + "." + arch + ".ociarchive"
-	process := "runvm -- /usr/lib/coreos-assembler/build-extensions-container.sh " + arch + " $tmp_builddir/" + targetname + " " + buildID
+	process := "runvm -chardev \"file,id=ociarchiveout,path=${tmp_builddir}/\"" + targetname +
+		" -device \"virtserialport,chardev=ociarchiveout,name=ociarchiveout\"" +
+		" -- /usr/lib/coreos-assembler/build-extensions-container.sh " + arch +
+		" /dev/virtio-ports/ociarchiveout " + buildID
 	if err := sh.Process(process); err != nil {
 		return err
 	}

--- a/src/build-extensions-container.sh
+++ b/src/build-extensions-container.sh
@@ -11,14 +11,11 @@ workdir=$PWD
 builddir="${workdir}/builds/latest/${arch}"
 ostree_ociarchive=$(ls "${builddir}"/*-ostree*.ociarchive)
 
-if [ ! -d "${workdir}/src/yumrepos" ]; then
-    ctx_dir=${workdir}/src/config
-else
-    ctx_dir="${workdir}/tmp/build-extensions-container"
-    rm -rf "${ctx_dir}"
-    cp -a "${workdir}/src/config" "${ctx_dir}"
+ctx_dir=$(mktemp -d -p /var/tmp)
+cp -aLT "${workdir}/src/config" "${ctx_dir}"
+
+if [ -d "${workdir}/src/yumrepos" ]; then
     find "${workdir}/src/yumrepos/" -maxdepth 1 -type f -name '*.repo' -exec cp -t "${ctx_dir}" {} +
-    cleanup_ctx_dir=1
 fi
 
 # Build the image, replacing the FROM directive with the local image we have
@@ -26,10 +23,6 @@ img=localhost/extensions-container
 (set -x; podman build --from oci-archive:"$ostree_ociarchive" --network=host \
     --build-arg COSA=true --label version="$buildid" \
     -t "${img}" -f extensions/Dockerfile "${ctx_dir}")
-
-if [ -n "${cleanup_ctx_dir:-}" ]; then
-    rm -rf "${ctx_dir}"
-fi
 
 # Call skopeo to export it from the container storage to an oci-archive.
 (set -x; skopeo copy "containers-storage:${img}" oci-archive:"$filename")


### PR DESCRIPTION
This is like 13a6ee49a but for the extensions container where we also
started seeing ENOMEM. We can't trust writing files back over 9p, so
hackily use virtio-serial instead.