### PR TITLE
plume: handle stream name parameter

### DIFF
--- a/mantle/cmd/plume/cosa2stream.go
+++ b/mantle/cmd/plume/cosa2stream.go
@@ -117,7 +117,10 @@ func runCosaBuildToStream(cmd *cobra.Command, args []string) error {
 			ver := parts[1]
 			// Convert e.g. 48.82.<timestamp> to 4.8
 			verSplit := strings.Split(ver, ".")
-			streamName = fmt.Sprintf("%s.%s", verSplit[0][0:1], verSplit[0][1:])
+			if streamName == "" {
+				streamName = fmt.Sprintf("%s.%s", verSplit[0][0:1], verSplit[0][1:])
+			}
+
 			endpoint := rhcosCosaEndpoint
 			if streamBaseURL != "" {
 				endpoint = streamBaseURL


### PR DESCRIPTION
The stream name in the artifact URL can no longer be derived from the version string because there are streams like 4.12-9.0 and 4.13-9.2. There was already a switch for the stream name but it was not utilized.