### PR TITLE
[rhcos-4.13] ignition-gpg-key: Skip compression of ignition protection gpg key

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -6,7 +6,7 @@ def cpuCount = 6
 def cpuCount_s = cpuCount.toString()
 def imageName = buildImage(env: [ENABLE_GO_RACE_DETECTOR: "1", GOMAXPROCS: cpuCount_s], cpu: cpuCount_s)
 
-pod(image: imageName + ":latest", cpu: "2", memory: "2048Mi") {
+pod(image: imageName + ":latest", cpu: "2", memory: "3072Mi") {
     checkout scm
 
     stage("Unit tests") {

--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -298,7 +298,8 @@ j = json.load(sys.stdin)
 j['images']['ignition-gpg-key'] = {
     'path': '${gpg_key}',
     'sha256': '$(sha256sum_str < "${ignition_pubkey}")',
-    'size': $(stat -c '%s' "${ignition_pubkey}")
+    'size': $(stat -c '%s' "${ignition_pubkey}"),
+    'skip-compression': True
 }
 json.dump(j, sys.stdout, indent=4)
 " < "meta.json.new" | jq -s add > "key.json"


### PR DESCRIPTION
There is no need to compress the gpg public key, as that only adds more complexity for no gain.

cherry-picked from #3413