### PR TITLE
cmd-fetch: support "autolocking" from an arch build

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -259,6 +259,17 @@ prepare_git_artifacts "${configdir_gitrepo}" "${PWD}/coreos-assembler-config-git
 
 extra_compose_args=()
 
+# Apply autolock from another build for this version if no base lockfile exists.
+# Do this before so that overrides come after. Don't do this if in strict mode.
+# They're theoretically independent, but in practice it's unlikely that an
+# autolockfile will include all the packages needed to satisfy --strict.
+if [ ! -f "${manifest_lock}" ] && [ -n "${VERSION}" ] && [ -z "${STRICT}" ]; then
+    autolockfile=$(generate_autolock "${VERSION}")
+    if [ -n "${autolockfile}" ]; then
+        extra_compose_args+=("--ex-lockfile=${autolockfile}")
+    fi
+fi
+
 for lock in "${manifest_lock}" "${manifest_lock_overrides}" "${manifest_lock_arch_overrides}"; do
     if [ -f "${lock}" ]; then
         extra_compose_args+=("--ex-lockfile=${lock}")

--- a/src/cmd-buildfetch
+++ b/src/cmd-buildfetch
@@ -157,7 +157,7 @@ def main():
                                   stdout=subprocess.DEVNULL)
 
     # and finally the symlink
-    if args.build is None:
+    if args.build is None or args.build == builds.get_latest():
         rm_allow_noent('builds/latest')
         os.symlink(buildid, 'builds/latest')
 

--- a/src/cmd-fetch
+++ b/src/cmd-fetch
@@ -94,31 +94,33 @@ fi
 
 prepare_build
 
-args=
+lock_args=
+extra_args=
 if [ -n "${UPDATE_LOCKFILE}" ]; then
     # Put this under tmprepo so it gets automatically chown'ed if needed
-    args="--ex-write-lockfile-to=${tmprepo}/tmp/manifest-lock.json"
+    extra_args+=" --ex-write-lockfile-to=${tmprepo}/tmp/manifest-lock.json"
     # Include the overrides in the resulting lockfile here; otherwise, we
     # might not even be able to get a depsolve solely from the non-lockfile
     # repos.
     for lock in "${manifest_lock_overrides}" "${manifest_lock_arch_overrides}"; do
       if [ -f "${lock}" ]; then
-          args+=" --ex-lockfile=${lock}"
+          lock_args+=" --ex-lockfile=${lock}"
       fi
     done
 else
     for lock in "${manifest_lock}" "${manifest_lock_overrides}" "${manifest_lock_arch_overrides}"; do
         if [ -f "${lock}" ]; then
-            args+=" --ex-lockfile=${lock}"
+            lock_args+=" --ex-lockfile=${lock}"
         fi
     done
 fi
 
 if [ -n "${DRY_RUN}" ]; then
-    args="${args} --dry-run"
+    extra_args+=" --dry-run"
 fi
+
 if [ -n "${STRICT}" ]; then
-    args="${args} --ex-lockfile-strict"
+    extra_args+=" --ex-lockfile-strict"
 fi
 
 # By default, we ignore cosa overrides since they're temporary. With
@@ -129,7 +131,7 @@ fi
 prepare_compose_overlays ${IGNORE_COSA_OVERRIDES_ARG}
 
 # shellcheck disable=SC2086
-runcompose_tree --download-only ${args} ${FORCE_ARG}
+runcompose_tree --download-only ${lock_args} ${extra_args} ${FORCE_ARG}
 # This stamp file signifies we successfully fetched once; it's
 # validated in cmd-build.
 touch "${fetch_stamp}"

--- a/src/cmd-fetch
+++ b/src/cmd-fetch
@@ -31,10 +31,12 @@ Usage: coreos-assembler fetch --help
   --update-lockfile        Update base lockfile to latest packages
   --write-lockfile-to=FILE Write updated base lockfile to separate file
   --with-cosa-overrides    Don't ignore cosa overrides in `overrides/rpm`
+  --autolock=VERSION       If no base lockfile used, create one from any arch build of `VERSION`
 
 EOF
 }
 
+AUTOLOCK_VERSION=
 UPDATE_LOCKFILE=
 OUTPUT_LOCKFILE=
 IGNORE_COSA_OVERRIDES_ARG=--ignore-cosa-overrides
@@ -42,7 +44,7 @@ DRY_RUN=
 FORCE_ARG=
 STRICT=
 rc=0
-options=$(getopt --options h --longoptions help,update-lockfile,dry-run,with-cosa-overrides,write-lockfile-to:,strict,force -- "$@") || rc=$?
+options=$(getopt --options h --longoptions help,update-lockfile,dry-run,with-cosa-overrides,write-lockfile-to:,strict,force,autolock: -- "$@") || rc=$?
 [ $rc -eq 0 ] || {
     print_help
     exit 1
@@ -74,6 +76,10 @@ while true; do
         --force)
             FORCE_ARG=--force-nocache
             ;;
+        --autolock)
+            shift;
+            AUTOLOCK_VERSION=$1
+            ;;
         --)
             shift
             break
@@ -96,6 +102,20 @@ prepare_build
 
 lock_args=
 extra_args=
+
+# Apply autolock from another build for this version if no base lockfile
+# exists. Do this before so that overrides come after.
+if  [ -n "${AUTOLOCK_VERSION}" ]; then
+    if [ -f "${manifest_lock}" ]; then
+        fatal "ERROR: Requested --autolock, but base lockfile found"
+    fi
+    autolockfile=$(generate_autolock "${AUTOLOCK_VERSION}")
+    if [ -z "${autolockfile}" ]; then
+        fatal "ERROR: Requested --autolock, but no generated lockfile found"
+    fi
+    lock_args+=" --ex-lockfile=${autolockfile}"
+fi
+
 if [ -n "${UPDATE_LOCKFILE}" ]; then
     # Put this under tmprepo so it gets automatically chown'ed if needed
     extra_args+=" --ex-write-lockfile-to=${tmprepo}/tmp/manifest-lock.json"
@@ -120,6 +140,12 @@ if [ -n "${DRY_RUN}" ]; then
 fi
 
 if [ -n "${STRICT}" ]; then
+    if [ -n "${AUTOLOCK_VERSION}" ]; then
+        # They're theoretically independent, but in practice it's unlikely
+        # that an autolockfile will include all the packages needed to satisfy
+        # --strict. So let's just catch it early.
+        fatal "ERROR: Can't use --autolock and --strict together"
+    fi
     extra_args+=" --ex-lockfile-strict"
 fi
 

--- a/src/cmd-fetch
+++ b/src/cmd-fetch
@@ -20,9 +20,18 @@ fi
 print_help() {
     cat 1>&2 <<'EOF'
 Usage: coreos-assembler fetch --help
-       coreos-assembler fetch [--update-lockfile] [--write-lockfile-to=file] [--with-cosa-overrides] [--strict] [--force]
+       coreos-assembler fetch [OPTIONS]...
 
   Fetch and import the latest packages.
+
+  The following options are supported:
+
+  --force                  Redownload packages even if nothing changed since last build
+  --strict                 Only download locked packages when using lockfiles
+  --update-lockfile        Update base lockfile to latest packages
+  --write-lockfile-to=FILE Write updated base lockfile to separate file
+  --with-cosa-overrides    Don't ignore cosa overrides in `overrides/rpm`
+
 EOF
 }
 


### PR DESCRIPTION
In a multi-arch build, we want to be able to provide some guarantees
that the RPM set across arches is the same (of course, save for any
arch-specific packages). The canonical way to do this is with lockfiles,
but RHCOS currently doesn't have that. However, since we currently build
x86_64 before building the multi-arch variants, what we can do is derive
a lockfile from the x86_64 build and use that in the multi-arch builds.
This patch adds a new "autolock" feature to the `fetch` and `build`
commands to do just that.

Even once RHCOS gets lockfiles, this will also be useful for development
streams where we purposely don't want to maintain lockfiles (such as
rawhide).

This isn't foolproof. Notably if a package is included in more than one
multi-arch build, but not x86_64, it's possible for that package to
diverge. Presently in RHCOS 4.13 at least, only one such package exists
(`libatomic`), so in practice that risk is quite low.