### PR TITLE
cmdlib.sh: include GPG keys in supermin VM

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -113,8 +113,9 @@ trust_redhat_gpg_keys() {
         local base
         base=$(basename "$f")
         if [ ! -e "/etc/pki/rpm-gpg/$base" ]; then
-            # libdnf at least ignores symlinks, so copy it
-            cp -vt /etc/pki/rpm-gpg "$f"
+            # libdnf at least ignores symlinks, so we need to copy.
+            # but might as well keep symlinks as symlinks.
+            cp -vPt /etc/pki/rpm-gpg "$f"
         fi
     done
 }

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -728,6 +728,9 @@ runvm() {
     # include COSA in the image
     find /usr/lib/coreos-assembler/ -type f > "${vmpreparedir}/hostfiles"
 
+    # and include all GPG keys
+    find /etc/pki/rpm-gpg/ -type f >> "${vmpreparedir}/hostfiles"
+
     # the reason we do a heredoc here is so that the var substition takes
     # place immediately instead of having to proxy them through to the VM
     cat > "${vmpreparedir}/init" <<EOF


### PR DESCRIPTION
Follow-up to dbb8cba85 ("build.sh: add Red Hat keys to RPM keyring").

The keys aren't tracked by any RPM, so supermin doesn't know to copy
it in. Add it manually via `hostfiles`.

This should fix dbb8cba85 when running unprivileged.