### PR TITLE
Change `gce` to `gcp` (cosmetic only)

### DIFF
--- a/docs/building-fcos.md
+++ b/docs/building-fcos.md
@@ -37,7 +37,7 @@ There are various public cloud options that provide either bare metal or nested
 virt, such as:
 
 - [Packet](https://www.packet.com/)
-- [GCE nested virt](https://cloud.google.com/compute/docs/instances/enable-nested-virtualization-vm-instances)
+- [GCP nested virt](https://cloud.google.com/compute/docs/instances/enable-nested-virtualization-vm-instances)
 - EC2 `i3.metal` instances
 - [IBM Bare Metal](https://www.ibm.com/cloud/bare-metal-servers)
 - etc.

--- a/docs/kola.md
+++ b/docs/kola.md
@@ -10,7 +10,7 @@ Kola is a framework for testing software integration in CoreOS systems
 across multiple platforms. It is primarily designed to operate within
 the CoreOS Assembler for testing software that has landed in the OS image.
 
-Kola supports running tests on multiple platforms, currently QEMU, GCE,
+Kola supports running tests on multiple platforms, currently QEMU, GCP,
 AWS, VMware VSphere, Packet, and OpenStack. In the future systemd-nspawn and
 other platforms may be added.
 Local platforms do not rely on access to the Internet as a design
@@ -241,5 +241,5 @@ In order to see the logs for these tests you must enter the `tmp/kola/name_of_th
 
 `kola run -p=gce --gce-image=projects/fedora-coreos-cloud/global/images/fedora-coreos-37-20230227-20-2-gcp-x86-64 --gce-json-key=/data/gce.json --gce-project=fedora-coreos-testing basic` This will run the basic tests on GCP using default machine type `n1-standard-1`.
 - `gce-image` is in the format of `projects/<GCP Image Project>/global/images/<GCP Image Name>`, to find related info refer to https://builds.coreos.fedoraproject.org/browser?stream=testing-devel&arch=x86_64.
-- `gce-json-key` is using a service account's JSON key for authentication, how to create service account keys refer to https://github.com/coreos/coreos-assembler/blob/main/docs/mantle/credentials.md#gce.
+- `gce-json-key` is using a service account's JSON key for authentication, how to create service account keys refer to https://github.com/coreos/coreos-assembler/blob/main/docs/mantle/credentials.md#gcp.
 - `gce-project` is meant for testing in the specified project, or it will use the same as `<GCP Image Project>`.

--- a/docs/mantle/credentials.md
+++ b/docs/mantle/credentials.md
@@ -153,7 +153,7 @@ via the `--azure-credentials` option on the command line.
 }
 ```
 
-## gce
+## gcp
 
 If you want to create a service account's JSON key for authentication, refer to [create service account keys](https://cloud.google.com/iam/docs/).
 

--- a/mantle/README.md
+++ b/mantle/README.md
@@ -23,7 +23,7 @@ the Container Linux SDK for testing software that has landed in the OS image.
 Ideally, all software needed for a test should be included by building
 it into the image from the SDK.
 
-Kola supports running tests on multiple platforms, currently QEMU, GCE,
+Kola supports running tests on multiple platforms, currently QEMU, GCP,
 AWS, VMware VSphere, Packet, and OpenStack. In the future systemd-nspawn and other
 platforms may be added.
 Local platforms do not rely on access to the Internet as a design
@@ -167,7 +167,7 @@ each with their own command: pre-release and release. Both of these commands are
 
 #### plume pre-release
 The pre-release command does as much of the release process as possible without making anything public.
-This includes uploading images to cloud providers (except those like gce which don't allow us to upload
+This includes uploading images to cloud providers (except those like gcp which don't allow us to upload
 images without making them public).
 
 ### plume release
@@ -312,8 +312,8 @@ The JSON file exported to the variable `AZURE_AUTH_LOCATION` should be generated
 }
 ```
 
-### gce
-`gce` uses `~/.config/gce.json`, which contains a JSON-formatted service
+### gcp
+`gcp` uses `~/.config/gce.json`, which contains a JSON-formatted service
 account key. This can be downloaded from the Google Cloud console under
 IAM > Service Accounts > [account] > Keys.
 

--- a/mantle/auth/google.go
+++ b/mantle/auth/google.go
@@ -26,7 +26,7 @@ import (
 	"golang.org/x/oauth2/google"
 )
 
-const GCEConfigPath = ".config/gce.json"
+const GCPConfigPath = ".config/gce.json"
 
 var scopes = []string{
 	"https://www.googleapis.com/auth/devstorage.full_control",
@@ -34,7 +34,7 @@ var scopes = []string{
 }
 
 // GoogleServiceClient fetchs a token from Google Compute Engine's
-// metadata service. This should be used on GCE vms. The Default account
+// metadata service. This should be used on GCP vms. The Default account
 // is used.
 func GoogleServiceClient() *http.Client {
 	return &http.Client{
@@ -56,7 +56,7 @@ func GoogleClientFromKeyFile(path string, scope ...string) (*http.Client, error)
 		if err != nil {
 			return nil, err
 		}
-		path = filepath.Join(user.HomeDir, GCEConfigPath)
+		path = filepath.Join(user.HomeDir, GCPConfigPath)
 	}
 	b, err := os.ReadFile(path)
 	if err != nil {

--- a/mantle/cmd/kola/kola.go
+++ b/mantle/cmd/kola/kola.go
@@ -291,7 +291,7 @@ func writeProps() error {
 		Server     string `json:"server"`
 		BaseVMName string `json:"base_vm_name"`
 	}
-	type GCE struct {
+	type GCP struct {
 		Image       string `json:"image"`
 		MachineType string `json:"type"`
 	}
@@ -323,7 +323,7 @@ func writeProps() error {
 		Azure       Azure     `json:"azure"`
 		DO          DO        `json:"do"`
 		ESX         ESX       `json:"esx"`
-		GCE         GCE       `json:"gce"`
+		GCP         GCP       `json:"gcp"`
 		OpenStack   OpenStack `json:"openstack"`
 		Packet      Packet    `json:"packet"`
 		QEMU        QEMU      `json:"qemu"`
@@ -355,9 +355,9 @@ func writeProps() error {
 			Server:     kola.ESXOptions.Server,
 			BaseVMName: kola.ESXOptions.BaseVMName,
 		},
-		GCE: GCE{
-			Image:       kola.GCEOptions.Image,
-			MachineType: kola.GCEOptions.MachineType,
+		GCP: GCP{
+			Image:       kola.GCPOptions.Image,
+			MachineType: kola.GCPOptions.MachineType,
 		},
 		OpenStack: OpenStack{
 			Region: kola.OpenStackOptions.Region,
@@ -605,7 +605,7 @@ func syncFindParentImageOptions() error {
 			return err
 		}
 	case "gce":
-		kola.GCEOptions.Image, err = parentCosaBuild.FindGCPImage()
+		kola.GCPOptions.Image, err = parentCosaBuild.FindGCPImage()
 		if err != nil {
 			return err
 		}

--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -113,16 +113,16 @@ func init() {
 	sv(&kola.ESXOptions.Profile, "esx-profile", "", "ESX profile (default \"default\")")
 	sv(&kola.ESXOptions.BaseVMName, "esx-base-vm", "", "ESX base VM name")
 
-	// gce-specific options
-	sv(&kola.GCEOptions.Image, "gce-image", "", "GCE image, full api endpoints names are accepted if resource is in a different project")
-	sv(&kola.GCEOptions.Project, "gce-project", "fedora-coreos-devel", "GCE project name")
-	sv(&kola.GCEOptions.Zone, "gce-zone", "us-central1-a", "GCE zone name")
-	sv(&kola.GCEOptions.MachineType, "gce-machinetype", "n1-standard-1", "GCE machine type")
-	sv(&kola.GCEOptions.DiskType, "gce-disktype", "pd-ssd", "GCE disk type")
-	sv(&kola.GCEOptions.Network, "gce-network", "default", "GCE network")
-	sv(&kola.GCEOptions.ServiceAcct, "gce-service-account", "", "GCE service account to attach to instance (default project default)")
-	bv(&kola.GCEOptions.ServiceAuth, "gce-service-auth", false, "for non-interactive auth when running within GCE")
-	sv(&kola.GCEOptions.JSONKeyFile, "gce-json-key", "", "use a service account's JSON key for authentication (default \"~/"+auth.GCEConfigPath+"\")")
+	// gcp-specific options
+	sv(&kola.GCPOptions.Image, "gce-image", "", "GCP image, full api endpoints names are accepted if resource is in a different project")
+	sv(&kola.GCPOptions.Project, "gce-project", "fedora-coreos-devel", "GCP project name")
+	sv(&kola.GCPOptions.Zone, "gce-zone", "us-central1-a", "GCP zone name")
+	sv(&kola.GCPOptions.MachineType, "gce-machinetype", "n1-standard-1", "GCP machine type")
+	sv(&kola.GCPOptions.DiskType, "gce-disktype", "pd-ssd", "GCP disk type")
+	sv(&kola.GCPOptions.Network, "gce-network", "default", "GCP network")
+	sv(&kola.GCPOptions.ServiceAcct, "gce-service-account", "", "GCP service account to attach to instance (default project default)")
+	bv(&kola.GCPOptions.ServiceAuth, "gce-service-auth", false, "for non-interactive auth when running within GCP")
+	sv(&kola.GCPOptions.JSONKeyFile, "gce-json-key", "", "use a service account's JSON key for authentication (default \"~/"+auth.GCPConfigPath+"\")")
 
 	// openstack-specific options
 	sv(&kola.OpenStackOptions.ConfigPath, "openstack-config-file", "", "Path to a clouds.yaml formatted OpenStack config file. The underlying library defaults to ./clouds.yaml")
@@ -364,13 +364,13 @@ func syncCosaOptions() error {
 		}
 	case "gce":
 		// Pick up the GCP image from the build metadata
-		if kola.GCEOptions.Image == "" && kola.CosaBuild.Meta.Gcp != nil {
-			kola.GCEOptions.Image =
+		if kola.GCPOptions.Image == "" && kola.CosaBuild.Meta.Gcp != nil {
+			kola.GCPOptions.Image =
 				fmt.Sprintf("projects/%s/global/images/%s",
 					kola.CosaBuild.Meta.Gcp.ImageProject,
 					kola.CosaBuild.Meta.Gcp.ImageName)
 
-			fmt.Printf("Using GCP image %s\n", kola.GCEOptions.Image)
+			fmt.Printf("Using GCP image %s\n", kola.GCPOptions.Image)
 		}
 	}
 

--- a/mantle/cmd/ore/gcloud/create-image.go
+++ b/mantle/cmd/ore/gcloud/create-image.go
@@ -31,8 +31,8 @@ import (
 var (
 	cmdCreateImage = &cobra.Command{
 		Use:   "create-image",
-		Short: "Create GCE image",
-		Long:  "Create GCE image from an existing file in Google Storage",
+		Short: "Create GCP image",
+		Long:  "Create GCP image from an existing file in Google Storage",
 		Run:   runCreateImage,
 	}
 
@@ -47,7 +47,7 @@ var (
 func init() {
 	user := os.Getenv("USER")
 	cmdCreateImage.Flags().StringVar(&createImageFamily, "family",
-		user, "GCE image group and name prefix")
+		user, "GCP image group and name prefix")
 	cmdCreateImage.Flags().StringVar(&createImageBoard, "board",
 		"amd64-usr", "OS board name")
 	cmdCreateImage.Flags().StringVar(&createImageVersion, "version",
@@ -56,10 +56,10 @@ func init() {
 		"gs://users.developer.core-os.net/"+user+"/boards",
 		"Storage URL prefix")
 	cmdCreateImage.Flags().StringVar(&createImageName, "source-name",
-		"coreos_production_gce.tar.gz",
+		"coreos_production_gcp.tar.gz",
 		"Storage image name")
 	cmdCreateImage.Flags().BoolVar(&createImageForce, "force",
-		false, "overwrite existing GCE images without prompt")
+		false, "overwrite existing GCP images without prompt")
 	GCloud.AddCommand(cmdCreateImage)
 }
 
@@ -91,7 +91,7 @@ func runCreateImage(cmd *cobra.Command, args []string) {
 	bucket := gsURL.Host
 	imageNameGS := strings.TrimPrefix(path.Join(gsURL.Path,
 		createImageBoard, createImageVersion, createImageName), "/")
-	imageNameGCE := gceSanitize(createImageFamily + "-" + createImageVersion)
+	imageNameGCP := gcpSanitize(createImageFamily + "-" + createImageVersion)
 
 	ctx := context.Background()
 	storageAPI, err := storage.NewService(ctx)
@@ -111,19 +111,19 @@ func runCreateImage(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	fmt.Printf("Creating image in GCE: %v...\n", imageNameGCE)
+	fmt.Printf("Creating image in GCP: %v...\n", imageNameGCP)
 
-	// create image on gce
+	// create image on gcp
 	storageSrc := fmt.Sprintf("https://storage.googleapis.com/%v/%v", bucket, imageNameGS)
 	_, pending, err := api.CreateImage(&gcloud.ImageSpec{
-		Name:        imageNameGCE,
+		Name:        imageNameGCP,
 		SourceImage: storageSrc,
 	}, createImageForce)
 	if err == nil {
 		err = pending.Wait()
 	}
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Creating GCE image failed: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Creating GCP image failed: %v\n", err)
 		os.Exit(1)
 	}
 }

--- a/mantle/cmd/ore/gcloud/delete-images.go
+++ b/mantle/cmd/ore/gcloud/delete-images.go
@@ -26,7 +26,7 @@ import (
 var (
 	cmdDeleteImage = &cobra.Command{
 		Use:   "delete-images <name>...",
-		Short: "Delete GCE images",
+		Short: "Delete GCP images",
 		Run:   runDeleteImage,
 	}
 )

--- a/mantle/cmd/ore/gcloud/destroy.go
+++ b/mantle/cmd/ore/gcloud/destroy.go
@@ -24,8 +24,8 @@ import (
 var (
 	cmdDestroy = &cobra.Command{
 		Use:   "destroy-instances --prefix=<prefix> ",
-		Short: "destroy cluster on GCE",
-		Long:  "Destroy GCE instances based on name prefix.",
+		Short: "destroy cluster on GCP",
+		Long:  "Destroy GCP instances based on name prefix.",
 		Run:   runDestroy,
 	}
 )

--- a/mantle/cmd/ore/gcloud/gc.go
+++ b/mantle/cmd/ore/gcloud/gc.go
@@ -25,7 +25,7 @@ import (
 var (
 	cmdGC = &cobra.Command{
 		Use:   "gc",
-		Short: "GC resources in GCE",
+		Short: "GC resources in GCP",
 		Long:  `Delete instances created over the given duration ago.`,
 		RunE:  runGC,
 

--- a/mantle/cmd/ore/gcloud/gcloud.go
+++ b/mantle/cmd/ore/gcloud/gcloud.go
@@ -47,7 +47,7 @@ func init() {
 	sv(&opts.BaseName, "basename", "kola", "instance name prefix")
 	sv(&opts.Network, "network", "default", "network name")
 	sv(&opts.JSONKeyFile, "json-key", "", "use a service account's JSON key for authentication")
-	GCloud.PersistentFlags().BoolVar(&opts.ServiceAuth, "service-auth", false, "use non-interactive auth when running within GCE")
+	GCloud.PersistentFlags().BoolVar(&opts.ServiceAuth, "service-auth", false, "use non-interactive auth when running within GCP")
 
 	cli.WrapPreRun(GCloud, preauth)
 }

--- a/mantle/cmd/ore/gcloud/image.go
+++ b/mantle/cmd/ore/gcloud/image.go
@@ -25,7 +25,7 @@ import (
 var (
 	cmdImage = &cobra.Command{
 		Use:   "list-images --prefix=<prefix>",
-		Short: "List images in GCE",
+		Short: "List images in GCP",
 		Run:   runImage,
 	}
 

--- a/mantle/cmd/ore/gcloud/list.go
+++ b/mantle/cmd/ore/gcloud/list.go
@@ -26,7 +26,7 @@ import (
 var (
 	cmdList = &cobra.Command{
 		Use:   "list-instances --prefix=<prefix>",
-		Short: "List instances on GCE",
+		Short: "List instances on GCP",
 		Run:   runList,
 	}
 )

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -106,7 +106,7 @@ var (
 	AzureOptions     = azureapi.Options{Options: &Options}     // glue to set platform options from main
 	DOOptions        = doapi.Options{Options: &Options}        // glue to set platform options from main
 	ESXOptions       = esxapi.Options{Options: &Options}       // glue to set platform options from main
-	GCEOptions       = gcloudapi.Options{Options: &Options}    // glue to set platform options from main
+	GCPOptions       = gcloudapi.Options{Options: &Options}    // glue to set platform options from main
 	OpenStackOptions = openstackapi.Options{Options: &Options} // glue to set platform options from main
 	PacketOptions    = packetapi.Options{Options: &Options}    // glue to set platform options from main
 	QEMUOptions      = unprivqemu.Options{Options: &Options}   // glue to set platform options from main
@@ -274,7 +274,7 @@ func NewFlight(pltfrm string) (flight platform.Flight, err error) {
 	case "esx":
 		flight, err = esx.NewFlight(&ESXOptions)
 	case "gce":
-		flight, err = gcloud.NewFlight(&GCEOptions)
+		flight, err = gcloud.NewFlight(&GCPOptions)
 	case "openstack":
 		flight, err = openstack.NewFlight(&OpenStackOptions)
 	case "packet":

--- a/mantle/platform/api/gcloud/compute.go
+++ b/mantle/platform/api/gcloud/compute.go
@@ -125,7 +125,7 @@ func (a *API) CreateInstance(userdata string, keys []*agent.Key, useServiceAcct 
 
 	op, err := a.compute.Instances.Insert(a.options.Project, a.options.Zone, inst).Do()
 	if err != nil {
-		return nil, fmt.Errorf("failed to request new GCE instance: %v\n", err)
+		return nil, fmt.Errorf("failed to request new GCP instance: %v\n", err)
 	}
 
 	doable := a.compute.ZoneOperations.Get(a.options.Project, a.options.Zone, op.Name)

--- a/mantle/platform/api/gcloud/image.go
+++ b/mantle/platform/api/gcloud/image.go
@@ -65,7 +65,7 @@ func getImageAPIEndpoint(image, project string) (string, error) {
 		" begin with 'projects/', or use the short name")
 }
 
-// CreateImage creates an image on GCE and returns operation details and
+// CreateImage creates an image on GCP and returns operation details and
 // a Pending. If overwrite is true, an existing image will be overwritten
 // if it exists.
 func (a *API) CreateImage(spec *ImageSpec, overwrite bool) (*compute.Operation, *Pending, error) {
@@ -78,7 +78,7 @@ func (a *API) CreateImage(spec *ImageSpec, overwrite bool) (*compute.Operation, 
 			// If not in URI format then query GCP for that info
 			license, err := a.compute.Licenses.Get(a.options.Project, l).Do()
 			if err != nil {
-				return nil, nil, fmt.Errorf("Invalid GCE license %s: %v", l, err)
+				return nil, nil, fmt.Errorf("Invalid GCP license %s: %v", l, err)
 			}
 			licenses[i] = license.SelfLink
 		}
@@ -156,7 +156,7 @@ func (a *API) ListImages(ctx context.Context, prefix string, family string) ([]*
 		return nil
 	})
 	if err != nil {
-		return nil, fmt.Errorf("Listing GCE images failed: %v", err)
+		return nil, fmt.Errorf("Listing GCP images failed: %v", err)
 	}
 	return images, nil
 }

--- a/mantle/platform/machine/gcloud/cluster.go
+++ b/mantle/platform/machine/gcloud/cluster.go
@@ -38,19 +38,19 @@ func (gc *cluster) NewMachine(userdata *conf.UserData) (platform.Machine, error)
 
 func (gc *cluster) NewMachineWithOptions(userdata *conf.UserData, options platform.MachineOptions) (platform.Machine, error) {
 	if len(options.AdditionalDisks) > 0 {
-		return nil, errors.New("platform gce does not yet support additional disks")
+		return nil, errors.New("platform gcp does not yet support additional disks")
 	}
 	if options.MultiPathDisk {
-		return nil, errors.New("platform gce does not support multipathed disks")
+		return nil, errors.New("platform gcp does not support multipathed disks")
 	}
 	if options.AdditionalNics > 0 {
-		return nil, errors.New("platform gce does not support additional nics")
+		return nil, errors.New("platform gcp does not support additional nics")
 	}
 	if options.AppendKernelArgs != "" {
-		return nil, errors.New("platform gce does not support appending kernel arguments")
+		return nil, errors.New("platform gcp does not support appending kernel arguments")
 	}
 	if options.AppendFirstbootKernelArgs != "" {
-		return nil, errors.New("platform gce does not support appending firstboot kernel arguments")
+		return nil, errors.New("platform gcp does not support appending firstboot kernel arguments")
 	}
 
 	conf, err := gc.RenderUserData(userdata, map[string]string{

--- a/mantle/platforms.md
+++ b/mantle/platforms.md
@@ -105,11 +105,11 @@ Like Azure, but not.
  - Userdata is passed to the instances via the `ovfenv`. When a machine is created the API updates the `config.vAppConfig.property.guestinfo.coreos.config.data` field to be a base64 encoded userdata config.
  - The general workflow for running tests on ESX is to run the `ore esx create-base` to upload an OVF image and then the resulting image name is specified to `kola` via the `esx-base-vm` parameter. This is done to only require kola to perform a clone operation rather than a full re-upload of the image.
 
-## GCE
+## GCP
 
- - The GCE/gcloud platform wraps [this SDK](google.golang.org/api).
- - By default SSH keys will be passed via both the GCE metadata AND the userdata.
- - UserData is passed to the instances via the GCE metadata service.
+ - The GCP/gcloud platform wraps [this SDK](google.golang.org/api).
+ - By default SSH keys will be passed via both the GCP metadata AND the userdata.
+ - UserData is passed to the instances via the GCP metadata service.
  - Instances are tagged with `created-by:mantle` which is used when filtering instances for `GC`.
 
 ## OpenStack


### PR DESCRIPTION
Now we are using new platform id `gcp` as Google Cloud Platform, so should eradicate all uses of `gce` from the mantle code base to reduce confusion.
See https://github.com/coreos/coreos-assembler/issues/3378

This PR only includes `cosmetic` changes which will not break auto and pipeline jobs.