### PR TITLE
qemu: support `--add-disk 1G:channel=nvme`

### DIFF
--- a/docs/cosa/run.md
+++ b/docs/cosa/run.md
@@ -87,6 +87,7 @@ Additional disks CLI arguments support optional flags using the `--add-disk
 
 - `mpath`: enables multipathing for the disk (see below for details).
 - `4k`: sets the disk as 4Kn (4096 physical sector size)
+- `channel=CHANNEL`: set the channel type (e.g. `virtio`, `nvme`)
 - `serial=NAME`: sets the disk serial; this can then be used to customize the
   default `diskN` naming documented above (e.g. `serial=foobar` will make the
   device show up as `/dev/disk/by-id/virtio-foobar`)

--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -106,6 +106,7 @@ type Disk struct {
 func ParseDiskSpec(spec string) (*Disk, error) {
 	split := strings.Split(spec, ":")
 	var size string
+	var channel string
 	multipathed := false
 	sectorSize := 0
 	serial_opt := []string{}
@@ -118,6 +119,11 @@ func ParseDiskSpec(spec string) (*Disk, error) {
 				multipathed = true
 			} else if opt == "4k" {
 				sectorSize = 4096
+			} else if strings.HasPrefix(opt, "channel=") {
+				channel = strings.TrimPrefix(opt, "channel=")
+				if channel == "" {
+					return nil, fmt.Errorf("invalid channel opt %s", opt)
+				}
 			} else if strings.HasPrefix(opt, "serial=") {
 				serial := strings.TrimPrefix(opt, "serial=")
 				if serial == "" {
@@ -133,6 +139,7 @@ func ParseDiskSpec(spec string) (*Disk, error) {
 	}
 	return &Disk{
 		Size:          size,
+		Channel:       channel,
 		DeviceOpts:    serial_opt,
 		SectorSize:    sectorSize,
 		MultiPathDisk: multipathed,


### PR DESCRIPTION
I'm testing stuff related to NVMe and this is useful. Note the primary disk can already be put on NVMe using `--qemu-nvme`. But with this, you can customize the serial as you wish, e.g.
`--add-disk 1G:channel=nvme,serial=foo_bar`.