### PR TITLE
workflows: update actions to current major versions

### DIFF
--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install deps
         run: yum -y install ShellCheck
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - run: make shellcheck
   golangci-lint:
     name: golangci-lint


### PR DESCRIPTION
Fixes [deprecation warnings](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) for Node.js 12.