### PR TITLE
build.sh: freeze grub2 since it's not working for ppc64le PXE tests

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -41,8 +41,15 @@ install_rpms() {
     local builddeps
     local frozendeps
 
-    # no frozen deps right now
     frozendeps=""
+
+    # freeze grub2 for https://github.com/coreos/coreos-assembler/issues/3370
+    case "${arch}" in
+        x86_64) frozendeps=$(echo grub2-{common,tools,tools-extra,tools-minimal,efi-x64,pc,pc-modules}-1:2.06-75.fc37);;
+        aarch64) frozendeps=$(echo grub2-{common,tools,tools-extra,tools-minimal,efi-aa64}-1:2.06-75.fc37);;
+        ppc64le) frozendeps=$(echo grub2-{common,tools,tools-extra,tools-minimal,ppc64le,ppc64le-modules}-1:2.06-75.fc37);;
+        *) ;;
+    esac
 
     # First, a general update; this is best practice.  We also hit an issue recently
     # where qemu implicitly depended on an updated libusbx but didn't have a versioned


### PR DESCRIPTION
See https://github.com/coreos/coreos-assembler/issues/3370