### PR TITLE
plume: deprecate `release`, add `make-amis-public` and `update-release-index`

### DIFF
--- a/mantle/cmd/plume/release.go
+++ b/mantle/cmd/plume/release.go
@@ -96,7 +96,9 @@ func runFcosRelease(cmd *cobra.Command, args []string) {
 
 	api := getAWSApi()
 	doS3(api)
-	modifyReleaseMetadataIndex(api)
+	rel := getReleaseMetadata(api)
+	makeReleaseAMIsPublic(rel)
+	modifyReleaseMetadataIndex(api, rel)
 }
 
 func getAWSApi() *aws.API {
@@ -182,7 +184,7 @@ func makeReleaseAMIsPublic(rel release.Release) {
 	}
 }
 
-func modifyReleaseMetadataIndex(api *aws.API) {
+func modifyReleaseMetadataIndex(api *aws.API, rel release.Release) {
 	// Note we use S3 directly here instead of
 	// FetchAndParseCanonicalReleaseIndex(), since that one uses the
 	// CloudFronted URL and we need to be sure we're operating on the latest
@@ -225,8 +227,6 @@ func modifyReleaseMetadataIndex(api *aws.API) {
 		plog.Fatalf("creating metadata url: %v", err)
 	}
 
-	rel := getReleaseMetadata(api)
-
 	var commits []release.IndexReleaseCommit
 	for arch, vals := range rel.Architectures {
 		commits = append(commits, release.IndexReleaseCommit{
@@ -262,8 +262,6 @@ func modifyReleaseMetadataIndex(api *aws.API) {
 			}
 		}
 	}
-
-	makeReleaseAMIsPublic(rel)
 
 	releaseIdx.Releases = append(releaseIdx.Releases, newIdxRelease)
 

--- a/mantle/cmd/plume/release.go
+++ b/mantle/cmd/plume/release.go
@@ -35,7 +35,6 @@ var (
 	selectedDistro     string
 
 	specBucket  string
-	specPolicy  string
 	specProfile string
 	specRegion  string
 	specStream  string
@@ -60,7 +59,6 @@ func init() {
 		plog.Fatalf("failed to make --bucket deprecated: %v", err)
 	}
 	cmdRelease.Flags().StringVar(&specBucketPrefix, "bucket-prefix", "", "S3 bucket and prefix")
-	cmdRelease.Flags().StringVar(&specPolicy, "policy", "public-read", "Canned ACL policy")
 	cmdRelease.Flags().StringVar(&specProfile, "profile", "default", "AWS profile")
 	cmdRelease.Flags().StringVar(&specRegion, "region", "us-east-1", "S3 bucket region")
 	cmdRelease.Flags().StringVarP(&specStream, "stream", "S", "testing", "target stream")
@@ -267,7 +265,7 @@ func modifyReleaseMetadataIndex(api *aws.API, rel release.Release) {
 
 	// we don't want this to be cached for very long so that e.g. Cincinnati picks it up quickly
 	var releases_max_age = 60 * 5
-	err = api.UploadObjectExt(bytes.NewReader(out), bucket, path, true, specPolicy, aws.ContentTypeJSON, releases_max_age)
+	err = api.UploadObjectExt(bytes.NewReader(out), bucket, path, true, "public-read", aws.ContentTypeJSON, releases_max_age)
 	if err != nil {
 		plog.Fatalf("uploading release metadata json: %v", err)
 	}

--- a/mantle/cmd/plume/release.go
+++ b/mantle/cmd/plume/release.go
@@ -43,14 +43,30 @@ var (
 	specBucketPrefix string
 
 	cmdRelease = &cobra.Command{
-		Use:   "release [options]",
-		Short: "Publish a new CoreOS release.",
-		Run:   runRelease,
-		Long:  `Publish a new CoreOS release.`,
+		Use:        "release [options]",
+		Short:      "Publish a new CoreOS release.",
+		Run:        runRelease,
+		Long:       `Publish a new CoreOS release.`,
+		Deprecated: "please use make-amis-public and update-release-index instead",
+	}
+
+	cmdMakeAmisPublic = &cobra.Command{
+		Use:   "make-amis-public [options]",
+		Short: "Make the AMIs of a CoreOS release public.",
+		Run:   runMakeAmisPublic,
+		Long:  "Make the AMIs of a CoreOS release public.",
+	}
+
+	cmdUpdateReleaseIndex = &cobra.Command{
+		Use:   "update-release-index [options]",
+		Short: "Update a stream's release index for a CoreOS release.",
+		Run:   runUpdateReleaseIndex,
+		Long:  "Update a stream's release index for a CoreOS release.",
 	}
 )
 
 func init() {
+	// XXX: we'll remove this command soon
 	cmdRelease.Flags().StringVar(&awsCredentialsFile, "aws-credentials", "", "AWS credentials file")
 	cmdRelease.Flags().StringVar(&selectedDistro, "distro", "fcos", "system to release")
 	cmdRelease.Flags().StringVar(&specBucket, "bucket", "", "S3 bucket")
@@ -64,6 +80,23 @@ func init() {
 	cmdRelease.Flags().StringVarP(&specStream, "stream", "S", "testing", "target stream")
 	cmdRelease.Flags().StringVarP(&specVersion, "version", "V", "", "release version")
 	root.AddCommand(cmdRelease)
+
+	cmdMakeAmisPublic.Flags().StringVar(&awsCredentialsFile, "aws-credentials", "", "AWS credentials file")
+	cmdMakeAmisPublic.Flags().StringVar(&specBucketPrefix, "bucket-prefix", "", "S3 bucket and prefix")
+	cmdMakeAmisPublic.Flags().StringVar(&specProfile, "profile", "default", "AWS profile")
+	cmdMakeAmisPublic.Flags().StringVar(&specRegion, "region", "us-east-1", "S3 bucket region")
+	cmdMakeAmisPublic.Flags().StringVarP(&specStream, "stream", "", "", "target stream")
+	cmdMakeAmisPublic.Flags().StringVarP(&specVersion, "version", "", "", "release version")
+	root.AddCommand(cmdMakeAmisPublic)
+
+	cmdUpdateReleaseIndex.Flags().StringVar(&awsCredentialsFile, "aws-credentials", "", "AWS credentials file")
+	cmdUpdateReleaseIndex.Flags().StringVar(&specBucketPrefix, "bucket-prefix", "", "S3 bucket and prefix")
+	cmdUpdateReleaseIndex.Flags().StringVar(&specProfile, "profile", "default", "AWS profile")
+	cmdUpdateReleaseIndex.Flags().StringVar(&specRegion, "region", "", "S3 bucket region")
+	cmdUpdateReleaseIndex.Flags().StringVarP(&specStream, "stream", "", "", "target stream")
+	cmdUpdateReleaseIndex.Flags().StringVarP(&specVersion, "version", "", "", "release version")
+	root.AddCommand(cmdUpdateReleaseIndex)
+
 }
 
 func runRelease(cmd *cobra.Command, args []string) {
@@ -95,6 +128,18 @@ func runFcosRelease(cmd *cobra.Command, args []string) {
 	api := getAWSApi()
 	rel := getReleaseMetadata(api)
 	makeReleaseAMIsPublic(rel)
+	modifyReleaseMetadataIndex(api, rel)
+}
+
+func runMakeAmisPublic(cmd *cobra.Command, args []string) {
+	api := getAWSApi()
+	rel := getReleaseMetadata(api)
+	makeReleaseAMIsPublic(rel)
+}
+
+func runUpdateReleaseIndex(cmd *cobra.Command, args []string) {
+	api := getAWSApi()
+	rel := getReleaseMetadata(api)
 	modifyReleaseMetadataIndex(api, rel)
 }
 

--- a/mantle/cmd/plume/release.go
+++ b/mantle/cmd/plume/release.go
@@ -95,7 +95,6 @@ func runFcosRelease(cmd *cobra.Command, args []string) {
 	}
 
 	api := getAWSApi()
-	doS3(api)
 	rel := getReleaseMetadata(api)
 	makeReleaseAMIsPublic(rel)
 	modifyReleaseMetadataIndex(api, rel)
@@ -127,14 +126,6 @@ func getBucketAndStreamPrefix() (string, string) {
 	// https://github.com/coreos/fedora-coreos-tracker/issues/189.
 	// We'll drop support for this soon.
 	return specBucket, filepath.Join("prod", "streams", specStream)
-}
-
-func doS3(api *aws.API) {
-	bucket, prefix := getBucketAndStreamPrefix()
-	err := api.UpdateBucketObjectsACL(bucket, filepath.Join(prefix, "builds", specVersion), specPolicy)
-	if err != nil {
-		plog.Fatalf("updating object ACLs: %v", err)
-	}
 }
 
 func getReleaseMetadata(api *aws.API) release.Release {

--- a/mantle/cmd/plume/release.go
+++ b/mantle/cmd/plume/release.go
@@ -165,6 +165,7 @@ func makeReleaseAMIsPublic(rel release.Release) {
 				plog.Fatalf("creating AWS API for modifying launch permissions: %v", err)
 			}
 
+			plog.Noticef("making AMI %s public", ami.Image)
 			err = aws_api.PublishImage(ami.Image)
 			if err != nil {
 				plog.Fatalf("couldn't publish image in %v: %v", region, err)
@@ -239,6 +240,7 @@ func modifyReleaseMetadataIndex(api *aws.API, rel release.Release) {
 			comp := compareCommits(rel.Commits, newIdxRelease.Commits)
 			if comp == 0 {
 				// the build is already the latest release, exit
+				plog.Notice("build is already present and is the latest release")
 				return
 			} else if comp == -1 {
 				// the build is present and contains a subset of the new release data,


### PR DESCRIPTION
Focus for FCOS release logic has shifted to the `release` Jenkins job. I
think we could've gone the other way and put more of the release logic
like pushing containers and promoting GCP images into plume. We might
end up there eventually, but right now the pipeline is heavily centered
around doing cosa/mantle calls for specific things, and so it's really
awkward to have this generic `plume release` call that acts like a
blackbox and does multiple things under the hood.

Let's split the `release` command into two:
- `make-amis-public`: to make all the AMIs in a specific release public
- `update-release-index`: to inject new releases into the release index

Then it's really clear what each command does. This will also allow us
to get rid of a hack we're carrying for not calling this command for
RHCOS (though I'd like to make use of `make-amis-public` for RHCOS to
match the flow of FCOS).