### PR TITLE
extensions: Add support for `hotfixes-$variant.yaml`

### DIFF
--- a/internal/pkg/cosa/variant.go
+++ b/internal/pkg/cosa/variant.go
@@ -1,0 +1,31 @@
+package cosa
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+const initConfigPath = "src/config.json"
+
+type configVariant struct {
+	Variant string `json:"coreos-assembler.config-variant"`
+}
+
+// GetVariant finds the configured variant, or "" if unset
+func GetVariant() (string, error) {
+	contents, err := os.ReadFile(initConfigPath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return "", err
+		}
+		return "", nil
+	}
+
+	var variantData configVariant
+	if err := json.Unmarshal(contents, &variantData); err != nil {
+		return "", fmt.Errorf("parsing %s: %w", initConfigPath, err)
+	}
+
+	return variantData.Variant, nil
+}

--- a/src/build-extensions-container.sh
+++ b/src/build-extensions-container.sh
@@ -23,6 +23,9 @@ if [[ -f "${workdir}/src/config.json" ]]; then
     variant="$(jq --raw-output '."coreos-assembler.config-variant"' "${workdir}/src/config.json")"
 fi
 
+mkdir "${ctx_dir}/hotfixes"
+tar -xC "${ctx_dir}/hotfixes" -f /dev/disk/by-id/virtio-hotfixes
+
 # Build the image, replacing the FROM directive with the local image we have.
 # The `variant` variable is explicitely unquoted to be skipped when empty.
 img=localhost/extensions-container


### PR DESCRIPTION
We have a bug in https://issues.redhat.com/browse/OCPBUGS-7275 where we need an updated rpm-ostree on the host in order to make future upgrades work.

This adds basic support for hotfixes, which are RPMs that live in the extensions container, but are intended to be applied-live by the MCD.

They appear in `/usr/share/rpm-ostree/extensions/hotfixes` with the hotfix data (YAML) reserialized to JSON.