### PR TITLE
ci: Use scos (at least for now)

### DIFF
--- a/ci/prow-rhcos.sh
+++ b/ci/prow-rhcos.sh
@@ -17,6 +17,6 @@ esac
 export COSA_SKIP_OVERLAY=1
 # Create a temporary cosa workdir
 cd "$(mktemp -d)"
-cosa init --transient -b "${RHCOS_BRANCH}" https://github.com/openshift/os
+cosa init --variant scos --transient -b "${RHCOS_BRANCH}" https://github.com/openshift/os
 # Use a COSA specifc test entry point to focus on tests relevant for COSA
 exec src/config/ci/prow-entrypoint.sh rhcos-cosa-prow-pr-ci


### PR DESCRIPTION
Current setup has broken Prow builds of RHCOS.  Maybe in the future we have both, or at least one with the other opt-in?

Closes: https://github.com/coreos/coreos-assembler/issues/3388