### PR TITLE
use new bucket layout for release stream metadata

### DIFF
--- a/mantle/cmd/plume/cosa2stream.go
+++ b/mantle/cmd/plume/cosa2stream.go
@@ -34,7 +34,7 @@ import (
 
 const (
 	// This will hopefully migrate to mirror.openshift.com, see https://github.com/openshift/os/issues/477
-	rhcosCosaEndpoint = "https://rhcos.mirror.openshift.com/art/storage/releases"
+	rhcosCosaEndpoint = "https://rhcos.mirror.openshift.com/art/storage/prod/streams"
 )
 
 var (
@@ -106,7 +106,6 @@ func runCosaBuildToStream(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		var archStreamName = streamName
 		if !strings.HasPrefix(arg, "https://") {
 			if distro != "rhcos" {
 				return errors.New("Arguments must be https:// URLs (or with --distro rhcos, ARCH=VERSION)")
@@ -117,24 +116,21 @@ func runCosaBuildToStream(cmd *cobra.Command, args []string) error {
 			}
 			arch := parts[0]
 			ver := parts[1]
-			// Convert e.g. 48.82.<timestamp> to rhcos-4.8
+			// Convert e.g. 48.82.<timestamp> to 4.8
 			verSplit := strings.Split(ver, ".")
-			archStreamName = fmt.Sprintf("rhcos-%s.%s", verSplit[0][0:1], verSplit[0][1:])
-			if arch != "x86_64" {
-				archStreamName += "-" + arch
-			}
+			streamName = fmt.Sprintf("%s.%s", verSplit[0][0:1], verSplit[0][1:])
 			endpoint := rhcosCosaEndpoint
 			if streamBaseURL != "" {
 				endpoint = streamBaseURL
 			}
-			base := fmt.Sprintf("%s/%s", endpoint, archStreamName)
-			u := fmt.Sprintf("%s/%s/%s/meta.json", base, ver, arch)
+			base := fmt.Sprintf("%s/%s", endpoint, streamName)
+			u := fmt.Sprintf("%s/builds/%s/%s/meta.json", base, ver, arch)
 			arg = u
 			childArgs = append(childArgs, "--stream-baseurl="+endpoint)
 		}
 		cosaArgs := append([]string{}, childArgs...)
 		cosaArgs = append(cosaArgs, "--url="+arg)
-		cosaArgs = append(cosaArgs, "--stream-name="+archStreamName)
+		cosaArgs = append(cosaArgs, "--stream-name="+streamName)
 		cosaArgs = append(cosaArgs, "--output="+releaseTmpf.Name())
 		c := exec.Command("cosa", cosaArgs...)
 		c.Stderr = os.Stderr

--- a/src/cmd-generate-release-meta
+++ b/src/cmd-generate-release-meta
@@ -27,11 +27,7 @@ def ensure_dup(inp, out, inp_key, out_key):
 
 
 def url_builder(stream, version, arch, path):
-    # This is a bug to be fixed with later work on https://github.com/openshift/os/issues/477
-    if args.distro == 'rhcos':
-        return f"{args.stream_baseurl}/{stream}/{version}/{arch}/{path}"
-    else:
-        return f"{args.stream_baseurl}/{stream}/builds/{version}/{arch}/{path}"
+    return f"{args.stream_baseurl}/{stream}/builds/{version}/{arch}/{path}"
 
 
 def get_extension(path, modifier, arch):


### PR DESCRIPTION
The bucket layout was changed when migrating the RHCOS pipeline to use the same code as the FCOS pipeline. Using one instance of Jenkins allowed all arches to use the same build ID and therefore share the parent build directory.

Plume is used to update the boot images in the OCP installer so update it to handl the new bucket layout.