### PR TITLE
cmd-buildextend-extensions: fix import_ostree_commit arg

### DIFF
--- a/src/cmd-buildextend-extensions
+++ b/src/cmd-buildextend-extensions
@@ -44,7 +44,7 @@ def main():
         raise Exception(f"Missing {extensions_src}")
 
     commit = buildmeta['ostree-commit']
-    cmdlib.import_ostree_commit('tmp/repo', builddir, buildmeta)
+    cmdlib.import_ostree_commit(workdir, builddir, buildmeta)
 
     tmpworkdir = prepare_tmpworkdir()
     changed = run_rpmostree(tmpworkdir, commit, treefile_src, extensions_src)


### PR DESCRIPTION
The first arg is the workdir, not the OSTree repo path. The previous version still worked because `import_ostree_commit` treated it as a blank `tmp/` and repopulated the repo, which means we were paying the cost of re-extracting the oscontainer and recompressing all the files during the pull-local into the archive repo.