### PR TITLE
mantle/kola: fix systemd generator failure detection

### DIFF
--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -212,7 +212,7 @@ var (
 		{
 			// https://github.com/coreos/fedora-coreos-config/pull/1797
 			desc:  "systemd generator failure",
-			match: regexp.MustCompile(`systemd\[[0-9]+\]: (.*) failed with exit status`),
+			match: regexp.MustCompile(`(/.*/system-generators/.*) (failed with exit status|terminated by signal|failed due to unknown reason)`),
 		},
 	}
 )


### PR DESCRIPTION
Apparently it can start with `systemd` or `sd-execu`. I think the difference may be whether the failure happens in the initramfs or the real root. Let's detect both.

Here is an example:

```
Feb 23 21:50:38.240188 /usr/lib/systemd/system-generators/coreos-platform-chrony: line 44: /etc/sysconfig/network: Read-only file system
Feb 23 21:50:38.240195 (sd-execu[1020]: /usr/lib/systemd/system-generators/coreos-platform-chrony failed with exit status 1.
```