### PR TITLE
OCPBUGS-11574: s390x/Secure Execution: Set swiotlb to recommended value

### DIFF
--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -611,11 +611,12 @@ if [[ ${secure_execution} -eq 1 ]]; then
         rdcore_zipl_args+=("--secex-mode=enforce" "--hostkey=/dev/disk/by-id/virtio-hostkey")
         rdcore_zipl_args+=("--append-karg=rootfs.roothash=$(cat /tmp/root-roothash)")
         rdcore_zipl_args+=("--append-karg=bootfs.roothash=$(cat /tmp/boot-roothash)")
+        rdcore_zipl_args+=("--append-karg=swiotlb=262144")
         rdcore_zipl_args+=("--append-file=/usr/lib/coreos/ignition.asc")
         chroot_run /usr/lib/dracut/modules.d/50rdcore/rdcore zipl "${rdcore_zipl_args[@]}"
     else
         echo "Building release Secure Execution Image, zipl and genprotimg will be run later"
-        rdcore_replacement "rootfs.roothash=$(cat /tmp/root-roothash)" "bootfs.roothash=$(cat /tmp/boot-roothash)"
+        rdcore_replacement "rootfs.roothash=$(cat /tmp/root-roothash)" "bootfs.roothash=$(cat /tmp/boot-roothash)" "swiotlb=262144"
     fi
 
     # unmount and close everything


### PR DESCRIPTION
The recommended value for swiotlob is swiotlb=262144. Set the value in the kernel cmdline during image creation.

This fixes https://issues.redhat.com/browse/OCPBUGS-11574