### PR TITLE
cmdlib: merge inner lists when merging dicts

### DIFF
--- a/src/cosalib/cmdlib.py
+++ b/src/cosalib/cmdlib.py
@@ -423,7 +423,6 @@ def flatten_image_yaml(srcfile, base=None):
 
     # first, special-case list values
     merge_lists(base, srcyaml, 'extra-kargs')
-    merge_lists(base, srcyaml, 'ignition-network-kcmdline')
 
     # then handle all the non-list values
     base = merge_dicts(base, srcyaml)

--- a/src/cosalib/cmdlib.py
+++ b/src/cosalib/cmdlib.py
@@ -103,6 +103,9 @@ def merge_dicts(x, y):
             elif type(x[k]) == dict and type(y[k]) == dict:
                 # recursively merge
                 ret.update({k: merge_dicts(x[k], y[k])})
+            elif type(x[k]) == list and type(y[k]) == list:
+                ret.update({k: x[k]})
+                merge_lists(ret, y, k)
             else:
                 # first dictionary always takes precedence
                 ret.update({k: x[k]})

--- a/src/cosalib/cmdlib.py
+++ b/src/cosalib/cmdlib.py
@@ -406,12 +406,14 @@ def write_image_json(srcfile, outfile):
         json.dump(r, f, sort_keys=True)
 
 
+# Merge two lists, avoiding duplicates. Exact duplicate kargs could be valid
+# but we have no use case for them right now in our official images.
 def merge_lists(x, y, k):
     x[k] = x.get(k, [])
     assert type(x[k]) == list
     y[k] = y.get(k, [])
     assert type(y[k]) == list
-    x[k].extend(y[k])
+    x[k].extend([i for i in y[k] if i not in x[k]])
 
 
 def flatten_image_yaml(srcfile, base=None):


### PR DESCRIPTION
The expected semantic when merging two e.g. `meta.json` files is that
list keys are merged together, not that one clobbers the other. We
interestingly don't have many list types in the schema, but `amis` is
one of them and hits this right now because we upload to regular AWS and
AWS GovCloud in parallel. (In retrospect, `amis` should have probably
been a `dict` too, with the region as the key name. So a future cleanup
would be to migrate the schema to that model.)