### PR TITLE
mantle/aws: set boot mode to `uefi-preferred`

### DIFF
--- a/mantle/platform/api/aws/images.go
+++ b/mantle/platform/api/aws/images.go
@@ -331,14 +331,17 @@ func (a *API) CreateImportRole(bucket string) error {
 
 func (a *API) CreateHVMImage(snapshotID string, diskSizeGiB uint, name string, description string, architecture string) (string, error) {
 	var awsArch string
+	var bootmode string
 	if architecture == "" {
 		architecture = runtime.GOARCH
 	}
 	switch architecture {
 	case "amd64", "x86_64":
 		awsArch = ec2.ArchitectureTypeX8664
+		bootmode = "uefi-preferred"
 	case "arm64", "aarch64":
 		awsArch = ec2.ArchitectureTypeArm64
+		bootmode = "uefi"
 	default:
 		return "", fmt.Errorf("unsupported ec2 architecture %q", architecture)
 	}
@@ -366,6 +369,7 @@ func (a *API) CreateHVMImage(snapshotID string, diskSizeGiB uint, name string, d
 		},
 		EnaSupport:      aws.Bool(true),
 		SriovNetSupport: aws.String("simple"),
+		BootMode:        aws.String(bootmode),
 	})
 }
 


### PR DESCRIPTION
AWS now allows marking an AMI as "UEFI-preferred"; i.e. that both BIOS and UEFI are supported, but the latter is preferred if the instance type supports it.

Let's make use of it.

A change proposal has been submitted for Fedora 39 to also do this for the Fedora Cloud image.

Ref: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ami-boot.html
Ref: https://fedoraproject.org/wiki/Changes/CloudEC2UEFIPreferred