### PR TITLE
[rhcos-4.9-new] Dockerfile: Add repovar for RHCOS repos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,9 @@ RUN chmod g=u /etc/passwd
 # also allow adding certificates
 RUN chmod -R g=u /etc/pki/ca-trust
 
+# Add dnf repovar to be used in the RHCOS repos
+RUN echo "4.9" > /etc/dnf/vars/ocprelease
+
 # run as `builder` user
 USER builder
 ENTRYPOINT ["/usr/bin/dumb-init", "/usr/bin/coreos-assembler"]


### PR DESCRIPTION
 - For old releases, the feature adding support for repovars in rpm-ostree don't work. That's why we are adding it manually.
 - It is need to determine the ocp version for repos like rhel-8-server-ose, in order the use a single branch for the internal redhat-coreos repo.

More info:
 - coreos/rpm-ostree#4152

Signed-off-by: Renata Ravanelli <rravanel@redhat.com>