### PR TITLE
Fix test loading logic with symlinks

### DIFF
--- a/mantle/cmd/kola/kola.go
+++ b/mantle/cmd/kola/kola.go
@@ -386,6 +386,7 @@ func runList(cmd *cobra.Command, args []string) error {
 	}
 	var testlist []*item
 	for name, test := range register.Tests {
+		// fmt.Printf("Looking at test: %s\n", name)
 		item := &item{
 			name,
 			test.Platforms,

--- a/mantle/cmd/kola/switchkernel.go
+++ b/mantle/cmd/kola/switchkernel.go
@@ -17,7 +17,6 @@ package main
 import (
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"strings"
@@ -151,7 +150,7 @@ func runSwitchKernel(cmd *cobra.Command, args []string) error {
 func dropRpmFilesAll(m platform.Machine, localPath string) error {
 	fmt.Println("Dropping RT Kernel RPMs...")
 	re := regexp.MustCompile(`^kernel-rt-.*\.rpm$`)
-	files, err := ioutil.ReadDir(localPath)
+	files, err := os.ReadDir(localPath)
 	if err != nil {
 		return err
 	}

--- a/mantle/util/repo.go
+++ b/mantle/util/repo.go
@@ -16,7 +16,6 @@ package util
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -67,7 +66,7 @@ func GetLocalFastBuildQemu() (string, error) {
 		}
 		return "", err
 	}
-	ents, err := ioutil.ReadDir(fastBuildCosaDir)
+	ents, err := os.ReadDir(fastBuildCosaDir)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Fix test loading logic with symlinks (used in RHCOS)

Fixes: #3135

This reverts commit 96c0295.

---

Not working. Published as draft to let someone else pick it up.