### PR TITLE
kola: Add `--append-ignition` too

### DIFF
--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -69,6 +69,7 @@ func init() {
 	sv(&kola.Options.CosaBuildId, "build", "", "coreos-assembler build ID")
 	sv(&kola.Options.CosaBuildArch, "arch", coreosarch.CurrentRpmArch(), "The target architecture of the build")
 	sv(&kola.Options.AppendButane, "append-butane", "", "Path to Butane config which is merged with test code")
+	sv(&kola.Options.AppendIgnition, "append-ignition", "", "Path to Ignition config which is merged with test code")
 	// rhcos-specific options
 	sv(&kola.Options.OSContainer, "oscontainer", "", "oscontainer image pullspec for pivot (RHCOS only)")
 

--- a/mantle/platform/cluster.go
+++ b/mantle/platform/cluster.go
@@ -222,6 +222,20 @@ func (bc *BaseCluster) RenderUserData(userdata *platformConf.UserData, ignitionV
 		confSources = append(confSources, subConf)
 	}
 
+	// If Ignition is specified, parse and add that.
+	if bc.bf.baseopts.AppendIgnition != "" {
+		buf, err := ioutil.ReadFile(bc.bf.baseopts.AppendIgnition)
+		if err != nil {
+			return nil, err
+		}
+		subData := platformConf.Ignition(string(buf))
+		subConf, err := subData.Render(platformConf.ReportWarnings)
+		if err != nil {
+			return nil, err
+		}
+		confSources = append(confSources, subConf)
+	}
+
 	// Look at the array of configs we have so far; if there is exactly one,
 	// then we don't need to do any merging.
 	var conf *platformConf.Conf

--- a/mantle/platform/platform.go
+++ b/mantle/platform/platform.go
@@ -184,7 +184,8 @@ type Options struct {
 
 	NoTestExitError bool
 
-	AppendButane string
+	AppendButane   string
+	AppendIgnition string
 
 	// OSContainer is an image pull spec that can be given to the pivot service
 	// in RHCOS machines to perform machine content upgrades.


### PR DESCRIPTION
Actually for the use case of injecting a secret, I want to use butane's local-file inclusion to avoid quoting or constructing YAML from code, so we need to support accepting Ignition too.