### PR TITLE
create_disk: Create image layer refs by default

### DIFF
--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -338,8 +338,13 @@ if test -n "${deploy_via_container}"; then
     deploy_commit=$(cat /tmp/commit.txt)
     rm /tmp/commit.txt
 else
-    # Pull the commit
-    time ostree container unencapsulate --repo=$rootfs/ostree/repo "${ostree_container}"
+    # Pull the container image...
+    time ostree container image pull $rootfs/ostree/repo "${ostree_container}"
+    # But we default to not leaving a ref for the image around, so the
+    # layers will get GC'd on the first update if the
+    # user doesn't switch to a container image.
+    ostree --repo=$rootfs/ostree/repo refs --delete ostree/container/image
+    ostree --repo=$rootfs/ostree/repo prune --refs-only --depth=0
     # Deploy it, using an optional remote prefix
     if test -n "${remote_name}"; then
         deploy_ref="${remote_name}:${ref}"


### PR DESCRIPTION
Fedora CoreOS is not yet using containers by default for updates; xref https://github.com/coreos/fedora-coreos-tracker/issues/1263 etc.

Consequently, when one boots a FCOS system and wants to rebase to a custom image, one ends up downloading the entire image, including the parts of FCOS that you already have.

This changes things so that when we generate disk images by default, we write the *layer refs* of the component parts - but we delete the "merged" container image ref.

The semantics here will be:

- Only a tiny amount of additional data used by default; the layer refs are just metadata, the bulk of the data still lives in regular file content.
- When a FCOS system auto-updates to its by-default usage of an ostree commit, the unused layer refs will be garbage collected.
- But, as noted above when rebasing to a container image instead, if the target container image reuses some of those layers (as we expect when rebasing FCOS to a FCOS-derived container) then we don't need to redownload them - we only download what the user provided.

Hence, this significantly improves rebasing to container images, with basically no downsides.

The alternative code path to actually deploy *as a container* remains off by default.  When that is enabled, `rpm-ostree upgrade` fetches a container by default, which is a distinct thing.