### PR TITLE
libguestfish: bump libguestfs VM memory size for ppc64le

### DIFF
--- a/src/libguestfish.sh
+++ b/src/libguestfish.sh
@@ -19,6 +19,12 @@ if [ "$arch" = "ppc64le" ] ; then
     fi
 fi
 
+# Hack to give ppc64le more memory inside the libguestfs VM.
+# The compiled in default I see when running `guestfish get-memsize`
+# is 1280. We need this because we are seeing issues from
+# buildextend-live when running gf-mksquashfs.
+[ "$arch" = "ppc64le" ] && export LIBGUESTFS_MEMSIZE=2048
+
 # http://libguestfs.org/guestfish.1.html#using-remote-control-robustly-from-shell-scripts
 GUESTFISH_PID=
 coreos_gf_launch() {


### PR DESCRIPTION
We've seen errors running buildextend-live on ppc64le:

```
subprocess.CalledProcessError: Command
'['/usr/lib/coreos-assembler/gf-mksquashfs',
  'builds/412.86.202211102204-0/ppc64le/rhcos-412.86.202211102204-0-metal.ppc64le.raw',
  '/home/jenkins/agent/workspace/build-arch/tmp/buildpost-live/initrd-rootfs/root.squashfs',
  'gzip']' returned non-zero exit status 1.
```

It appears to be running out of memory inside the libgestfs VM. This may be because we are setting the smp value high on this particular machine (because it has 128 processors) with the
`coreos_gf set-smp "$(kola ncpu)"` call.