### PR TITLE
cmd-buildextend-legacy-oscontainer: fix extra quotes in display name

### DIFF
--- a/src/cmd-buildextend-legacy-oscontainer
+++ b/src/cmd-buildextend-legacy-oscontainer
@@ -105,7 +105,7 @@ oci_archive = f"{build_path}/{name}"
 cosa_argv = (['/usr/lib/coreos-assembler/buildextend-legacy-oscontainer.sh', oci_archive, 'build', f'--from={args.from_image}'])
 for d in args.add_directory:
     cosa_argv.append(f'--add-directory="{d}"')
-cosa_argv.append(f'--display-name="{display_name}"')
+cosa_argv.append(f'--display-name={display_name}')
 if 'labeled-packages' in configyaml:
     pkgs = ' '.join(configyaml['labeled-packages'])
     cosa_argv.append(f'--labeled-packages="{pkgs}"')


### PR DESCRIPTION
These quotes are becoming literal in the final image label. I suspect this code predates e4d5d1ee0 which fixes argument quoting so that spaces survive the `runvm` -> supermin trip without having to add quotes.

This was throwing off `oc adm release new`.

Tested-by: Dusty Mabe <dusty@dustymabe.com>