### PR TITLE
mantle/openstack: detect instance error before 10m timeout

### DIFF
--- a/mantle/platform/api/openstack/api.go
+++ b/mantle/platform/api/openstack/api.go
@@ -328,6 +328,9 @@ func (a *API) CreateServer(name, sshKeyID, userdata string) (*Server, error) {
 		if err != nil {
 			return false, err
 		}
+		if server.Status == "ERROR" {
+			return false, fmt.Errorf("Server reported ERROR status: %v", server.Fault)
+		}
 		return server.Status == "ACTIVE", nil
 	})
 	if err != nil {


### PR DESCRIPTION
In cases where the instance enters an error state we shouldn't wait around 10 minutes since it will never go to ACTIVE state. Let's bail out early here.