### PR TITLE
[rhcos-4.10-new] schema: regenerate for legacy-oscontainer

### DIFF
--- a/mantle/vendor/github.com/coreos/coreos-assembler-schema/cosa/cosa_v1.go
+++ b/mantle/vendor/github.com/coreos/coreos-assembler-schema/cosa/cosa_v1.go
@@ -89,6 +89,7 @@ type BuildArtifacts struct {
 	Initramfs          *Artifact `json:"initramfs,omitempty"`
 	Iso                *Artifact `json:"iso,omitempty"`
 	Kernel             *Artifact `json:"kernel,omitempty"`
+	LegacyOscontainer  *Artifact `json:"legacy-oscontainer,omitempty"`
 	LiveInitramfs      *Artifact `json:"live-initramfs,omitempty"`
 	LiveIso            *Artifact `json:"live-iso,omitempty"`
 	LiveKernel         *Artifact `json:"live-kernel,omitempty"`

--- a/mantle/vendor/github.com/coreos/coreos-assembler-schema/cosa/schema_doc.go
+++ b/mantle/vendor/github.com/coreos/coreos-assembler-schema/cosa/schema_doc.go
@@ -414,6 +414,7 @@ var generatedSchemaJSON = `{
        "dasd",
        "digitalocean",
        "exoscale",
+       "legacy-oscontainer",
        "gcp",
        "ibmcloud",
        "powervs",
@@ -449,6 +450,12 @@ var generatedSchemaJSON = `{
          "$id":"#/properties/images/properties/exoscale",
          "type":"object",
          "title":"exoscale",
+         "$ref": "#/definitions/artifact"
+       },
+       "legacy-oscontainer": {
+         "$id": "#/properties/images/properties/legacy-oscontainer",
+         "type": "object",
+         "title": "legacy-oscontainer",
          "$ref": "#/definitions/artifact"
        },
        "qemu": {

--- a/schema/cosa/cosa_v1.go
+++ b/schema/cosa/cosa_v1.go
@@ -89,6 +89,7 @@ type BuildArtifacts struct {
 	Initramfs          *Artifact `json:"initramfs,omitempty"`
 	Iso                *Artifact `json:"iso,omitempty"`
 	Kernel             *Artifact `json:"kernel,omitempty"`
+	LegacyOscontainer  *Artifact `json:"legacy-oscontainer,omitempty"`
 	LiveInitramfs      *Artifact `json:"live-initramfs,omitempty"`
 	LiveIso            *Artifact `json:"live-iso,omitempty"`
 	LiveKernel         *Artifact `json:"live-kernel,omitempty"`

--- a/schema/cosa/schema_doc.go
+++ b/schema/cosa/schema_doc.go
@@ -414,6 +414,7 @@ var generatedSchemaJSON = `{
        "dasd",
        "digitalocean",
        "exoscale",
+       "legacy-oscontainer",
        "gcp",
        "ibmcloud",
        "powervs",
@@ -449,6 +450,12 @@ var generatedSchemaJSON = `{
          "$id":"#/properties/images/properties/exoscale",
          "type":"object",
          "title":"exoscale",
+         "$ref": "#/definitions/artifact"
+       },
+       "legacy-oscontainer": {
+         "$id": "#/properties/images/properties/legacy-oscontainer",
+         "type": "object",
+         "title": "legacy-oscontainer",
          "$ref": "#/definitions/artifact"
        },
        "qemu": {

--- a/schema/v1.json
+++ b/schema/v1.json
@@ -409,6 +409,7 @@
        "dasd",
        "digitalocean",
        "exoscale",
+       "legacy-oscontainer",
        "gcp",
        "ibmcloud",
        "powervs",
@@ -444,6 +445,12 @@
          "$id":"#/properties/images/properties/exoscale",
          "type":"object",
          "title":"exoscale",
+         "$ref": "#/definitions/artifact"
+       },
+       "legacy-oscontainer": {
+         "$id": "#/properties/images/properties/legacy-oscontainer",
+         "type": "object",
+         "title": "legacy-oscontainer",
          "$ref": "#/definitions/artifact"
        },
        "qemu": {


### PR DESCRIPTION
We forgot to do this during the legacy-oscontainer backports.