### PR TITLE
libguestfish: bump libguestfs VM memory size for  ppc64le to 3G

### DIFF
--- a/src/libguestfish.sh
+++ b/src/libguestfish.sh
@@ -23,7 +23,7 @@ fi
 # The compiled in default I see when running `guestfish get-memsize`
 # is 1280. We need this because we are seeing issues from
 # buildextend-live when running gf-mksquashfs.
-[ "$arch" = "ppc64le" ] && export LIBGUESTFS_MEMSIZE=2048
+[ "$arch" = "ppc64le" ] && export LIBGUESTFS_MEMSIZE=3072
 
 # http://libguestfs.org/guestfish.1.html#using-remote-control-robustly-from-shell-scripts
 GUESTFISH_PID=


### PR DESCRIPTION
It seems like RHEL 9.2 content makes `mksquashfs` require enough memory to make the oom-killer bring down its mighty hammer. There's `mksquashfs` knobs that could help here, like `-mem` and `-processors` but those are not exposed by the libguestfs wrapper. And trying to call `mksquashfs` directly via the `guestfish debug` escape hatch doesn't seem worth the effort.

See also cfa0a43d7 ("libguestfish: bump libguestfs VM memory size for ppc64le") which originally bumped the default on ppc64le.

Closes: https://github.com/openshift/os/issues/1157