### PR TITLE
build.sh: freeze grub2 to fix PXE + UEFI tests

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -34,7 +34,7 @@ pod(image: imageName + ":latest", kvm: true, cpu: "${cpuCount}", memory: "${memo
         utils.cosaCmd(cosaDir: "/srv", args: "buildextend-live --fast")
     }
 
-    kolaTestIso(cosaDir: "/srv", extraArgs4k: "--no-pxe")
+    kolaTestIso(cosaDir: "/srv")
 
     stage("Build Cloud Images") {
         cosaParallelCmds(cosaDir: "/srv", commands: ["Aliyun", "AWS", "Azure", "DigitalOcean", "Exoscale", "GCP",

--- a/build.sh
+++ b/build.sh
@@ -41,8 +41,14 @@ install_rpms() {
     local builddeps
     local frozendeps
 
-    # no frozen deps right now
     frozendeps=""
+
+    # freeze grub2 for https://github.com/coreos/fedora-coreos-tracker/issues/1352
+    case "${arch}" in
+        x86_64) frozendeps=$(echo grub2-{common,efi-x64,pc,pc-modules,tools,tools-extra,tools-minimal}-1:2.06-63.fc37);;
+        aarch64) frozendeps=$(echo grub2-{common,efi-aa64,tools,tools-extra,tools-minimal}-1:2.06-63.fc37);;
+        *) ;;
+    esac
 
     # First, a general update; this is best practice.  We also hit an issue recently
     # where qemu implicitly depended on an updated libusbx but didn't have a versioned

--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -615,23 +615,23 @@ func testPXE(ctx context.Context, inst platform.Install, outdir string, offline 
 	}
 	tmpd, err := ioutil.TempDir("", "kola-testiso")
 	if err != nil {
-		return 0, err
+		return 0, errors.Wrapf(err, "creating tempdir")
 	}
 	defer os.RemoveAll(tmpd)
 
 	sshPubKeyBuf, _, err := util.CreateSSHAuthorizedKey(tmpd)
 	if err != nil {
-		return 0, err
+		return 0, errors.Wrapf(err, "creating SSH AuthorizedKey")
 	}
 
 	builder, virtioJournalConfig, err := newQemuBuilderWithDisk(outdir)
 	if err != nil {
-		return 0, err
+		return 0, errors.Wrapf(err, "creating QemuBuilder")
 	}
 	inst.Builder = builder
 	completionChannel, err := inst.Builder.VirtioChannelRead("testisocompletion")
 	if err != nil {
-		return 0, err
+		return 0, errors.Wrapf(err, "setting up virtio-serial channel")
 	}
 
 	var keys []string


### PR DESCRIPTION
The `pxe-install` build started failing after grub2-2.06-67.fc37 entered
cosa:

    Loading kernel
    error: ../../grub-core/fs/fshelp.c:257:file
    `/rhcos-413.86.202211301346-0-live-kernel-x86_64' not found.

Possibly the same root cause as
https://github.com/coreos/fedora-coreos-tracker/issues/1352.

Freeze on the previous version for now until we figure this out.
