### PR TITLE
cmd-sign: set priority level on Robosignatory fedmsg

### DIFF
--- a/src/cmd-sign
+++ b/src/cmd-sign
@@ -30,6 +30,9 @@ from gi.repository import GLib, Gio, OSTree
 # this is really the worst case scenario, it's usually pretty fast otherwise
 ROBOSIGNATORY_REQUEST_TIMEOUT_SEC = 60 * 60
 
+# https://pagure.io/fedora-infrastructure/issue/10899#comment-854645
+ROBOSIGNATORY_MESSAGE_PRIORITY = 4
+
 fedenv = 'prod'
 
 
@@ -123,6 +126,7 @@ def robosign_ostree(args, s3, build, gpgkey):
         request_type='ostree-sign',
         config=args.fedmsg_conf,
         request_timeout=ROBOSIGNATORY_REQUEST_TIMEOUT_SEC,
+        priority=ROBOSIGNATORY_MESSAGE_PRIORITY,
         environment=fedenv,
         body={
             'build_id': args.build,
@@ -215,6 +219,7 @@ def robosign_images(args, s3, build, gpgkey):
         request_type='artifacts-sign',
         config=args.fedmsg_conf,
         request_timeout=ROBOSIGNATORY_REQUEST_TIMEOUT_SEC,
+        priority=ROBOSIGNATORY_MESSAGE_PRIORITY,
         environment=fedenv,
         body={
             'build_id': args.build,


### PR DESCRIPTION
There is work in Fedora infra[[1]] to use a Robosignatory queue that supports priority levels so that e.g. our artifact signing messages are handled before RPM signing of mass rebuilds.

Start setting a priority level. Set it to 4 as proposed.[[2]]

[1]: https://pagure.io/fedora-infrastructure/issue/10899
[2]: https://pagure.io/fedora-infrastructure/issue/10899#comment-854645