### PR TITLE
[4.12] kola: support tags for --allow-rerun-success

### DIFF
--- a/mantle/cmd/kola/kola.go
+++ b/mantle/cmd/kola/kola.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strings"
 	"text/tabwriter"
 	"time"
 
@@ -127,7 +128,7 @@ This can be useful for e.g. serving locally built OSTree repos to qemu.
 	runExternals      []string
 	runMultiply       int
 	runRerunFlag      bool
-	allowRerunSuccess bool
+	allowRerunSuccess string
 
 	nonexclusiveWrapperMatch = regexp.MustCompile(`^non-exclusive-test-bucket-[0-9]$`)
 )
@@ -137,7 +138,7 @@ func init() {
 	cmdRun.Flags().StringArrayVarP(&runExternals, "exttest", "E", nil, "Externally defined tests (will be found in DIR/tests/kola)")
 	cmdRun.Flags().IntVar(&runMultiply, "multiply", 0, "Run the provided tests N times (useful to find race conditions)")
 	cmdRun.Flags().BoolVar(&runRerunFlag, "rerun", false, "re-run failed tests once")
-	cmdRun.Flags().BoolVar(&allowRerunSuccess, "allow-rerun-success", false, "Allow kola test run to be successful when tests pass during re-run")
+	cmdRun.Flags().StringVar(&allowRerunSuccess, "allow-rerun-success", "", "Allow kola test run to be successful when tests with given 'tags=...[,...]' pass during re-run")
 
 	root.AddCommand(cmdList)
 	cmdList.Flags().StringArrayVarP(&runExternals, "exttest", "E", nil, "Externally defined tests in directory")
@@ -238,6 +239,27 @@ func runRerun(cmd *cobra.Command, args []string) error {
 	return kolaRunPatterns(patterns, false)
 }
 
+// parseRerunSuccess converts rerun specification into a tags
+func parseRerunSuccess() ([]string, error) {
+	// In the future we may extend format to something like: <SELECTOR>[:<OPTIONS>]
+	//   SELECTOR
+	//     tags=...,...,...
+	//     tests=...,...,...
+	//   OPTIONS
+	//     n=...
+	//     allow-single=..
+	tags := []string{}
+	if len(allowRerunSuccess) == 0 {
+		return tags, nil
+	}
+	if !strings.HasPrefix(allowRerunSuccess, "tags=") {
+		return nil, fmt.Errorf("invalid rerun spec %s", allowRerunSuccess)
+	}
+	split := strings.TrimPrefix(allowRerunSuccess, "tags=")
+	tags = append(tags, strings.Split(split, ",")...)
+	return tags, nil
+}
+
 func kolaRunPatterns(patterns []string, rerun bool) error {
 	var err error
 	outputDir, err = kola.SetupOutputDir(outputDir, kolaPlatform)
@@ -249,7 +271,12 @@ func kolaRunPatterns(patterns []string, rerun bool) error {
 		return err
 	}
 
-	runErr := kola.RunTests(patterns, runMultiply, rerun, allowRerunSuccess, kolaPlatform, outputDir, !kola.Options.NoTestExitError)
+	rerunSuccessTags, err := parseRerunSuccess()
+	if err != nil {
+		return err
+	}
+
+	runErr := kola.RunTests(patterns, runMultiply, rerun, rerunSuccessTags, kolaPlatform, outputDir, !kola.Options.NoTestExitError)
 
 	// needs to be after RunTests() because harness empties the directory
 	if err := writeProps(); err != nil {

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -642,7 +642,7 @@ func filterTests(tests map[string]*register.Test, patterns []string, pltfrm stri
 // register tests in their init() function.  outputDir is where various test
 // logs and data will be written for analysis after the test run. If it already
 // exists it will be erased!
-func runProvidedTests(testsBank map[string]*register.Test, patterns []string, multiply int, rerun bool, allowRerunSuccess bool, pltfrm, outputDir string, propagateTestErrors bool) error {
+func runProvidedTests(testsBank map[string]*register.Test, patterns []string, multiply int, rerun bool, rerunSuccessTags []string, pltfrm, outputDir string, propagateTestErrors bool) error {
 	var versionStr string
 
 	// Avoid incurring cost of starting machine in getClusterSemver when
@@ -782,14 +782,46 @@ func runProvidedTests(testsBank map[string]*register.Test, patterns []string, mu
 	if len(testsToRerun) > 0 && rerun {
 		newOutputDir := filepath.Join(outputDir, "rerun")
 		fmt.Printf("\n\n======== Re-running failed tests (flake detection) ========\n\n")
-		reRunErr := runProvidedTests(testsBank, testsToRerun, multiply, false, allowRerunSuccess, pltfrm, newOutputDir, propagateTestErrors)
-		if allowRerunSuccess {
+		reRunErr := runProvidedTests(testsBank, testsToRerun, multiply, false, rerunSuccessTags, pltfrm, newOutputDir, propagateTestErrors)
+
+		// Return the results from the rerun if rerun success allowed
+		if allTestsAllowRerunSuccess(testsBank, testsToRerun, rerunSuccessTags) {
 			return reRunErr
 		}
 	}
-
 	// If the intial run failed and the rerun passed, we still return an error
 	return firstRunErr
+}
+
+func allTestsAllowRerunSuccess(testsBank map[string]*register.Test, testsToRerun, rerunSuccessTags []string) bool {
+	// No tags, we can return early
+	if len(rerunSuccessTags) == 0 {
+		return false
+	}
+	// Build up a map of rerunSuccessTags so that we can easily check
+	// if a given tag is in the map.
+	rerunSuccessTagMap := make(map[string]bool)
+	for _, tag := range rerunSuccessTags {
+		if tag == "all" || tag == "*" {
+			// If `all` or `*` is in rerunSuccessTags then we can return early
+			return true
+		}
+		rerunSuccessTagMap[tag] = true
+	}
+	// Iterate over the tests that were re-ran. If any of them don't
+	// allow rerun success then just exit early.
+	for _, test := range testsToRerun {
+		testAllowsRerunSuccess := false
+		for _, tag := range testsBank[test].Tags {
+			if rerunSuccessTagMap[tag] {
+				testAllowsRerunSuccess = true
+			}
+		}
+		if !testAllowsRerunSuccess {
+			return false
+		}
+	}
+	return true
 }
 
 func GetRerunnableTestName(testName string) (string, bool) {
@@ -837,12 +869,12 @@ func getRerunnable(tests []*harness.H) []string {
 	return testsToRerun
 }
 
-func RunTests(patterns []string, multiply int, rerun bool, allowRerunSuccess bool, pltfrm, outputDir string, propagateTestErrors bool) error {
-	return runProvidedTests(register.Tests, patterns, multiply, rerun, allowRerunSuccess, pltfrm, outputDir, propagateTestErrors)
+func RunTests(patterns []string, multiply int, rerun bool, rerunSuccessTags []string, pltfrm, outputDir string, propagateTestErrors bool) error {
+	return runProvidedTests(register.Tests, patterns, multiply, rerun, rerunSuccessTags, pltfrm, outputDir, propagateTestErrors)
 }
 
 func RunUpgradeTests(patterns []string, rerun bool, pltfrm, outputDir string, propagateTestErrors bool) error {
-	return runProvidedTests(register.UpgradeTests, patterns, 0, rerun, false, pltfrm, outputDir, propagateTestErrors)
+	return runProvidedTests(register.UpgradeTests, patterns, 0, rerun, nil, pltfrm, outputDir, propagateTestErrors)
 }
 
 // externalTestMeta is parsed from kola.json in external tests

--- a/src/cmd-build
+++ b/src/cmd-build
@@ -104,7 +104,6 @@ while true; do
             ;;
         -*)
             fatal "$0: unrecognized option: $1"
-            exit 1
             ;;
         *)
             break

--- a/src/cmd-build-fast
+++ b/src/cmd-build-fast
@@ -47,7 +47,6 @@ while true; do
             ;;
         -*)
             fatal "$0: unrecognized option: $1"
-            exit 1
             ;;
         *)
             break

--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -72,7 +72,6 @@ while true; do
             ;;
         -*)
             fatal "$0: unrecognized option: $1"
-            exit 1
             ;;
         *)
             break

--- a/src/cmd-fetch
+++ b/src/cmd-fetch
@@ -71,7 +71,6 @@ while true; do
             ;;
         *)
             fatal "$0: unrecognized option: $1"
-            exit 1
             ;;
     esac
     shift
@@ -80,7 +79,6 @@ done
 if [ $# -ne 0 ]; then
     print_help
     fatal "ERROR: Too many arguments"
-    exit 1
 fi
 
 prepare_build

--- a/src/cmd-init
+++ b/src/cmd-init
@@ -125,7 +125,6 @@ while true; do
     *)
         print_help
         fatal "init: unrecognized option: $1"
-        exit 1
         ;;
     esac
     shift
@@ -135,7 +134,6 @@ done
 if [ $# -ne 1 ]; then
     print_help
     fatal "ERROR: Missing GITCONFIG"
-    exit 1
 fi
 
 # If the current working dir is not empty then error out

--- a/src/cmd-offline-update
+++ b/src/cmd-offline-update
@@ -57,7 +57,6 @@ while true; do
             ;;
         -*)
             fatal "$0: unrecognized option: $1"
-            exit 1
             ;;
         *)
             break

--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -525,9 +525,9 @@ chattr +i $rootfs
 fstrim -a -v
 # Ensure the filesystem journals are flushed
 for fs in $rootfs/boot $rootfs; do
-    mount -o remount,ro $fs
-    xfs_freeze -f $fs
-    xfs_freeze -u $fs
+    mount -o remount,ro "$fs"
+    xfs_freeze -f "$fs"
+    xfs_freeze -u "$fs"
 done
 
 umount -R $rootfs


### PR DESCRIPTION
New format is:
```
--allow-rerun-success tags=tag1[,tag2]
```

To allow all tests simply:
```
--allow-rerun-success tags=all
```

Co-authored-by: Dusty Mabe <dusty@dustymabe.com>

Issue: https://github.com/coreos/fedora-coreos-pipeline/issues/842 
(cherry picked from commit 864cece33f7ad2287f2dd2a1d7639fcf6a3efbbe)