### PR TITLE
kola: Use 'qemu-unpriv' for 'platform-independent' tests

### DIFF
--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -87,7 +87,7 @@ const NeedsInternetTag = "needs-internet"
 const PlatformIndependentTag = "platform-independent"
 
 // defaultPlatformIndependentPlatform is the platform where we run tests that claim platform independence
-const defaultPlatformIndependentPlatform = "qemu"
+const defaultPlatformIndependentPlatform = "qemu-unpriv"
 
 // Don't e.g. check console for kernel errors, SELinux AVCs, etc.
 const SkipBaseChecksTag = "skip-base-checks"


### PR DESCRIPTION
Kola runs tests locally using the `qemu-unpriv` platform by default so we should use that platform for 'platform-independent' tests.

The `qemu` platform should only be used for tests that explicitely require a privileged `qemu` instance.

Fixes: https://github.com/coreos/coreos-assembler/issues/3279