### PR TITLE
supermin-init-prelude: add timeout on `udevadm trigger --settle` and make non-fatal

### DIFF
--- a/src/supermin-init-prelude.sh
+++ b/src/supermin-init-prelude.sh
@@ -23,7 +23,9 @@ LANG=C /sbin/load_policy  -i
 
 # we want /dev/disk symlinks for coreos-installer
 /usr/lib/systemd/systemd-udevd --daemon
-/usr/sbin/udevadm trigger --settle
+# We've seen this hang before, so add a timeout. This is best-effort anyway, so
+# let's not fail on it.
+timeout 30s /usr/sbin/udevadm trigger --settle || :
 
 # set up networking
 if [ -z "${RUNVM_NONET:-}" ]; then


### PR DESCRIPTION
We hit a case on ppc64le where this just hung forever. Let's add a timeout on it.

And since this is best effort, let's just ignore any errors from the command. If a symlink is missing, we'll just error out with a clearer error down the line anyway.