### PR TITLE
Refactor buildextend compression and add zip

### DIFF
--- a/src/cosalib/ibmcloud.py
+++ b/src/cosalib/ibmcloud.py
@@ -37,7 +37,7 @@ VARIANTS = {
         "image_format": "raw",
         "image_suffix": "ova.gz",
         "platform": "powervs",
-        "gzip": True,
+        "compression": "gzip",
         "tar_members": [
             "disk.raw"
         ]

--- a/src/cosalib/qemuvariants.py
+++ b/src/cosalib/qemuvariants.py
@@ -72,14 +72,14 @@ VARIANTS = {
         "image_format": "qcow2",
         "image_suffix": "qcow2.gz",
         "platform": "digitalocean",
-        "gzip": True
+        "compression": "gzip"
     },
     "gcp": {
         # See https://cloud.google.com/compute/docs/import/import-existing-image#requirements_for_the_image_file
         "image_format": "raw",
         "platform": "gcp",
         "image_suffix": "tar.gz",
-        "gzip": True,
+        "compression": "gzip",
         "convert_options": {
             '-o': 'preallocation=off'
         },
@@ -93,8 +93,9 @@ VARIANTS = {
     },
     "hyperv": {
         "image_format": "vhdx",
-        "image_suffix": "vhdx",
+        "image_suffix": "vhdx.zip",
         "platform": "hyperv",
+        "compression": "zip"
     },
     "kubevirt": {
         "image_format": "qcow2",
@@ -108,7 +109,7 @@ VARIANTS = {
     "nutanix": {
         "image_format": "qcow2",
         "platform": "nutanix",
-        "skip_compression": True,
+        "compression": "skip",
         "convert_options": {
             '-c': None
         }
@@ -182,10 +183,9 @@ class QemuVariantImage(_Build):
         self.compress = kwargs.get("compress", False)
         self.tar_members = kwargs.pop("tar_members", None)
         self.tar_flags = kwargs.pop("tar_flags", [DEFAULT_TAR_FLAGS])
-        self.gzip = kwargs.pop("gzip", False)
+        self.compression = kwargs.pop("compression", None)
         self.virtual_size = kwargs.pop("virtual_size", None)
         self.mutate_callback_creates_final_image = False
-        self.skip_compression = kwargs.pop("skip_compression", False)
 
         # this is used in case the image has a different disk
         # name than the platform
@@ -304,24 +304,30 @@ class QemuVariantImage(_Build):
             log.info(f"Moving {work_img} to {final_img}")
             shutil.move(work_img, final_img)
 
-        if self.gzip:
+        if self.compression == "skip":
+            meta_patch.update({
+                'skip-compression': True
+            })
+        elif self.compression is not None:
             sha256 = sha256sum_file(final_img)
             size = os.stat(final_img).st_size
             temp_path = f"{final_img}.tmp"
+
+            match self.compression:
+                case "gzip":
+                    rc = ['gzip', '-9c', final_img]
+                case "zip":
+                    rc = ['zip', '-9', "-", final_img]
+                case _:
+                    raise ImageError(f"unsupported compression type: {self.compression}")
             with open(temp_path, "wb") as fh:
-                runcmd(['gzip', '-9c', final_img], stdout=fh)
+                runcmd(rc, stdout=fh)
             shutil.move(temp_path, final_img)
             meta_patch.update({
                 'skip-compression': True,
                 'uncompressed-sha256': sha256,
                 'uncompressed-size': size,
             })
-
-        if self.skip_compression:
-            meta_patch.update({
-                'skip-compression': True
-            })
-
         return meta_patch
 
     def _build_artifacts(self, *args, **kwargs):


### PR DESCRIPTION
buildextend --compress supports gzip as an alternate compression over xz using a key called "gzip" where the value is a bool.  This is now refactored to a key called "compression" with a value of "gzip", "skip", or "zip" (see below).  The "skip-compression" key is no longer applicable.
    
HyperV images which are used on Windows need to be compressed with zip because xz and gzip are not supported natively.  Added zip support to buildextend and set the hyperv platform compression to "zip".

Supports:
    * https://github.com/coreos/fedora-coreos-tracker/issues/1411
    * https://github.com/coreos/fedora-coreos-tracker/issues/1421