### PR TITLE
docs/devel: update kola/ore/plume build instructions

### DIFF
--- a/docs/devel.md
+++ b/docs/devel.md
@@ -37,6 +37,9 @@ $ make
 $ sudo make install
 ```
 
+In the local developer case, you usually don't care about building kolet for
+other arches. You can skip building them using e.g. `make KOLET_ARCHES=x86_64`.
+
 From that point on, you only need to run `make && sudo make install` if you're
 hacking on cosa itself (unless there are new RPM requirements added).
 

--- a/docs/devel.md
+++ b/docs/devel.md
@@ -50,9 +50,8 @@ Similarly, if you are only working on kola, ore or plume, you can build, test
 and use them directly with:
 
 ```
-$ cd mantle
-$ ./build kola ore plume
-$ ./test
+$ make kola ore plume
+$ make mantle-check
 $ ./bin/kola ...
 ```
 


### PR DESCRIPTION
The previous instructions almost worked as is, except that now the
mantle binaries are output in the top level `bin/` directory. Let's
recommend the `make` targets instead to avoid the `cd`.