### PR TITLE
cosalib/kubevirt: build the kubevirt ociarchive in supermin

### DIFF
--- a/src/cosalib/kubevirt.py
+++ b/src/cosalib/kubevirt.py
@@ -1,5 +1,4 @@
 import os
-import subprocess
 import logging as log
 
 from cosalib.cmdlib import (
@@ -42,41 +41,22 @@ class KubeVirtImage(QemuVariantImage):
 
 
 def kubevirt_run_ore(build, args):
-    if not args.repository:
-        raise Exception("--repository must not be empty")
-
-    name = f"{build.build_name}"
-    if args.name is not None:
-        name = args.name
-    tags = [f"{build.build_id}-{build.basearch}"]
-    if args.tag is not None:
-        tags.extend(args.tag)
-    full_name = os.path.join(args.repository, name)
-
-    digest = runcmd(["skopeo", "inspect", f"oci-archive:{build.image_path}", "-f", "{{.Digest}}"],
-                    stdout=subprocess.PIPE).stdout.decode("utf-8").strip()
-    for tag in tags:
-        log.info(f"pushing {full_name}:{tag} with digest {digest}")
-        runcmd(["skopeo", "copy", f"oci-archive:{build.image_path}", f"docker://{full_name}:{tag}"])
-
-    build.meta['kubevirt'] = {
-        'image': f"{full_name}@{digest}",
-    }
-    build.meta_write()
+    """
+    This function is not necessary for Kubevirt. We'll push the ociarchive
+    files using cosa push-container-manifest in the release job.
+    """
+    raise Exception("not implemented")
 
 
 def kubevirt_run_ore_replicate(*args, **kwargs):
-    print("""
-KubeVirt does not require regional replication. This command is a
-placeholder.
-""")
+    """
+    This function is not necessary for Kubevirt. We'll push the ociarchive
+    files using cosa push-container-manifest in the release job.
+    """
+    raise Exception("not implemented")
 
 
 def kubevirt_cli(parser):
-    parser.add_argument("--name",
-                        help="Name to append to the repository (e.g. fedora-coreos). Defaults to the build name.")
-    parser.add_argument("--repository", help="Repository to push to (e.g. quay.io or quay.io/myorg)")
-    parser.add_argument("--tag", action="append", help="Additional image tag. Can be provided multiple times.")
     return parser
 
 

--- a/src/cosalib/qemuvariants.py
+++ b/src/cosalib/qemuvariants.py
@@ -100,6 +100,7 @@ VARIANTS = {
         "image_format": "qcow2",
         "platform": "kubevirt",
         "image_suffix": "ociarchive",
+        "skip_compression": True,
     },
     "openstack": {
         "image_format": "qcow2",

--- a/src/runvm.sh
+++ b/src/runvm.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+
+# This script just loads cmdlib.sh and executes runvm() with the given
+# command line arguemnts to the script. It's used as a convenience
+# wrapper for calling into runvm from other languages (i.e. python).
+
+dn=$(dirname "$0")
+# shellcheck source=src/cmdlib.sh
+. "${dn}"/cmdlib.sh
+
+runvm "$@"


### PR DESCRIPTION
This should allow us to try to build kubevirt in the pipeline again (see https://github.com/coreos/fedora-coreos-pipeline/pull/846).

Also a few other fixes/cleanups in there.

```
commit aec4ea8ac6c210c4295ea364498e95b830265089
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Sat Apr 15 14:01:05 2023 -0400

    cosalib/kubevirt: build the kubevirt ociarchive in supermin
    
    Since our pipeline runs unprivileged in OpenShift it won't be able
    to do most "container" things, but we do have access to /dev/kvm
    so let's just run the `podman build` inside a supermin VM.

commit cf3f7727a2208650bc7287732ca0adb0633588ce
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Sat Apr 15 14:03:26 2023 -0400

    src: add runvm.sh
    
    This script just loads cmdlib.sh and executes runvm() with the given
    command line arguemnts to the script. It's used as a convenience
    wrapper for calling into runvm from other languages (i.e. python).

commit bca8ba027b00ab2ce35269eb5600c82041434238
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Sat Apr 15 13:59:00 2023 -0400

    cosalib/kubevirt: drop container pushing code
    
    We already have `cosa push-container-manifest` that handles container pushes
    and the release job in our pipeline already knows how to use it. Let's drop
    the code here that tries to do the same thing.

commit f122f31cbf843f85ce72d86f3b929bbb505f6535
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Sat Apr 15 09:53:25 2023 -0400

    cosalib/qemuvariants: set skip_compression=True for kubevirt
    
    We don't want the ociarchive file to be compressed again.

```