### PR TITLE
Add tmux to cosa

### DIFF
--- a/src/build-deps.txt
+++ b/src/build-deps.txt
@@ -2,3 +2,6 @@
 time
 # Used by mantle
 golang
+# Use tmux for developer multi-arch builder access UX 
+#https://github.com/coreos/fedora-coreos-pipeline/issues/803
+tmux


### PR DESCRIPTION
We can use tmux to create terminal sessions that can be attached to later

Ref: https://github.com/coreos/fedora-coreos-pipeline/issues/803