### PR TITLE
platform/metal: set serial console in PXE and ISO tests

### DIFF
--- a/mantle/platform/metal.go
+++ b/mantle/platform/metal.go
@@ -47,7 +47,7 @@ var baseKargs = []string{"rd.neednet=1", "ip=dhcp", "ignition.firstboot", "ignit
 var (
 	// TODO expose this as an API that can be used by cosa too
 	consoleKernelArgument = map[string]string{
-		"x86_64":  "ttyS0",
+		"x86_64":  "ttyS0,115200n8",
 		"ppc64le": "hvc0",
 		"aarch64": "ttyAMA0",
 		"s390x":   "ttysclp0",

--- a/mantle/platform/metal.go
+++ b/mantle/platform/metal.go
@@ -122,6 +122,17 @@ func (inst *Install) PXE(kargs []string, liveIgnition, ignition conf.Conf, offli
 		return nil, err
 	}
 
+	installerConfig := installerConfig{
+		Console: []string{consoleKernelArgument[coreosarch.CurrentRpmArch()]},
+	}
+	installerConfigData, err := yaml.Marshal(installerConfig)
+	if err != nil {
+		return nil, err
+	}
+	mode := 0644
+
+	liveIgnition.AddFile("/etc/coreos/installer.d/mantle.yaml", string(installerConfigData), mode)
+
 	inst.kargs = kargs
 	inst.ignition = ignition
 	inst.liveIgnition = liveIgnition
@@ -564,7 +575,8 @@ type installerConfig struct {
 	Insecure     bool     `yaml:",omitempty"`
 	AppendKargs  []string `yaml:"append-karg,omitempty"`
 	CopyNetwork  bool     `yaml:"copy-network,omitempty"`
-	DestDevice   string   `yaml:"dest-device"`
+	DestDevice   string   `yaml:"dest-device,omitempty"`
+	Console      []string `yaml:"console,omitempty"`
 }
 
 func (inst *Install) InstallViaISOEmbed(kargs []string, liveIgnition, targetIgnition conf.Conf, outdir string, offline, minimal bool) (*InstalledMachine, error) {
@@ -592,6 +604,7 @@ func (inst *Install) InstallViaISOEmbed(kargs []string, liveIgnition, targetIgni
 	installerConfig := installerConfig{
 		IgnitionFile: "/var/opt/pointer.ign",
 		DestDevice:   "/dev/vda",
+		Console:      []string{consoleKernelArgument[coreosarch.CurrentRpmArch()]},
 	}
 
 	if inst.MultiPathDisk {

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -37,10 +37,10 @@ arch=$(uname -m)
 export arch
 
 case $arch in
-    "x86_64")  DEFAULT_TERMINAL="ttyS0"   ;;
-    "ppc64le") DEFAULT_TERMINAL="hvc0"    ;;
-    "aarch64") DEFAULT_TERMINAL="ttyAMA0" ;;
-    "s390x")   DEFAULT_TERMINAL="ttysclp0";;
+    "x86_64")  DEFAULT_TERMINAL="ttyS0,115200n8" ;;
+    "ppc64le") DEFAULT_TERMINAL="hvc0"           ;;
+    "aarch64") DEFAULT_TERMINAL="ttyAMA0"        ;;
+    "s390x")   DEFAULT_TERMINAL="ttysclp0"       ;;
     *)         fatal "Architecture ${arch} not supported"
 esac
 export DEFAULT_TERMINAL


### PR DESCRIPTION
In both PXE and ISO tests, we aren't modifying the console settings of
the installed system. This means that the `console.txt` artifact doesn't
contain any data from the installed system when we reboot into it. This
makes debugging failing tests harder.

In ISO tests, we were already dropping a `installer.d/mantle.yaml` file
to customize the install. Extend the file to also include a `console`
key.

In PXE tests, we drive coreos-installer from the `coreos.inst.*` kargs.
There is no way to tell coreos-installer to use a specific console
setting from just kargs, so drop an `installer.d/mantle.yaml` file
containing just the `console` key.