### PR TITLE
mantle: Clean up firmware handling

### DIFF
--- a/mantle/cmd/kola/qemuexec.go
+++ b/mantle/cmd/kola/qemuexec.go
@@ -277,7 +277,9 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 		builder.AppendFirstbootKernelArgs = firstbootkargs
 	}
 	builder.AppendKernelArgs = strings.Join(kargs, " ")
-	builder.Firmware = kola.QEMUOptions.Firmware
+	if kola.QEMUOptions.Firmware != "" {
+		builder.Firmware = kola.QEMUOptions.Firmware
+	}
 	if kola.QEMUOptions.DiskImage != "" {
 		channel := "virtio"
 		if kola.QEMUOptions.Nvme {

--- a/mantle/platform/machine/unprivqemu/cluster.go
+++ b/mantle/platform/machine/unprivqemu/cluster.go
@@ -106,7 +106,9 @@ func (qc *Cluster) NewMachineWithQemuOptions(userdata *conf.UserData, options pl
 			return nil, err
 		}
 	}
-	builder.Firmware = qc.flight.opts.Firmware
+	if qc.flight.opts.Firmware != "" {
+		builder.Firmware = qc.flight.opts.Firmware
+	}
 	builder.Swtpm = qc.flight.opts.Swtpm
 	builder.Hostname = fmt.Sprintf("qemu%d", qc.BaseCluster.AllocateMachineSerial())
 	builder.ConsoleFile = qm.consolePath

--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -471,8 +471,17 @@ type QemuBuilder struct {
 
 // NewQemuBuilder creates a new build for QEMU with default settings.
 func NewQemuBuilder() *QemuBuilder {
+	var defaultFirmware string
+	switch coreosarch.CurrentRpmArch() {
+	case "x86_64":
+		defaultFirmware = "bios"
+	case "aarch64":
+		defaultFirmware = "uefi"
+	default:
+		defaultFirmware = ""
+	}
 	ret := QemuBuilder{
-		Firmware:     "bios",
+		Firmware:     defaultFirmware,
 		Swtpm:        true,
 		Pdeathsig:    true,
 		Argv:         []string{},
@@ -1433,8 +1442,8 @@ func (builder *QemuBuilder) Exec() (*QemuInstance, error) {
 	argv = append(argv, "-smp", fmt.Sprintf("%d", builder.Processors))
 
 	switch builder.Firmware {
-	case "bios":
-		break
+	case "":
+		// Nothing to do, use qemu default
 	case "uefi":
 		if err := builder.setupUefi(false); err != nil {
 			return nil, err
@@ -1443,8 +1452,12 @@ func (builder *QemuBuilder) Exec() (*QemuInstance, error) {
 		if err := builder.setupUefi(true); err != nil {
 			return nil, err
 		}
+	case "bios":
+		if coreosarch.CurrentRpmArch() != "x86_64" {
+			return nil, fmt.Errorf("unknown firmware: %s", builder.Firmware)
+		}
 	default:
-		panic(fmt.Sprintf("Unknown firmware: %s", builder.Firmware))
+		return nil, fmt.Errorf("unknown firmware: %s", builder.Firmware)
 	}
 
 	// We always provide a random source


### PR DESCRIPTION
Prep for switching the default to UEFI on x86_64 in https://github.com/coreos/coreos-assembler/pull/3159

- Move the logic for default firmware into the constructor
- Fix various places that were overriding it with the empty string
- Return errors instead of panic on unknown firmware