### PR TITLE
cosalib/qemuvariants: fix compression skipping for kubevirt

### DIFF
--- a/src/cosalib/qemuvariants.py
+++ b/src/cosalib/qemuvariants.py
@@ -101,7 +101,7 @@ VARIANTS = {
         "image_format": "qcow2",
         "platform": "kubevirt",
         "image_suffix": "ociarchive",
-        "skip_compression": True,
+        "compression": "skip",
     },
     "openstack": {
         "image_format": "qcow2",


### PR DESCRIPTION
This is a fixup to 91f478e. Given this it looks like I didn't test the last change, but I swear I did. Must have been an invalid test.