### PR TITLE
[rhcos-4.9] kola/testiso: run `pxe-online-install.4k` test on UEFI

### DIFF
--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -77,7 +77,7 @@ var (
 		"pxe-offline-install.bios",
 		"pxe-offline-install.4k.uefi",
 		"pxe-online-install.bios",
-		"pxe-online-install.4k.bios",
+		"pxe-online-install.4k.uefi",
 	}
 	tests_s390x = []string{
 		"pxe-online-install.s390fw",


### PR DESCRIPTION
Running the 4Kn tests are only supported on UEFI.