### PR TITLE
RFC: Revert "Remove the `tag` command"

### DIFF
--- a/cmd/coreos-assembler.go
+++ b/cmd/coreos-assembler.go
@@ -15,7 +15,7 @@ import (
 var buildCommands = []string{"init", "fetch", "build", "run", "prune", "clean", "list"}
 var advancedBuildCommands = []string{"buildfetch", "buildupload", "oc-adm-release", "push-container", "upload-oscontainer", "buildextend-extensions"}
 var buildextendCommands = []string{"aliyun", "aws", "azure", "digitalocean", "exoscale", "extensions", "extensions-container", "gcp", "ibmcloud", "kubevirt", "legacy-oscontainer", "live", "metal", "metal4k", "nutanix", "openstack", "qemu", "secex", "virtualbox", "vmware", "vultr"}
-var utilityCommands = []string{"aws-replicate", "compress", "copy-container", "generate-hashlist", "koji-upload", "kola", "push-container-manifest", "remote-build-container", "remote-prune", "remote-session", "sign", "update-variant"}
+var utilityCommands = []string{"aws-replicate", "compress", "copy-container", "generate-hashlist", "koji-upload", "kola", "push-container-manifest", "remote-build-container", "remote-prune", "remote-session", "sign", "tag", "update-variant"}
 var otherCommands = []string{"shell", "meta"}
 
 func init() {

--- a/src/cmd-build
+++ b/src/cmd-build
@@ -30,6 +30,7 @@ Usage: coreos-assembler build --help
   -F | --fetch        Also perform a fetch
   --strict            Only allow installing locked packages when using lockfiles
   --prepare-only      Do not actually build, only set things up so that `rpm-ostree compose image` works.
+  --tag TAG           Set the given tag in the build metadata
   --version VERSION   Use the given version instead of generating one based on current time
 
   Additional environment variables supported:
@@ -50,9 +51,10 @@ PREPARE_ONLY=0
 VERSION=
 PARENT=
 PARENT_BUILD=
+TAG=
 STRICT=
 rc=0
-options=$(getopt --options hfFt: --longoptions help,fetch,force,version:,parent:,parent-build:,delay-meta-merge,force-nocache,force-image,skip-prune,prepare-only,strict -- "$@") || rc=$?
+options=$(getopt --options hfFt: --longoptions tag:,help,fetch,force,version:,parent:,parent-build:,delay-meta-merge,force-nocache,force-image,skip-prune,prepare-only,strict -- "$@") || rc=$?
 [ $rc -eq 0 ] || {
     print_help
     exit 1
@@ -97,6 +99,10 @@ while true; do
         --parent-build)
             shift
             PARENT_BUILD=$1
+            ;;
+        -t | --tag)
+            shift
+            TAG=$1
             ;;
         --)
             shift
@@ -549,6 +555,12 @@ else
   "${dn}"/cmd-prune --workdir "${workdir}"
 fi
 rm builds/.build-commit
+
+if [ -n "${TAG}" ]; then
+    # ideally, we'd do this atomically before moving to builds/latest, but
+    # meh... not much can go wrong with `cosa tag`
+    /usr/lib/coreos-assembler/cmd-tag update --build "${buildid}" --tag "${TAG}"
+fi
 
 # and finally, build the specified targets
 build_followup_targets

--- a/src/cmd-tag
+++ b/src/cmd-tag
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+# NOTE: PYTHONUNBUFFERED is set in the entrypoint for unbuffered output
+#
+# Allows users to operate on the tags in `builds.json`
+#
+# Examples:
+#
+#   $ coreos-assembler tag update --tag smoketested --build 47.152
+#   $ coreos-assembler tag delete --tag beta
+#   $ coreos-assembler tag list
+#
+import argparse
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from cosalib.builds import Builds
+from cosalib.cmdlib import fatal, rfc3339_time
+
+
+def main():
+    """Main entry point"""
+
+    args = parse_args()
+    args.func(args)
+
+
+def parse_args():
+    """Parse args and dispatch"""
+
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="cmd", title="Tag actions")
+    subparsers.required = True
+
+    delete = subparsers.add_parser("delete",
+                                   help="Delete a tag from the metadata")
+    delete.add_argument("--tag", help="Tag to delete from metadata")
+    delete.add_argument("--all", help="Delete all tags",
+                        action="store_true")
+    delete.set_defaults(func=cmd_delete)
+
+    list_tags = subparsers.add_parser("list", help="List available tags in "
+                                                   "the metadata")
+    list_tags.set_defaults(func=cmd_list)
+
+    update = subparsers.add_parser("update", help="Update existing tag or "
+                                                  "create a new tag")
+    update.add_argument("--tag", help="Tag to be updated", required=True)
+    update.add_argument("--description", help="Message to associate with tag")
+    update.add_argument("--build", help="Build to update tag with")
+    update.add_argument("--force", help="Force the update of a tag",
+                        action="store_true")
+    update.set_defaults(func=cmd_update)
+
+    return parser.parse_args()
+
+
+def available_tags(build_data):
+    """Returns the available tag names from build metadata"""
+
+    return [t.get("name") for t in build_data.get("tags", {})]
+
+
+def cmd_list(args):
+    """List available tags in build metadata"""
+
+    builds = Builds()
+    build_data = builds.raw()
+    avail_tags = available_tags(build_data)
+    if not avail_tags:
+        print("No tags found")
+        return
+
+    for tag in build_data["tags"]:
+        print(f"name: {tag['name']}\n"
+              f"created: {tag['created']}\n"
+              f"target: {tag['target']}\n", end='')
+        if 'description' in tag:
+            print(f"description:\n\t{tag['description']}\n", end='')
+        print()
+
+
+def cmd_update(args):
+    """Create or update a tag to new build ID"""
+
+    builds = Builds()
+    if args.build is None:
+        args.build = builds.get_latest()
+    build_data = builds.raw()
+
+    avail_tags = available_tags(build_data)
+
+    if "tags" not in build_data:
+        build_data["tags"] = []
+
+    # if the build doesn't exist, check for the force flag and bail out
+    # if it is not used.
+    if not builds.has(args.build):
+        if not args.force:
+            fatal("Cannot operate on a tag with a build that does not exist")
+        print(f"INFO: Operating on a tag ({args.tag}) with a build "
+              f"({args.build}) that does not exist")
+
+    # we've got a build (either forced or not), so time to make/update a tag
+    created = rfc3339_time()
+    new_tag = {
+        "name": args.tag,
+        "created": created,
+        "target": args.build,
+    }
+    if args.description:
+        new_tag['description'] = args.description
+    if args.tag not in avail_tags:
+        build_data["tags"].append(new_tag)
+    else:
+        build_data["tags"] = [new_tag if t.get("name") == args.tag
+                              else t for t in build_data["tags"]]
+    builds.flush()
+
+
+def cmd_delete(args):
+    """Delete a tag from build metadata"""
+
+    # To delete a tag, iterate through existing tags list, and
+    # drop the entry we want
+    builds = Builds()
+    build_data = builds.raw()
+
+    if args.all:
+        if "tags" in build_data:
+            del build_data["tags"]
+    elif args.tag:
+        avail_tags = available_tags(build_data)
+        if args.tag not in avail_tags:
+            fatal("Cannot delete a tag that does not exist")
+        build_data["tags"] = [t for t in build_data["tags"]
+                              if t["name"] != args.tag]
+    else:
+        fatal("Either --tag or --all required")
+
+    builds.flush()
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
This reverts commit 1f62f5ad9c89ff84acf67ce17bd934f01bea8075.

I find this command useful for debugging issues that require multiple cosa builds.

Let's restore its functionality for now and we can look at rewriting it in Go in the future.