### PR TITLE
kola: add `Description` property for tests

### DIFF
--- a/docs/kola.md
+++ b/docs/kola.md
@@ -236,6 +236,8 @@ In order to see the logs for these tests you must enter the `tmp/kola/name_of_th
 
 `cosa run -i ignition_path` You can run it passing your Ignition, or the Ignition used in the the test that failed for troubleshooting reasons.
 
+`kola list --json | jq -r '.[] | [.Name,.Description]| @tsv'` This will list all tests name and the description.
+
 ## Run tests on cloud platforms
 `cosa kola run -p aws --aws-ami ami-0431766f2498820b8 --aws-region us-east-1 basic` This will run the basic tests on AWS using `ami-0431766f2498820b8` (fedora-coreos-37.20230227.20.2) with default instance type `m5.large`. Add `--aws-type <t3.micro>` if you want to use custom type. How to create the credentials refer to https://github.com/coreos/coreos-assembler/blob/main/docs/mantle/credentials.md#aws
 

--- a/docs/kola/adding-tests.md
+++ b/docs/kola/adding-tests.md
@@ -49,6 +49,7 @@ func init() {
         ClusterSize: 1,
         Name:        `podman.noop`,
         Distros:     []string{"rhcos"},
+        Description: "Simple NOOP test for podman",
     })
 <snip/>
 $ popd
@@ -84,6 +85,7 @@ Continuing with the look at the `podman` package we can see that `podman.base` i
             ClusterSize: 1,
             Name:        `podman.base`,
             Distros:     []string{"rhcos"},
+            Description: "Verifies podman info and running with various options",
     })
 ```
 
@@ -161,6 +163,7 @@ func init() {
             Flags:       []register.Flag{}, // See: https://godoc.org/github.com/coreos/coreos-assembler/mantle/kola/register#Flag
             Distros:     []string{"rhcos"},
             FailFast:    true,
+            Description: "Example test group",
     })
 }
 

--- a/docs/kola/external-tests.md
+++ b/docs/kola/external-tests.md
@@ -199,7 +199,8 @@ Here's an example `kola.json`:
     "appendFirstbootKernelArgs": "ip=bond0:dhcp bond=bond0:ens5,ens6:mode=active-backup,miimon=100"
     "timeoutMin": 8,
     "exclusive": true,
-    "conflicts": ["ext.config.some-test", "podman.some-other-test"]
+    "conflicts": ["ext.config.some-test", "podman.some-other-test"],
+    "description": "test description"
 }
 ```
 
@@ -276,7 +277,7 @@ inline per test, like this:
 ```sh
 #!/bin/bash
 set -xeuo pipefail
-# kola: { "architectures": "x86_64", "platforms": "aws gce", "tags": "needs-internet" }
+# kola: { "architectures": "x86_64", "platforms": "aws gce", "tags": "needs-internet", "description": "test" }
 test code here
 ```
 
@@ -293,6 +294,7 @@ set -xeuo pipefail
 ##   architectures: x86_64
 ##   platforms: "aws gce"  # azure support is pending
 ##   tags: needs-internet
+##   description: test description
 test code here
 ```
 
@@ -321,7 +323,7 @@ $ cd my-project/tests/kola
 $ $EDITOR basic/noop # Add the `noop` test
 #!/bin/bash
 set -xeuo pipefail
-# kola: { "architectures": "x86_64", "platforms": "qemu", "tags": "needs-internet" }
+# kola: { "architectures": "x86_64", "platforms": "qemu", "tags": "needs-internet", "description": "test" }
 # Test: I'm a NOOP!
 test 2 -gt 1
 $ chmod a+x basic/noop # Make sure the test is executable

--- a/mantle/cmd/kola/kola.go
+++ b/mantle/cmd/kola/kola.go
@@ -393,7 +393,8 @@ func runList(cmd *cobra.Command, args []string) error {
 			test.ExcludeArchitectures,
 			test.Distros,
 			test.ExcludeDistros,
-			test.Tags}
+			test.Tags,
+			test.Description}
 		item.updateValues()
 		testlist = append(testlist, item)
 	}
@@ -453,6 +454,7 @@ type item struct {
 	Distros              []string
 	ExcludeDistros       []string `json:"-"`
 	Tags                 []string
+	Description          string
 }
 
 func (i *item) updateValues() {

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -886,6 +886,7 @@ type externalTestMeta struct {
 	Conflicts                 []string `json:"conflicts"                           yaml:"conflicts"`
 	AllowConfigWarnings       bool     `json:"allowConfigWarnings"                 yaml:"allowConfigWarnings"`
 	NoInstanceCreds           bool     `json:"noInstanceCreds"                     yaml:"noInstanceCreds"`
+	Description               string   `json:"description"                         yaml:"description"`
 }
 
 // metadataFromTestBinary extracts JSON-in-comment like:
@@ -1079,6 +1080,7 @@ ExecStart=%s
 
 	t := &register.Test{
 		Name:          testname,
+		Description:   targetMeta.Description,
 		ClusterSize:   1, // Hardcoded for now
 		ExternalTest:  executable,
 		DependencyDir: destDirs,

--- a/mantle/kola/register/register.go
+++ b/mantle/kola/register/register.go
@@ -69,6 +69,7 @@ type Test struct {
 	Tags                 []string      // list of tags that can be matched against -- defaults to none
 	Timeout              time.Duration // the duration for which a test will be allowed to run
 	RequiredTag          string        // if specified, test is filtered by default unless tag is provided -- defaults to none
+	Description          string        // test description
 
 	// Whether the primary disk is multipathed.
 	MultiPathDisk bool


### PR DESCRIPTION
Add `Description` property, it will show in `json` format if run `kola list --json`.

For example:
```
$ ./bin/kola -E rhcos9/src/config/ list --json | jq -r '.[] | [.Name,.Description]| @tsv'
basic	Tests basic functionality like SSH, systemd services, useradd, etc
coreos.auth.verify	Verifies invalid passwords do not grant access to the system
coreos.boot-mirror	Verifies if the boot-mirror RAID1 flow works properly in both BIOS and UEFI mode
coreos.boot-mirror.luks	Verifies if the boot-mirror+LUKS RAID1 flow works properly in both BIOS and UEFI modes
...	
ext.config.afterburn.platform-id	Verify afterburn works with kernel argument ignition.platform.id ec2(gce).
```
Fix https://github.com/coreos/coreos-assembler/issues/2509