### PR TITLE
cmd-buildextend-hashlist-experimental: make all directories in tmp checkout readable

### DIFF
--- a/src/cmd-buildextend-hashlist-experimental
+++ b/src/cmd-buildextend-hashlist-experimental
@@ -91,10 +91,12 @@ class HashListV1(dict):
             'ostree', 'checkout',
             '--repo=tmp/repo', '-U',
             self._metadata['ostree-commit'], checkout])
-        # Force all dirs to be owner writable so that we can delete the
-        # checkout at the end. XXX: Lower into a new `ostree checkout` flag.
+        #  Make all dirs in 'tmp' checkout readable.
+        #  'find' can't recurse into tmp dir files, we add 'x' so that it can recurse into it.
+        #  With '+', 'find' accumulates paths and runs 'chmod' once (or batched by the arg limit).
+        #  To 'chmod' the dir before it tries to recurse into it, we use ';'.
         subprocess.check_call(['find', checkout, '-type', 'd', '-exec',
-                               'chmod', 'u+w', '{}', '+'])
+                               'chmod', 'u+rwx', '{}', ';'])
         self.hash_from_path(checkout)
 
         # Extract initramfs contents


### PR DESCRIPTION
With reference to the latest changes in systemd-253, on executing `cmd-builextend-hashlist-experimental` the default `tmp` dir files configuration automatically creates `/etc/credstore` with secure permissions. We are changing the `find` invocation permissions to access the `/etc/credstore` directory. `find` can't recurse into /etc/credstore, we add `x` so that it can recurse into it. With `+`, find accumulates paths and runs `chmod` once (or batched by the arg limit). But for this, we need it to `chmod` the dir before it tries to recurse into it, so we change to `;`

Fixes : https://github.com/coreos/fedora-coreos-tracker/issues/1429