### PR TITLE
kola: Add support for injecting Butane

### DIFF
--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -68,6 +68,7 @@ func init() {
 	sv(&kola.Options.CosaWorkdir, "workdir", "", "coreos-assembler working directory")
 	sv(&kola.Options.CosaBuildId, "build", "", "coreos-assembler build ID")
 	sv(&kola.Options.CosaBuildArch, "arch", coreosarch.CurrentRpmArch(), "The target architecture of the build")
+	sv(&kola.Options.AppendButane, "append-butane", "", "Path to Butane config which is merged with test code")
 	// rhcos-specific options
 	sv(&kola.Options.OSContainer, "oscontainer", "", "oscontainer image pullspec for pivot (RHCOS only)")
 

--- a/mantle/platform/platform.go
+++ b/mantle/platform/platform.go
@@ -184,6 +184,8 @@ type Options struct {
 
 	NoTestExitError bool
 
+	AppendButane string
+
 	// OSContainer is an image pull spec that can be given to the pivot service
 	// in RHCOS machines to perform machine content upgrades.
 	// When specified additional files & units will be automatically generated


### PR DESCRIPTION
I'm trying to add some tests for bootc using kola and external tests running in Prow.  I hit the problem that the test containers we built in Prow require a pull secret to access - and we simply don't have an ergonomic way to do deal with that.

I think until now we've been glossing over this problem, but in the fully general case there may be some setup needed to run some of our tests.  (For example, proxy configuration, TLS certificates)

It'd also make sense in some cases to configure hosts to fetch content from local mirrors using e.g. `/etc/containers/registries.conf`.

This general mechanism allows injecting arbitrary Butane (i.e. Ignition) into all tests.