### PR TITLE
cmd-generate-hashlist: rename to buildextend-hashlist-experimental

### DIFF
--- a/cmd/coreos-assembler.go
+++ b/cmd/coreos-assembler.go
@@ -14,8 +14,8 @@ import (
 // commands we'd expect to use in the local dev path
 var buildCommands = []string{"init", "fetch", "build", "run", "prune", "clean", "list"}
 var advancedBuildCommands = []string{"buildfetch", "buildupload", "oc-adm-release", "push-container", "upload-oscontainer", "buildextend-extensions"}
-var buildextendCommands = []string{"aliyun", "aws", "azure", "digitalocean", "exoscale", "extensions", "extensions-container", "gcp", "ibmcloud", "kubevirt", "legacy-oscontainer", "live", "metal", "metal4k", "nutanix", "openstack", "qemu", "secex", "virtualbox", "vmware", "vultr"}
-var utilityCommands = []string{"aws-replicate", "compress", "copy-container", "generate-hashlist", "koji-upload", "kola", "push-container-manifest", "remote-build-container", "remote-prune", "remote-session", "sign", "tag", "update-variant"}
+var buildextendCommands = []string{"aliyun", "aws", "azure", "digitalocean", "exoscale", "extensions", "extensions-container", "gcp", "hashlist-experimental", "ibmcloud", "kubevirt", "legacy-oscontainer", "live", "metal", "metal4k", "nutanix", "openstack", "qemu", "secex", "virtualbox", "vmware", "vultr"}
+var utilityCommands = []string{"aws-replicate", "compress", "copy-container", "koji-upload", "kola", "push-container-manifest", "remote-build-container", "remote-prune", "remote-session", "sign", "tag", "update-variant"}
 var otherCommands = []string{"shell", "meta"}
 
 func init() {

--- a/src/cmd-buildextend-hashlist-experimental
+++ b/src/cmd-buildextend-hashlist-experimental
@@ -18,6 +18,7 @@ cosa_dir = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, cosa_dir)
 
 from cosalib import meta
+from cosalib.builds import Builds
 from cosalib.cmdlib import (
     ensure_glob,
     get_basearch,
@@ -143,6 +144,8 @@ class HashListV1(dict):
         """
         with open(output, 'w') as out:
             out.write(json.dumps(self, indent=4))
+        with open(f'{output}-CHECKSUM', 'w') as out:
+            subprocess.check_call(['sha256sum', output], stdout=out)
 
 
 def main():
@@ -162,12 +165,16 @@ def main():
     parser.add_argument(
         '-a', '--arch', default=get_basearch(),
         help='Target Architecture')
-    parser.add_argument(
-        '-o', '--output',
-        help='Where the output should be written', default='hashlist.json')
+    parser.add_argument('-b', '--build', default='latest', help='Target build')
 
     # Parse arguments and ignore anything we didn't explicitly request
     args = parser.parse_args()
+
+    builds = Builds()
+    builddir = builds.get_build_dir(build_id=args.build, basearch=args.arch)
+
+    # it's not in the schema nor in meta.json yet
+    output = os.path.join(builddir, "exp-hash.json")
 
     # Load metadata
     metadata = meta.GenericBuildMeta(schema=None, basearch=args.arch)
@@ -180,8 +187,8 @@ def main():
     hashlist.populate_hash_list()
 
     # Step 2: Write the hashlist to disk
-    hashlist.write(args.output)
-    print(f'Hash list created at {args.output}')
+    hashlist.write(output)
+    print(f'Hash list created at {output}')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
That way we can call it using the same pattern we call other buildextend commands. It's not a bona-fide artifact (we don't add anything to `meta.json` yet) because it's still experimental. But doing it this way will allow us to easily skip running this on pipeliens where we don't need it.

Motivated by issues we're currently hitting in RHCOS with generating the hashlist being excruciatingly slow. Current theory is that the disk is rotational and the random reads that the command triggers by checking out the full commit and hashing everything is extremely expensive on hard drives. I'd like to skip hashlists in RHCOS for now until we can either move parts of it to tmpfs or ideally move to a builder with better storage.

But regardless, this will also help us clean up in the pipeline how this command is called.