### PR TITLE
qemu.go: drop `vsmt=8` and `cap-fwnmi=off` qemu args for ppc64le

### DIFF
--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -1110,7 +1110,9 @@ func baseQemuArgs() []string {
 	case "ppc64le":
 		ret = []string{
 			"qemu-system-ppc64",
-			"-machine", "pseries,kvm-type=HV,vsmt=8,cap-fwnmi=off," + accel,
+			// kvm-type=HV ensures we use bare metal KVM and not "user mode"
+			// https://qemu.readthedocs.io/en/latest/system/ppc/pseries.html#switching-between-the-kvm-pr-and-kvm-hv-kernel-module
+			"-machine", "pseries,kvm-type=HV," + accel,
 		}
 	default:
 		panic(fmt.Sprintf("RpmArch %s combo not supported for qemu ", coreosarch.CurrentRpmArch()))


### PR DESCRIPTION
We're troubleshooting performance issues on a ppc64le machine and one of the things that came up comparing what we do to e.g. libguestfs is that the latter just does `-machine pseries,accel=kvm:tcg` whereas we have these extra args.

- `vsmt=8` was added to work around issues with RHEL7 kernels, which is no longer relevant to us
- `cap-fwnmi=off` was added in #1975; it's not clear if we still need it or not. Things seem to work fine without it in manual tests on a ppc64le machine.

Keep `kvm-type=HV` which dates from the introduction of ppc64le support in kola. Looking at the QEMU docs at
https://qemu.readthedocs.io/en/latest/system/ppc/pseries.html#switching-between-the-kvm-pr-and-kvm-hv-kernel-module it ensures that we directly use virtualization support in the CPU.