### PR TITLE
Switch to virtiofs

### DIFF
--- a/docs/working.md
+++ b/docs/working.md
@@ -164,9 +164,6 @@ allowing you to directly execute binaries from there.  You can also use e.g.
 `rpm-ostree usroverlay` and then copy binaries from your host `/run/workdir` into
 the VM's rootfs.
 
-(This currently only works on Fedora CoreOS which ships `9p`, not RHCOS.  A future version
- will use https://virtio-fs.gitlab.io/ )
-
 ## Using host binaries
 
 Another related trick is:

--- a/mantle/cmd/kola/qemuexec.go
+++ b/mantle/cmd/kola/qemuexec.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -213,8 +212,7 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 		ignitionFragments = append(ignitionFragments, "autologin")
 		cpuCountHost = true
 		usernet = true
-		// Can't use 9p on RHEL8, need https://virtio-fs.gitlab.io/ instead in the future
-		if kola.Options.CosaWorkdir != "" && !strings.HasPrefix(filepath.Base(kola.QEMUOptions.DiskImage), "rhcos") && !strings.HasPrefix(filepath.Base(kola.QEMUOptions.DiskImage), "scos") && kola.Options.Distribution != "rhcos" && kola.Options.Distribution != "scos" {
+		if kola.Options.CosaWorkdir != "" {
 			// Conservatively bind readonly to avoid anything in the guest (stray tests, whatever)
 			// from destroying stuff
 			bindro = append(bindro, fmt.Sprintf("%s,/var/mnt/workdir", kola.Options.CosaWorkdir))

--- a/mantle/cmd/kola/qemuexec.go
+++ b/mantle/cmd/kola/qemuexec.go
@@ -296,7 +296,7 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 		}
 		builder.MountHost(src, dest, true)
 		ensureConfig()
-		config.MountHost(dest, builder.UseVirtiofs, true)
+		config.MountHost(dest, true)
 	}
 	for _, b := range bindrw {
 		src, dest, err := parseBindOpt(b)
@@ -305,7 +305,7 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 		}
 		builder.MountHost(src, dest, false)
 		ensureConfig()
-		config.MountHost(dest, builder.UseVirtiofs, false)
+		config.MountHost(dest, false)
 	}
 	builder.ForceConfigInjection = forceConfigInjection
 	if len(firstbootkargs) > 0 {

--- a/mantle/cmd/kola/qemuexec.go
+++ b/mantle/cmd/kola/qemuexec.go
@@ -91,8 +91,8 @@ func init() {
 	cmdQemuExec.Flags().BoolVarP(&devshellConsole, "devshell-console", "c", false, "Connect directly to serial console in devshell mode")
 	cmdQemuExec.Flags().StringVarP(&ignition, "ignition", "i", "", "Path to Ignition config")
 	cmdQemuExec.Flags().StringVarP(&butane, "butane", "B", "", "Path to Butane config")
-	cmdQemuExec.Flags().StringArrayVar(&bindro, "bind-ro", nil, "Mount readonly via 9pfs a host directory (use --bind-ro=/path/to/host,/var/mnt/guest")
-	cmdQemuExec.Flags().StringArrayVar(&bindrw, "bind-rw", nil, "Same as above, but writable")
+	cmdQemuExec.Flags().StringArrayVar(&bindro, "bind-ro", nil, "Mount $hostpath,$guestpath readonly; for example --bind-ro=/path/on/host,/var/mnt/guest)")
+	cmdQemuExec.Flags().StringArrayVar(&bindrw, "bind-rw", nil, "Mount $hostpath,$guestpath writable; for example --bind-rw=/path/on/host,/var/mnt/guest)")
 	cmdQemuExec.Flags().BoolVarP(&forceConfigInjection, "inject-ignition", "", false, "Force injecting Ignition config using guestfs")
 	cmdQemuExec.Flags().BoolVar(&propagateInitramfsFailure, "propagate-initramfs-failure", false, "Error out if the system fails in the initramfs")
 	cmdQemuExec.Flags().StringVarP(&consoleFile, "console-to-file", "", "", "Filepath in which to save serial console logs")
@@ -296,18 +296,18 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		builder.Mount9p(src, dest, true)
+		builder.MountHost(src, dest, true)
 		ensureConfig()
-		config.Mount9p(dest, true)
+		config.MountHost(dest, builder.UseVirtiofs, true)
 	}
 	for _, b := range bindrw {
 		src, dest, err := parseBindOpt(b)
 		if err != nil {
 			return err
 		}
-		builder.Mount9p(src, dest, false)
+		builder.MountHost(src, dest, false)
 		ensureConfig()
-		config.Mount9p(dest, false)
+		config.MountHost(dest, builder.UseVirtiofs, false)
 	}
 	builder.ForceConfigInjection = forceConfigInjection
 	if len(firstbootkargs) > 0 {

--- a/mantle/platform/conf/conf.go
+++ b/mantle/platform/conf/conf.go
@@ -1363,21 +1363,11 @@ PROMPT_COMMAND+=(resize_terminal)`, 0644)
 }
 
 // MountHost adds an Ignition config to mount an folder
-func (c *Conf) MountHost(dest string, virtiofs, readonly bool) {
+func (c *Conf) MountHost(dest string, readonly bool) {
 	mountType := "virtiofs"
-	if !virtiofs {
-		mountType = "9p"
-	}
 	options := ""
-	if virtiofs {
-		if readonly {
-			options = "ro"
-		}
-	} else {
-		options = "trans=virtio,version=9p2000.L,msize=10485760"
-		if readonly {
-			options += ",ro"
-		}
+	if readonly {
+		options = "ro"
 	}
 	content := fmt.Sprintf(`[Unit]
 DefaultDependencies=no

--- a/mantle/platform/conf/conf.go
+++ b/mantle/platform/conf/conf.go
@@ -1362,11 +1362,22 @@ resize_terminal() {
 PROMPT_COMMAND+=(resize_terminal)`, 0644)
 }
 
-// Mount9p adds an Ignition config to mount an folder with 9p
-func (c *Conf) Mount9p(dest string, readonly bool) {
-	readonlyStr := ""
-	if readonly {
-		readonlyStr = ",ro"
+// MountHost adds an Ignition config to mount an folder
+func (c *Conf) MountHost(dest string, virtiofs, readonly bool) {
+	mountType := "virtiofs"
+	if !virtiofs {
+		mountType = "9p"
+	}
+	options := ""
+	if virtiofs {
+		if readonly {
+			options = "ro"
+		}
+	} else {
+		options = "trans=virtio,version=9p2000.L,msize=10485760"
+		if readonly {
+			options += ",ro"
+		}
 	}
 	content := fmt.Sprintf(`[Unit]
 DefaultDependencies=no
@@ -1375,11 +1386,11 @@ Before=basic.target
 [Mount]
 What=%s
 Where=%s
-Type=9p
-Options=trans=virtio,version=9p2000.L%s,msize=10485760
+Type=%s
+Options=%s
 [Install]
 WantedBy=multi-user.target
-`, dest, dest, readonlyStr)
+`, dest, dest, mountType, options)
 	c.AddSystemdUnit(fmt.Sprintf("%s.mount", systemdunit.UnitNameEscape(dest[1:])), content, Enable)
 }
 

--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -510,14 +510,14 @@ func NewQemuBuilder() *QemuBuilder {
 	default:
 		defaultFirmware = ""
 	}
-	_, useVirtiofs := os.LookupEnv("COSA_VIRTIOFS")
+	_, use9P := os.LookupEnv("COSA_9P_FALLBACK")
 	ret := QemuBuilder{
 		Firmware:     defaultFirmware,
 		Swtpm:        true,
 		Pdeathsig:    true,
 		Argv:         []string{},
 		architecture: coreosarch.CurrentRpmArch(),
-		UseVirtiofs:  useVirtiofs,
+		UseVirtiofs:  !use9P,
 	}
 	return &ret
 }
@@ -715,8 +715,9 @@ func (builder *QemuBuilder) encryptIgnitionConfig() error {
 	return nil
 }
 
-// MountVirtiofs sets up a mount point from the host to guest.
-// Note that virtiofs does not currently support read-only mounts (which is really surprising!)
+// MountHost sets up a mount point from the host to guest.
+// Note that virtiofs does not currently support read-only mounts (which is really surprising!).
+// We do mount it read-only by default in the guest, however.
 func (builder *QemuBuilder) MountHost(source, dest string, readonly bool) {
 	builder.hostMounts = append(builder.hostMounts, HostMount{src: source, dest: dest, readonly: readonly})
 }

--- a/src/buildextend-legacy-oscontainer.sh
+++ b/src/buildextend-legacy-oscontainer.sh
@@ -5,10 +5,6 @@ set -euo pipefail
 
 # Start VM and call buildah
 final_outfile=$(realpath "$1"); shift
-if [ "$(uname -m)" == 'ppc64le' ]; then
-    # helps with 9p 'cannot allocate memory' errors on ppc64le
-    COSA_SUPERMIN_MEMORY=6144
-fi
 IMAGE_TYPE=legacy-oscontainer
 prepare_build
 tmp_outfile=${tmp_builddir}/legacy-oscontainer.ociarchive

--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -171,7 +171,7 @@ if jq -re '.["deploy-via-container"]' < "${image_json}"; then
     deploy_via_container="true"
 fi
 container_imgref=$(jq -r '.["container-imgref"]//""' < "${image_json}")
-# Nowadays we pull the container across 9p rather than accessing the repo, see
+# Nowadays we pull the container across virtiofs rather than accessing the repo, see
 # https://github.com/openshift/os/issues/594
 ostree_container=ostree-unverified-image:oci-archive:$builddir/$(meta_key images.ostree.path)
 

--- a/src/cmd-run
+++ b/src/cmd-run
@@ -9,7 +9,7 @@ set -euo pipefail
 # You can exit via either exiting the login session cleanly
 # in SSH (ctrl-d/exit in bash), or via `poweroff`.
 #
-# If 9p is available and this is started from a coreos-assembler
+# If this is started from a coreos-assembler
 # working directory, the build directory will be mounted readonly
 # at /var/mnt/workdir, and the tmp/ directory will be read *write*
 # at /var/mnt/workdir-tmp.  This allows you to easily exchange

--- a/src/compose.sh
+++ b/src/compose.sh
@@ -9,14 +9,14 @@ composejson=cache/repo/compose.json
 rm -rf "${repo}"
 ostree init --repo="${repo}" --mode=archive-z2
 
-# we do need to pull at least the overlay bits over 9p, but it shouldn't be that
+# we do need to pull at least the overlay bits over virtiofs, but it shouldn't be that
 # many files
 ostree refs --repo tmp/repo overlay --list | \
     xargs -r ostree pull-local --repo "${repo}" tmp/repo
 # And import commit metadata for all refs; this will bring in the previous
 # build if there is one. Ideally, we'd import the SELinux policy too to take
 # advantage of https://github.com/coreos/rpm-ostree/pull/1704 but that's yet
-# more files over 9p and our pipelines don't have cache anyway (and devs likely
+# more files over virtiofs and our pipelines don't have cache anyway (and devs likely
 # use the privileged path).
 ostree refs --repo tmp/repo | \
     xargs -r ostree pull-local --commit-metadata-only --repo "${repo}" tmp/repo

--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -77,7 +77,7 @@ if [ -z "$platforms_json" ]; then
     echo "Missing --platforms-json" >&2
     exit 1
 fi
-# just copy it over to /tmp and work from there to minimize 9p I/O
+# just copy it over to /tmp and work from there to minimize virtiofs I/O
 cp "${platforms_json}" /tmp/platforms.json
 platforms_json=/tmp/platforms.json
 platform_grub_cmds=$(jq -r ".${arch}.${platform}.grub_commands // [] | join(\"\\\\n\")" < "${platforms_json}")

--- a/src/deps.txt
+++ b/src/deps.txt
@@ -29,7 +29,7 @@ genisoimage
 make git rpm-build
 
 # virt dependencies
-libguestfs-tools libguestfs-tools-c /usr/bin/qemu-img qemu-kvm swtpm
+libguestfs-tools libguestfs-tools-c virtiofsd /usr/bin/qemu-img qemu-kvm swtpm
 # And the main arch emulators for cross-arch testing
 qemu-system-aarch64-core qemu-system-ppc-core qemu-system-s390x-core qemu-system-x86-core
 

--- a/src/supermin-init-prelude.sh
+++ b/src/supermin-init-prelude.sh
@@ -15,8 +15,6 @@ mount -t tmpfs tmpfs /dev/shm
 # load selinux policy
 LANG=C /sbin/load_policy  -i
 
-# load kernel module for 9pnet_virtio for 9pfs mount
-/sbin/modprobe 9pnet_virtio
 
 # need fuse module for rofiles-fuse/bwrap during post scripts run
 /sbin/modprobe fuse
@@ -36,17 +34,16 @@ fi
 umask 002
 
 # set up workdir
-# For 9p mounts set msize to 100MiB
 # https://github.com/coreos/coreos-assembler/issues/2171
 mkdir -p "${workdir:?}"
-mount -t 9p -o rw,trans=virtio,version=9p2000.L,msize=10485760 workdir "${workdir}"
+mount -t virtiofs -o rw workdir "${workdir}"
 
 # This loop pairs with virtfs setups for qemu in cmdlib.sh.  Keep them in sync.
-for maybe_symlink in "${workdir}"/{src/config,src/yumrepos,builds}; do
+for maybe_symlink in "${workdir}"/{src/config,src/yumrepos}; do
     if [ -L "${maybe_symlink}" ]; then
         bn=$(basename "${maybe_symlink}")
         mkdir -p "$(readlink "${maybe_symlink}")"
-        mount -t 9p -o rw,trans=virtio,version=9p2000.L,msize=10485760 "${bn}" "${maybe_symlink}"
+        mount -t virtiofs -o ro "/cosa/src/${bn}" "${maybe_symlink}"
     fi
 done
 


### PR DESCRIPTION
qemu: Refactor memory to actually use memfd

The previous change here didn't break anything, but didn't
actually work for virtiofs because we need to actually reference
the device.  It appeared to work for me in local testing
because I accidentally duplicated the logic in the larger virtiofs
PR.

---

mantle/kola: Add `COSA_VIRTIOFS=1` and dual 9p/virtiofs support

In https://github.com/coreos/coreos-assembler/pull/3428 I tried
a wholesale switch to virtiofs.  That's a large change in one go;
it wasn't hard to factor things out so that it becomes a dynamic
choice, keeping the previous 9p support.

This way for e.g. local development one can now
`env COSA_VIRTIOFS=1 cosa run --qemu-image rhcos.qcow2 --bind-ro ...`

Further work can then build on this to switch to virtiofs by default,
and allow falling back to 9p.  Once we're confident in virtiofs
we can drop the 9p support.

---

Switch to virtiofs by default

Closes: https://github.com/coreos/coreos-assembler/issues/1812

The key benefits here are:

- This also works for RHEL (this is a *big deal* for my dev workflow
  parity)
- It correctly handles symlinks
- It's more maintained (e.g. used for kata containers) and hopefully
  we won't hit obscure bugs like the 9p OOM ones.

---

mantle: Drop 9p support

Per request to avoid carrying it as tech debt.

---

