### PR TITLE
create_disk.sh: naively try to workaround more 9p woes

### DIFF
--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -72,6 +72,12 @@ export PATH=$PATH:/sbin:/usr/sbin
 arch="$(uname -m)"
 
 if [ -n "$platforms_json" ]; then
+    # just copy it over to /tmp and work from there to minimize 9p I/O
+    cp "${platforms_json}" /tmp/platforms.json
+    platforms_json=/tmp/platforms.json
+fi
+
+if [ -n "$platforms_json" ]; then
     platform_grub_cmds=$(jq -r ".${arch}.${platform}.grub_commands // [] | join(\"\\\\n\")" < "${platforms_json}")
     platform_kargs=$(jq -r ".${arch}.${platform}.kernel_arguments // [] | join(\" \")" < "${platforms_json}")
 else


### PR DESCRIPTION
9p being 9p, we're hitting ENOMEM when trying to read `platforms.json` in `install_grub_cfg()`. Yet, it works fine at the top of the file when we initially parse the kargs and GRUB cmds. So somehow initial reads do go through. Let's try to leverage this by doing an early copy of the file into the supermin filesystem and then do any further introspections from there. That way, we only access it over 9p once.

Maybe fixes https://github.com/coreos/coreos-assembler/issues/3180.