### PR TITLE
bump supermin memory for building legacy oscontainer on ppc64le

### DIFF
--- a/src/buildextend-legacy-oscontainer.sh
+++ b/src/buildextend-legacy-oscontainer.sh
@@ -5,6 +5,10 @@ set -euo pipefail
 
 # Start VM and call buildah
 final_outfile=$(realpath "$1"); shift
+if [ "$(uname -m)" == 'ppc64le' ]; then
+    # helps with 9p 'cannot allocate memory' errors on ppc64le
+    COSA_SUPERMIN_MEMORY=6144
+fi
 IMAGE_TYPE=legacy-oscontainer
 prepare_build
 tmp_outfile=${tmp_builddir}/legacy-oscontainer.ociarchive


### PR DESCRIPTION
We're seeing `cannot allocate memory` errors pretty consistently right now on ppc64le when trying to build the legacy oscontainer. Let's throw some more memory at it for now, which seems to be working.

Here's an example of what the error looks like:

```
2022-11-11 02:08:26,095 INFO - Running command: ['ostree', '--repo=/var/lib/containers/storage/overlay/bc2dc5abbd3fd58d5db95d673ff0c30bde2e6c04963186ab42656499e2ee0023/merged/srv/repo', 'pull-local', '--disable-fsync', '/home/jenkins/agent/workspace/build-arch/tmp/repo', 'fe1abec6cd59ffc02b5ae8f616d1211614ba99e5061dd427e77d4001bfc3403e']
error: Importing 2193179e6b5b4f5040c842f6cc1f309c617e9f5705a642d234a162a681db5b51.file: fstatat(21/93179e6b5b4f5040c842f6cc1f309c617e9f5705a642d234a162a681db5b51.filez): Cannot allocate memory
```