### PR TITLE
build.sh: add Red Hat keys to RPM keyring

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ COPY ./build.sh /root/containerbuild/
 RUN ./build.sh configure_yum_repos
 RUN ./build.sh install_rpms
 RUN ./build.sh install_ocp_tools
+RUN ./build.sh trust_redhat_gpg_keys
 
 # This allows Prow jobs for other projects to use our cosa image as their
 # buildroot image (so clonerefs can copy the repo into `/go`). For cosa itself,

--- a/build.sh
+++ b/build.sh
@@ -107,6 +107,18 @@ install_ocp_tools() {
         && mv oc /usr/bin
 }
 
+# By default, we trust the official Red Hat GPG keys
+trust_redhat_gpg_keys() {
+    for f in /usr/share/distribution-gpg-keys/redhat/*; do
+        local base
+        base=$(basename "$f")
+        if [ ! -e "/etc/pki/rpm-gpg/$base" ]; then
+            # libdnf at least ignores symlinks, so copy it
+            cp -vt /etc/pki/rpm-gpg "$f"
+        fi
+    done
+}
+
 make_and_makeinstall() {
     make
     make install
@@ -164,5 +176,6 @@ else
   write_archive_info
   make_and_makeinstall
   install_ocp_tools
+  trust_redhat_gpg_keys
   configure_user
 fi


### PR DESCRIPTION
Fedora by default does not have the Red Hat GPG keys in its keyring. But
we need them available so that we can verify RHEL RPMs we download when
building RHCOS. Interestingly, we get the primary release key right now
in cosa via containers-common, which ships it for its own purposes of
verifying signed RHEL images:

https://src.fedoraproject.org/rpms/containers-common/c/67fd4062

Relying on that however isn't great (that package should probably stop
modifying the public RPM keyring). Let's have our own code code that
copies the keys from `/usr/share/distribution-gpg-keys/redhat` to
`/etc/pki/rpm-gpg`.