### PR TITLE
Set `IMAGE_TYPE` when calling `prepare_build` from buildextend commands

### DIFF
--- a/cmd/build-extensions-container.go
+++ b/cmd/build-extensions-container.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/coreos/coreos-assembler/internal/pkg/cosash"
 	cosa "github.com/coreos/coreos-assembler/pkg/builds"
+	"github.com/pkg/errors"
 
 	"crypto/sha256"
 	"encoding/json"
@@ -30,7 +31,7 @@ func buildExtensionContainer() error {
 		return err
 	}
 	if _, err := sh.PrepareBuild(); err != nil {
-		return err
+		return errors.Wrapf(err, "calling prepare_build")
 	}
 	targetname := cosaBuild.Name + "-" + buildID + "-extensions-container" + "." + arch + ".ociarchive"
 	process := "runvm -chardev \"file,id=ociarchiveout,path=${tmp_builddir}/\"" + targetname +
@@ -38,16 +39,16 @@ func buildExtensionContainer() error {
 		" -- /usr/lib/coreos-assembler/build-extensions-container.sh " + arch +
 		" /dev/virtio-ports/ociarchiveout " + buildID
 	if err := sh.Process(process); err != nil {
-		return err
+		return errors.Wrapf(err, "calling build-extensions-container.sh")
 	}
 	// Find the temporary directory allocated by the shell process, and put the OCI archive in its final place
 	tmpdir, err := sh.ProcessWithReply("echo $tmp_builddir>&3\n")
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "querying tmpdir")
 	}
 	targetPath := filepath.Join(buildPath, targetname)
 	if err := exec.Command("/usr/lib/coreos-assembler/finalize-artifact", filepath.Join(tmpdir, targetname), targetPath).Run(); err != nil {
-		return err
+		return errors.Wrapf(err, "finalizing artifact")
 	}
 
 	fmt.Printf("Built %s\n", targetPath)
@@ -55,16 +56,16 @@ func buildExtensionContainer() error {
 	// Gather metadata of the OCI archive (sha256, size)
 	file, err := os.Open(targetPath)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "opening %s", targetPath)
 	}
 	defer file.Close()
 	hash := sha256.New()
 	if _, err := io.Copy(hash, file); err != nil {
-		return err
+		return errors.Wrapf(err, "hashing %s", targetPath)
 	}
 	stat, err := file.Stat()
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "stat(%s)", targetPath)
 	}
 	sha256sum := fmt.Sprintf("%x", hash.Sum(nil))
 
@@ -83,7 +84,7 @@ func buildExtensionContainer() error {
 	extensions_container_meta_path := filepath.Join(buildPath, "meta.extensions-container.json")
 	err = ioutil.WriteFile(extensions_container_meta_path, newBytes, 0644)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "writing %s", extensions_container_meta_path)
 	}
 	defer os.Remove(extensions_container_meta_path)
 	workdir, err := filepath.Abs(".")
@@ -97,7 +98,7 @@ func buildExtensionContainer() error {
 	// Calling `cosa meta` as it locks the file and we need to make sure no other process writes to the file at the same time.
 	// Golang does not appear to have a public api to lock files at the moment. https://github.com/coreos/coreos-assembler/issues/3149
 	if err := exec.Command("cosa", "meta", "--workdir", workdir, "--build", buildID, "--artifact-json", abs_new_json).Run(); err != nil {
-		return err
+		return errors.Wrapf(err, "calling `cosa meta`")
 	}
 	return nil
 }

--- a/cmd/build-extensions-container.go
+++ b/cmd/build-extensions-container.go
@@ -30,7 +30,7 @@ func buildExtensionContainer() error {
 	if err != nil {
 		return err
 	}
-	if _, err := sh.PrepareBuild(); err != nil {
+	if _, err := sh.PrepareBuild("extensions-container"); err != nil {
 		return errors.Wrapf(err, "calling prepare_build")
 	}
 	targetname := cosaBuild.Name + "-" + buildID + "-extensions-container" + "." + arch + ".ociarchive"

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -34,7 +34,8 @@ Delete all build artifacts.  Use --all to also clean the cache/ directory.
 	if err != nil {
 		return err
 	}
-	if _, err := sh.PrepareBuild(); err != nil {
+	// XXX: why do we need to prepare_build here?
+	if _, err := sh.PrepareBuild(""); err != nil {
 		return err
 	}
 

--- a/internal/pkg/cosash/cosash.go
+++ b/internal/pkg/cosash/cosash.go
@@ -164,7 +164,10 @@ func (sh *CosaSh) Process(buf string) error {
 }
 
 // PrepareBuild prepares for a build, returning the newly allocated build directory
-func (sh *CosaSh) PrepareBuild() (string, error) {
+func (sh *CosaSh) PrepareBuild(artifact_name string) (string, error) {
+	if artifact_name != "" {
+		sh.Process(fmt.Sprintf("IMAGE_TYPE=%s", artifact_name))
+	}
 	return sh.ProcessWithReply(`prepare_build
 pwd >&3
 `)

--- a/src/buildextend-legacy-oscontainer.sh
+++ b/src/buildextend-legacy-oscontainer.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 # Start VM and call buildah
 . /usr/lib/coreos-assembler/cmdlib.sh
 final_outfile=$(realpath "$1"); shift
+IMAGE_TYPE=legacy-oscontainer
 prepare_build
 # shellcheck disable=SC2154
 tmp_outfile=${tmp_builddir}/legacy-oscontainer.ociarchive

--- a/src/buildextend-legacy-oscontainer.sh
+++ b/src/buildextend-legacy-oscontainer.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC1091
 set -euo pipefail
-# Start VM and call buildah
+# shellcheck source=src/cmdlib.sh
 . /usr/lib/coreos-assembler/cmdlib.sh
+
+# Start VM and call buildah
 final_outfile=$(realpath "$1"); shift
 IMAGE_TYPE=legacy-oscontainer
 prepare_build
-# shellcheck disable=SC2154
 tmp_outfile=${tmp_builddir}/legacy-oscontainer.ociarchive
 runvm -chardev "file,id=ociarchiveout,path=${tmp_outfile}" \
     -device "virtserialport,chardev=ociarchiveout,name=ociarchiveout" -- \


### PR DESCRIPTION
This is necessary so that the `tmp_builddir`s allocated are distinct per
artifact run. Otherwise, running the two commands in parallel will stomp
on each other as they try to use the same dir.

`buildextend-metal` already does this, so we're missing
`buildextend-extensions-container` and `buildextend-legacy-oscontainer`.

I believe this is the reason why `buildextend-extensions-container` has
been failing in the RHCOS pipeline.

I avoided a larger cleanup here around enforcing `IMAGE_TYPE` (probably
should be renamed to e.g. `ARTIFACT`) getting set in `prepare_build`.
That requires more work because we should also make sure to consistently
clean up the dir at the end. Right now, we're relying on the fact that
the same dir gets cleaned and reused each time. We'll also need to
backport this so I wanted to keep the changes minimal.