### PR TITLE
create_disk.sh: add more details to secex pubkey user ID and remove expiration

### DIFF
--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -456,7 +456,7 @@ generate_gpgkeys() {
     pkey="${1}"
     local tmp_home
     tmp_home=$(mktemp -d /tmp/gpg-XXXXXX)
-    gpg --homedir "${tmp_home}" --batch --passphrase '' --yes --quick-gen-key "Secure Execution (secex) $buildid" default default none
+    gpg --homedir "${tmp_home}" --batch --passphrase '' --yes --quick-gen-key "Secure Execution (secex) $buildid" rsa4096 encr none
     gpg --homedir "${tmp_home}" --armor --export secex > "${ignition_pubkey}"
     gpg --homedir "${tmp_home}" --armor --export-secret-key secex > "${pkey}"
     rm -rf "${tmp_home}"

--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -456,7 +456,7 @@ generate_gpgkeys() {
     pkey="${1}"
     local tmp_home
     tmp_home=$(mktemp -d /tmp/gpg-XXXXXX)
-    gpg --homedir "${tmp_home}" --batch --passphrase '' --yes --quick-gen-key "Secure Execution (secex) $buildid"  default
+    gpg --homedir "${tmp_home}" --batch --passphrase '' --yes --quick-gen-key "Secure Execution (secex) $buildid" default default none
     gpg --homedir "${tmp_home}" --armor --export secex > "${ignition_pubkey}"
     gpg --homedir "${tmp_home}" --armor --export-secret-key secex > "${pkey}"
     rm -rf "${tmp_home}"

--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -456,7 +456,7 @@ generate_gpgkeys() {
     pkey="${1}"
     local tmp_home
     tmp_home=$(mktemp -d /tmp/gpg-XXXXXX)
-    gpg --homedir "${tmp_home}" --batch --passphrase '' --yes --quick-gen-key secex default
+    gpg --homedir "${tmp_home}" --batch --passphrase '' --yes --quick-gen-key "Secure Execution (secex) $buildid"  default
     gpg --homedir "${tmp_home}" --armor --export secex > "${ignition_pubkey}"
     gpg --homedir "${tmp_home}" --armor --export-secret-key secex > "${pkey}"
     rm -rf "${tmp_home}"


### PR DESCRIPTION
**create_disk.sh: add more details to secex pubkey user ID**

Include "Secure Execution" since `secex` might be too cryptic. Still
keep `secex` as an easy and stable handle to use. Include the build ID
the key is associated with to make it easier to tell apart multiple
secex keys.

---

**create_disk.sh: don't set an expiry date on secex pubkey**

The default is 2 years, which is much too short for us since we
theoretically need to support arbitrarily old bootimages. We don't want
users to have to e.g. fake the system time to work around this. Anyway,
since the keys are build-specific and will otherwise not be trusted
anywhere else, it seems reasonable to just not have an expiry date at
all.

