### PR TITLE
[rhcos-4.9-new] cmdlib: mount supermin root disk by UUID

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -607,6 +607,7 @@ EOF
         cat "${tmp_builddir}/supermin.out"
         fatal "Failed to run: supermin --build"
     fi
+    superminrootfsuuid=$(blkid --output=value --match-tag=UUID "${vmbuilddir}/root")
 
     # this is the command run in the supermin container
     # we hardcode a umask of 0022 here to make sure that composes are run
@@ -630,12 +631,12 @@ EOF
                --console-to-file "${runvm_console}")
 
     base_qemu_args=(-drive 'if=none,id=root,format=raw,snapshot=on,file='"${vmbuilddir}"'/root,index=1' \
-                    -device 'virtio-blk,drive=root'
+                    -device 'virtio-blk,drive=root' \
                     -kernel "${vmbuilddir}/kernel" -initrd "${vmbuilddir}/initrd" \
                     -no-reboot -nodefaults \
                     -device virtio-serial \
                     -virtfs 'local,id=workdir,path='"${workdir}"',security_model=none,mount_tag=workdir' \
-                    -append "root=/dev/vda console=${DEFAULT_TERMINAL} selinux=1 enforcing=0 autorelabel=1" \
+                    -append "root=UUID=${superminrootfsuuid} console=${DEFAULT_TERMINAL} selinux=1 enforcing=0 autorelabel=1" \
                    )
 
     # support local dev cases where src/config is a symlink.  Note if you change or extend to this set,


### PR DESCRIPTION
On s390x we've seen the supermin VM get the two disks attached to it when running buildextend-qemu mixed up such that the blank 10G disk to be populated is vda and superman fails to start because it can't mount a blank disk. Let's mount via filesystem UUID here.

Fixes https://github.com/coreos/coreos-assembler/issues/2941

(cherry picked from commit f9332a5381a954b605ed64adde6934fde4644f9b)