### PR TITLE
[rhcos-4.12] Dockerfile: Add repovar for RHCOS repos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,10 @@ RUN chmod g=u /etc/passwd
 # also allow adding certificates
 RUN chmod -R g=u /etc/pki/ca-trust
 
+# Add dnf repovar to be used in the RHCOS repos
+# It should be removed once we get merged: https://github.com/coreos/rpm-ostree/pull/4152
+RUN echo "4.12" > /etc/dnf/vars/ocprelease
+
 # run as `builder` user
 USER builder
 ENTRYPOINT ["/usr/bin/dumb-init", "/usr/bin/coreos-assembler"]


### PR DESCRIPTION
 - It is need to determine the ocp version for repos like rhel-8-server-ose, in order the use a single branch for the internal redhat-coreos repo.
 - It should be removed for 4.12 once we get coreos/rpm-ostree#4152 merged

Signed-off-by: Renata Ravanelli <rravanel@redhat.com>