### PR TITLE
plume/release: consistently add default region for `--region` switch

### DIFF
--- a/mantle/cmd/plume/release.go
+++ b/mantle/cmd/plume/release.go
@@ -92,7 +92,7 @@ func init() {
 	cmdUpdateReleaseIndex.Flags().StringVar(&awsCredentialsFile, "aws-credentials", "", "AWS credentials file")
 	cmdUpdateReleaseIndex.Flags().StringVar(&specBucketPrefix, "bucket-prefix", "", "S3 bucket and prefix")
 	cmdUpdateReleaseIndex.Flags().StringVar(&specProfile, "profile", "default", "AWS profile")
-	cmdUpdateReleaseIndex.Flags().StringVar(&specRegion, "region", "", "S3 bucket region")
+	cmdUpdateReleaseIndex.Flags().StringVar(&specRegion, "region", "us-east-1", "S3 bucket region")
 	cmdUpdateReleaseIndex.Flags().StringVarP(&specStream, "stream", "", "", "target stream")
 	cmdUpdateReleaseIndex.Flags().StringVarP(&specVersion, "version", "", "", "release version")
 	root.AddCommand(cmdUpdateReleaseIndex)


### PR DESCRIPTION
In the final command we define, we set the default region to the empty string. This takes effect regardless of the command that actually gets called and so we lose the default value of `us-east-1` on earlier commands.

I think requiring the caller to pass a region would be cleaner, but we can't break the deprecated `plume release` command yet.

Fixes d039e8830 ("plume: deprecate `release`, add `make-amis-public` and `update-release-index`").