### PR TITLE
[rhcos-4.11-new] Dockerfile: Add repovar for RHCOS repos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,9 @@ RUN chmod g=u /etc/passwd
 # also allow adding certificates
 RUN chmod -R g=u /etc/pki/ca-trust
 
+# Add dnf repovar to be used in the RHCOS repos
+RUN echo "4.11" > /etc/dnf/vars/ocprelease
+
 # run as `builder` user
 USER builder
 ENTRYPOINT ["/usr/bin/dumb-init", "/usr/bin/coreos-assembler"]


### PR DESCRIPTION
 - We need a way to determine the ocp version for the `rhel-8-server-ose` repository configuration. It is needed in order to use a single branch for the internal redhat-coreos repo,

Signed-off-by: Renata Ravanelli <rravanel@redhat.com>