### PR TITLE
kola: Don't incorrectly set `bios` by default

### DIFF
--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -210,8 +210,6 @@ func syncOptionsImpl(useCosa bool) error {
 			kola.QEMUOptions.Firmware = "uefi"
 		} else if kola.Options.CosaBuildArch == "x86_64" && kola.QEMUOptions.Native4k {
 			kola.QEMUOptions.Firmware = "uefi"
-		} else {
-			kola.QEMUOptions.Firmware = "bios"
 		}
 	}
 


### PR DESCRIPTION
With the recent changes, we want to use the empty string here for !x86.