### PR TITLE
ignition-gpg-key: Skip compression of ignition protection gpg key

### DIFF
--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -298,7 +298,8 @@ j = json.load(sys.stdin)
 j['images']['ignition-gpg-key'] = {
     'path': '${gpg_key}',
     'sha256': '$(sha256sum_str < "${ignition_pubkey}")',
-    'size': $(stat -c '%s' "${ignition_pubkey}")
+    'size': $(stat -c '%s' "${ignition_pubkey}"),
+    'skip-compression': True
 }
 json.dump(j, sys.stdout, indent=4)
 " < "meta.json.new" | jq -s add > "key.json"


### PR DESCRIPTION
There is no need to compress the gpg public key, as that only adds more complexity for no gain.