### PR TITLE
gcloud: Enable `GVNIC` and `SEV_CAPABLE`

### DIFF
--- a/mantle/platform/api/gcloud/image.go
+++ b/mantle/platform/api/gcloud/image.go
@@ -107,6 +107,14 @@ func (a *API) CreateImage(spec *ImageSpec, overwrite bool) (*compute.Operation, 
 		{
 			Type: "VIRTIO_SCSI_MULTIQUEUE",
 		},
+		// RHEL supports this since 8.4; TODO share logic here with
+		// https://github.com/osbuild/osbuild-composer/blob/c6570f6c94149b47f2f8e2f82d7467d6b96755bb/internal/cloud/gcp/compute.go#L16
+		{
+			Type: "SEV_CAPABLE",
+		},
+		{
+			Type: "GVNIC",
+		},
 		{
 			Type: "UEFI_COMPATIBLE",
 		},


### PR DESCRIPTION


https://issues.redhat.com/browse/COS-1794

RHEL has supported SEV since 8.4; long term we should figure
out how to share logic with Image Builder here since the
feature set depends on the OS version.

---

