### PR TITLE
mantle/platform/conf: use 3.1.0 Ignition spec version for MergeAllConfigs()

### DIFF
--- a/mantle/platform/conf/conf.go
+++ b/mantle/platform/conf/conf.go
@@ -379,20 +379,20 @@ func (c *Conf) MergeV35exp(newConfig v35exptypes.Config) {
 	c.ignitionV35exp = &mergeConfig
 }
 
-// Merge all configs into a V3.3 config
+// Merge all configs into a V3.1 config
 func MergeAllConfigs(confObjs []*Conf) (*UserData, error) {
 	config := Conf{
-		ignitionV33: &v33types.Config{
-			Ignition: v33types.Ignition{
-				Version: "3.3.0",
+		ignitionV31: &v31types.Config{
+			Ignition: v31types.Ignition{
+				Version: "3.1.0",
 			},
 		},
 	}
-	objectsToMerge := &config.ignitionV33.Ignition.Config.Merge
+	objectsToMerge := &config.ignitionV31.Ignition.Config.Merge
 	for _, conf := range confObjs {
 		ud := conf.String()
 		url := dataurl.EncodeBytes([]byte(ud))
-		obj := v33types.Resource{
+		obj := v31types.Resource{
 			Source: &url,
 		}
 		*objectsToMerge = append(*objectsToMerge, obj)


### PR DESCRIPTION
For MergeAllConfigs() let's use an older spec version to enable testing bringup on older Fedora CoreOS releases in the aid of extended upgrade testing. Specifically, now the --append-butane workflow enabled and described in [1] will work.

I chose spec 3.1.0 because it was old enough (F32 nodes support it) and it includes [2], which enabled us to not change using the Resource() type in Ignition, which didn't exist in 3.0.0.

[1] https://github.com/coreos/fedora-coreos-config/commit/2b0fe09b75c7200b538724be97081f035085164d
[2] https://github.com/coreos/ignition/commit/082b45478d18381f959ec578846a19366344268e