### PR TITLE
kola/testiso: remove stray '.' at the end of `miniso-install.nm.bios`

### DIFF
--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -81,7 +81,7 @@ var (
 		"iso-offline-install.mpath.bios",
 		"iso-offline-install.4k.uefi",
 		"miniso-install.bios",
-		"miniso-install.nm.bios.",
+		"miniso-install.nm.bios",
 		"miniso-install.4k.uefi",
 		"miniso-install.4k.nm.uefi",
 		"pxe-offline-install.bios",


### PR DESCRIPTION
Follow-up to f98481f1f ("kola: Refactor testiso tests").