### PR TITLE
Misc virtinstall

### DIFF
--- a/src/cmd-virt-install
+++ b/src/cmd-virt-install
@@ -124,6 +124,7 @@ domname = f"{args.name}-{args.instid}"
 qemu_args = " ".join(['-fw_cfg', f'name=opt/com.coreos/config,file={poolpath}/{ignvol}'])
 basevinstall_args = ['virt-install', f"--connect={args.connect}",
                      '--import', f'--disk=source.pool={args.pool},source.volume={volname}',
+                     '--tpm', 'emulator',
                      f'--name={domname}', '--os-variant=rhel8-unknown',
                      f'--qemu-commandline={qemu_args}',
                      '--noautoconsole']

--- a/src/cmd-virt-install
+++ b/src/cmd-virt-install
@@ -124,7 +124,7 @@ domname = f"{args.name}-{args.instid}"
 qemu_args = " ".join(['-fw_cfg', f'name=opt/com.coreos/config,file={poolpath}/{ignvol}'])
 basevinstall_args = ['virt-install', f"--connect={args.connect}",
                      '--import', f'--disk=source.pool={args.pool},source.volume={volname}',
-                     f'--name={domname}', '--os-type=linux', '--os-variant=rhel8-unknown',
+                     f'--name={domname}', '--os-variant=rhel8-unknown',
                      f'--qemu-commandline={qemu_args}',
                      '--noautoconsole']
 cmdlib.runcmd(basevinstall_args + vinstall_args)


### PR DESCRIPTION
virt-install: Stop using deprecated `--os-type`

The command now says
`WARNING  --os-type is deprecated and does nothing. Please stop using it.`

---

virt-install: Add `--tpm emulator`

So we can test LUKS etc.

---

