### PR TITLE
kola: Add support for `--sharding`

### DIFF
--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -62,6 +62,7 @@ func init() {
 	bv(&kola.NoNet, "no-net", false, "Don't run tests that require an Internet connection")
 	bv(&kola.ForceRunPlatformIndependent, "run-platform-independent", false, "Run tests that claim platform independence")
 	ssv(&kola.Tags, "tag", []string{}, "Test tag to run. Can be specified multiple times.")
+	sv(&kola.Sharding, "sharding", "", "Provide e.g. 'hash:m/n' where m and n are integers, 1 <= m <= n.  Only tests hashing to m will be run.")
 	bv(&kola.Options.SSHOnTestFailure, "ssh-on-test-failure", false, "SSH into a machine when tests fail")
 	sv(&kola.Options.Stream, "stream", "", "CoreOS stream ID (e.g. for Fedora CoreOS: stable, testing, next)")
 	sv(&kola.Options.CosaWorkdir, "workdir", "", "coreos-assembler working directory")

--- a/mantle/harness/suite.go
+++ b/mantle/harness/suite.go
@@ -75,6 +75,9 @@ type Options struct {
 	// Limit number of tests to run in parallel (0 means GOMAXPROCS).
 	Parallel int
 
+	// Sharding splits tests across runners
+	Sharding string
+
 	Reporters reporters.Reporters
 }
 
@@ -297,7 +300,11 @@ func (s *Suite) runTests(out, tap io.Writer) error {
 		go func() { <-t.signal }()
 	})
 	if !t.ran {
-		return SuiteEmpty
+		if s.opts.Sharding != "" {
+			fmt.Printf("notice: sharding %s enabled, no tests matched\n", s.opts.Sharding)
+		} else {
+			return SuiteEmpty
+		}
 	}
 	if t.Failed() {
 		s.opts.Reporters.SetResult(testresult.Fail)


### PR DESCRIPTION
Currently several of our pipeline executes all tests in a single pod. We've seen some cases where we're hitting the 3 hour Prow timeout. This is just not sustainable.

A standard approach to address this problem is test "sharding" or "partitioning".  See for example
https://nexte.st/book/partitioning.html

This implements only hash-based sharding (partitioning); I expect most of our pipelines to use something like
`kola run --sharding hash:n/5`, where we split the test execution across 5 scheduled pods, each choosing a value between 1 and 5.