### PR TITLE
cmd-compress: support `compressor` field in `image.yaml`

### DIFF
--- a/src/cmd-compress
+++ b/src/cmd-compress
@@ -11,7 +11,9 @@ import argparse
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from cosalib.builds import Builds
+from cosalib.meta import GenericBuildMeta
 from cosalib.cmdlib import (
+    extract_image_json,
     ncpu,
     rm_allow_noent,
     runcmd,
@@ -56,7 +58,14 @@ if args.fast:
     args.compressor = 'gzip'
     gzip_level = 1
 elif not args.compressor:
-    args.compressor = DEFAULT_COMPRESSOR
+    workdir = os.getcwd()
+    arches = builds.get_build_arches(build)
+    # image.json isn't arch-dependent, so just extract it from the first arch
+    buildmeta = GenericBuildMeta(workdir=workdir, build=build, basearch=arches[0])
+    extract_image_json(workdir, buildmeta['ostree-commit'])
+    with open(os.path.join(workdir, 'tmp/image.json')) as f:
+        image_json = json.load(f)
+    args.compressor = image_json.get('compressor', DEFAULT_COMPRESSOR)
 
 # find extension for compressor
 ext_dict = {'xz': '.xz', 'gzip': '.gz'}

--- a/src/cmd-compress
+++ b/src/cmd-compress
@@ -30,10 +30,8 @@ parser = argparse.ArgumentParser()
 parser.add_argument("--build", help="Build ID")
 parser.add_argument("--artifact", default=[], action='append',
                     help="Only compress given image ARTIFACT", metavar="ARTIFACT")
-parser.add_argument("--compressor",
-                    choices=['xz', 'gzip'],
-                    default=DEFAULT_COMPRESSOR,
-                    help=f"Compressor to use, default is {DEFAULT_COMPRESSOR}")
+parser.add_argument("--compressor", choices=['xz', 'gzip'],
+                    help="Override compressor to use")
 parser.add_argument("--mode",
                     choices=['compress', 'uncompress'],
                     default=DEFAULT_MODE,
@@ -57,6 +55,8 @@ gzip_level = 6
 if args.fast:
     args.compressor = 'gzip'
     gzip_level = 1
+elif not args.compressor:
+    args.compressor = DEFAULT_COMPRESSOR
 
 # find extension for compressor
 ext_dict = {'xz': '.xz', 'gzip': '.gz'}

--- a/src/cmd-compress
+++ b/src/cmd-compress
@@ -42,16 +42,6 @@ parser.add_argument("--fast", action='store_true',
                     help="Override compression to `gzip -1`")
 args = parser.parse_args()
 
-# that's the tool default
-gzip_level = 6
-if args.fast:
-    args.compressor = 'gzip'
-    gzip_level = 1
-
-# find extension for --compressor
-ext_dict = {'xz': '.xz', 'gzip': '.gz'}
-ext = ext_dict[args.compressor]
-
 builds = Builds()
 
 # default to latest build if not specified
@@ -61,6 +51,16 @@ else:
     build = builds.get_latest()
 
 print(f"Targeting build: {build}")
+
+# that's the tool default
+gzip_level = 6
+if args.fast:
+    args.compressor = 'gzip'
+    gzip_level = 1
+
+# find extension for compressor
+ext_dict = {'xz': '.xz', 'gzip': '.gz'}
+ext = ext_dict[args.compressor]
 
 
 def get_cpu_param(param):


### PR DESCRIPTION
FCOS compresses its artifacts with xz, RHCOS with gzip. This is
currently encoded in the pipeline, but it should be driven at a lower
level so that we don't have to care about this in the pipeline and also
so developers don't have to think about passing the right switch
locally.

Extend `image.yaml` to support a `compressor` field for this. This will
be used by FCOS to override the default `gzip`.

This will allow us to drop a hack in the CoreOS pipeline.