### PR TITLE
qemu: Add support for IOPs limits && qemu: Add `--qemu-drive-opts`

### DIFF
--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -149,6 +149,7 @@ func init() {
 	sv(&kola.QEMUOptions.Firmware, "qemu-firmware", "", "Boot firmware: bios,uefi,uefi-secure (default bios)")
 	sv(&kola.QEMUOptions.DiskImage, "qemu-image", "", "path to CoreOS disk image")
 	sv(&kola.QEMUOptions.DiskSize, "qemu-size", "", "Resize target disk via qemu-img resize [+]SIZE")
+	sv(&kola.QEMUOptions.DriveOpts, "qemu-drive-opts", "", "Arbitrary options to append to qemu -drive for primary disk")
 	sv(&kola.QEMUOptions.Memory, "qemu-memory", "", "Default memory size in MB")
 	bv(&kola.QEMUOptions.NbdDisk, "qemu-nbd-socket", false, "Present the disks over NBD socket to qemu")
 	bv(&kola.QEMUOptions.MultiPathDisk, "qemu-multipath", false, "Enable multiple paths for the main disk")

--- a/mantle/cmd/kola/qemuexec.go
+++ b/mantle/cmd/kola/qemuexec.go
@@ -289,11 +289,16 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 		if kola.QEMUOptions.Native4k {
 			sectorSize = 4096
 		}
+		options := []string{}
+		if kola.QEMUOptions.DriveOpts != "" {
+			options = append(options, strings.Split(kola.QEMUOptions.DriveOpts, ",")...)
+		}
 		err = builder.AddBootDisk(&platform.Disk{
 			BackingFile:   kola.QEMUOptions.DiskImage,
 			Channel:       channel,
 			Size:          kola.QEMUOptions.DiskSize,
 			SectorSize:    sectorSize,
+			DriveOpts:     options,
 			MultiPathDisk: kola.QEMUOptions.MultiPathDisk,
 			NbdDisk:       kola.QEMUOptions.NbdDisk,
 		})

--- a/mantle/platform/machine/unprivqemu/flight.go
+++ b/mantle/platform/machine/unprivqemu/flight.go
@@ -31,6 +31,8 @@ type Options struct {
 	DiskImage string
 	// DiskSize if non-empty will expand the disk
 	DiskSize string
+	// DriveOpts is arbitrary comma-separated list of options
+	DriveOpts string
 	// Firmware will be passed to qemu
 	Firmware string
 	Memory   string

--- a/mantle/platform/machine/unprivqemu/flight.go
+++ b/mantle/platform/machine/unprivqemu/flight.go
@@ -31,7 +31,7 @@ type Options struct {
 	DiskImage string
 	// DiskSize if non-empty will expand the disk
 	DiskSize string
-	Board    string
+	// Firmware will be passed to qemu
 	Firmware string
 	Memory   string
 	Arch     string

--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -91,7 +91,8 @@ type Disk struct {
 	BackingFile   string   // raw disk image to use.
 	BackingFormat string   // qcow2, raw, etc.  If unspecified will be autodetected.
 	Channel       string   // virtio (default), nvme
-	DeviceOpts    []string // extra options to pass to qemu. "serial=XXXX" makes disks show up as /dev/disk/by-id/virtio-<serial>
+	DeviceOpts    []string // extra options to pass to qemu -device. "serial=XXXX" makes disks show up as /dev/disk/by-id/virtio-<serial>
+	DriveOpts     []string // extra options to pass to -drive
 	SectorSize    int      // if not 0, override disk sector size
 	NbdDisk       bool     // if true, the disks should be presented over nbd:unix socket
 	MultiPathDisk bool     // if true, present multiple paths
@@ -997,6 +998,9 @@ func (builder *QemuBuilder) addDiskImpl(disk *Disk, primary bool) error {
 	// Avoid file locking detection, and the disks we create
 	// here are always currently ephemeral.
 	defaultDiskOpts := "auto-read-only=off,cache=unsafe"
+	if len(disk.DriveOpts) > 0 {
+		defaultDiskOpts += "," + strings.Join(disk.DriveOpts, ",")
+	}
 
 	if disk.MultiPathDisk {
 		// Fake a NVME device with a fake WWN. All these attributes are needed in order


### PR DESCRIPTION
qemu: Remove unused Board parameter

This is a relic of CL we don't use.

---

qemu: Add `--qemu-drive-opts`

This allows passing arbitrary options to the primary disk;
specifically e.g. `--qemu-drive-opts iops_wr=1000` to simulate
slow writes, but allow fast reads to avoid simply booting being
really slow.

---

