### PR TITLE
Bump minimum Go version to 1.19

### DIFF
--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -33,6 +33,6 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.46.2
+          version: v1.50.1
           working-directory: mantle
           args: --timeout=5m

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/cmd/build-extensions-container.go
+++ b/cmd/build-extensions-container.go
@@ -11,7 +11,6 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -82,7 +81,7 @@ func buildExtensionContainer() error {
 		return err
 	}
 	extensions_container_meta_path := filepath.Join(buildPath, "meta.extensions-container.json")
-	err = ioutil.WriteFile(extensions_container_meta_path, newBytes, 0644)
+	err = os.WriteFile(extensions_container_meta_path, newBytes, 0644)
 	if err != nil {
 		return errors.Wrapf(err, "writing %s", extensions_container_meta_path)
 	}

--- a/cmd/coreos-assembler.go
+++ b/cmd/coreos-assembler.go
@@ -3,7 +3,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"sort"
@@ -165,8 +165,8 @@ func initializeGlobalState(argv []string) error {
 	// This was taken from 'Support Arbitrary User IDs' section of:
 	//   https://docs.openshift.com/container-platform/3.10/creating_images/guidelines.html
 	c := exec.Command("whoami")
-	c.Stdout = ioutil.Discard
-	c.Stderr = ioutil.Discard
+	c.Stdout = io.Discard
+	c.Stderr = io.Discard
 	if err := c.Run(); err != nil {
 		fmt.Fprintln(os.Stderr, "notice: failed to look up uid in /etc/passwd; enabling workaround")
 		home := fmt.Sprintf("/var/tmp/%s", user)

--- a/cmd/remote-session.go
+++ b/cmd/remote-session.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 	"github.com/spf13/cobra"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -80,8 +80,8 @@ var (
 func isatty() bool {
 	cmd := exec.Command("tty")
 	cmd.Stdin = os.Stdin
-	cmd.Stdout = ioutil.Discard
-	cmd.Stderr = ioutil.Discard
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
 	err := cmd.Run()
 	return err == nil
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/coreos/coreos-assembler
 
-go 1.17
+go 1.19
 
 require (
 	github.com/Azure/azure-sdk-for-go v8.1.0-beta+incompatible

--- a/go.sum
+++ b/go.sum
@@ -475,8 +475,6 @@ golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f h1:v4INt8xihDGvnrfjMDVXGxw9wrfxYyCjk0KbXjhR55s=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -636,7 +634,6 @@ google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=

--- a/mantle/auth/azure.go
+++ b/mantle/auth/azure.go
@@ -17,7 +17,7 @@ package auth
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -150,5 +150,5 @@ func decodeBOMFile(path string) ([]byte, error) {
 	defer f.Close()
 	decoder := unicode.UTF8.NewDecoder()
 	reader := transform.NewReader(f, unicode.BOMOverride(decoder))
-	return ioutil.ReadAll(reader)
+	return io.ReadAll(reader)
 }

--- a/mantle/auth/google.go
+++ b/mantle/auth/google.go
@@ -17,8 +17,8 @@ package auth
 
 import (
 	"context"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"os/user"
 	"path/filepath"
 
@@ -58,7 +58,7 @@ func GoogleClientFromKeyFile(path string, scope ...string) (*http.Client, error)
 		}
 		path = filepath.Join(user.HomeDir, GCEConfigPath)
 	}
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/mantle/cmd/kola/console.go
+++ b/mantle/cmd/kola/console.go
@@ -17,7 +17,7 @@ package main
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -65,9 +65,9 @@ func runCheckConsole(cmd *cobra.Command, args []string) error {
 			if checkConsoleVerbose {
 				fmt.Printf("Reading input from %s...\n", sourceName)
 			}
-			console, err = ioutil.ReadAll(os.Stdin)
+			console, err = io.ReadAll(os.Stdin)
 		} else {
-			console, err = ioutil.ReadFile(arg)
+			console, err = os.ReadFile(arg)
 		}
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%s\n", err)

--- a/mantle/cmd/kola/devshell.go
+++ b/mantle/cmd/kola/devshell.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -72,7 +71,7 @@ func runDevShellSSH(ctx context.Context, builder *platform.QemuBuilder, conf *co
 		termMaxWidth = 100
 	}
 
-	tmpd, err := ioutil.TempDir("", "kola-devshell")
+	tmpd, err := os.MkdirTemp("", "kola-devshell")
 	if err != nil {
 		return err
 	}
@@ -109,7 +108,7 @@ func runDevShellSSH(ctx context.Context, builder *platform.QemuBuilder, conf *co
 	if err != nil {
 		return err
 	}
-	serialLog, err := ioutil.TempFile(tmpd, "cosa-run-serial")
+	serialLog, err := os.CreateTemp(tmpd, "cosa-run-serial")
 	if err != nil {
 		return err
 	}

--- a/mantle/cmd/kola/kola.go
+++ b/mantle/cmd/kola/kola.go
@@ -17,7 +17,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"os"
@@ -585,7 +584,7 @@ func syncFindParentImageOptions() error {
 	switch kolaPlatform {
 	case "qemu-unpriv":
 		if qemuImageDir == "" {
-			if qemuImageDir, err = ioutil.TempDir("/var/tmp", "kola-run-upgrade"); err != nil {
+			if qemuImageDir, err = os.MkdirTemp("/var/tmp", "kola-run-upgrade"); err != nil {
 				return err
 			}
 			qemuImageDirIsTemp = true

--- a/mantle/cmd/kola/qemuexec.go
+++ b/mantle/cmd/kola/qemuexec.go
@@ -19,7 +19,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -216,7 +216,7 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 
 	var config *conf.Conf
 	if butane != "" {
-		buf, err := ioutil.ReadFile(butane)
+		buf, err := os.ReadFile(butane)
 		if err != nil {
 			return err
 		}
@@ -225,7 +225,7 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 			return errors.Wrapf(err, "parsing %s", butane)
 		}
 	} else if !directIgnition && ignition != "" {
-		buf, err := ioutil.ReadFile(ignition)
+		buf, err := os.ReadFile(ignition)
 		if err != nil {
 			return err
 		}

--- a/mantle/cmd/kola/spawn.go
+++ b/mantle/cmd/kola/spawn.go
@@ -17,7 +17,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/user"
@@ -99,7 +98,7 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 
 	var userdata *conf.UserData
 	if spawnUserData != "" {
-		userbytes, err := ioutil.ReadFile(spawnUserData)
+		userbytes, err := os.ReadFile(spawnUserData)
 		if err != nil {
 			return errors.Wrapf(err, "Reading userdata failed")
 		}
@@ -167,7 +166,7 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 				DisablePDeathSig: !spawnRemove,
 			}
 			if spawnMachineOptions != "" {
-				b, err := ioutil.ReadFile(spawnMachineOptions)
+				b, err := os.ReadFile(spawnMachineOptions)
 				if err != nil {
 					return errors.Wrapf(err, "Could not read machine options")
 				}
@@ -272,7 +271,7 @@ func addSSHKeys(userdata *conf.UserData) (*conf.UserData, error) {
 
 	// read key files, failing if any are missing
 	for _, path := range spawnSSHKeys {
-		keybytes, err := ioutil.ReadFile(path)
+		keybytes, err := os.ReadFile(path)
 		if err != nil {
 			return nil, err
 		}

--- a/mantle/cmd/kola/switchkernel.go
+++ b/mantle/cmd/kola/switchkernel.go
@@ -17,7 +17,6 @@ package main
 import (
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"strings"
@@ -151,7 +150,7 @@ func runSwitchKernel(cmd *cobra.Command, args []string) error {
 func dropRpmFilesAll(m platform.Machine, localPath string) error {
 	fmt.Println("Dropping RT Kernel RPMs...")
 	re := regexp.MustCompile(`^kernel-rt-.*\.rpm$`)
-	files, err := ioutil.ReadDir(localPath)
+	files, err := os.ReadDir(localPath)
 	if err != nil {
 		return err
 	}

--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -24,7 +24,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -530,7 +529,7 @@ func awaitCompletion(ctx context.Context, inst *platform.QemuInstance, outdir st
 				if errBuf != "" {
 					plog.Info("entered emergency.target in initramfs")
 					path := filepath.Join(outdir, "ignition-virtio-dump.txt")
-					if err := ioutil.WriteFile(path, []byte(errBuf), 0644); err != nil {
+					if err := os.WriteFile(path, []byte(errBuf), 0644); err != nil {
 						plog.Errorf("Failed to write journal: %v", err)
 					}
 					err = platform.ErrInitramfsEmergency
@@ -619,7 +618,7 @@ func testPXE(ctx context.Context, inst platform.Install, outdir string, offline 
 	if addNmKeyfile {
 		return 0, errors.New("--add-nm-keyfile not yet supported for PXE")
 	}
-	tmpd, err := ioutil.TempDir("", "kola-testiso")
+	tmpd, err := os.MkdirTemp("", "kola-testiso")
 	if err != nil {
 		return 0, errors.Wrapf(err, "creating tempdir")
 	}
@@ -672,7 +671,7 @@ func testPXE(ctx context.Context, inst platform.Install, outdir string, offline 
 }
 
 func testLiveIso(ctx context.Context, inst platform.Install, outdir string, offline, minimal bool) (time.Duration, error) {
-	tmpd, err := ioutil.TempDir("", "kola-testiso")
+	tmpd, err := os.MkdirTemp("", "kola-testiso")
 	if err != nil {
 		return 0, err
 	}

--- a/mantle/cmd/kolet/kolet.go
+++ b/mantle/cmd/kolet/kolet.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"os/exec"
@@ -262,10 +262,10 @@ func initiateReboot(mark string) error {
 func runExtUnit(cmd *cobra.Command, args []string) error {
 	rebootOff, _ := cmd.Flags().GetBool("deny-reboots")
 	// Write the autopkgtest wrappers
-	if err := ioutil.WriteFile(autopkgTestRebootPath, []byte(autopkgtestRebootScript), 0755); err != nil {
+	if err := os.WriteFile(autopkgTestRebootPath, []byte(autopkgtestRebootScript), 0755); err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(autopkgTestRebootPreparePath, []byte(autopkgtestRebootPrepareScript), 0755); err != nil {
+	if err := os.WriteFile(autopkgTestRebootPreparePath, []byte(autopkgtestRebootPrepareScript), 0755); err != nil {
 		return err
 	}
 
@@ -287,7 +287,7 @@ func runExtUnit(cmd *cobra.Command, args []string) error {
 				return
 			}
 			defer rebootReader.Close()
-			buf, err := ioutil.ReadAll(rebootReader)
+			buf, err := io.ReadAll(rebootReader)
 			if err != nil {
 				errChan <- err
 			}
@@ -370,7 +370,7 @@ func runReboot(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(rebootRequestFifo, []byte(mark), 0644)
+	err = os.WriteFile(rebootRequestFifo, []byte(mark), 0644)
 	if err != nil {
 		return err
 	}

--- a/mantle/cmd/ore/gcloud/upload.go
+++ b/mantle/cmd/ore/gcloud/upload.go
@@ -17,7 +17,6 @@ package gcloud
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"strings"
@@ -200,7 +199,7 @@ func runUpload(cmd *cobra.Command, args []string) {
 	}
 
 	if uploadWriteUrl != "" {
-		err = ioutil.WriteFile(uploadWriteUrl, []byte(imageStorageURL), 0644)
+		err = os.WriteFile(uploadWriteUrl, []byte(imageStorageURL), 0644)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Writing file (%v) failed: %v\n", uploadWriteUrl, err)
 			os.Exit(1)

--- a/mantle/cmd/ore/ibmcloud/ibmcloud.go
+++ b/mantle/cmd/ore/ibmcloud/ibmcloud.go
@@ -19,7 +19,7 @@ package ibmcloud
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -96,7 +96,7 @@ func preflightCheck(cmd *cobra.Command, args []string) error {
 		defer file.Close()
 
 		var apiKeyValues apiKeyFile
-		bytes, err := ioutil.ReadAll(file)
+		bytes, err := io.ReadAll(file)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "could not read apikey file: %v\n", err)
 			os.Exit(1)

--- a/mantle/cmd/ore/packet/create-device.go
+++ b/mantle/cmd/ore/packet/create-device.go
@@ -17,7 +17,6 @@ package packet
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -55,7 +54,7 @@ func runCreateDevice(cmd *cobra.Command, args []string) error {
 
 	userdata := conf.Empty()
 	if userDataPath != "" {
-		data, err := ioutil.ReadFile(userDataPath)
+		data, err := os.ReadFile(userDataPath)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Couldn't read userdata file %v: %v\n", userDataPath, err)
 			os.Exit(1)

--- a/mantle/cmd/plume/cosa2stream.go
+++ b/mantle/cmd/plume/cosa2stream.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -66,7 +65,7 @@ func runCosaBuildToStream(cmd *cobra.Command, args []string) error {
 	var outStream stream.Stream
 
 	if target != "" {
-		buf, err := ioutil.ReadFile(target)
+		buf, err := os.ReadFile(target)
 		if err != nil {
 			return err
 		}
@@ -102,7 +101,7 @@ func runCosaBuildToStream(cmd *cobra.Command, args []string) error {
 	}
 
 	for _, arg := range args {
-		releaseTmpf, err := ioutil.TempFile("", "release")
+		releaseTmpf, err := os.CreateTemp("", "release")
 		if err != nil {
 			return err
 		}
@@ -139,7 +138,7 @@ func runCosaBuildToStream(cmd *cobra.Command, args []string) error {
 		}
 
 		var rel release.Release
-		buf, err := ioutil.ReadAll(releaseTmpf)
+		buf, err := io.ReadAll(releaseTmpf)
 		if err != nil {
 			return err
 		}

--- a/mantle/cmd/plume/release.go
+++ b/mantle/cmd/plume/release.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -140,7 +140,7 @@ func getReleaseMetadata(api *aws.API) release.Release {
 	}
 	defer releaseFile.Close()
 
-	releaseData, err := ioutil.ReadAll(releaseFile)
+	releaseData, err := io.ReadAll(releaseFile)
 	if err != nil {
 		plog.Fatalf("reading release metadata: %v", err)
 	}
@@ -222,7 +222,7 @@ func modifyReleaseMetadataIndex(api *aws.API, rel release.Release) {
 			return []byte{}, fmt.Errorf("downloading release metadata index: %v", err)
 		}
 		defer f.Close()
-		d, err := ioutil.ReadAll(f)
+		d, err := io.ReadAll(f)
 		if err != nil {
 			return []byte{}, fmt.Errorf("reading release metadata index: %v", err)
 		}

--- a/mantle/cmd/plume/stream_mirror.go
+++ b/mantle/cmd/plume/stream_mirror.go
@@ -17,7 +17,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -131,7 +130,7 @@ func runStreamMirror(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Must specify --dest-file with --url")
 	}
 	var srcStream stream.Stream
-	buf, err := ioutil.ReadFile(srcFile)
+	buf, err := os.ReadFile(srcFile)
 	if err != nil {
 		return err
 	}
@@ -174,7 +173,7 @@ func runStreamMirror(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		err = ioutil.WriteFile(destFile, buf, 0644)
+		err = os.WriteFile(destFile, buf, 0644)
 		if err != nil {
 			return err
 		}

--- a/mantle/fcos/metadata.go
+++ b/mantle/fcos/metadata.go
@@ -17,7 +17,7 @@ package fcos
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -34,7 +34,7 @@ func fetchURL(u url.URL) ([]byte, error) {
 		return nil, err
 	}
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	res.Body.Close()
 	if err != nil {
 		return nil, err

--- a/mantle/harness/harness.go
+++ b/mantle/harness/harness.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -437,7 +436,7 @@ func (h *H) TempDir(prefix string) string {
 		h.log(err.Error())
 		h.FailNow()
 	}
-	tmp, err := ioutil.TempDir(dir, prefix)
+	tmp, err := os.MkdirTemp(dir, prefix)
 	if err != nil {
 		h.log(fmt.Sprintf("Failed to create temp dir: %v", err))
 		h.FailNow()
@@ -453,7 +452,7 @@ func (h *H) TempFile(prefix string) *os.File {
 		h.log(err.Error())
 		h.FailNow()
 	}
-	tmp, err := ioutil.TempFile(dir, prefix)
+	tmp, err := os.CreateTemp(dir, prefix)
 	if err != nil {
 		h.log(fmt.Sprintf("Failed to create temp file: %v", err))
 		h.FailNow()

--- a/mantle/harness/reporters/json.go
+++ b/mantle/harness/reporters/json.go
@@ -16,7 +16,7 @@ package reporters
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"sync"
@@ -51,7 +51,7 @@ func DeserialiseReport(filename string) (*jsonReporter, error) {
 		return nil, err
 	}
 
-	bytes, err := ioutil.ReadAll(file)
+	bytes, err := io.ReadAll(file)
 	if err != nil {
 		return nil, err
 	}

--- a/mantle/kola/tests/coretest/helpers.go
+++ b/mantle/kola/tests/coretest/helpers.go
@@ -2,7 +2,7 @@ package coretest
 
 import (
 	"bufio"
-	"io/ioutil"
+	"io"
 	"net"
 	"os"
 	"strings"
@@ -52,7 +52,7 @@ func MachineID() string {
 
 	defer f.Close()
 
-	buf, err := ioutil.ReadAll(f)
+	buf, err := io.ReadAll(f)
 	if err != nil {
 		panic(err)
 	}

--- a/mantle/kola/tests/crio/crio.go
+++ b/mantle/kola/tests/crio/crio.go
@@ -17,7 +17,7 @@ package crio
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"strings"
 	"time"
@@ -220,7 +220,7 @@ func crioBaseTests(c cluster.TestCluster) {
 func generateCrioConfig(podName, imageName string, command []string) (string, string, error) {
 	fileContentsPod := fmt.Sprintf(crioPodTemplate, podName, imageName)
 
-	tmpFilePod, err := ioutil.TempFile("", podName+"Pod")
+	tmpFilePod, err := os.CreateTemp("", podName+"Pod")
 	if err != nil {
 		return "", "", err
 	}
@@ -231,7 +231,7 @@ func generateCrioConfig(podName, imageName string, command []string) (string, st
 	cmd := strings.Join(command, " ")
 	fileContentsContainer := fmt.Sprintf(crioContainerTemplate, imageName, imageName, cmd)
 
-	tmpFileContainer, err := ioutil.TempFile("", imageName+"Container")
+	tmpFileContainer, err := os.CreateTemp("", imageName+"Container")
 	if err != nil {
 		return "", "", err
 	}

--- a/mantle/kola/tests/ignition/security.go
+++ b/mantle/kola/tests/ignition/security.go
@@ -17,10 +17,10 @@ package ignition
 import (
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"time"
 
@@ -107,12 +107,12 @@ EOF
 }
 
 func ServeTLS(customFile []byte) error {
-	publicKey, err := ioutil.ReadFile("/var/tls/server.crt")
+	publicKey, err := os.ReadFile("/var/tls/server.crt")
 	if err != nil {
 		return fmt.Errorf("reading public key: %v", err)
 	}
 
-	privateKey, err := ioutil.ReadFile("/var/tls/server.key")
+	privateKey, err := os.ReadFile("/var/tls/server.key")
 	if err != nil {
 		return fmt.Errorf("reading private key: %v", err)
 	}

--- a/mantle/network/journal/record_test.go
+++ b/mantle/network/journal/record_test.go
@@ -17,7 +17,6 @@ package journal
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 	"time"
@@ -50,7 +49,7 @@ func (d discardCloser) Close() error {
 }
 
 func (d discardCloser) Write(b []byte) (int, error) {
-	return ioutil.Discard.Write(b)
+	return io.Discard.Write(b)
 }
 
 // Escapes ; chars in cursor with \

--- a/mantle/network/ssh.go
+++ b/mantle/network/ssh.go
@@ -18,7 +18,6 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"strings"
@@ -77,7 +76,7 @@ func NewSSHAgent(dialer Dialer) (*SSHAgent, error) {
 	var ok, sockdirOwned bool
 	if sockDir, ok = os.LookupEnv("MANTLE_SSH_DIR"); !ok {
 		if DefaultSSHDir == "" {
-			sockDir, err = ioutil.TempDir("", "mantle-ssh-")
+			sockDir, err = os.MkdirTemp("", "mantle-ssh-")
 			sockdirOwned = true
 			if err != nil {
 				return nil, err

--- a/mantle/platform/api/aws/s3.go
+++ b/mantle/platform/api/aws/s3.go
@@ -17,7 +17,6 @@ package aws
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"os"
 
@@ -204,7 +203,7 @@ func (a *API) UpdateBucketObjectsACL(srcBucket, prefix, policy string) error {
 
 // Downloads a file from S3 to a temporary file. This file must be closed by the caller.
 func (a *API) DownloadFile(srcBucket, srcPath string) (*os.File, error) {
-	f, err := ioutil.TempFile("", "mantle-file")
+	f, err := os.CreateTemp("", "mantle-file")
 	if err != nil {
 		return nil, err
 	}

--- a/mantle/platform/api/azure/instance.go
+++ b/mantle/platform/api/azure/instance.go
@@ -19,7 +19,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"math/big"
 	"regexp"
@@ -252,5 +251,5 @@ func (a *API) GetConsoleOutput(name, resourceGroup, storageAccount string) ([]by
 		return nil, err
 	}
 
-	return ioutil.ReadAll(data)
+	return io.ReadAll(data)
 }

--- a/mantle/platform/api/esx/api.go
+++ b/mantle/platform/api/esx/api.go
@@ -20,7 +20,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/url"
 	"path"
@@ -275,7 +275,7 @@ func (a *API) GetConsoleOutput(name string) (string, error) {
 	}
 	defer f.Close()
 
-	buf, err := ioutil.ReadAll(f)
+	buf, err := io.ReadAll(f)
 	if err != nil {
 		return "", fmt.Errorf("couldn't read serial output: %v", err)
 	}

--- a/mantle/platform/api/esx/archive.go
+++ b/mantle/platform/api/esx/archive.go
@@ -19,7 +19,6 @@ import (
 	"archive/tar"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 
@@ -46,7 +45,7 @@ func (t *archive) readOvf(fpath string) ([]byte, error) {
 	}
 	defer r.Close()
 
-	return ioutil.ReadAll(r)
+	return io.ReadAll(r)
 }
 
 func (t *archive) readEnvelope(fpath string) (*ovf.Envelope, error) {

--- a/mantle/platform/api/openstack/api.go
+++ b/mantle/platform/api/openstack/api.go
@@ -16,7 +16,6 @@ package openstack
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -90,7 +89,7 @@ func (opts Options) LoadCloudsYAML() (map[string]clientconfig.Cloud, error) {
 	// If provided a path to a config file then we load it here.
 	if opts.ConfigPath != "" {
 		var clouds clientconfig.Clouds
-		if content, err := ioutil.ReadFile(opts.ConfigPath); err != nil {
+		if content, err := os.ReadFile(opts.ConfigPath); err != nil {
 			return nil, err
 		} else if err := yaml.Unmarshal(content, &clouds); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal yaml %s: %v", opts.ConfigPath, err)

--- a/mantle/platform/cluster.go
+++ b/mantle/platform/cluster.go
@@ -18,7 +18,6 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -210,7 +209,7 @@ func (bc *BaseCluster) RenderUserData(userdata *platformConf.UserData, ignitionV
 
 	// If butane is specified, parse and add that.
 	if bc.bf.baseopts.AppendButane != "" {
-		buf, err := ioutil.ReadFile(bc.bf.baseopts.AppendButane)
+		buf, err := os.ReadFile(bc.bf.baseopts.AppendButane)
 		if err != nil {
 			return nil, err
 		}
@@ -224,7 +223,7 @@ func (bc *BaseCluster) RenderUserData(userdata *platformConf.UserData, ignitionV
 
 	// If Ignition is specified, parse and add that.
 	if bc.bf.baseopts.AppendIgnition != "" {
-		buf, err := ioutil.ReadFile(bc.bf.baseopts.AppendIgnition)
+		buf, err := os.ReadFile(bc.bf.baseopts.AppendIgnition)
 		if err != nil {
 			return nil, err
 		}

--- a/mantle/platform/conf/conf.go
+++ b/mantle/platform/conf/conf.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -455,7 +454,7 @@ func (c *Conf) ValidConfig() bool {
 
 // WriteFile writes the userdata in Conf to a local file.
 func (c *Conf) WriteFile(name string) error {
-	return ioutil.WriteFile(name, []byte(c.String()), 0666)
+	return os.WriteFile(name, []byte(c.String()), 0666)
 }
 
 // Bytes returns the serialized userdata in Conf.

--- a/mantle/platform/journal.go
+++ b/mantle/platform/journal.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -134,7 +133,7 @@ func (j *Journal) Read() ([]byte, error) {
 		return nil, errors.Wrapf(err, "reading journal")
 	}
 	defer f.Close()
-	return ioutil.ReadAll(f)
+	return io.ReadAll(f)
 }
 
 func (j *Journal) Destroy() {

--- a/mantle/platform/machine/qemuiso/machine.go
+++ b/mantle/platform/machine/qemuiso/machine.go
@@ -17,7 +17,7 @@ package qemuiso
 import (
 	"context"
 	"errors"
-	"io/ioutil"
+	"os"
 	"time"
 
 	"golang.org/x/crypto/ssh"
@@ -92,7 +92,7 @@ func (m *machine) Destroy() {
 
 	m.journal.Destroy()
 
-	if buf, err := ioutil.ReadFile(m.consolePath); err == nil {
+	if buf, err := os.ReadFile(m.consolePath); err == nil {
 		m.console = string(buf)
 	} else {
 		plog.Errorf("Error reading console for instance %v: %v", m.ID(), err)

--- a/mantle/platform/machine/unprivqemu/machine.go
+++ b/mantle/platform/machine/unprivqemu/machine.go
@@ -17,7 +17,7 @@ package unprivqemu
 import (
 	"context"
 	"errors"
-	"io/ioutil"
+	"os"
 	"time"
 
 	"golang.org/x/crypto/ssh"
@@ -92,7 +92,7 @@ func (m *machine) Destroy() {
 
 	m.journal.Destroy()
 
-	if buf, err := ioutil.ReadFile(m.consolePath); err == nil {
+	if buf, err := os.ReadFile(m.consolePath); err == nil {
 		m.console = string(buf)
 	} else {
 		plog.Errorf("Error reading console for instance %v: %v", m.ID(), err)

--- a/mantle/platform/metal.go
+++ b/mantle/platform/metal.go
@@ -18,7 +18,6 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -211,7 +210,7 @@ func (inst *Install) setup(kern *kernelSetup) (*installerRun, error) {
 
 	builder := inst.Builder
 
-	tempdir, err := ioutil.TempDir("/var/tmp", "mantle-pxe")
+	tempdir, err := os.MkdirTemp("/var/tmp", "mantle-pxe")
 	if err != nil {
 		return nil, err
 	}
@@ -383,7 +382,7 @@ func (t *installerRun) completePxeSetup(kargs []string) error {
 			pxeconfig = []byte(kargsStr)
 		}
 		pxeconfig_path := filepath.Join(pxeconfigdir, "default")
-		if err := ioutil.WriteFile(pxeconfig_path, pxeconfig, 0777); err != nil {
+		if err := os.WriteFile(pxeconfig_path, pxeconfig, 0777); err != nil {
 			return errors.Wrapf(err, "writing file %s", pxeconfig_path)
 		}
 
@@ -422,7 +421,7 @@ func (t *installerRun) completePxeSetup(kargs []string) error {
 				return errors.Wrapf(err, "running cp-reflink %s %s", t.pxe.pxeimagepath, dstpath)
 			}
 		}
-		if err := ioutil.WriteFile(filepath.Join(t.tftpdir, "boot/grub2/grub.cfg"), []byte(fmt.Sprintf(`
+		if err := os.WriteFile(filepath.Join(t.tftpdir, "boot/grub2/grub.cfg"), []byte(fmt.Sprintf(`
 			default=0
 			timeout=1
 			menuentry "CoreOS (BIOS/UEFI)" {
@@ -605,7 +604,7 @@ func (inst *Install) InstallViaISOEmbed(kargs []string, liveIgnition, targetIgni
 	inst.ignition = targetIgnition
 	inst.liveIgnition = liveIgnition
 
-	tempdir, err := ioutil.TempDir("/var/tmp", "mantle-metal")
+	tempdir, err := os.MkdirTemp("/var/tmp", "mantle-metal")
 	if err != nil {
 		return nil, err
 	}
@@ -707,7 +706,7 @@ func (inst *Install) InstallViaISOEmbed(kargs []string, liveIgnition, targetIgni
 	var keyfileArgs []string
 	for nmName, nmContents := range inst.NmKeyfiles {
 		path := filepath.Join(tempdir, nmName)
-		if err := ioutil.WriteFile(path, []byte(nmContents), 0600); err != nil {
+		if err := os.WriteFile(path, []byte(nmContents), 0600); err != nil {
 			return nil, err
 		}
 		keyfileArgs = append(keyfileArgs, "--keyfile", path)

--- a/mantle/platform/util.go
+++ b/mantle/platform/util.go
@@ -19,7 +19,6 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -196,7 +195,7 @@ func StartMachine(m Machine, j *Journal) error {
 			msg := fmt.Sprintf("machine %s entered emergency.target in initramfs", m.ID())
 			plog.Info(msg)
 			path := filepath.Join(filepath.Dir(j.journalPath), "ignition-virtio-dump.txt")
-			if err := ioutil.WriteFile(path, []byte(err.Error()), 0644); err != nil {
+			if err := os.WriteFile(path, []byte(err.Error()), 0644); err != nil {
 				plog.Errorf("Failed to write journal: %v", err)
 			}
 			errchan <- errors.New(msg)

--- a/mantle/rhcos/metadata.go
+++ b/mantle/rhcos/metadata.go
@@ -17,7 +17,7 @@ package rhcos
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -36,7 +36,7 @@ func fetchURL(u url.URL) ([]byte, error) {
 		return nil, err
 	}
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	res.Body.Close()
 	if err != nil {
 		return nil, err

--- a/mantle/system/copy_test.go
+++ b/mantle/system/copy_test.go
@@ -16,7 +16,7 @@ package system
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -37,7 +37,7 @@ func checkFile(t *testing.T, path string, data []byte, mode os.FileMode) {
 		t.Fatalf("Unexpected mode: %s != %s %s", info.Mode(), mode, path)
 	}
 
-	newData, err := ioutil.ReadAll(file)
+	newData, err := io.ReadAll(file)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -51,7 +51,7 @@ func TestCopyRegularFile(t *testing.T) {
 	tmp := t.TempDir()
 
 	src := filepath.Join(tmp, "src")
-	if err := ioutil.WriteFile(src, data, 0600); err != nil {
+	if err := os.WriteFile(src, data, 0600); err != nil {
 		t.Fatal(err)
 	}
 	checkFile(t, src, data, 0600)

--- a/mantle/util/common.go
+++ b/mantle/util/common.go
@@ -16,7 +16,6 @@ package util
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -86,7 +85,7 @@ func CreateSSHAuthorizedKey(tmpd string) ([]byte, string, error) {
 	if err != nil {
 		return nil, "", errors.Wrapf(err, "running ssh-keygen")
 	}
-	sshPubKeyBuf, err := ioutil.ReadFile(sshPubKeyPath)
+	sshPubKeyBuf, err := os.ReadFile(sshPubKeyPath)
 	if err != nil {
 		return nil, "", errors.Wrapf(err, "reading pubkey")
 	}

--- a/mantle/util/repo.go
+++ b/mantle/util/repo.go
@@ -16,7 +16,6 @@ package util
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -67,7 +66,7 @@ func GetLocalFastBuildQemu() (string, error) {
 		}
 		return "", err
 	}
-	ents, err := ioutil.ReadDir(fastBuildCosaDir)
+	ents, err := os.ReadDir(fastBuildCosaDir)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/builds/build.go
+++ b/pkg/builds/build.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -189,7 +188,7 @@ func (build *Build) WriteMeta(path string, validate bool) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(path, out, 0644)
+	return os.WriteFile(path, out, 0644)
 }
 
 // GetArtifact returns an artifact by JSON tag

--- a/pkg/builds/build.go
+++ b/pkg/builds/build.go
@@ -27,9 +27,9 @@ import (
 	"sort"
 	"strings"
 
+	coreosarch "github.com/coreos/stream-metadata-go/arch"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
-	coreosarch "github.com/coreos/stream-metadata-go/arch"
 )
 
 var (

--- a/pkg/builds/builds_test.go
+++ b/pkg/builds/builds_test.go
@@ -1,7 +1,6 @@
 package builds
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -27,7 +26,7 @@ func TestBuildsMeta(t *testing.T) {
 	_ = os.MkdirAll(filepath.Join(tmpd, "builds"), 0755)
 
 	bjson := filepath.Join(tmpd, CosaBuildsJSON)
-	if err := ioutil.WriteFile(bjson, []byte(testData), 0666); err != nil {
+	if err := os.WriteFile(bjson, []byte(testData), 0666); err != nil {
 		t.Fatalf("failed to write the test data %v", err)
 	}
 

--- a/pkg/builds/schema.go
+++ b/pkg/builds/schema.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -41,7 +40,7 @@ func SetSchemaFromFile(r io.Reader) error {
 	if r == nil {
 		return errors.New("schema input is invalid")
 	}
-	in, err := ioutil.ReadAll(r)
+	in, err := io.ReadAll(r)
 	if err != nil {
 		return err
 	}

--- a/pkg/builds/schema_test.go
+++ b/pkg/builds/schema_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -167,7 +166,7 @@ func TestMergeMeta(t *testing.T) {
 	if err := os.MkdirAll(fakeBuildDir, 0777); err != nil {
 		t.Fatalf("failed to create test meta structure")
 	}
-	if err := ioutil.WriteFile(filepath.Join(tmpd, "builds", "builds.json"), bjson, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(tmpd, "builds", "builds.json"), bjson, 0644); err != nil {
 		t.Fatalf("error creating builds.json")
 	}
 	if err := b.WriteMeta(filepath.Join(fakeBuildDir, "meta.json"), false); err != nil {


### PR DESCRIPTION
Go 1.17 is EOL and we don't have a particular reason to support 1.18.

`go mod tidy` defaults to a compat version one release older than the version specified in `go.mod`, so we're now tidying with Go 1.18 semantics, which drop a lot of dependencies from `go.sum` due to [graph pruning](https://go.dev/ref/mod#graph-pruning).