### PR TITLE
coreos-assembler/src/cmdlib: rearrange option sequence

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -38,7 +38,7 @@ pod(image: imageName + ":latest", kvm: true, cpu: "${cpuCount}", memory: "${memo
 
     stage("Build Cloud Images") {
         cosaParallelCmds(cosaDir: "/srv", commands: ["Aliyun", "AWS", "Azure", "DigitalOcean", "Exoscale", "GCP",
-                                                     "IBMCloud", "KubeVirt", "OpenStack", "VMware", "Vultr"])
+                                                     "IBMCloud", "OpenStack", "VMware", "Vultr"])
 
         // quick schema validation
         utils.cosaCmd(cosaDir: "/srv", args: "meta --get name")

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -395,7 +395,7 @@ EOF
         # Because right now rpm-ostree doesn't look for .repo files in
         # each included dir.
         # https://github.com/projectatomic/rpm-ostree/issues/1628
-        find "${configdir}/" -name '*.repo' -maxdepth 1 -type f -exec cp -t "${tmp_overridesdir}" {} +
+        find "${configdir}/" -maxdepth 1 -type f -name '*.repo' -exec cp -t "${tmp_overridesdir}" {} +
         if [ -d "${workdir}/src/yumrepos" ]; then
             find "${workdir}/src/yumrepos/" -maxdepth 1 -type f -name '*.repo' -exec cp -t "${tmp_overridesdir}" {} +
         fi


### PR DESCRIPTION
Rearrange location of '-maxdepth' option to eliminate 'find' warning

See: https://github.com/coreos/coreos-assembler/issues/3199