### PR TITLE
add support for cosa powervs-replicate; fix some error handling

### DIFF
--- a/mantle/platform/api/ibmcloud/s3.go
+++ b/mantle/platform/api/ibmcloud/s3.go
@@ -174,10 +174,9 @@ func (a *API) CopyObject(srcBucket, srcName, destBucket string) error {
 	})
 	if err != nil {
 		if awserr, ok := err.(awserr.Error); ok {
-			if awserr.Code() == "BucketAlreadyOwnedByYou" {
-				return nil
-			}
+			err = awserr
 		}
+		return fmt.Errorf("Error copying object to bucket: %v", err)
 	}
 
 	// Wait to see if the item got copied

--- a/src/cmd-powervs-replicate
+++ b/src/cmd-powervs-replicate
@@ -1,0 +1,1 @@
+./cmd-ore-wrapper


### PR DESCRIPTION
```
commit 3c5516aa88a6fdf79e1fd6546029c5f0b39d7730
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Sat Nov 12 16:26:18 2022 -0500

    mantle/platform: fix error handling in ibmcloud/s3 CopyObject
    
    I suspect this was a copy/paste error. `BucketAlreadyOwnedByYou` is
    an error reported from createBucket(), which we aren't calling here.

commit 62f9039b63bca5c979b7a9376396de88de489118
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Sat Nov 12 14:54:22 2022 -0500

    add support for `cosa powervs-replicate`
    
    All we need to do is symlink to cmd-ore-wrapper.

```