### PR TITLE
kola: Enable ignition.journald-log for rhcos

### DIFF
--- a/mantle/kola/tests/ignition/journaldEntry.go
+++ b/mantle/kola/tests/ignition/journaldEntry.go
@@ -29,8 +29,6 @@ func init() {
 		Name:        "coreos.ignition.journald-log",
 		Run:         sendJournaldLog,
 		ClusterSize: 1,
-		// Since RHCOS uses the 2x spec and not 3x.
-		ExcludeDistros: []string{"rhcos"},
 	})
 }
 


### PR DESCRIPTION
Enabling `ignition.journald-log` as the test now runs and passes for RHCOS. 
Ref: https://github.com/coreos/coreos-assembler/issues/1173