### PR TITLE
platform/metal: don't set `console` key on s390x

### DIFF
--- a/mantle/platform/metal.go
+++ b/mantle/platform/metal.go
@@ -131,7 +131,10 @@ func (inst *Install) PXE(kargs []string, liveIgnition, ignition conf.Conf, offli
 	}
 	mode := 0644
 
-	liveIgnition.AddFile("/etc/coreos/installer.d/mantle.yaml", string(installerConfigData), mode)
+	// XXX: https://github.com/coreos/coreos-installer/issues/1171
+	if coreosarch.CurrentRpmArch() != "s390x" {
+		liveIgnition.AddFile("/etc/coreos/installer.d/mantle.yaml", string(installerConfigData), mode)
+	}
 
 	inst.kargs = kargs
 	inst.ignition = ignition
@@ -604,7 +607,11 @@ func (inst *Install) InstallViaISOEmbed(kargs []string, liveIgnition, targetIgni
 	installerConfig := installerConfig{
 		IgnitionFile: "/var/opt/pointer.ign",
 		DestDevice:   "/dev/vda",
-		Console:      []string{consoleKernelArgument[coreosarch.CurrentRpmArch()]},
+	}
+
+	// XXX: https://github.com/coreos/coreos-installer/issues/1171
+	if coreosarch.CurrentRpmArch() != "s390x" {
+		installerConfig.Console = []string{consoleKernelArgument[coreosarch.CurrentRpmArch()]}
 	}
 
 	if inst.MultiPathDisk {


### PR DESCRIPTION
Otherwise, coreos-installer will look for a GRUB config even though
one does not exist.[[1]] Anyway, it seems like we don't need to change
anything on s390x since looking at the testiso logs, one can see that
`console.txt` does contain all the logs already. So don't even bother
setting a karg instead.

Follow-up to 694f96fd8 ("platform/metal: set serial console in PXE and
ISO tests").

[1]: https://github.com/coreos/coreos-installer/issues/1171