### PR TITLE
[4.9] Fix kola testiso name

### DIFF
--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -77,7 +77,7 @@ var (
 		"pxe-offline-install.bios",
 		"pxe-offline-install.4k.uefi",
 		"pxe-online-install.bios",
-		"pxe-online-install.4k.bios",
+		"pxe-online-install.4k.uefi",
 	}
 	tests_s390x = []string{
 		"pxe-online-install.s390fw",


### PR DESCRIPTION
 - Fix test name, the pxe-online-install.4k.bios test is using the wrong firmware, it should use uefi instead due 4k.