### PR TITLE
[rhcos-4.12] backports to get ppc64le working

### DIFF
--- a/mantle/platform/api/ibmcloud/s3.go
+++ b/mantle/platform/api/ibmcloud/s3.go
@@ -174,10 +174,9 @@ func (a *API) CopyObject(srcBucket, srcName, destBucket string) error {
 	})
 	if err != nil {
 		if awserr, ok := err.(awserr.Error); ok {
-			if awserr.Code() == "BucketAlreadyOwnedByYou" {
-				return nil
-			}
+			err = awserr
 		}
+		return fmt.Errorf("Error copying object to bucket: %v", err)
 	}
 
 	// Wait to see if the item got copied

--- a/src/cmd-powervs-replicate
+++ b/src/cmd-powervs-replicate
@@ -1,0 +1,1 @@
+./cmd-ore-wrapper

--- a/src/libguestfish.sh
+++ b/src/libguestfish.sh
@@ -19,6 +19,12 @@ if [ "$arch" = "ppc64le" ] ; then
     fi
 fi
 
+# Hack to give ppc64le more memory inside the libguestfs VM.
+# The compiled in default I see when running `guestfish get-memsize`
+# is 1280. We need this because we are seeing issues from
+# buildextend-live when running gf-mksquashfs.
+[ "$arch" = "ppc64le" ] && export LIBGUESTFS_MEMSIZE=2048
+
 # http://libguestfs.org/guestfish.1.html#using-remote-control-robustly-from-shell-scripts
 GUESTFISH_PID=
 coreos_gf_launch() {


### PR DESCRIPTION
Includes:

- https://github.com/coreos/coreos-assembler/pull/3194
- https://github.com/coreos/coreos-assembler/pull/3195