### PR TITLE
mantle/kola/tests: Use qemu platform only

### DIFF
--- a/docs/kola.md
+++ b/docs/kola.md
@@ -25,9 +25,8 @@ inspection.
 Kola is still under heavy development and it is expected that its
 interface will continue to change.
 
-By default, kola uses the `qemu-unprivileged` platform with the most recently
-built image (assuming it is run from within a CoreOS Assembler working
-directory).
+By default, kola uses the `qemu` platform with the most recently built image
+(assuming it is run from within a CoreOS Assembler working directory).
 
 1. TOC
 {:toc}
@@ -215,7 +214,7 @@ After you run the kola test, you can find more information in `tmp/kola/<test-na
 Example output:
 
 ```
-kola -p qemu-unpriv --output-dir tmp/kola testiso -P --qemu-native-4k
+kola -p qemu --output-dir tmp/kola testiso -P --qemu-native-4k
 Testing scenarios: [iso-offline-install iso-live-login iso-as-disk miniso-install miniso-install-nm]
 Detected development build; disabling signature verification
 Successfully tested scenario iso-offline-install for 35.20220217.dev.0 on uefi (metal4k)

--- a/docs/kola/external-tests.md
+++ b/docs/kola/external-tests.md
@@ -188,7 +188,7 @@ Here's an example `kola.json`:
 {
     "architectures": "!s390x ppc64le",
     "distros": "fcos",
-    "platforms": "qemu-unpriv",
+    "platforms": "qemu",
     "tags": "sometagname needs-internet skip-base-checks othertag",
     "requiredTag": "special",
     "additionalDisks": [ "5G" ],
@@ -229,7 +229,7 @@ If a test has a `requiredTag`, it is run only if the required tag is specified.
 In the example above, the test would only run if `--tag special` was provided.
 
 The `additionalDisks` key has the same semantics as the `--add-disk` argument
-to `qemuexec`. It is currently only supported on `qemu-unpriv`.
+to `qemuexec`. It is currently only supported on `qemu`.
 
 The `injectContainer` boolean if set will cause the framework to inject
 the ostree base image container into the target system; the path can be
@@ -240,21 +240,21 @@ via `skopeo copy oci-archive:$KOLA_OSTREE_OCIARCHIVE containers-storage:localhos
 The `minDisk` key takes a size in GB and ensures that an instance type with at
 least the specified amount of primary disk space is used. On QEMU, this is
 equivalent to the `--qemu-size` argument to `qemuexec`. This is currently only
-enforced on `qemu-unpriv` and `aws`.
+enforced on `qemu` and `aws`.
 
 The `minMemory` key takes a size in MB and ensures that an instance type with
 at least the specified amount of memory is used. On QEMU, this is equivalent to
 the `--memory` argument to `qemuexec`. This is currently only enforced on
-`qemu-unpriv`.
+`qemu`.
 
 The `additionalNics` key has the same semantics as the `--additional-nics` argument
-to `qemuexec`. It is currently only supported on `qemu-unpriv`.
+to `qemuexec`. It is currently only supported on `qemu`.
 
 The `appendKernelArgs` key has the same semantics at the `--kargs` argument to
-`qemuexec`. It is currently only supported on `qemu-unpriv`.
+`qemuexec`. It is currently only supported on `qemu`.
 
 The `appendFirstbootKernelArgs` key has the same semantics at the `--firstbootkargs`
-argument to `qemuexec`. It is currently only supported on `qemu-unpriv`.
+argument to `qemuexec`. It is currently only supported on `qemu`.
 
 The `timeoutMin` key takes a positive integer and specifies a timeout for the test
 in minutes. After the specified amount of time, the test will be interrupted.
@@ -330,7 +330,7 @@ $ chmod a+x basic/noop # Make sure the test is executable
 $ cosa kola run -p qemu --qemu-image path/to/qcow2 -E path/to/my-project/ 'ext.my-project.basic' # Run the test
 === RUN   ext.my-project.basic
 --- PASS: ext.my-project.basic (35.57s)
-PASS, output in _kola_temp/qemu-unpriv-2020-08-18-1815-2295199
+PASS, output in _kola_temp/qemu-2020-08-18-1815-2295199
 ```
 
 ## Fast build and iteration on your project's tests

--- a/docs/mantle/credentials.md
+++ b/docs/mantle/credentials.md
@@ -191,16 +191,12 @@ If you want to create a service account's JSON key for authentication, refer to 
 
 ## qemu
 
-`qemu` is run locally and needs no credentials, but does need to be run as root.
-
-## qemu-unpriv
-
-`qemu-unpriv` is run locally and needs no credentials. It has a restricted set of functionality compared to the `qemu` platform, such as:
+`qemu` is run locally and needs no credentials. It has a few restrictions:
 
 - No [Local cluster](platform/local/)
-- Usermode networking instead of namespaced networks
+- Usermode networking (no namespaced networks):
   * Single node only, no machine to machine networking
-  * Machines have internet access
+  * Machines have internet access by default
 
 ## kubevirt
 

--- a/mantle/README.md
+++ b/mantle/README.md
@@ -372,12 +372,9 @@ The json file should have the following fields at the minimum with the api key b
 ```
 
 ### qemu
-`qemu` is run locally and needs no credentials, but does need to be run as root.
-
-### qemu-unpriv
-`qemu-unpriv` is run locally and needs no credentials. It has a restricted set of functionality compared to the `qemu` platform, such as:
+`qemu` is run locally and needs no credentials. It has a few restrictions:
 
 - No [Local cluster](platform/local/)
-- Usermode networking instead of namespaced networks
+- Usermode networking (no namespaced networks):
   * Single node only, no machine to machine networking
-  * Machines have internet access
+  * Machines have internet access by default

--- a/mantle/cmd/kola/kola.go
+++ b/mantle/cmd/kola/kola.go
@@ -617,7 +617,7 @@ func syncFindParentImageOptions() error {
 	// Here we handle the --fetch-parent-image --> platform-specific options
 	// based on its cosa build metadata
 	switch kolaPlatform {
-	case "qemu-unpriv":
+	case "qemu":
 		if qemuImageDir == "" {
 			if qemuImageDir, err = os.MkdirTemp("/var/tmp", "kola-run-upgrade"); err != nil {
 				return err

--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -40,7 +40,7 @@ var (
 	kolaPlatform      string
 	kolaParallelArg   string
 	kolaArchitectures = []string{"amd64"}
-	kolaPlatforms     = []string{"aws", "azure", "do", "esx", "gcp", "openstack", "packet", "qemu", "qemu-unpriv", "qemu-iso"}
+	kolaPlatforms     = []string{"aws", "azure", "do", "esx", "gcp", "openstack", "packet", "qemu", "qemu-iso"}
 	kolaDistros       = []string{"fcos", "rhcos", "scos"}
 )
 
@@ -177,21 +177,21 @@ func syncOptionsImpl(useCosa bool) error {
 		return fmt.Errorf("unsupported %v %q", name, item)
 	}
 
-	// TODO: Could also auto-synchronize if e.g. --aws-ami is passed
-	if kolaPlatform == "" {
-		if kola.QEMUIsoOptions.IsoPath != "" {
-			kolaPlatform = "qemu-iso"
-		} else {
-			kolaPlatform = "qemu-unpriv"
-		}
+	if kolaPlatform == "iso" {
+		kolaPlatform = "qemu-iso"
 	}
 
-	// There used to be a "privileged" qemu path, it is no longer supported.
-	// Alias qemu to qemu-unpriv.
-	if kolaPlatform == "qemu" {
-		kolaPlatform = "qemu-unpriv"
-	} else if kolaPlatform == "iso" {
+	if kolaPlatform == "" && kola.QEMUIsoOptions.IsoPath != "" {
 		kolaPlatform = "qemu-iso"
+	}
+
+	// There used to be two QEMU platforms: privileged ('qemu') and
+	// unprivileged ('qemu-unpriv'). We first removed support for privileged
+	// QEMU and aliased it to 'qemu-unpriv' and then renamed and merged
+	// 'qemu-unpriv' to 'qemu' to unify on a single name. 'qemu' is now the
+	// default.
+	if kolaPlatform == "" {
+		kolaPlatform = "qemu"
 	}
 
 	// test parallelism
@@ -339,7 +339,7 @@ func syncOptions() error {
 // options that can be derived from the cosa build metadata
 func syncCosaOptions() error {
 	switch kolaPlatform {
-	case "qemu-unpriv", "qemu":
+	case "qemu":
 		if kola.QEMUOptions.SecureExecution && kola.QEMUOptions.DiskImage == "" && kola.CosaBuild.Meta.BuildArtifacts.SecureExecutionQemu != nil {
 			kola.QEMUOptions.DiskImage = filepath.Join(kola.CosaBuild.Dir, kola.CosaBuild.Meta.BuildArtifacts.SecureExecutionQemu.Path)
 		}

--- a/mantle/cmd/kola/spawn.go
+++ b/mantle/cmd/kola/spawn.go
@@ -32,7 +32,7 @@ import (
 	"github.com/coreos/coreos-assembler/mantle/kola"
 	"github.com/coreos/coreos-assembler/mantle/platform"
 	"github.com/coreos/coreos-assembler/mantle/platform/conf"
-	"github.com/coreos/coreos-assembler/mantle/platform/machine/unprivqemu"
+	"github.com/coreos/coreos-assembler/mantle/platform/machine/qemu"
 )
 
 var (
@@ -178,7 +178,7 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 			}
 
 			switch qc := cluster.(type) {
-			case *unprivqemu.Cluster:
+			case *qemu.Cluster:
 				mach, err = qc.NewMachineWithQemuOptions(userdata, machineOpts)
 			default:
 				plog.Fatalf("unreachable: qemu cluster %v unknown type", qc)

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -54,8 +54,8 @@ import (
 	"github.com/coreos/coreos-assembler/mantle/platform/machine/gcloud"
 	"github.com/coreos/coreos-assembler/mantle/platform/machine/openstack"
 	"github.com/coreos/coreos-assembler/mantle/platform/machine/packet"
+	"github.com/coreos/coreos-assembler/mantle/platform/machine/qemu"
 	"github.com/coreos/coreos-assembler/mantle/platform/machine/qemuiso"
-	"github.com/coreos/coreos-assembler/mantle/platform/machine/unprivqemu"
 	"github.com/coreos/coreos-assembler/mantle/system"
 	"github.com/coreos/coreos-assembler/mantle/util"
 	coreosarch "github.com/coreos/stream-metadata-go/arch"
@@ -114,7 +114,7 @@ var (
 	GCPOptions       = gcloudapi.Options{Options: &Options}    // glue to set platform options from main
 	OpenStackOptions = openstackapi.Options{Options: &Options} // glue to set platform options from main
 	PacketOptions    = packetapi.Options{Options: &Options}    // glue to set platform options from main
-	QEMUOptions      = unprivqemu.Options{Options: &Options}   // glue to set platform options from main
+	QEMUOptions      = qemu.Options{Options: &Options}         // glue to set platform options from main
 	QEMUIsoOptions   = qemuiso.Options{Options: &Options}      // glue to set platform options from main
 
 	CosaBuild *util.LocalBuild // this is a parsed cosa build
@@ -299,8 +299,8 @@ func NewFlight(pltfrm string) (flight platform.Flight, err error) {
 		flight, err = openstack.NewFlight(&OpenStackOptions)
 	case "packet":
 		flight, err = packet.NewFlight(&PacketOptions)
-	case "qemu-unpriv":
-		flight, err = unprivqemu.NewFlight(&QEMUOptions)
+	case "qemu":
+		flight, err = qemu.NewFlight(&QEMUOptions)
 	case "qemu-iso":
 		flight, err = qemuiso.NewFlight(&QEMUIsoOptions)
 	default:
@@ -480,11 +480,6 @@ func filterTests(tests map[string]*register.Test, patterns []string, pltfrm stri
 
 	checkPlatforms := []string{pltfrm}
 
-	// qemu-unpriv has the same restrictions as QEMU but might also want additional restrictions due to the lack of a Local cluster
-	if pltfrm == "qemu-unpriv" {
-		checkPlatforms = append(checkPlatforms, "qemu")
-	}
-
 	// sort tags into include/exclude
 	positiveTags := []string{}
 	negativeTags := []string{}
@@ -638,7 +633,7 @@ func filterTests(tests map[string]*register.Test, patterns []string, pltfrm stri
 		if allowed, excluded := isAllowed(Options.Distribution, t.Distros, t.ExcludeDistros); !allowed || excluded {
 			continue
 		}
-		if pltfrm == "qemu-unpriv" {
+		if pltfrm == "qemu" {
 			if allowed, excluded := isAllowed(QEMUOptions.Firmware, t.Firmwares, t.ExcludeFirmwares); !allowed || excluded {
 				continue
 			}

--- a/mantle/kola/tests/coretest/core.go
+++ b/mantle/kola/tests/coretest/core.go
@@ -55,7 +55,7 @@ func init() {
 		},
 	})
 	// TODO: Enable DockerPing/DockerEcho once fixed
-	// TODO: Only enable PodmanPing on non qemu-unpriv. Needs:
+	// TODO: Only enable PodmanPing on non qemu. Needs:
 	// https://github.com/coreos/mantle/issues/1132
 	register.RegisterTest(&register.Test{
 		Name:        "fcos.internet",

--- a/mantle/kola/tests/crio/crio.go
+++ b/mantle/kola/tests/crio/crio.go
@@ -205,8 +205,8 @@ func init() {
 		UserData:    enableCrioIgn,
 		// this test requires net connections outside the host
 		Tags: []string{"crio", kola.NeedsInternetTag},
-		// qemu-unpriv machines cannot communicate between each other
-		ExcludePlatforms: []string{"qemu-unpriv"},
+		// qemu machines cannot communicate between each other
+		ExcludePlatforms: []string{"qemu"},
 	})
 }
 

--- a/mantle/kola/tests/docker/docker.go
+++ b/mantle/kola/tests/docker/docker.go
@@ -60,8 +60,8 @@ func init() {
 		Name:        "docker.network",
 		Distros:     []string{"cl"},
 
-		// qemu-unpriv machines cannot communicate
-		ExcludePlatforms: []string{"qemu-unpriv"},
+		// qemu machines cannot communicate
+		ExcludePlatforms: []string{"qemu"},
 	})
 	register.RegisterTest(&register.Test{
 		Run:         dockerOldClient,
@@ -103,8 +103,8 @@ passwd:
   users:
   - name: dockremap`),
 
-		// qemu-unpriv machines cannot communicate
-		ExcludePlatforms: []string{"qemu-unpriv"},
+		// qemu machines cannot communicate
+		ExcludePlatforms: []string{"qemu"},
 	})
 
 	// This test covers all functionality that should be quick to run and can be
@@ -226,10 +226,10 @@ systemd:
      enable: true`),
 
 		// https://github.com/coreos/mantle/issues/999
-		// On the qemu-unpriv platform the DHCP provides no data, pre-systemd 241 the DHCP server sending
+		// On the qemu platform the DHCP provides no data, pre-systemd 241 the DHCP server sending
 		// no routes to the link to spin in the configuring state. docker.service pulls in the network-online
 		// target which causes the basic machine checks to fail
-		ExcludePlatforms: []string{"qemu-unpriv"},
+		ExcludePlatforms: []string{"qemu"},
 	})
 }
 

--- a/mantle/kola/tests/etcd/rhcos.go
+++ b/mantle/kola/tests/etcd/rhcos.go
@@ -55,8 +55,8 @@ func init() {
 }`),
 		Tags:    []string{kola.NeedsInternetTag}, // fetching etcd requires networking
 		Distros: []string{"rhcos"},
-		// qemu-unpriv machines cannot communicate between each other
-		ExcludePlatforms: []string{"qemu-unpriv"},
+		// qemu machines cannot communicate between each other
+		ExcludePlatforms: []string{"qemu"},
 	})
 	register.RegisterTest(&register.Test{
 		Run:         rhcosClusterTLS,
@@ -90,8 +90,8 @@ func init() {
 }`),
 		Tags:    []string{kola.NeedsInternetTag}, // fetching etcd requires networking
 		Distros: []string{"rhcos"},
-		// qemu-unpriv machines cannot communicate between each other
-		ExcludePlatforms: []string{"qemu-unpriv"},
+		// qemu machines cannot communicate between each other
+		ExcludePlatforms: []string{"qemu"},
 	})
 }
 

--- a/mantle/kola/tests/fips/fips.go
+++ b/mantle/kola/tests/fips/fips.go
@@ -63,7 +63,7 @@ func init() {
 		Description: "Verify that fips enabled works if custom partitions are present.",
 		Flags:       []register.Flag{},
 		Distros:     []string{"rhcos"},
-		Platforms:   []string{"qemu", "qemu-unpriv"},
+		Platforms:   []string{"qemu"},
 		UserData: conf.Ignition(`{
 			"ignition": {
 				"config": {

--- a/mantle/kola/tests/ignition/luks.go
+++ b/mantle/kola/tests/ignition/luks.go
@@ -12,7 +12,7 @@ import (
 	ut "github.com/coreos/coreos-assembler/mantle/kola/tests/util"
 	"github.com/coreos/coreos-assembler/mantle/platform"
 	"github.com/coreos/coreos-assembler/mantle/platform/conf"
-	"github.com/coreos/coreos-assembler/mantle/platform/machine/unprivqemu"
+	"github.com/coreos/coreos-assembler/mantle/platform/machine/qemu"
 	"github.com/coreos/coreos-assembler/mantle/util"
 )
 
@@ -76,7 +76,7 @@ func setupTangMachine(c cluster.TestCluster) ut.TangServer {
 	// the golang compiler no longer checks that the individual types in the case have the
 	// NewMachineWithQemuOptions function, but rather whether platform.Cluster
 	// does which fails
-	case *unprivqemu.Cluster:
+	case *qemu.Cluster:
 		m, err = pc.NewMachineWithQemuOptions(ignition, options)
 		for _, hfp := range options.HostForwardPorts {
 			if hfp.Service == "tang" {

--- a/mantle/kola/tests/ignition/luks.go
+++ b/mantle/kola/tests/ignition/luks.go
@@ -35,7 +35,7 @@ func init() {
 		Description:          "Verify that the rootfs is encrypted with SSS with t=1.",
 		Flags:                []register.Flag{},
 		Distros:              []string{"rhcos"},
-		Platforms:            []string{"qemu-unpriv"},
+		Platforms:            []string{"qemu"},
 		ExcludeArchitectures: []string{"s390x"}, // no TPM backend support for s390x
 		Tags:                 []string{"luks", "tpm", "tang", "sss", kola.NeedsInternetTag, "reprovision"},
 	})
@@ -46,7 +46,7 @@ func init() {
 		Description:          "Verify that the rootfs is encrypted with SSS with t=2.",
 		Flags:                []register.Flag{},
 		Distros:              []string{"rhcos"},
-		Platforms:            []string{"qemu-unpriv"},
+		Platforms:            []string{"qemu"},
 		ExcludeArchitectures: []string{"s390x"}, // no TPM backend support for s390x
 		Tags:                 []string{"luks", "tpm", "tang", "sss", kola.NeedsInternetTag, "reprovision"},
 	})

--- a/mantle/kola/tests/ignition/qemufailure.go
+++ b/mantle/kola/tests/ignition/qemufailure.go
@@ -34,7 +34,7 @@ func init() {
 		Description: "Verify ignition will fail with unsupported action.",
 		Run:         runIgnitionFailure,
 		ClusterSize: 0,
-		Platforms:   []string{"qemu-unpriv"},
+		Platforms:   []string{"qemu"},
 		Tags:        []string{"ignition"},
 	})
 }

--- a/mantle/kola/tests/ignition/resource.go
+++ b/mantle/kola/tests/ignition/resource.go
@@ -73,7 +73,7 @@ func init() {
 			"Serve": register.CreateNativeFuncWrap(Serve),
 		},
 		Tags:             []string{"ignition"},
-		ExcludePlatforms: []string{"qemu-unpriv"},
+		ExcludePlatforms: []string{"qemu"},
 		Timeout:          20 * time.Minute,
 	})
 }

--- a/mantle/kola/tests/ignition/security.go
+++ b/mantle/kola/tests/ignition/security.go
@@ -62,7 +62,7 @@ func init() {
 			"TLSServe": register.CreateNativeFuncWrap(TLSServe),
 		},
 		Tags: []string{"ignition"},
-		// QEMU unprivileged doesn't support multiple VMs communicating with each other.
+		// QEMU doesn't support multiple VMs communicating with each other.
 		ExcludePlatforms: []string{"qemu"},
 		Timeout:          20 * time.Minute,
 	})

--- a/mantle/kola/tests/misc/boot-mirror.go
+++ b/mantle/kola/tests/misc/boot-mirror.go
@@ -26,7 +26,7 @@ import (
 	"github.com/coreos/coreos-assembler/mantle/kola/tests/util"
 	"github.com/coreos/coreos-assembler/mantle/platform"
 	"github.com/coreos/coreos-assembler/mantle/platform/conf"
-	"github.com/coreos/coreos-assembler/mantle/platform/machine/unprivqemu"
+	"github.com/coreos/coreos-assembler/mantle/platform/machine/qemu"
 	ut "github.com/coreos/coreos-assembler/mantle/util"
 )
 
@@ -103,7 +103,7 @@ func runBootMirrorTest(c cluster.TestCluster) {
 	// FIXME: for QEMU tests kola currently assumes the host CPU architecture
 	// matches the one under test
 	userdata := bootmirror.Subst("LAYOUT", coreosarch.CurrentRpmArch())
-	m, err = c.Cluster.(*unprivqemu.Cluster).NewMachineWithQemuOptions(userdata, options)
+	m, err = c.Cluster.(*qemu.Cluster).NewMachineWithQemuOptions(userdata, options)
 	if err != nil {
 		c.Fatal(err)
 	}
@@ -150,7 +150,7 @@ func runBootMirrorLUKSTest(c cluster.TestCluster) {
 	// FIXME: for QEMU tests kola currently assumes the host CPU architecture
 	// matches the one under test
 	userdata := bootmirrorluks.Subst("LAYOUT", coreosarch.CurrentRpmArch())
-	m, err = c.Cluster.(*unprivqemu.Cluster).NewMachineWithQemuOptions(userdata, options)
+	m, err = c.Cluster.(*qemu.Cluster).NewMachineWithQemuOptions(userdata, options)
 	if err != nil {
 		c.Fatal(err)
 	}

--- a/mantle/kola/tests/misc/boot-mirror.go
+++ b/mantle/kola/tests/misc/boot-mirror.go
@@ -61,7 +61,7 @@ func init() {
 		ClusterSize: 0,
 		Name:        `coreos.boot-mirror`,
 		Description: "Verify the boot-mirror RAID1 flow works properly in both BIOS and UEFI mode.",
-		Platforms:   []string{"qemu-unpriv"},
+		Platforms:   []string{"qemu"},
 		// Can't mirror boot disk on s390x
 		ExcludeArchitectures: []string{"s390x"},
 		// skipping this test on UEFI until https://github.com/coreos/coreos-assembler/issues/2039
@@ -76,7 +76,7 @@ func init() {
 		ClusterSize: 0,
 		Name:        `coreos.boot-mirror.luks`,
 		Description: "Verify the boot-mirror+LUKS RAID1 flow works properly in both BIOS and UEFI modes.",
-		Platforms:   []string{"qemu-unpriv"},
+		Platforms:   []string{"qemu"},
 		// Can't mirror boot disk on s390x, and qemu s390x doesn't
 		// support TPM
 		ExcludeArchitectures: []string{"s390x"},

--- a/mantle/kola/tests/misc/multipath.go
+++ b/mantle/kola/tests/misc/multipath.go
@@ -100,7 +100,7 @@ func init() {
 		Description:   "Verify that multipath can be configured day 1 through Ignition.",
 		Run:           runMultipathDay1,
 		ClusterSize:   1,
-		Platforms:     []string{"qemu-unpriv"},
+		Platforms:     []string{"qemu"},
 		UserData:      mpath_on_boot_day1,
 		MultiPathDisk: true,
 	})
@@ -109,7 +109,7 @@ func init() {
 		Description:   "Verify that multipath can be configured day 2 through Ignition.",
 		Run:           runMultipathDay2,
 		ClusterSize:   1,
-		Platforms:     []string{"qemu-unpriv"},
+		Platforms:     []string{"qemu"},
 		MultiPathDisk: true,
 	})
 	register.RegisterTest(&register.Test{
@@ -117,7 +117,7 @@ func init() {
 		Description:     "Verify that multipath can be configured for a partition.",
 		Run:             runMultipathPartition,
 		ClusterSize:     1,
-		Platforms:       []string{"qemu-unpriv"},
+		Platforms:       []string{"qemu"},
 		UserData:        mpath_on_var_lib_containers,
 		AdditionalDisks: []string{"1G:mpath"},
 	})

--- a/mantle/kola/tests/misc/network.go
+++ b/mantle/kola/tests/misc/network.go
@@ -56,7 +56,7 @@ func init() {
 		Description: "Verify configuring networking with multiple NICs work.",
 		Timeout:     20 * time.Minute,
 		Distros:     []string{"rhcos"},
-		Platforms:   []string{"qemu-unpriv"},
+		Platforms:   []string{"qemu"},
 	})
 	// This test follows the same network configuration used on https://github.com/RHsyseng/rhcos-slb
 	// with a slight change, where the script originally run by MCO is run from
@@ -68,7 +68,7 @@ func init() {
 		Description: "Verify init-interfaces script works in both fresh setup and reboot.",
 		Timeout:     40 * time.Minute,
 		Distros:     []string{"rhcos"},
-		Platforms:   []string{"qemu-unpriv"},
+		Platforms:   []string{"qemu"},
 	})
 }
 

--- a/mantle/kola/tests/misc/network.go
+++ b/mantle/kola/tests/misc/network.go
@@ -26,7 +26,7 @@ import (
 	"github.com/coreos/coreos-assembler/mantle/kola/register"
 	"github.com/coreos/coreos-assembler/mantle/platform"
 	"github.com/coreos/coreos-assembler/mantle/platform/conf"
-	"github.com/coreos/coreos-assembler/mantle/platform/machine/unprivqemu"
+	"github.com/coreos/coreos-assembler/mantle/platform/machine/qemu"
 	"github.com/coreos/coreos-assembler/mantle/util"
 )
 
@@ -488,7 +488,7 @@ func setupMultipleNetworkTest(c cluster.TestCluster, primaryMac, secondaryMac st
 	// the golang compiler no longer checks that the individual types in the case have the
 	// NewMachineWithQemuOptions function, but rather whether platform.Cluster
 	// does which fails
-	case *unprivqemu.Cluster:
+	case *qemu.Cluster:
 		m, err = pc.NewMachineWithQemuOptions(userdata, options)
 	default:
 		panic("unreachable")
@@ -553,7 +553,7 @@ func setupWithInterfacesTest(c cluster.TestCluster, primaryMac, secondaryMac str
 	// the golang compiler no longer checks that the individual types in the case have the
 	// NewMachineWithQemuOptions function, but rather whether platform.Cluster
 	// does which fails
-	case *unprivqemu.Cluster:
+	case *qemu.Cluster:
 		m, err = pc.NewMachineWithQemuOptions(userdata, options)
 	default:
 		panic("unreachable")

--- a/mantle/kola/tests/misc/nfs.go
+++ b/mantle/kola/tests/misc/nfs.go
@@ -62,8 +62,8 @@ func init() {
 
 		// Disabled on Azure because setting hostname
 		// is required at the instance creation level
-		// qemu-unpriv machines cannot communicate
-		ExcludePlatforms: []string{"azure", "qemu-unpriv"},
+		// qemu machines cannot communicate
+		ExcludePlatforms: []string{"azure", "qemu"},
 	})
 }
 

--- a/mantle/kola/tests/rhcos/upgrade.go
+++ b/mantle/kola/tests/rhcos/upgrade.go
@@ -34,7 +34,7 @@ import (
 	"github.com/coreos/coreos-assembler/mantle/kola/tests/util"
 	"github.com/coreos/coreos-assembler/mantle/platform"
 	"github.com/coreos/coreos-assembler/mantle/platform/conf"
-	"github.com/coreos/coreos-assembler/mantle/platform/machine/unprivqemu"
+	"github.com/coreos/coreos-assembler/mantle/platform/machine/qemu"
 	installer "github.com/coreos/coreos-assembler/mantle/util"
 	"github.com/coreos/go-semver/semver"
 )
@@ -213,7 +213,7 @@ func rhcosUpgradeFromOcpRhcos(c cluster.TestCluster) {
 	}`)
 
 	switch pc := c.Cluster.(type) {
-	case *unprivqemu.Cluster:
+	case *qemu.Cluster:
 		ostreeCommit := kola.CosaBuild.Meta.OstreeCommit
 		temp := os.TempDir()
 		rhcosQcow2, err := downloadLatestReleasedRHCOS(temp)

--- a/mantle/platform/machine/qemu/cluster.go
+++ b/mantle/platform/machine/qemu/cluster.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package unprivqemu
+package qemu
 
 import (
 	"fmt"
@@ -102,7 +102,7 @@ func (qc *Cluster) NewMachineWithQemuOptions(userdata *conf.UserData, options pl
 		}
 	} else if conf.IsEmpty() {
 	} else {
-		return nil, fmt.Errorf("unprivileged qemu only supports Ignition or empty configs")
+		return nil, fmt.Errorf("qemu only supports Ignition or empty configs")
 	}
 
 	builder.ConfigFile = confPath

--- a/mantle/platform/machine/qemu/flight.go
+++ b/mantle/platform/machine/qemu/flight.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package unprivqemu
+package qemu
 
 import (
 	"github.com/coreos/pkg/capnslog"

--- a/mantle/platform/machine/qemu/machine.go
+++ b/mantle/platform/machine/qemu/machine.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package unprivqemu
+package qemu
 
 import (
 	"context"

--- a/src/cmd-kola
+++ b/src/cmd-kola
@@ -49,7 +49,7 @@ r = re.compile("-p(=.+)?|--platform(=.+)?")
 platformargs = list(filter(r.match, unknown_args))
 
 if os.getuid() != 0 and len(platformargs) == 0:
-    kolaargs.extend(['-p', 'qemu-unpriv'])
+    kolaargs.extend(['-p', 'qemu'])
 
 if args.build is not None:
     kolaargs.extend(['--build', args.build])

--- a/src/cmd-offline-update
+++ b/src/cmd-offline-update
@@ -10,7 +10,7 @@
 # cd /path/to/rhcos-4.8
 # cp --reflink=auto /path/to/rhcos-4.6.0-x86_64-qemu.qcow2 tmp/
 # cosa offline-update tmp/rhcos-4.6.0-x86_64-qemu.qcow2
-# kola run -p qemu-unpriv -b rhcos --qemu-image tmp/rhcos-4.6.0-x86_64-qemu.qcow2 basic
+# kola run -p qemu -b rhcos --qemu-image tmp/rhcos-4.6.0-x86_64-qemu.qcow2 basic
 
 set -euo pipefail
 


### PR DESCRIPTION
mantle/kola/tests: Replace 'qemu-unpriv' with 'qemu'

There is no longer a privileged 'qemu' platform and the 'qemu' and
'qemu-unpriv' platforms are the same.

Let's use qemu everywhere in order to be able to remove all
'qemu-unpriv' usage.

---

docs: Replace 'qemu-unpriv' with 'qemu'

There is no longer a privileged 'qemu' platform and the 'qemu' and
'qemu-unpriv' platforms are the same.

Let's use qemu everywhere in order to be able to remove all
'qemu-unpriv' usage.

---

kola: Remove 'qemu-unpriv' and make 'qemu' the default

There is no longer a privileged 'qemu' platform and the 'qemu' and
'qemu-unpriv' platforms are the same.