### PR TITLE
[rhcos-4.9-new] Install `oc`

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Currently used to determine the version of `oc` we install
+OCP_VERSION=4.10
+
 # Detect what platform we are on
 if ! grep -q '^Fedora' /etc/redhat-release; then
     echo 1>&2 "should be on either Fedora"
@@ -87,6 +90,14 @@ install_rpms() {
     yum clean all
 }
 
+# For now, we ship `oc` in coreos-assembler as {Fedora,RHEL} CoreOS is an essential part of OCP4,
+# and it is very useful to have in the same place/flow as where we do builds/tests related
+# to CoreOS.
+install_ocp_tools() {
+    curl -L https://mirror.openshift.com/pub/openshift-v4/"$(arch)"/clients/ocp/latest-$OCP_VERSION/openshift-client-linux.tar.gz | tar zxf - oc \
+        && mv oc /usr/bin
+}
+
 make_and_makeinstall() {
     make && make install
 }
@@ -137,5 +148,6 @@ else
   install_rpms
   write_archive_info
   make_and_makeinstall
+  install_ocp_tools
   configure_user
 fi


### PR DESCRIPTION
The immediate motivation is https://github.com/openshift/release/blob/master/ci-operator/config/openshift/os/openshift-os-master.yaml#L77

For RHEL CoreOS related stuff in particular it's just really useful to have the `oc` binary in coreos-assembler to streamline things like "build a new release image that overrides the OS" etc.

I suspect this would help OKD too.

(cherry picked from commit 71bdff49d18db0f9c961ecd11c720cda2bc1f9e2)

jlebon: Trivial conflict resolution needed. Backporting this because the
        pipeline uses `oc` for querying annotations.