### PR TITLE
[rhcos-4.11] *: address golangci-lint lints

### DIFF
--- a/mantle/cmd/kola/devshell.go
+++ b/mantle/cmd/kola/devshell.go
@@ -100,7 +100,9 @@ func runDevShellSSH(ctx context.Context, builder *platform.QemuBuilder, conf *co
 	// stateChan reports in-instance state such as shutdown, reboot, etc.
 	stateChan := make(chan guestState)
 
-	watchJournal(builder, conf, stateChan, errChan)
+	if err = watchJournal(builder, conf, stateChan, errChan); err != nil {
+		return err
+	}
 
 	// SerialPipe is the pipe output from the serial console.
 	serialPipe, err := builder.SerialPipe()
@@ -180,7 +182,7 @@ func runDevShellSSH(ctx context.Context, builder *platform.QemuBuilder, conf *co
 		// it directly to the instance. The intercept of ctrl-c will only happen when
 		// ssh is not in the foreground.
 		case <-sigintChan:
-			inst.Kill()
+			_ = inst.Kill()
 
 		// handle console messages. If SSH is not ready, then display a
 		// a status message on the console.
@@ -218,7 +220,7 @@ func runDevShellSSH(ctx context.Context, builder *platform.QemuBuilder, conf *co
 					statusMsg = "QEMU guest is shutting down"
 				case guestStateHalted:
 					statusMsg = "QEMU guest is halted"
-					inst.Kill()
+					_ = inst.Kill()
 				case guestStateInReboot:
 					statusMsg = "QEMU guest initiated reboot"
 				case guestStateOpenSshStopped:

--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -379,7 +379,6 @@ func syncStreamOptions() error {
 		if err != nil {
 			return errors.Wrapf(err, "failed to fetch stream")
 		}
-		break
 	default:
 		return fmt.Errorf("Unhandled stream for distribution %s", kola.Options.Distribution)
 	}

--- a/mantle/cmd/kola/qemuexec.go
+++ b/mantle/cmd/kola/qemuexec.go
@@ -307,7 +307,9 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 		}
 		builder.Memory = int(parsedMem)
 	}
-	builder.AddDisksFromSpecs(addDisks)
+	if err = builder.AddDisksFromSpecs(addDisks); err != nil {
+		return err
+	}
 	if cpuCountHost {
 		builder.Processors = -1
 	}

--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -142,7 +142,7 @@ ExecStart=/bin/sh -c '/usr/bin/echo %s >/dev/virtio-ports/testisocompletion && s
 RequiredBy=multi-user.target
 `, signalCompleteString)
 
-var checkNoIgnition = fmt.Sprintf(`[Unit]
+var checkNoIgnition = `[Unit]
 Description=TestISO Verify No Ignition Config
 OnFailure=emergency.target
 OnFailureJobMode=isolate
@@ -154,9 +154,9 @@ Type=oneshot
 RemainAfterExit=yes
 ExecStart=/bin/sh -c '[ ! -e /boot/ignition ]'
 [Install]
-RequiredBy=multi-user.target`)
+RequiredBy=multi-user.target`
 
-var multipathedRoot = fmt.Sprintf(`[Unit]
+var multipathedRoot = `[Unit]
 Description=TestISO Verify Multipathed Root
 OnFailure=emergency.target
 OnFailureJobMode=isolate
@@ -166,9 +166,9 @@ Type=oneshot
 RemainAfterExit=yes
 ExecStart=/bin/bash -c '[[ $(findmnt -nvro SOURCE /sysroot) == /dev/mapper/mpatha4 ]]'
 [Install]
-RequiredBy=multi-user.target`)
+RequiredBy=multi-user.target`
 
-var verifyNoEFIBootEntry = fmt.Sprintf(`[Unit]
+var verifyNoEFIBootEntry = `[Unit]
 Description=TestISO Verify No EFI Boot Entry
 OnFailure=emergency.target
 OnFailureJobMode=isolate
@@ -182,7 +182,7 @@ ExecStart=/bin/sh -c '! efibootmgr -v | grep -E "(HD|CDROM)\("'
 # for install scenarios
 RequiredBy=coreos-installer.target
 # for iso-as-disk
-RequiredBy=multi-user.target`)
+RequiredBy=multi-user.target`
 
 var nmConnectionId = "CoreOS DHCP"
 var nmConnectionFile = "coreos-dhcp.nmconnection"

--- a/mantle/cmd/ore/aliyun/visibility.go
+++ b/mantle/cmd/ore/aliyun/visibility.go
@@ -64,7 +64,7 @@ func changeVisibility(cmd *cobra.Command, args []string) error {
 	}
 
 	for _, pair := range args {
-		if strings.Contains(pair, ":") == false {
+		if !strings.Contains(pair, ":") {
 			return fmt.Errorf("Argument isn't a valid region:image pair: %v\n", pair)
 		}
 

--- a/mantle/cmd/ore/gcloud/promote-image.go
+++ b/mantle/cmd/ore/gcloud/promote-image.go
@@ -104,6 +104,7 @@ func runPromoteImage(cmd *cobra.Command, args []string) {
 		// Perform the deprecation if the image is not already deprecated.
 		// We detect if it is active by checking if it either doesn't
 		// have any deprecation state or if it is explicitly ACTIVE.
+		// nolint (see comment above)
 		if image.Deprecated == nil ||
 			image.Deprecated.State == string(gcloud.DeprecationStateActive) {
 			deprecateImage(

--- a/mantle/cmd/ore/ibmcloud/copy-object.go
+++ b/mantle/cmd/ore/ibmcloud/copy-object.go
@@ -46,11 +46,17 @@ func init() {
 	cmdCopyObject.Flags().StringVar(&copyCloudObjectStorage, "cloud-object-storage", "coreos-dev-image-ibmcloud", "cloud object storage to be used")
 	cmdCopyObject.Flags().StringVar(&sourceBucket, "source-bucket", "coreos-dev-image-ibmcloud-us-east", "bucket where object needs to be copied from")
 	cmdCopyObject.Flags().StringVar(&sourceName, "source-name", "", "name of object to be copied")
-	cmdCopyObject.MarkFlagRequired("source-name")
+	if err := cmdCopyObject.MarkFlagRequired("source-name"); err != nil {
+		panic(err)
+	}
 	cmdCopyObject.Flags().StringVar(&destRegion, "destination-region", "", "region to be copied to")
-	cmdCopyObject.MarkFlagRequired("destination-region")
+	if err := cmdCopyObject.MarkFlagRequired("destination-region"); err != nil {
+		panic(err)
+	}
 	cmdCopyObject.Flags().StringVar(&destBucket, "destination-bucket", "", "destination bucket to copy to")
-	cmdCopyObject.MarkFlagRequired("destination-bucket")
+	if err := cmdCopyObject.MarkFlagRequired("destination-bucket"); err != nil {
+		panic(err)
+	}
 }
 
 func runCopyObject(cmd *cobra.Command, args []string) error {

--- a/mantle/cmd/plume/stream_mirror.go
+++ b/mantle/cmd/plume/stream_mirror.go
@@ -48,9 +48,13 @@ var (
 
 func init() {
 	cmdStreamMirror.Flags().StringVar(&srcFile, "src-file", "", "Source path for stream JSON")
-	cmdStreamMirror.MarkFlagRequired("src-file")
+	if err := cmdStreamMirror.MarkFlagRequired("src-file"); err != nil {
+		panic(err)
+	}
 	cmdStreamMirror.Flags().StringVar(&dest, "dest", "", "Write images to this directory")
-	cmdStreamMirror.MarkFlagRequired("dest")
+	if err := cmdStreamMirror.MarkFlagRequired("dest"); err != nil {
+		panic(err)
+	}
 	cmdStreamMirror.Flags().StringVar(&destFile, "dest-file", "", "Destination path for stream JSON (only useful with --url)")
 	cmdStreamMirror.Flags().StringVar(&newBaseURLArg, "url", "", "New base URL for build")
 	cmdStreamMirror.Flags().StringArrayVarP(&artifactTypes, "artifact", "a", nil, "Only fetch this specific artifact type")

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -750,9 +750,7 @@ func getRerunnable(tests []*harness.H) []string {
 		// subtests start due to some initial failure.
 		if nonexclusiveWrapperMatch.MatchString(h.Name()) && !h.GetNonExclusiveTestStarted() {
 			if h.Failed() {
-				for _, testName := range h.Subtests() {
-					testsToRerun = append(testsToRerun, testName)
-				}
+				testsToRerun = append(testsToRerun, h.Subtests()...)
 			}
 		} else {
 			name, isRerunnable := GetRerunnableTestName(h.Name())

--- a/mantle/kola/tests/rhcos/upgrade.go
+++ b/mantle/kola/tests/rhcos/upgrade.go
@@ -309,7 +309,9 @@ func downloadLatestReleasedRHCOS(target string) (string, error) {
 
 	graph := &Graph{}
 	graphUrl := fmt.Sprintf("https://api.openshift.com/api/upgrades_info/v1/graph?channel=%s", channel)
-	getJson(graphUrl, &graph)
+	if err := getJson(graphUrl, &graph); err != nil {
+		return "", err
+	}
 
 	// no-op on unreleased OCP versions
 	if len(graph.Nodes) == 0 {
@@ -363,7 +365,9 @@ func downloadLatestReleasedRHCOS(target string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	json.Unmarshal(output, &ocpRelease)
+	if err = json.Unmarshal(output, &ocpRelease); err != nil {
+		return "", err
+	}
 
 	var latestOcpRhcosBuild *cosa.Build
 	rhcosVersion := ocpRelease.DisplayVersions.MachineOS.Version
@@ -372,7 +376,9 @@ func downloadLatestReleasedRHCOS(target string) (string, error) {
 		rhcosVersion,
 		system.RpmArch())
 	latestRhcosBuildMetaUrl := fmt.Sprintf("%s/meta.json", latestBaseUrl)
-	getJson(latestRhcosBuildMetaUrl, &latestOcpRhcosBuild)
+	if err := getJson(latestRhcosBuildMetaUrl, &latestOcpRhcosBuild); err != nil {
+		return "", err
+	}
 
 	latestRhcosQcow2 := latestOcpRhcosBuild.BuildArtifacts.Qemu.Path
 	latestRhcosQcow2Url := fmt.Sprintf("%s/%s", latestBaseUrl, latestRhcosQcow2)

--- a/mantle/kola/tests/upgrade/basic.go
+++ b/mantle/kola/tests/upgrade/basic.go
@@ -35,7 +35,6 @@ import (
 
 const workdir = "/var/srv/upgrade"
 const ostreeRepo = workdir + "/repo"
-const zincatiMetricsSocket = "/run/zincati/public/metrics.promsock"
 
 var plog = capnslog.NewPackageLogger("github.com/coreos/mantle", "kola/tests/upgrade")
 

--- a/mantle/platform/api/aliyun/api.go
+++ b/mantle/platform/api/aliyun/api.go
@@ -146,7 +146,12 @@ func (a *API) CopyImage(source_id, dest_name, dest_region, dest_description, kms
 	// queuing would explain some of the delays observed.
 	if wait_for_ready {
 		plog.Infof("waiting for %v in %v to be available before returning", response.ImageId, dest_region)
-		a.WaitForImageReady(dest_region, response.ImageId)
+		if err = a.WaitForImageReady(dest_region, response.ImageId); err != nil {
+			// Waiting failed... Let's just log it and move on since this is
+			// just to be nice. if we do have to use the image right after,
+			// we'll fail.
+			plog.Warningf("failed to wait: %v", err)
+		}
 	}
 	return response.ImageId, nil
 }

--- a/mantle/platform/api/ibmcloud/s3.go
+++ b/mantle/platform/api/ibmcloud/s3.go
@@ -130,10 +130,8 @@ func (a *API) checkIfObjectExists(objectName, bucketName string) bool {
 	}
 
 	_, err := a.s3client.s3Session.GetObject(input)
-	if err != nil {
-		return false
-	}
-	return true
+	// XXX: this should actually check the exact error returned
+	return err == nil
 }
 
 //UploadObject - upload to s3 bucket

--- a/mantle/platform/api/openstack/api.go
+++ b/mantle/platform/api/openstack/api.go
@@ -609,7 +609,7 @@ func (a *API) DeleteImage(imageID string, force bool) error {
 					NewProtected: false,
 				},
 			}
-			image, err = images.Update(a.imageClient, imageID, updateOpts).Extract()
+			_, err = images.Update(a.imageClient, imageID, updateOpts).Extract()
 			if err != nil {
 				return fmt.Errorf(
 					"Error removing protection from image %s: %v", imageID, err)

--- a/mantle/platform/conf/conf.go
+++ b/mantle/platform/conf/conf.go
@@ -390,6 +390,9 @@ func (c *Conf) MaybeCompress() (string, error) {
 	var buff bytes.Buffer
 	config := c.String()
 	writer, err := gzip.NewWriterLevel(&buff, gzip.BestCompression)
+	if err != nil {
+		return "", err
+	}
 	defer writer.Close()
 	if _, err := writer.Write([]byte(config)); err != nil {
 		return "", err

--- a/mantle/platform/machine/qemuiso/cluster.go
+++ b/mantle/platform/machine/qemuiso/cluster.go
@@ -119,7 +119,9 @@ func (qc *Cluster) NewMachineWithQemuOptions(userdata *conf.UserData, options pl
 		return nil, errors.Wrapf(err, "adding ISO image")
 	}
 
-	builder.AddDisksFromSpecs(options.AdditionalDisks)
+	if err = builder.AddDisksFromSpecs(options.AdditionalDisks); err != nil {
+		return nil, err
+	}
 
 	if len(options.HostForwardPorts) > 0 {
 		builder.EnableUsermodeNetworking(options.HostForwardPorts)

--- a/mantle/platform/machine/unprivqemu/cluster.go
+++ b/mantle/platform/machine/unprivqemu/cluster.go
@@ -143,11 +143,12 @@ func (qc *Cluster) NewMachineWithQemuOptions(userdata *conf.UserData, options pl
 		primaryDisk.BackingFile = options.OverrideBackingFile
 	}
 
-	err = builder.AddBootDisk(&primaryDisk)
-	if err != nil {
+	if err = builder.AddBootDisk(&primaryDisk); err != nil {
 		return nil, err
 	}
-	builder.AddDisksFromSpecs(options.AdditionalDisks)
+	if err = builder.AddDisksFromSpecs(options.AdditionalDisks); err != nil {
+		return nil, err
+	}
 
 	if len(options.HostForwardPorts) > 0 {
 		builder.EnableUsermodeNetworking(options.HostForwardPorts)

--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -314,7 +314,7 @@ func (inst *QemuInstance) SwitchBootOrder() (err2 error) {
 	}
 	// Get boot device (for iso-installs) and block device
 	for _, dev := range blkdevs.Return {
-		devpath := filepath.Clean(strings.Trim(dev.DevicePath, "virtio-backend"))
+		devpath := filepath.Clean(strings.TrimSuffix(dev.DevicePath, "virtio-backend"))
 		switch dev.Device {
 		case "installiso":
 			bootdev = devpath
@@ -613,8 +613,9 @@ func (builder *QemuBuilder) supportsFwCfg() bool {
 
 // supportsSwtpm if the target system supports a virtual TPM device
 func (builder *QemuBuilder) supportsSwtpm() bool {
-	if system.RpmArch() == "s390x" {
-		// ppc64le and aarch64 support TPM as of f33. s390x does not support a backend for TPM
+	switch system.RpmArch() {
+	case "s390x":
+		// s390x does not support a backend for TPM
 		return false
 	}
 	return true

--- a/mantle/system/copy_test.go
+++ b/mantle/system/copy_test.go
@@ -30,6 +30,9 @@ func checkFile(t *testing.T, path string, data []byte, mode os.FileMode) {
 	defer file.Close()
 
 	info, err := file.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if info.Mode() != mode {
 		t.Fatalf("Unexpected mode: %s != %s %s", info.Mode(), mode, path)
 	}

--- a/mantle/system/ns/enter.go
+++ b/mantle/system/ns/enter.go
@@ -60,7 +60,16 @@ func Create() (netns.NsHandle, error) {
 		return netns.None(), err
 	}
 	defer origns.Close()
-	defer netns.Set(origns)
 
-	return netns.New()
+	newns, err := netns.New()
+	if err != nil {
+		return netns.None(), err
+	}
+
+	if err := netns.Set(origns); err != nil {
+		newns.Close()
+		return netns.None(), err
+	}
+
+	return newns, nil
 }

--- a/mantle/system/ns/exec.go
+++ b/mantle/system/ns/exec.go
@@ -37,9 +37,14 @@ func (cmd *Cmd) CombinedOutput() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer nsExit()
 
-	return cmd.ExecCmd.CombinedOutput()
+	r, rerr := cmd.ExecCmd.CombinedOutput()
+
+	if err := nsExit(); err != nil {
+		return nil, err
+	}
+
+	return r, rerr
 }
 
 func (cmd *Cmd) Output() ([]byte, error) {
@@ -47,9 +52,14 @@ func (cmd *Cmd) Output() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer nsExit()
 
-	return cmd.ExecCmd.Output()
+	r, rerr := cmd.ExecCmd.Output()
+
+	if err := nsExit(); err != nil {
+		return nil, err
+	}
+
+	return r, rerr
 }
 
 func (cmd *Cmd) Run() error {
@@ -57,9 +67,14 @@ func (cmd *Cmd) Run() error {
 	if err != nil {
 		return err
 	}
-	defer nsExit()
 
-	return cmd.ExecCmd.Run()
+	rerr := cmd.ExecCmd.Run()
+
+	if err := nsExit(); err != nil {
+		return err
+	}
+
+	return rerr
 }
 
 func (cmd *Cmd) Start() error {
@@ -67,7 +82,12 @@ func (cmd *Cmd) Start() error {
 	if err != nil {
 		return err
 	}
-	defer nsExit()
 
-	return cmd.ExecCmd.Start()
+	rerr := cmd.ExecCmd.Start()
+
+	if err := nsExit(); err != nil {
+		return err
+	}
+
+	return rerr
 }

--- a/mantle/util/common.go
+++ b/mantle/util/common.go
@@ -114,7 +114,7 @@ func RunCmdTimeout(timeout time.Duration, cmd string, args ...string) error {
 	case <-time.After(timeout):
 		// this uses the waitid(WNOWAIT) trick to avoid racing:
 		// https://github.com/golang/go/commit/cea29c4a358004d84d8711a07628c2f856b381e8
-		c.Process.Kill()
+		_ = c.Process.Kill()
 		<-errc
 		return fmt.Errorf("%s timed out after %s", cmd, timeout)
 	}


### PR DESCRIPTION
There's a lot going on here, but mostly a lot of error-checking added. Ignored errors in a few cases.  Logged in a few others.

Deleted deprecated package golang.org/x/crypto/ssh/terminal in favour of golang.org/x/term.

Delete a bunch of unused variables.

(cherry picked from commit e3cbf040279375e6869adcb7fb253d5839edb714)

jlebon: I didn't backport the migration from
        `golang.org/x/crypto/ssh/terminal` to `golang.org/x/term` to
        keep it simple. The main thing I'm interested in is the improved
        error-handling because we're hitting an issue right now in
        `rhcos/upgrade.go` which I think would be helped by this.