### PR TITLE
kola: Add support for generic `instanceType`

### DIFF
--- a/docs/kola/external-tests.md
+++ b/docs/kola/external-tests.md
@@ -191,6 +191,7 @@ Here's an example `kola.json`:
     "platforms": "qemu-unpriv",
     "tags": "sometagname needs-internet skip-base-checks othertag",
     "requiredTag": "special",
+    "instanceType": "nano",
     "additionalDisks": [ "5G" ],
     "minMemory": 4096,
     "minDisk": 15,
@@ -240,6 +241,10 @@ The `minDisk` key takes a size in GB and ensures that an instance type with at
 least the specified amount of primary disk space is used. On QEMU, this is
 equivalent to the `--qemu-size` argument to `qemuexec`. This is currently only
 enforced on `qemu-unpriv` and `aws`.
+
+The `instanceType` key accepts a generic instance type specifier, currently one
+of `nano | micro | small | medium | large | xlarge`.  The specific CPU/memory
+sizes for these can be found in the mantle codebase.
 
 The `minMemory` key takes a size in MB and ensures that an instance type with
 at least the specified amount of memory is used. On QEMU, this is equivalent to

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -865,6 +865,7 @@ type externalTestMeta struct {
 	RequiredTag               string   `json:"requiredTag,omitempty"               yaml:"requiredTag,omitempty"`
 	AdditionalDisks           []string `json:"additionalDisks,omitempty"           yaml:"additionalDisks,omitempty"`
 	InjectContainer           bool     `json:"injectContainer,omitempty"           yaml:"injectContainer,omitempty"`
+	InstanceType              string   `json:"instanceType,omitempty"              yaml:"instanceType,omitempty"`
 	MinMemory                 int      `json:"minMemory,omitempty"                 yaml:"minMemory,omitempty"`
 	MinDiskSize               int      `json:"minDisk,omitempty"                   yaml:"minDisk,omitempty"`
 	AdditionalNics            int      `json:"additionalNics,omitempty"            yaml:"additionalNics,omitempty"`
@@ -1075,6 +1076,7 @@ ExecStart=%s
 
 		AdditionalDisks:           targetMeta.AdditionalDisks,
 		InjectContainer:           targetMeta.InjectContainer,
+		InstanceType:              targetMeta.InstanceType,
 		MinMemory:                 targetMeta.MinMemory,
 		MinDiskSize:               targetMeta.MinDiskSize,
 		AdditionalNics:            targetMeta.AdditionalNics,
@@ -1564,6 +1566,7 @@ func runTest(h *harness.H, t *register.Test, pltfrm string, flight platform.Flig
 		options := platform.MachineOptions{
 			MultiPathDisk:             t.MultiPathDisk,
 			AdditionalDisks:           t.AdditionalDisks,
+			InstanceType:              t.InstanceType,
 			MinMemory:                 t.MinMemory,
 			MinDiskSize:               t.MinDiskSize,
 			AdditionalNics:            t.AdditionalNics,

--- a/mantle/kola/register/register.go
+++ b/mantle/kola/register/register.go
@@ -81,6 +81,9 @@ type Test struct {
 	// InjectContainer will cause the ostree base image to be injected into the target
 	InjectContainer bool
 
+	// InstanceType is a generic instance type
+	InstanceType string
+
 	// Minimum amount of memory in MB required for test.
 	MinMemory int
 

--- a/mantle/kola/tests/ignition/luks.go
+++ b/mantle/kola/tests/ignition/luks.go
@@ -159,12 +159,12 @@ func runTest(c cluster.TestCluster, tpm2 bool, threshold int, killTangAfterFirst
 	}`, tpm2, tangd.Address, tangd.Thumbprint, threshold))
 
 	opts := platform.MachineOptions{
-		MinMemory: 4096,
+		InstanceType: "medium",
 	}
 	// ppc64le and aarch64 use 64K pages
 	switch coreosarch.CurrentRpmArch() {
 	case "ppc64le", "aarch64":
-		opts.MinMemory = 8192
+		opts.InstanceType = "large"
 	}
 	m, err := c.NewMachineWithOptions(ignition, opts)
 	if err != nil {

--- a/mantle/platform/instancetypes.go
+++ b/mantle/platform/instancetypes.go
@@ -1,0 +1,30 @@
+package platform
+
+import "fmt"
+
+type GenericInstanceType struct {
+	// Name is a string used to identify this type
+	Name string
+	// Cpu is a count of exposed host vCPUs
+	Cpu uint
+	// Memory is in mebibytes
+	Memory uint
+}
+
+var InstanceNano = GenericInstanceType{Name: "nano", Cpu: 1, Memory: 512}
+var InstanceMicro = GenericInstanceType{Name: "micro", Cpu: 1, Memory: 1024}
+var InstanceSmall = GenericInstanceType{Name: "small", Cpu: 1, Memory: 2 * 1024}
+var InstanceMedium = GenericInstanceType{Name: "medium", Cpu: 2, Memory: 4 * 1024}
+var InstanceLarge = GenericInstanceType{Name: "large", Cpu: 2, Memory: 8 * 1024}
+var InstanceXlarge = GenericInstanceType{Name: "xlarge", Cpu: 4, Memory: 16 * 1024}
+
+var InstanceTypes = []GenericInstanceType{InstanceNano, InstanceMicro, InstanceSmall, InstanceMedium, InstanceLarge, InstanceXlarge}
+
+func LookupInstanceType(t string) (*GenericInstanceType, error) {
+	for _, it := range InstanceTypes {
+		if t == it.Name {
+			return &it, nil
+		}
+	}
+	return nil, fmt.Errorf("unknown instance type: %s", t)
+}

--- a/mantle/platform/machine/unprivqemu/cluster.go
+++ b/mantle/platform/machine/unprivqemu/cluster.go
@@ -123,6 +123,12 @@ func (qc *Cluster) NewMachineWithQemuOptions(userdata *conf.UserData, options pl
 		builder.Memory = options.MinMemory
 	}
 
+	if options.InstanceType != "" {
+		if err := builder.SetInstanceType(options.InstanceType); err != nil {
+			return nil, err
+		}
+	}
+
 	channel := "virtio"
 	if qc.flight.opts.Nvme {
 		channel = "nvme"

--- a/mantle/platform/platform.go
+++ b/mantle/platform/platform.go
@@ -156,6 +156,7 @@ type Flight interface {
 type MachineOptions struct {
 	MultiPathDisk             bool
 	AdditionalDisks           []string
+	InstanceType              string
 	MinMemory                 int
 	MinDiskSize               int
 	AdditionalNics            int

--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -650,6 +650,16 @@ func (builder *QemuBuilder) SetArchitecture(arch string) error {
 	return fmt.Errorf("architecture %s not supported by coreos-assembler qemu", arch)
 }
 
+func (builder *QemuBuilder) SetInstanceType(t string) error {
+	it, err := LookupInstanceType(t)
+	if err != nil {
+		return err
+	}
+	builder.Memory = int(it.Memory)
+	builder.Processors = int(it.Cpu)
+	return nil
+}
+
 // Mount9p sets up a mount point from the host to guest.  To be replaced
 // with https://virtio-fs.gitlab.io/ once it lands everywhere.
 func (builder *QemuBuilder) Mount9p(source, destHint string, readonly bool) {


### PR DESCRIPTION
We have `minMemory`, but it's much more natural to express test sizing in terms of something more like cloud instance sizes.

I copied the AWS `t2.` sizes as a baseline; so far this is only implemented for qemu, where it's now convenient to do e.g. `cosa run -I nano` to get a small machine.

Further, kola tests can now specify e.g. `instanceType: nano`.

A notable next step we could do from here is to actually use this in cloud environments too.  It should save us a little bit of money.  (We'd likely get much bigger savings from spot instances, or just running our tests more intelligently, but those are distinct topics)

Some of the non-rootfs-reprovisioning Ignition tests for example are perfectly happy to run with `nano`.