### PR TITLE
testiso: improve error when QEMU is terminated

### DIFF
--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -147,6 +147,11 @@ type QemuInstance struct {
 	qmpSocketPath string
 }
 
+// Signaled returns whether QEMU process was signaled.
+func (inst *QemuInstance) Signaled() bool {
+	return inst.qemu.Signaled()
+}
+
 // Pid returns the PID of QEMU process.
 func (inst *QemuInstance) Pid() int {
 	return inst.qemu.Pid()

--- a/mantle/system/exec/exec.go
+++ b/mantle/system/exec/exec.go
@@ -47,6 +47,9 @@ type Cmd interface {
 
 	// Simplified wrapper for Process.Pid
 	Pid() int
+
+	// Simplified wrapper to know if a process was signaled
+	Signaled() bool
 }
 
 // Basic Cmd implementation based on exec.Cmd
@@ -91,6 +94,14 @@ func (cmd *ExecCmd) Kill() error {
 		}
 	}
 	return err
+}
+
+func (cmd *ExecCmd) Signaled() bool {
+	if cmd.ProcessState == nil {
+		return false
+	}
+	status := cmd.ProcessState.Sys().(syscall.WaitStatus)
+	return status.Signaled()
 }
 
 func (cmd *ExecCmd) Pid() int {


### PR DESCRIPTION
Right now when QEMU gets killed during a testiso run, the error is:

    FAIL: pxe-offline-install (bios + metal) (1m10.277s)
        Got EOF from completion channel, coreos-installer-test-OK expected

This is accurate but doesn't hint well enough at the underlying cause.
Rework the two spots in which we wait for virtio-serial strings to also
check if QEMU was killed to provide a better error. E.g.:

    FAIL: pxe-install (bios + metal) (34.483s)
        QEMU unexpectedly exited while waiting awaiting completion: process killed

Related: https://github.com/coreos/fedora-coreos-tracker/issues/1339