### PR TITLE
[4.9] Backport: Refactor testiso by breaking tests and adding denylist

### DIFF
--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -240,8 +240,8 @@ func NewFlight(pltfrm string) (flight platform.Flight, err error) {
 	return
 }
 
-// matchesPatterns returns true if `s` matches one of the patterns in `patterns`.
-func matchesPatterns(s string, patterns []string) (bool, error) {
+// MatchesPatterns returns true if `s` matches one of the patterns in `patterns`.
+func MatchesPatterns(s string, patterns []string) (bool, error) {
 	for _, pattern := range patterns {
 		match, err := filepath.Match(pattern, s)
 		if err != nil {
@@ -254,8 +254,8 @@ func matchesPatterns(s string, patterns []string) (bool, error) {
 	return false, nil
 }
 
-// hasString returns true if `s` equals one of the strings in `slice`.
-func hasString(s string, slice []string) bool {
+// HasString returns true if `s` equals one of the strings in `slice`.
+func HasString(s string, slice []string) bool {
 	for _, e := range slice {
 		if e == s {
 			return true
@@ -294,7 +294,7 @@ type ManifestData struct {
 	} `yaml:"add-commit-metadata"`
 }
 
-func parseDenyListYaml(pltfrm string) error {
+func ParseDenyListYaml(pltfrm string) error {
 	var objs []DenyListObj
 
 	// Parse kola-denylist into structs
@@ -336,15 +336,15 @@ func parseDenyListYaml(pltfrm string) error {
 	// Accumulate patterns filtering by set policies
 	plog.Debug("Processing denial patterns from yaml...")
 	for _, obj := range objs {
-		if len(obj.Arches) > 0 && !hasString(arch, obj.Arches) {
+		if len(obj.Arches) > 0 && !HasString(arch, obj.Arches) {
 			continue
 		}
 
-		if len(obj.Platforms) > 0 && !hasString(pltfrm, obj.Platforms) {
+		if len(obj.Platforms) > 0 && !HasString(pltfrm, obj.Platforms) {
 			continue
 		}
 
-		if len(stream) > 0 && len(obj.Streams) > 0 && !hasString(stream, obj.Streams) {
+		if len(stream) > 0 && len(obj.Streams) > 0 && !HasString(stream, obj.Streams) {
 			continue
 		}
 
@@ -389,7 +389,7 @@ func filterTests(tests map[string]*register.Test, patterns []string, pltfrm stri
 		}
 	}
 
-	noPattern := hasString("*", patterns)
+	noPattern := HasString("*", patterns)
 	for name, t := range tests {
 		if NoNet && testRequiresInternet(t) {
 			plog.Debugf("Skipping test that requires network: %s", t.Name)
@@ -434,14 +434,14 @@ func filterTests(tests map[string]*register.Test, patterns []string, pltfrm stri
 			continue
 		}
 
-		match, err := matchesPatterns(t.Name, patterns)
+		match, err := MatchesPatterns(t.Name, patterns)
 		if err != nil {
 			return nil, err
 		}
 
 		tagMatch := false
 		for _, tag := range positiveTags {
-			tagMatch = hasString(tag, t.Tags)
+			tagMatch = HasString(tag, t.Tags)
 			if tagMatch {
 				break
 			}
@@ -449,7 +449,7 @@ func filterTests(tests map[string]*register.Test, patterns []string, pltfrm stri
 
 		negativeTagMatch := false
 		for _, tag := range negativeTags {
-			negativeTagMatch = hasString(tag, t.Tags)
+			negativeTagMatch = HasString(tag, t.Tags)
 			if negativeTagMatch {
 				break
 			}
@@ -540,7 +540,7 @@ func runProvidedTests(tests map[string]*register.Test, patterns []string, multip
 	//    either way
 
 	// Add denylisted tests in kola-denylist.yaml to DenylistedTests
-	err := parseDenyListYaml(pltfrm)
+	err := ParseDenyListYaml(pltfrm)
 	if err != nil {
 		plog.Fatal(err)
 	}


### PR DESCRIPTION
Backport changes from [#3298](https://github.com/coreos/coreos-assembler/pull/3298)