### PR TITLE
harness.go: make `architectures: "!ppc64le !s390x"` works

### DIFF
--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -573,6 +573,7 @@ func filterTests(tests map[string]*register.Test, patterns []string, pltfrm stri
 				}
 			}
 			for _, i := range exclude {
+				i = strings.TrimPrefix(i, "!")
 				if i == item {
 					allowed = false
 					excluded = true


### PR DESCRIPTION
To skip arch both on `ppc64le` and `s390x` using `"architectures": "!ppc64le s390x"`(works), but sometimes this is confused, we also want to make `"!ppc64le !s390x"` working