### PR TITLE
run: Add `noautoupdate` ignition fragment

### DIFF
--- a/mantle/cmd/kola/qemuexec.go
+++ b/mantle/cmd/kola/qemuexec.go
@@ -80,7 +80,7 @@ func init() {
 	cmdQemuExec.Flags().StringVarP(&firstbootkargs, "firstbootkargs", "", "", "Additional first boot kernel arguments")
 	cmdQemuExec.Flags().StringArrayVar(&kargs, "kargs", nil, "Additional kernel arguments applied")
 	cmdQemuExec.Flags().BoolVarP(&usernet, "usernet", "U", false, "Enable usermode networking")
-	cmdQemuExec.Flags().StringSliceVar(&ignitionFragments, "add-ignition", nil, "Append well-known Ignition fragment: [\"autologin\", \"autoresize\"]")
+	cmdQemuExec.Flags().StringSliceVar(&ignitionFragments, "add-ignition", nil, "Append well-known Ignition fragment: [\"autologin\", \"autoresize\", \"noautoupdate\"]")
 	cmdQemuExec.Flags().StringVarP(&hostname, "hostname", "", "", "Set hostname via DHCP")
 	cmdQemuExec.Flags().IntVarP(&memory, "memory", "m", 0, "Memory in MB")
 	cmdQemuExec.Flags().StringVar(&architecture, "arch", "", "Use full emulation for target architecture (e.g. aarch64, x86_64, s390x, ppc64le)")
@@ -108,6 +108,8 @@ func renderFragments(fragments []string, c *conf.Conf) error {
 			c.AddAutoLogin()
 		case "autoresize":
 			c.AddAutoResize()
+		case "noautoupdate":
+			c.DisableAutomaticUpdates()
 		default:
 			return fmt.Errorf("Unknown fragment: %s", fragtype)
 		}

--- a/mantle/platform/conf/conf.go
+++ b/mantle/platform/conf/conf.go
@@ -1261,6 +1261,12 @@ func (c *Conf) AddAutoLogin() {
 	c.AddSystemdUnitDropin("serial-getty@.service", "10-autologin.conf", getAutologinUnit("serial-getty@.service", "--keep-baud 115200,38400,9600"))
 }
 
+// DisableAutomaticUpdates turns off zincati
+func (c *Conf) DisableAutomaticUpdates() {
+	c.AddFile("/etc/zincati/config.d/90-disable-auto-updates.toml", `[updates]
+	enabled = false`, 0644)
+}
+
 // AddAutoResize adds an Ignition config for a `resize` function to resize serial consoles
 func (c *Conf) AddAutoResize() {
 	c.AddFile("/etc/profile.d/autoresize.sh", `


### PR DESCRIPTION
I commonly want to `cosa run` a prod image but with auto-updates disabled.