### PR TITLE
[rhcos-4.12] cosalib/build: only take artifact lock when actually building it

### DIFF
--- a/src/cosalib/build.py
+++ b/src/cosalib/build.py
@@ -140,8 +140,6 @@ class _Build:
                  self.summary, self.build_name.upper(), self.basearch,
                  self.build_id)
 
-        self.set_token()
-
     def __del__(self):
         try:
             tmpdir = getattr(self, "_tmpdir", None)
@@ -411,7 +409,9 @@ class _Build:
         :raises: NotImplementedError
         """
         log.info("Processing the build artifacts")
+        self.set_token()
         self._build_artifacts(*args, **kwargs)
+        self.unset_token()
         log.info("Finished building artifacts")
         if len(self._found_files.keys()) == 0:
             log.warn("There were no files found after building")


### PR DESCRIPTION
We have this lock to prevent multiple `buildextend-${platform}` from running concurrently. But it gets taken when the `_Build` object is initialized rather than when we actually need to build it.

This clashes with our use of `cosa buildextend-aws --upload`, where the artifact is already built and we just want to upload it. We should be able to support multiple concurrent uploads to different AWS partitions.

Fix this by moving locking to when we actually build the artifact so we don't take the lock during pure upload operations.

Note this is independent of the meta-update lock.

(cherry picked from commit 951d2496fca64889a1b3a9527afdf41f3e365975)