### PR TITLE
kola.md: add runnning tests on `aws/gcp` examples

### DIFF
--- a/docs/kola.md
+++ b/docs/kola.md
@@ -236,3 +236,10 @@ In order to see the logs for these tests you must enter the `tmp/kola/name_of_th
 
 `cosa run -i ignition_path` You can run it passing your Ignition, or the Ignition used in the the test that failed for troubleshooting reasons.
 
+## Run tests on cloud platforms
+`cosa kola run -p aws --aws-ami ami-0431766f2498820b8 --aws-region us-east-1 basic` This will run the basic tests on AWS using `ami-0431766f2498820b8` (fedora-coreos-37.20230227.20.2) with default instance type `m5.large`. Add `--aws-type <t3.micro>` if you want to use custom type. How to create the credentials refer to https://github.com/coreos/coreos-assembler/blob/main/docs/mantle/credentials.md#aws
+
+`kola run -p=gce --gce-image=projects/fedora-coreos-cloud/global/images/fedora-coreos-37-20230227-20-2-gcp-x86-64 --gce-json-key=/data/gce.json --gce-project=fedora-coreos-testing basic` This will run the basic tests on GCP using default machine type `n1-standard-1`.
+- `gce-image` is in the format of `projects/<GCP Image Project>/global/images/<GCP Image Name>`, to find related info refer to https://builds.coreos.fedoraproject.org/browser?stream=testing-devel&arch=x86_64.
+- `gce-json-key` is using a service account's JSON key for authentication, how to create service account keys refer to https://github.com/coreos/coreos-assembler/blob/main/docs/mantle/credentials.md#gce.
+- `gce-project` is meant for testing in the specified project, or it will use the same as `<GCP Image Project>`.

--- a/docs/kola/external-tests.md
+++ b/docs/kola/external-tests.md
@@ -276,7 +276,7 @@ inline per test, like this:
 ```sh
 #!/bin/bash
 set -xeuo pipefail
-# kola: { "architectures": "x86_64", "platforms": "aws gcp", "tags": "needs-internet" }
+# kola: { "architectures": "x86_64", "platforms": "aws gce", "tags": "needs-internet" }
 test code here
 ```
 
@@ -291,7 +291,7 @@ For example:
 set -xeuo pipefail
 ## kola:
 ##   architectures: x86_64
-##   platforms: "aws gcp"  # azure support is pending
+##   platforms: "aws gce"  # azure support is pending
 ##   tags: needs-internet
 test code here
 ```

--- a/docs/mantle/credentials.md
+++ b/docs/mantle/credentials.md
@@ -162,6 +162,8 @@ you can paste in. This will populate the `.boto` file.
 See [Google Cloud Platform's Documentation](https://cloud.google.com/storage/docs/boto-gsutil)
 for more information about the `.boto` file.
 
+If you want to create a service account's JSON key for authentication, refer to [create service account keys](https://cloud.google.com/iam/docs/).
+
 ## openstack
 
 `openstack` uses `~/.config/openstack.json`. This can be configured manually:

--- a/docs/mantle/credentials.md
+++ b/docs/mantle/credentials.md
@@ -155,13 +155,6 @@ via the `--azure-credentials` option on the command line.
 
 ## gce
 
-`gce` uses the `~/.boto` file. When the `gce` platform is first used, it will print
-a link that can be used to log into your account with gce and get a verification code
-you can paste in. This will populate the `.boto` file.
-
-See [Google Cloud Platform's Documentation](https://cloud.google.com/storage/docs/boto-gsutil)
-for more information about the `.boto` file.
-
 If you want to create a service account's JSON key for authentication, refer to [create service account keys](https://cloud.google.com/iam/docs/).
 
 ## openstack


### PR DESCRIPTION
kola.md: add runnning tests on `aws/gcp` examples

---

external-tests.md: fix kola platforms gcp -> gce

This looks confused as we are now using `gcp` as Google Cloud
Platform, but the mantle code is still using old `gce`, will make
them consistent when finish https://github.com/coreos/coreos-assembler/issues/3378