### PR TITLE
Fix s390x live ISO booting, enable Ignition embedding, enable ISO install tests

### DIFF
--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -90,6 +90,12 @@ var (
 		"pxe-online-install.4k.uefi",
 	}
 	tests_s390x = []string{
+		"iso-live-login.s390fw",
+		"iso-offline-install.s390fw",
+		// https://github.com/coreos/fedora-coreos-tracker/issues/1434
+		// "iso-offline-install.mpath.s390fw",
+		// https://github.com/coreos/fedora-coreos-tracker/issues/1261
+		// "iso-offline-install.4k.s390fw",
 		"pxe-online-install.s390fw",
 		"pxe-offline-install.s390fw",
 	}

--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -489,6 +489,14 @@ def generate_iso():
         shutil.move(os.path.join(tmpisoimagespxe, kernel_img), kernel_dest)
         kernel_img = 'kernel.img'
 
+        if args.fixture:
+            # truncate it to 128k so it includes the offsets to the initrd and kargs
+            # https://github.com/ibm-s390-linux/s390-tools/blob/032304d5034e/netboot/mk-s390image#L21-L24
+            with open(kernel_dest, 'rb+') as f:
+                f.truncate(128 * 1024)
+            with open(iso_initramfs, 'rb+') as f:
+                f.truncate(1024)
+
         # On s390x, we reserve space for the Ignition config in the initrd
         # image directly since the bootloader doesn't support multiple initrds.
         # We do this by inflating the initramfs just for the duration of the
@@ -693,17 +701,19 @@ boot
             fh.write('initrd data\n')
         with open(os.path.join(tmpisoimagespxe, 'vmlinuz'), 'w') as fh:
             fh.write('the kernel\n')
-        with open(os.path.join(tmpisoisolinux, 'isolinux.bin'), 'rb+') as fh:
-            flen = fh.seek(0, 2)
-            fh.truncate(0)
-            fh.truncate(flen)
-            fh.seek(64)
-            # isohybrid checks for this magic
-            fh.write(b'\xfb\xc0\x78\x70')
-        for f in ensure_glob(os.path.join(tmpisoisolinux, '*.c32')):
-            os.unlink(f)
-        for f in ensure_glob(os.path.join(tmpisoisolinux, '*.msg')):
-            os.unlink(f)
+        # this directory doesn't exist on s390x
+        if os.path.isdir(tmpisoisolinux):
+            with open(os.path.join(tmpisoisolinux, 'isolinux.bin'), 'rb+') as fh:
+                flen = fh.seek(0, 2)
+                fh.truncate(0)
+                fh.truncate(flen)
+                fh.seek(64)
+                # isohybrid checks for this magic
+                fh.write(b'\xfb\xc0\x78\x70')
+            for f in ensure_glob(os.path.join(tmpisoisolinux, '*.c32')):
+                os.unlink(f)
+            for f in ensure_glob(os.path.join(tmpisoisolinux, '*.msg')):
+                os.unlink(f)
 
     runcmd(genisoargs_final)
 

--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -219,8 +219,8 @@ def generate_iso():
     initrd_img = 'initrd.img'
     # other files
     rootfs_img = 'rootfs.img'
-    ignition_img = 'ignition.img'
     kargs_file = 'kargs.json'
+    igninfo_file = 'igninfo.json'
 
     tmpisofile = os.path.join(tmpdir, iso_name)
 
@@ -282,9 +282,13 @@ def generate_iso():
     # config in a cpio.xz and write it directly into this file in the ISO
     # image.  The cpio.xz will be read into the initramfs filesystem at
     # runtime and the Ignition Dracut module will ensure that the config is
-    # moved where Ignition will see it.
-    with open(os.path.join(tmpisoimages, ignition_img), 'wb') as fdst:
-        fdst.write(bytes(ignition_img_size))
+    # moved where Ignition will see it. We only handle !s390x here since that's
+    # the simple case (where layered initrds are supported). The s390x case is
+    # handled lower down
+    if basearch != 's390x':
+        with open(os.path.join(tmpisoimages, 'ignition.img'), 'wb') as fdst:
+            fdst.write(bytes(ignition_img_size))
+        igninfo_json = {'file': 'images/ignition.img'}
 
     # Generate JSON file that lists OS features available to
     # coreos-installer {iso|pxe} customize.  Put it in the initramfs for
@@ -485,12 +489,42 @@ def generate_iso():
         shutil.move(os.path.join(tmpisoimagespxe, kernel_img), kernel_dest)
         kernel_img = 'kernel.img'
 
+        # On s390x, we reserve space for the Ignition config in the initrd
+        # image directly since the bootloader doesn't support multiple initrds.
+        # We do this by inflating the initramfs just for the duration of the
+        # `mk-s390image` call.
+        initramfs_size = os.stat(iso_initramfs).st_size
+        # sanity-check it's 4-byte aligned (see align_initrd_for_uncompressed_append)
+        assert initramfs_size % 4 == 0
+
         # combine kernel, initramfs and cmdline using the mk-s390image tool
+        os.truncate(iso_initramfs, initramfs_size + ignition_img_size)
         runcmd(['/usr/bin/mk-s390image',
                kernel_dest,
                os.path.join(tmpisoimages, 'cdboot.img'),
                '-r', iso_initramfs,
                '-p', os.path.join(tmpisoimages, 'cdboot.prm')])
+        os.truncate(iso_initramfs, initramfs_size)
+
+        # Get the initramfs offset in the cdboot.img. For more info, see:
+        # https://github.com/ibm-s390-linux/s390-tools/blob/032304d5034e/netboot/mk-s390image#L21-L23
+        CDBOOT_IMG_OFFS_INITRD_START_BYTES = 66568
+        with open(os.path.join(tmpisoimages, 'cdboot.img'), 'rb') as f:
+            f.seek(CDBOOT_IMG_OFFS_INITRD_START_BYTES)
+            offset = struct.unpack(">Q", f.read(8))[0]
+
+            # sanity-check we're at the right spot by comparing a few bytes
+            f.seek(offset)
+            with open(iso_initramfs, 'rb') as canonical:
+                if f.read(1024) != canonical.read(1024):
+                    raise Exception(f"expected initrd at offset {offset}")
+
+            igninfo_json = {
+                'file': 'images/cdboot.img',
+                'offset': offset + initramfs_size,
+                'length': ignition_img_size,
+            }
+
         # generate .addrsize file for LPAR
         with open(os.path.join(tmpisoimages, 'initrd.addrsize'), 'wb') as addrsize:
             addrsize_data = struct.pack(">iiii", 0, int(INITRD_ADDRESS, 16), 0,
@@ -635,6 +669,12 @@ boot
         with open(os.path.join(tmpisocoreos, kargs_file), 'w') as fh:
             json.dump(kargs_json, fh, indent=2, sort_keys=True)
             fh.write('\n')
+
+    # Write out the igninfo.json file. This is used by coreos-installer to know
+    # how to embed the Ignition config.
+    with open(os.path.join(tmpisocoreos, igninfo_file), 'w') as fh:
+        json.dump(igninfo_json, fh, indent=2, sort_keys=True)
+        fh.write('\n')
 
     # Define inputs and outputs
     genisoargs_final = genisoargs + ['-o', tmpisofile, tmpisoroot]


### PR DESCRIPTION
This patch series fixes the s390x live ISO so that it can successfully boot, then adds support for Ignition config embedding like on other arches, and then enables some ISO tests, which successfully pass:

```
[coreos-assembler]$ kola testiso -S --no-pxe
Skipping iso-as-disk; not supported on s390x
Skipping miniso-install and miniso-install-nm; not supported on s390x
Testing scenarios: [iso-offline-install iso-live-login]
Ignoring verification of signature on metal image
PASS: iso-offline-install ( + metal) (1m58.02s)
PASS: iso-live-login ( + metal) (10.689s)
```

I've split prep patches into a separate PR: https://github.com/coreos/coreos-assembler/pull/3284. The remaining two commits will stay here. The following is the commit message for the primary one:

---

This patch will allow users to embed Ignition configs in s390x ISOs.
This narrows the live ISO gap a bit between s390x and other arches (but
notably, ISO kargs support is still missing). It also crucially unblocks
running live ISO tests.

s390x does not support layered initrds, so to do this, we allocate space
directly in the initramfs passed to `mk-s390img` for the Ignition
config. We then create a new `/coreos/igninfo.json` file in the ISO
containing the metadata on how to find the Ignition embed area. On
!s390x, where layered initrds are supported, we point at `ignition.img`,
which maintains current behaviour. On s390x, we point at the right
offset of the reserved space in the `cdboot.img`.

coreos-installer will look for this `igninfo.json` file and embed the
Ignition config in the area to which it points.
