### PR TITLE
s390x/secex: Remove hardcoded workdir assigment in runvm.sh

### DIFF
--- a/src/secex-genprotimgvm-scripts/runvm.sh
+++ b/src/secex-genprotimgvm-scripts/runvm.sh
@@ -2,7 +2,6 @@
 
 set -euo pipefail
 
-workdir="/srv"
 vmrundir="${workdir}/tmp/build.secex"
 memory_default=2048
 runvm_console="${vmrundir}/runvm-console.txt"


### PR DESCRIPTION
Currently the CI is failling, because it does not use the default /srv workdir. Remove the hardcoded assigment of the variable.

Signed-off-by: Jan Schintag <jan.schintag@de.ibm.com>