### PR TITLE
buildextend-legacy-oscontainer: extensions owned by UID that untars it

### DIFF
--- a/src/buildextend-legacy-oscontainer.py
+++ b/src/buildextend-legacy-oscontainer.py
@@ -184,7 +184,7 @@ def oscontainer_build(containers_storage, tmpdir, src, ref, image_name_and_tag,
             tarball = os.path.abspath(os.path.join(builddir, meta['extensions']['path']))
             dest_dir = os.path.join(mnt, 'extensions')
             os.makedirs(dest_dir, exist_ok=True)
-            cmdlib.runcmd(["tar", "-xf", tarball], cwd=dest_dir)
+            cmdlib.runcmd(["tar", "-xf", tarball, "--no-same-owner"], cwd=dest_dir)
 
             with open(os.path.join(dest_dir, 'extensions.json')) as f:
                 extensions = json.load(f)


### PR DESCRIPTION
@cgwalters suggested yesterday that 9p might be cause of /extensions having a high UID. By debugging the aarch image which works I noticed that the owner for /extensions/* was 1000 and not root. 

Checking the bad x86-64 oci-archive tarballs I see that the the files are also not root as the error says. 
```
do
   echo "${filename}" &&  tar tvf "${filename}" |grep "extensions"                                                    
done
./sha256/22a7443c237880d209a90a96d6793e554aa01aab8f8bc4524ef9a8a3b72b0dd0
drwxr-sr-x cosa/1001020000   0 2022-11-07 18:07 extensions/
-rw-r--r-- cosa/1001020000 128 2022-11-07 18:07 extensions/.rpm-ostree-state-chksum
-rw-r--r-- cosa/1001020000 3789004 2022-11-07 18:06 extensions/edk2-ovmf-20220126gitbb1bba3d77-2.el8.noarch.rpm
```

passing `--no-same-owner` to the code decompressing the extensions tarball makes the resulting image have /extensions owned by root like the rest of the files. This allowed me to pull the container and run it locally.