### PR TITLE
qemu: Add support for full emulation

### DIFF
--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -298,6 +298,9 @@ func syncOptionsImpl(useCosa bool) error {
 			return err
 		}
 	}
+	// Currently the `--arch` option is defined in terms of coreos-assembler, but
+	// we also unconditionally use it for qemu if present.
+	kola.QEMUOptions.Arch = kola.Options.CosaBuildArch
 
 	units, _ := root.PersistentFlags().GetStringSlice("debug-systemd-units")
 	for _, unit := range units {

--- a/mantle/cmd/kola/qemuexec.go
+++ b/mantle/cmd/kola/qemuexec.go
@@ -47,6 +47,8 @@ var (
 	usernet      bool
 	cpuCountHost bool
 
+	architecture string
+
 	hostname       string
 	ignition       string
 	butane         string
@@ -81,6 +83,7 @@ func init() {
 	cmdQemuExec.Flags().StringSliceVar(&ignitionFragments, "add-ignition", nil, "Append well-known Ignition fragment: [\"autologin\", \"autoresize\"]")
 	cmdQemuExec.Flags().StringVarP(&hostname, "hostname", "", "", "Set hostname via DHCP")
 	cmdQemuExec.Flags().IntVarP(&memory, "memory", "m", 0, "Memory in MB")
+	cmdQemuExec.Flags().StringVar(&architecture, "arch", "", "Use full emulation for target architecture (e.g. aarch64, x86_64, s390x, ppc64le)")
 	cmdQemuExec.Flags().StringArrayVarP(&addDisks, "add-disk", "D", []string{}, "Additional disk, human readable size (repeatable)")
 	cmdQemuExec.Flags().BoolVar(&cpuCountHost, "auto-cpus", false, "Automatically set number of cpus to host count")
 	cmdQemuExec.Flags().BoolVar(&directIgnition, "ignition-direct", false, "Do not parse Ignition, pass directly to instance")
@@ -204,6 +207,12 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 
 	builder := platform.NewQemuBuilder()
 	defer builder.Close()
+
+	if architecture != "" {
+		if err := builder.SetArchitecture(architecture); err != nil {
+			return err
+		}
+	}
 
 	var config *conf.Conf
 	if butane != "" {

--- a/mantle/platform/machine/unprivqemu/cluster.go
+++ b/mantle/platform/machine/unprivqemu/cluster.go
@@ -101,6 +101,11 @@ func (qc *Cluster) NewMachineWithQemuOptions(userdata *conf.UserData, options pl
 	builder.ConfigFile = confPath
 	defer builder.Close()
 	builder.UUID = qm.id
+	if qc.flight.opts.Arch != "" {
+		if err := builder.SetArchitecture(qc.flight.opts.Arch); err != nil {
+			return nil, err
+		}
+	}
 	builder.Firmware = qc.flight.opts.Firmware
 	builder.Swtpm = qc.flight.opts.Swtpm
 	builder.Hostname = fmt.Sprintf("qemu%d", qc.BaseCluster.AllocateMachineSerial())

--- a/mantle/platform/machine/unprivqemu/flight.go
+++ b/mantle/platform/machine/unprivqemu/flight.go
@@ -34,6 +34,7 @@ type Options struct {
 	Board    string
 	Firmware string
 	Memory   string
+	Arch     string
 
 	NbdDisk       bool
 	MultiPathDisk bool

--- a/src/deps.txt
+++ b/src/deps.txt
@@ -30,6 +30,8 @@ make git rpm-build
 
 # virt dependencies
 libguestfs-tools libguestfs-tools-c /usr/bin/qemu-img qemu-kvm swtpm
+# And the main arch emulators for cross-arch testing
+qemu-system-aarch64-core qemu-system-ppc-core qemu-system-s390x-core qemu-system-x86-core
 
 # Useful for moving files around
 rsync


### PR DESCRIPTION
With this, one can e.g.:
`cosa run --qemu-image fedora-coreos-36*s390x.qcow2 --arch s390x`

This was surprisingly easy.  It's tempting to do *some* full emulation testing for s390x and ppc64le on x86_64/aarch64.

My immediate motivation however is setting up an environment to debug https://github.com/coreos/rpm-ostree/issues/4146