### PR TITLE
cosalib/build: don't call os.unlink() twice

### DIFF
--- a/src/cosalib/build.py
+++ b/src/cosalib/build.py
@@ -182,6 +182,7 @@ class _Build:
         tf = getattr(self, "_token_file", None)
         if tf:
             os.unlink(tf)
+            setattr(self, "_token_file", None)
 
     @property
     def workdir(self):


### PR DESCRIPTION
Commit 951d2496f makes it so that when building a QEMU variant, we delete the token file as soon as we're done building the artifact. But the `__del__()` function of the `_Build` object still also fired and called `self.unset_token()`. This resulted in a scary but non-fatal error like:

    FileNotFoundError: [Errno 2] No such file or directory:
    'builds/37.20221121.dev.0/x86_64/.openstack.building'

Fix this by making `self.unset_token()` idempotent by actually unsetting the `_token_file` attribute.

Fixes 951d2496f ("cosalib/build: only take artifact lock when actually building it").