### PR TITLE
cmdlib: completely avoid 9p for OSTree compose

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -553,7 +553,7 @@ runcompose_tree() {
     else
         local tarball="${workdir}/tmp/repo/commit.tar"
         rm -f "${tarball}"
-        runvm_with_cache /usr/lib/coreos-assembler/compose.sh \
+        runvm_with_cache -- /usr/lib/coreos-assembler/compose.sh \
             "${tarball}" "${composejson}" "$@"
         if [ ! -f "${tarball}" ]; then
             return
@@ -592,7 +592,7 @@ runcompose_extensions() {
         (umask 0022 && sudo -E "$@")
         sudo chown -R -h "${USER}":"${USER}" "${outputdir}"
     else
-        runvm_with_cache "$@"
+        runvm_with_cache -- "$@"
     fi
 }
 
@@ -614,7 +614,7 @@ runvm_with_cache() {
     fi
     cache_args+=("-drive" "if=none,id=cache,$cachedriveargs,file=${workdir}/cache/cache2.qcow2" \
                         "-device" "virtio-blk,drive=cache")
-    runvm "${cache_args[@]}" -- "$@"
+    runvm "${cache_args[@]}" "$@"
 }
 
 # Strips out the digest field from lockfiles since they subtly conflict with

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -553,16 +553,20 @@ runcompose_tree() {
     else
         local tarball="${workdir}/tmp/repo/commit.tar"
         rm -f "${tarball}"
-        runvm_with_cache -- /usr/lib/coreos-assembler/compose.sh \
-            "${tarball}" "${composejson}" "$@"
-        if [ ! -f "${tarball}" ]; then
+        runvm_with_cache \
+            -chardev "file,id=tarout,path=${tarball}" \
+            -device "virtserialport,chardev=tarout,name=tarout" -- \
+            /usr/lib/coreos-assembler/compose.sh \
+                "/dev/virtio-ports/tarout" "$@"
+        if [ ! -s "${tarball}" ]; then
             return
         fi
-        local commit
-        commit=$(jq -r '.["ostree-commit"]' < "${composejson}")
         local import_repo="${workdir}/tmp/repo-import"
         rm -rf "${import_repo}" && mkdir "${import_repo}"
         tar -C "${import_repo}" -xf "${tarball}" && rm -f "${tarball}"
+        mv "${import_repo}/compose.json" "${composejson}"
+        local commit
+        commit=$(jq -r '.["ostree-commit"]' < "${composejson}")
         # this is archive to archive so will hardlink
         ostree pull-local --repo "${repo}" "${import_repo}" "${commit}"
         if [ -n "${ref}" ]; then

--- a/src/compose.sh
+++ b/src/compose.sh
@@ -2,13 +2,11 @@
 set -euo pipefail
 
 output_tarball=$1; shift
-output_composejson=$1; shift
-
-tarball=cache/output.tar
-composejson=cache/compose.json
 
 repo=cache/repo
-rm -rf "${repo}" "${composejson}"
+composejson=cache/repo/compose.json
+
+rm -rf "${repo}"
 ostree init --repo="${repo}" --mode=archive-z2
 
 # we do need to pull at least the overlay bits over 9p, but it shouldn't be that
@@ -31,8 +29,4 @@ if [ ! -f "${composejson}" ]; then
     exit 0
 fi
 
-tar -f "${tarball}" -C "${repo}" -c .
-
-# this is key bit where we move the OSTree content over 9p
-mv "${tarball}" "${output_tarball}"
-mv "${composejson}" "${output_composejson}"
+tar -f "${output_tarball}" -C "${repo}" -c .


### PR DESCRIPTION
The RHCOS pipeline has been intermittently hitting the classic 9p
`ENOMEM` issue during composes when moving the tarball back over 9p:

```
Wrote commit: e8087b3624055851f611a8db47601cf0dc405cd418d39e0fdc305957f805b979
mv: cannot stat '/home/jenkins/agent/workspace/build/tmp/repo/commit.tar': Cannot allocate memory
```

Until we fully move off of 9p, let's add more virtio-serial duct tape so
we don't rely on it at all.

