### PR TITLE
cmdlib: use lowercase query tags for `dnf repoquery --qf`

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -433,7 +433,7 @@ EOF
         # the same RPMs: the `dnf repoquery` below is to pick the latest one
         dnf repoquery  --repofrompath=tmp,"file://${overridesdir}/rpm" \
             --disablerepo '*' --enablerepo tmp --refresh --latest-limit 1 \
-            --exclude '*.src' --qf '%{NAME}\t%{EVR}\t%{ARCH}' \
+            --exclude '*.src' --qf '%{name}\t%{evr}\t%{arch}' \
             --quiet > "${tmp_overridesdir}/pkgs.txt"
 
         # shellcheck disable=SC2002


### PR DESCRIPTION
Uppercase query tags broke in dnf v4.15.0. There is an upstream PR[[1]] to track restoring support for them, but since the canonical tag names are lowercase, switch to that.

Fixes https://github.com/coreos/rpm-ostree/issues/4368.

[1]: https://github.com/rpm-software-management/dnf/pull/1922