### PR TITLE
tests: Stop checking for iscsid being disabled

### DIFF
--- a/mantle/kola/tests/coretest/core.go
+++ b/mantle/kola/tests/coretest/core.go
@@ -23,9 +23,6 @@ const (
 // RHCOS services we expect disabled/inactive
 var offServices = []string{
 	"dnsmasq.service",
-	"iscsid.service",
-	"iscsid.socket",
-	"iscsiuio.service",
 	"nfs-blkmap.service",
 	"nfs-idmapd.service",
 	"nfs-mountd.service",


### PR DESCRIPTION
Having socket units enabled in particular is standard and expected.  Every one of these should have had an explicit rationale.  In this case, the rationale is probably lost to time.

This fixes a test failure on rhel9.

Closes: https://github.com/openshift/os/issues/1016