### PR TITLE
kola: enable --kargs and --firstbootkargs to work on s390x

### DIFF
--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -898,7 +898,7 @@ func setupPreboot(arch, confPath, firstbootkargs, kargs string, diskImagePath st
 
 	// See /boot/grub2/grub.cfg
 	if firstbootkargs != "" {
-		grubStr := fmt.Sprintf("set ignition_network_kcmdline='%s'\n", firstbootkargs)
+		grubStr := fmt.Sprintf("set ignition_network_kcmdline=\"%s\"\n", firstbootkargs)
 		if err := exec.Command("guestfish", gf.remote, "write", "/boot/ignition.firstboot", grubStr).Run(); err != nil {
 			return errors.Wrapf(err, "guestfish write")
 		}


### PR DESCRIPTION
Now user can inject kargs:
```
cosa kola qemuexec --firstbootkargs foo --kargs boo
```

https://github.com/coreos/coreos-assembler/issues/2776
