### PR TITLE
[rhcos-4.11] Add time package as a build dependence

### DIFF
--- a/src/build-deps.txt
+++ b/src/build-deps.txt
@@ -1,2 +1,4 @@
+# A common utility, can/will be used for diagnostics in cosa builds
+time
 # Used by mantle
 golang


### PR DESCRIPTION
 - Since it is a small package with only glib as dep, let's add the time package for easily debug cosa related issues.

Signed-off-by: Renata Ravanelli <rravanel@redhat.com>
(cherry picked from commit 1bd7cfedce0fb1003a8efc9a7654f5290c1cd9e2)