### PR TITLE
ci: Test full-emulation `cosa run`

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -7,6 +7,7 @@ def cpuCount_s = cpuCount.toString()
 def imageName = buildImage(env: [ENABLE_GO_RACE_DETECTOR: "1", GOMAXPROCS: cpuCount_s], cpu: cpuCount_s)
 
 def memory = (cpuCount * 1536) as Integer
+parallel build: {
 pod(image: imageName + ":latest", kvm: true, cpu: "${cpuCount}", memory: "${memory}Mi") {
     checkout scm
 
@@ -52,6 +53,7 @@ pod(image: imageName + ":latest", kvm: true, cpu: "${cpuCount}", memory: "${memo
         utils.cosaCmd(cosaDir: "/srv", args: "buildupload --dry-run s3 --acl=public-read my-nonexistent-bucket/my/prefix")
     }
 
+
     // Random other tests that aren't about building. XXX: These should be part of `make
     // check` or something and use dummy cosa builds.
     stage("CLI Tests") {
@@ -60,4 +62,13 @@ pod(image: imageName + ":latest", kvm: true, cpu: "${cpuCount}", memory: "${memo
             ${env.WORKSPACE}/tests/test_pruning.sh
         """)
     }
+}
+}, selftests: {
+pod(image: imageName + ":latest", kvm: true, cpu: "${cpuCount}", memory: "4096Mi") {
+    checkout scm
+
+    stage("cosa run tests") {
+        shwrap("./tests/test-cosa-run.sh")
+    }
+}
 }

--- a/mantle/cmd/kola/devshell.go
+++ b/mantle/cmd/kola/devshell.go
@@ -64,8 +64,11 @@ func displayStatusMsg(status, msg string, termMaxWidth int) {
 }
 
 func runDevShellSSH(ctx context.Context, builder *platform.QemuBuilder, conf *conf.Conf, sshCommand string) error {
-	if !term.IsTerminal(0) {
-		return fmt.Errorf("stdin is not a tty")
+	ontty := term.IsTerminal(0)
+	if sshCommand == "" {
+		if !ontty {
+			return fmt.Errorf("stdin is not a tty")
+		}
 	}
 	termMaxWidth, _, err := term.GetSize(0)
 	if err != nil {
@@ -171,6 +174,7 @@ func runDevShellSSH(ctx context.Context, builder *platform.QemuBuilder, conf *co
 
 	// Start the SSH client
 	sc := newSshClient(ip, agent.Socket, sshCommand)
+	sc.ontty = ontty
 	go sc.controlStartStop()
 
 	ready := false
@@ -187,8 +191,10 @@ func runDevShellSSH(ctx context.Context, builder *platform.QemuBuilder, conf *co
 		// handle console messages. If SSH is not ready, then display a
 		// a status message on the console.
 		case serialMsg := <-serialChan:
-			if !ready {
-				displayStatusMsg(statusMsg, serialMsg, termMaxWidth)
+			if ontty {
+				if !ready {
+					displayStatusMsg(statusMsg, serialMsg, termMaxWidth)
+				}
 			}
 			lastMsg = serialMsg
 		// monitor the err channel
@@ -202,7 +208,9 @@ func runDevShellSSH(ctx context.Context, builder *platform.QemuBuilder, conf *co
 
 		// monitor the instance state
 		case <-qemuWaitChan:
-			displayStatusMsg("DONE", "QEMU instance terminated", termMaxWidth)
+			if ontty {
+				displayStatusMsg("DONE", "QEMU instance terminated", termMaxWidth)
+			}
 			return nil
 
 		// monitor the machine state events from console/serial logs
@@ -233,17 +241,23 @@ func runDevShellSSH(ctx context.Context, builder *platform.QemuBuilder, conf *co
 					statusMsg = "QEMU guest is booting"
 				}
 			}
-			displayStatusMsg(fmt.Sprintf("EVENT | %s", statusMsg), lastMsg, termMaxWidth)
+			if ontty {
+				displayStatusMsg(fmt.Sprintf("EVENT | %s", statusMsg), lastMsg, termMaxWidth)
+			}
 
 		// monitor the SSH connection
 		case err := <-sc.errChan:
 			if err == nil {
 				sc.controlChan <- sshNotReady
-				displayStatusMsg("SESSION", "Clean exit from SSH, terminating instance", termMaxWidth)
+				if ontty {
+					displayStatusMsg("SESSION", "Clean exit from SSH, terminating instance", termMaxWidth)
+				}
 				return nil
 			} else if sshCommand != "" {
 				sc.controlChan <- sshNotReady
-				displayStatusMsg("SESSION", "SSH command exited, terminating instance", termMaxWidth)
+				if ontty {
+					displayStatusMsg("SESSION", "SSH command exited, terminating instance", termMaxWidth)
+				}
 				return err
 			}
 			if ready {
@@ -456,6 +470,7 @@ type sshClient struct {
 	port        string
 	agent       string
 	cmd         string
+	ontty       bool
 	controlChan chan sshControlMessage
 	errChan     chan error
 	sshCmd      *exec.Cmd
@@ -512,8 +527,10 @@ func (sc *sshClient) start() {
 	if sc.cmd != "" {
 		sshArgs = append(sshArgs, "--", sc.cmd)
 	}
-	fmt.Printf("\033[2K\r")                // clear serial console line
-	fmt.Printf("[SESSION] Starting SSH\r") // and stage a status msg which will be erased
+	if sc.ontty {
+		fmt.Printf("\033[2K\r")                // clear serial console line
+		fmt.Printf("[SESSION] Starting SSH\r") // and stage a status msg which will be erased
+	}
 	sshCmd := exec.Command(sshArgs[0], sshArgs[1:]...)
 	sshCmd.Stdin = os.Stdin
 	sshCmd.Stdout = os.Stdout
@@ -532,7 +549,9 @@ func (sc *sshClient) start() {
 		for scanner.Scan() {
 			msg := scanner.Text()
 			if strings.Contains(msg, "Connection to 127.0.0.1 closed") {
-				displayStatusMsg("SSH", "connection closed", 0)
+				if sc.ontty {
+					displayStatusMsg("SSH", "connection closed", 0)
+				}
 			}
 		}
 	}()

--- a/tests/test-cosa-run.sh
+++ b/tests/test-cosa-run.sh
@@ -2,9 +2,9 @@
 # This verifies e.g. `cosa run`.
 set -xeuo pipefail
 tmpdir=$(mktemp -d -p /var/tmp)
-cd ${tmpdir}
+cd "${tmpdir}"
 coreos-installer download -a s390x -p qemu -f qcow2.xz --decompress
-cosa run --arch s390x *.qcow2 -x "cat /proc/cpuinfo" > cpuinfo.txt
+cosa run --arch s390x ./*.qcow2 -x "cat /proc/cpuinfo" > cpuinfo.txt
 grep -F 'IBM/S390' cpuinfo.txt
 cd -
 rm "${tmpdir}" -rf

--- a/tests/test-cosa-run.sh
+++ b/tests/test-cosa-run.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# This verifies e.g. `cosa run`.
+set -xeuo pipefail
+tmpdir=$(mktemp -d -p /var/tmp)
+cd ${tmpdir}
+coreos-installer download -a s390x -p qemu -f qcow2.xz --decompress
+cosa run --arch s390x *.qcow2 -x "cat /proc/cpuinfo" > cpuinfo.txt
+grep -F 'IBM/S390' cpuinfo.txt
+cd -
+rm "${tmpdir}" -rf
+echo "ok cosa run full emulation"


### PR DESCRIPTION
ci: Test full-emulation `cosa run`

We should have some CI that verifies this works.

---

devshell: Don't output status if not on a tty

This is just better behavior for the case of e.g.
`cosa run -x "somecmd" > out.txt` to execute a command and
capture the output - we don't want to intermix status stuff in
there.

Further, this makes it easier to test the code when not on
a tty (in e.g. CI).

---

