### PR TITLE
qemuexec: add support for 'IBM Secure Execution' qcow2 images 

### DIFF
--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -159,6 +159,10 @@ func init() {
 
 	sv(&kola.QEMUIsoOptions.IsoPath, "qemu-iso", "", "path to CoreOS ISO image")
 	bv(&kola.QEMUIsoOptions.AsDisk, "qemu-iso-as-disk", false, "attach ISO image as regular disk")
+	// s390x secex specific options
+	bv(&kola.QEMUOptions.SecureExecution, "qemu-secex", false, "Run IBM Secure Execution Image")
+	sv(&kola.QEMUOptions.SecureExecutionIgnitionPubKey, "qemu-secex-ignition-pubkey", "", "Path to Ignition GPG Public Key")
+	sv(&kola.QEMUOptions.SecureExecutionHostKey, "qemu-secex-hostkey", "", "Path to Secure Execution HKD certificate")
 }
 
 // Sync up the command line options if there is dependency
@@ -335,6 +339,12 @@ func syncOptions() error {
 func syncCosaOptions() error {
 	switch kolaPlatform {
 	case "qemu-unpriv", "qemu":
+		if kola.QEMUOptions.SecureExecution && kola.QEMUOptions.DiskImage == "" && kola.CosaBuild.Meta.BuildArtifacts.SecureExecutionQemu != nil {
+			kola.QEMUOptions.DiskImage = filepath.Join(kola.CosaBuild.Dir, kola.CosaBuild.Meta.BuildArtifacts.SecureExecutionQemu.Path)
+		}
+		if kola.QEMUOptions.SecureExecutionIgnitionPubKey == "" && kola.CosaBuild.Meta.BuildArtifacts.SecureExecutionIgnitionPubKey != nil {
+			kola.QEMUOptions.SecureExecutionIgnitionPubKey = filepath.Join(kola.CosaBuild.Dir, kola.CosaBuild.Meta.BuildArtifacts.SecureExecutionIgnitionPubKey.Path)
+		}
 		if kola.QEMUOptions.DiskImage == "" && kola.CosaBuild.Meta.BuildArtifacts.Qemu != nil {
 			kola.QEMUOptions.DiskImage = filepath.Join(kola.CosaBuild.Dir, kola.CosaBuild.Meta.BuildArtifacts.Qemu.Path)
 		}

--- a/mantle/cmd/kola/qemuexec.go
+++ b/mantle/cmd/kola/qemuexec.go
@@ -322,6 +322,8 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 			return errors.Wrapf(err, "parsing memory option")
 		}
 		builder.Memory = int(parsedMem)
+	} else if kola.QEMUOptions.SecureExecution {
+		builder.Memory = 4096 // SE needs at least 4GB
 	}
 	if err = builder.AddDisksFromSpecs(addDisks); err != nil {
 		return err
@@ -344,6 +346,14 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 	builder.InheritConsole = true
 	builder.ConsoleFile = consoleFile
 	builder.Append(args...)
+
+	// IBM Secure Execution
+	if kola.QEMUOptions.SecureExecution {
+		err := builder.SetSecureExecution(kola.QEMUOptions.SecureExecutionIgnitionPubKey, kola.QEMUOptions.SecureExecutionHostKey, config)
+		if err != nil {
+			return err
+		}
+	}
 
 	if devshell && !devshellConsole {
 		return runDevShellSSH(ctx, builder, config, sshCommand)

--- a/mantle/platform/machine/unprivqemu/flight.go
+++ b/mantle/platform/machine/unprivqemu/flight.go
@@ -46,6 +46,11 @@ type Options struct {
 	//Option to create a temporary software TPM - true by default
 	Swtpm bool
 
+	//IBM Secure Execution
+	SecureExecution               bool
+	SecureExecutionIgnitionPubKey string
+	SecureExecutionHostKey        string
+
 	*platform.Options
 }
 


### PR DESCRIPTION
Now user can run secex image:
```
cosa run --qemu-secex
```

or

```
cosa kola qemuexec --qemu-secex --devshell --qemu-secex-igniton-pubkey path/to/key.gpg.pub --qemu-image path/to/qemu-secex.s390x.qcow2
```

If user has a valid hostkey and uses `--qemu-secex-hostkey path/to/hostkey.crt` option, than VM survives reboot