### PR TITLE
 build: Add `fedora-coreos.stream` to image labels

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -435,6 +435,7 @@ else
         --label="coreos-assembler.image-input-checksum=${image_input_checksum}" \
         --label="org.opencontainers.image.source=${gitsrc}" \
         --label="org.opencontainers.image.revision=${config_gitrev}" \
+        --copymeta-opt=fedora-coreos.stream \
         "${labels[@]}" \
         "${buildid}" \
         oci-archive:"${ostree_tarfile_path}".tmp:latest

--- a/src/cmd-build
+++ b/src/cmd-build
@@ -412,7 +412,6 @@ else
     ostree_format=$(jq -r '.["ostree-format"]' < "${image_json}")
     ostree_tarfile_path="${name}-${buildid}-ostree.${basearch}.ociarchive"
     gitsrc=$(jq -r .git.origin < "${PWD}/coreos-assembler-config-git.json")
-    cmd=(ostree container encapsulate --copymeta="rpmostree.inputhash")
     openshift_cvo_labels=$(jq -r '.["ostree-container-inject-openshift-cvo-labels"]' < "${image_json}")
 
     # The ostree-ext default is 64, but this is still too much apparently
@@ -421,9 +420,7 @@ else
     # `cannot mount layer, mount label "" too large 4168 > page size 4096`
     MAX_OSTREECONTAINER_LAYERS=50
     case "${ostree_format}" in
-        oci-chunked-v1)
-            cmd=(rpm-ostree compose container-encapsulate --max-layers="$MAX_OSTREECONTAINER_LAYERS" --format-version=1)
-        ;;
+        oci-chunked-v1) ;;
         *) fatal "Unknown ostree-format: ${ostree_format}"
     esac
     labels=()
@@ -432,7 +429,8 @@ else
                  "--label=io.openshift.build.versions=machine-os=${buildid}"
                 )
     fi
-    runv "${cmd[@]}" --repo="${tmprepo}" \
+    runv rpm-ostree compose container-encapsulate --max-layers="$MAX_OSTREECONTAINER_LAYERS" --format-version=1 \
+        --repo="${tmprepo}" \
         --label="coreos-assembler.image-config-checksum=${image_config_checksum}" \
         --label="coreos-assembler.image-input-checksum=${image_input_checksum}" \
         --label="org.opencontainers.image.source=${gitsrc}" \


### PR DESCRIPTION
build: Drop reference to `ostree container encapsulate`

We aren't going to use this.

---

build: Add `fedora-coreos.stream` to image labels

From discussion in https://github.com/coreos/zincati/pull/878
related to https://github.com/coreos/fedora-coreos-tracker/issues/1263

---

