### PR TITLE
[rhcos-4.11-new] more recent backports

### DIFF
--- a/mantle/platform/api/ibmcloud/s3.go
+++ b/mantle/platform/api/ibmcloud/s3.go
@@ -176,10 +176,9 @@ func (a *API) CopyObject(srcBucket, srcName, destBucket string) error {
 	})
 	if err != nil {
 		if awserr, ok := err.(awserr.Error); ok {
-			if awserr.Code() == "BucketAlreadyOwnedByYou" {
-				return nil
-			}
+			err = awserr
 		}
+		return fmt.Errorf("Error copying object to bucket: %v", err)
 	}
 
 	// Wait to see if the item got copied

--- a/src/buildextend-legacy-oscontainer.sh
+++ b/src/buildextend-legacy-oscontainer.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 # Start VM and call buildah
 . /usr/lib/coreos-assembler/cmdlib.sh
 final_outfile=$(realpath "$1"); shift
+IMAGE_TYPE=legacy-oscontainer
 prepare_build
 # shellcheck disable=SC2154
 tmp_outfile=${tmp_builddir}/legacy-oscontainer.ociarchive

--- a/src/buildextend-legacy-oscontainer.sh
+++ b/src/buildextend-legacy-oscontainer.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC1091
 set -euo pipefail
-# Start VM and call buildah
+# shellcheck source=src/cmdlib.sh
 . /usr/lib/coreos-assembler/cmdlib.sh
+
+# Start VM and call buildah
 final_outfile=$(realpath "$1"); shift
 IMAGE_TYPE=legacy-oscontainer
 prepare_build
-# shellcheck disable=SC2154
 tmp_outfile=${tmp_builddir}/legacy-oscontainer.ociarchive
 runvm -chardev "file,id=ociarchiveout,path=${tmp_outfile}" \
     -device "virtserialport,chardev=ociarchiveout,name=ociarchiveout" -- \

--- a/src/buildextend-legacy-oscontainer.sh
+++ b/src/buildextend-legacy-oscontainer.sh
@@ -5,6 +5,10 @@ set -euo pipefail
 
 # Start VM and call buildah
 final_outfile=$(realpath "$1"); shift
+if [ "$(uname -m)" == 'ppc64le' ]; then
+    # helps with 9p 'cannot allocate memory' errors on ppc64le
+    COSA_SUPERMIN_MEMORY=6144
+fi
 IMAGE_TYPE=legacy-oscontainer
 prepare_build
 tmp_outfile=${tmp_builddir}/legacy-oscontainer.ociarchive

--- a/src/cmd-powervs-replicate
+++ b/src/cmd-powervs-replicate
@@ -1,0 +1,1 @@
+./cmd-ore-wrapper

--- a/src/libguestfish.sh
+++ b/src/libguestfish.sh
@@ -19,6 +19,12 @@ if [ "$arch" = "ppc64le" ] ; then
     fi
 fi
 
+# Hack to give ppc64le more memory inside the libguestfs VM.
+# The compiled in default I see when running `guestfish get-memsize`
+# is 1280. We need this because we are seeing issues from
+# buildextend-live when running gf-mksquashfs.
+[ "$arch" = "ppc64le" ] && export LIBGUESTFS_MEMSIZE=2048
+
 # http://libguestfs.org/guestfish.1.html#using-remote-control-robustly-from-shell-scripts
 GUESTFISH_PID=
 coreos_gf_launch() {


### PR DESCRIPTION
Contains all or part of:

- https://github.com/coreos/coreos-assembler/pull/3195
- https://github.com/coreos/coreos-assembler/pull/3194
- https://github.com/coreos/coreos-assembler/pull/3191
- https://github.com/coreos/coreos-assembler/pull/3188
- https://github.com/coreos/coreos-assembler/pull/3183