### PR TITLE
[rhcos-4.10] build.sh: freeze grub2 to fix PXE + UEFI tests

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -44,7 +44,14 @@ install_rpms() {
     # freeze coreos-installer to 0.12.0 because newer releases dropped support
     # for the legacy `iso extract pack-minimal-iso` alias:
     # https://github.com/openshift/os/issues/916
-    frozendeps="coreos-installer-0.12.0-2.fc35"
+    frozendeps="coreos-installer-0.12.0-2.fc35 "
+
+    # freeze grub2 for https://github.com/coreos/fedora-coreos-tracker/issues/1352
+    case "${arch}" in
+        x86_64) frozendeps+=$(echo grub2-{common,efi-x64,pc,pc-modules,tools,tools-extra,tools-minimal}-1:2.06-11.fc35);;
+        aarch64) frozendeps+=$(echo grub2-{common,efi-aa64,tools,tools-extra,tools-minimal}-1:2.06-11.fc35);;
+        *) ;;
+    esac
 
     # First, a general update; this is best practice.  We also hit an issue recently
     # where qemu implicitly depended on an updated libusbx but didn't have a versioned


### PR DESCRIPTION
The `pxe-install` build started failing after grub2-2.06-67.fc37 entered cosa:

    Loading kernel
    error: ../../grub-core/fs/fshelp.c:257:file
    `/rhcos-413.86.202211301346-0-live-kernel-x86_64' not found.

Possibly the same root cause as
https://github.com/coreos/fedora-coreos-tracker/issues/1352.

Freeze on the previous version for now until we figure this out.

(cherry picked from commit 89f3070c9d1fcbe3400eeb074826d6c12155e111)

jlebon: `rhcos-4.10` is on f35, so I froze on grub2-2.06-11.fc35
        instead, which was the grub2 version we were using before
        https://bodhi.fedoraproject.org/updates/FEDORA-2022-7ce9378e90
        was pushed.