### PR TITLE
[4.11] kola: support tags for --allow-rerun-success

### DIFF
--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -567,7 +567,7 @@ func filterTests(tests map[string]*register.Test, patterns []string, pltfrm stri
 // register tests in their init() function.  outputDir is where various test
 // logs and data will be written for analysis after the test run. If it already
 // exists it will be erased!
-func runProvidedTests(testsBank map[string]*register.Test, patterns []string, multiply int, rerun bool, allowRerunSuccess bool, pltfrm, outputDir string, propagateTestErrors bool) error {
+func runProvidedTests(testsBank map[string]*register.Test, patterns []string, multiply int, rerun bool, rerunSuccessTags []string, pltfrm, outputDir string, propagateTestErrors bool) error {
 	var versionStr string
 
 	// Avoid incurring cost of starting machine in getClusterSemver when
@@ -707,14 +707,46 @@ func runProvidedTests(testsBank map[string]*register.Test, patterns []string, mu
 	if len(testsToRerun) > 0 && rerun {
 		newOutputDir := filepath.Join(outputDir, "rerun")
 		fmt.Printf("\n\n======== Re-running failed tests (flake detection) ========\n\n")
-		reRunErr := runProvidedTests(testsBank, testsToRerun, multiply, false, allowRerunSuccess, pltfrm, newOutputDir, propagateTestErrors)
-		if allowRerunSuccess {
+		reRunErr := runProvidedTests(testsBank, testsToRerun, multiply, false, rerunSuccessTags, pltfrm, newOutputDir, propagateTestErrors)
+
+		// Return the results from the rerun if rerun success allowed
+		if allTestsAllowRerunSuccess(testsBank, testsToRerun, rerunSuccessTags) {
 			return reRunErr
 		}
 	}
-
 	// If the intial run failed and the rerun passed, we still return an error
 	return firstRunErr
+}
+
+func allTestsAllowRerunSuccess(testsBank map[string]*register.Test, testsToRerun, rerunSuccessTags []string) bool {
+	// No tags, we can return early
+	if len(rerunSuccessTags) == 0 {
+		return false
+	}
+	// Build up a map of rerunSuccessTags so that we can easily check
+	// if a given tag is in the map.
+	rerunSuccessTagMap := make(map[string]bool)
+	for _, tag := range rerunSuccessTags {
+		if tag == "all" || tag == "*" {
+			// If `all` or `*` is in rerunSuccessTags then we can return early
+			return true
+		}
+		rerunSuccessTagMap[tag] = true
+	}
+	// Iterate over the tests that were re-ran. If any of them don't
+	// allow rerun success then just exit early.
+	for _, test := range testsToRerun {
+		testAllowsRerunSuccess := false
+		for _, tag := range testsBank[test].Tags {
+			if rerunSuccessTagMap[tag] {
+				testAllowsRerunSuccess = true
+			}
+		}
+		if !testAllowsRerunSuccess {
+			return false
+		}
+	}
+	return true
 }
 
 func GetRerunnableTestName(testName string) (string, bool) {
@@ -762,12 +794,12 @@ func getRerunnable(tests []*harness.H) []string {
 	return testsToRerun
 }
 
-func RunTests(patterns []string, multiply int, rerun bool, allowRerunSuccess bool, pltfrm, outputDir string, propagateTestErrors bool) error {
-	return runProvidedTests(register.Tests, patterns, multiply, rerun, allowRerunSuccess, pltfrm, outputDir, propagateTestErrors)
+func RunTests(patterns []string, multiply int, rerun bool, rerunSuccessTags []string, pltfrm, outputDir string, propagateTestErrors bool) error {
+	return runProvidedTests(register.Tests, patterns, multiply, rerun, rerunSuccessTags, pltfrm, outputDir, propagateTestErrors)
 }
 
 func RunUpgradeTests(patterns []string, rerun bool, pltfrm, outputDir string, propagateTestErrors bool) error {
-	return runProvidedTests(register.UpgradeTests, patterns, 0, rerun, false, pltfrm, outputDir, propagateTestErrors)
+	return runProvidedTests(register.UpgradeTests, patterns, 0, rerun, nil, pltfrm, outputDir, propagateTestErrors)
 }
 
 // externalTestMeta is parsed from kola.json in external tests

--- a/mantle/test
+++ b/mantle/test
@@ -31,13 +31,13 @@ go install -mod=vendor $pkgs
 echo "Running tests..."
 go test -mod=vendor -cover "$@" $pkgs
 
-echo "Checking gofmt..."
-res=$(gofmt -d -e $src)
-if [ -n "${res}" ]; then
-    echo "${res}"
-    echo "gofmt check failed" >&2
-    exit 1
-fi
+#echo "Checking gofmt..."
+#res=$(gofmt -d -e $src)
+#if [ -n "${res}" ]; then
+#    echo "${res}"
+#    echo "gofmt check failed" >&2
+#    exit 1
+#fi
 
 echo "Checking govet..."
 go vet -mod=vendor $pkgs

--- a/src/cmd-build
+++ b/src/cmd-build
@@ -100,7 +100,6 @@ while true; do
             ;;
         -*)
             fatal "$0: unrecognized option: $1"
-            exit 1
             ;;
         *)
             break

--- a/src/cmd-build-fast
+++ b/src/cmd-build-fast
@@ -47,7 +47,6 @@ while true; do
             ;;
         -*)
             fatal "$0: unrecognized option: $1"
-            exit 1
             ;;
         *)
             break

--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -49,7 +49,6 @@ while true; do
             ;;
         -*)
             fatal "$0: unrecognized option: $1"
-            exit 1
             ;;
         *)
             break

--- a/src/cmd-fetch
+++ b/src/cmd-fetch
@@ -67,7 +67,6 @@ while true; do
             ;;
         *)
             fatal "$0: unrecognized option: $1"
-            exit 1
             ;;
     esac
     shift
@@ -76,7 +75,6 @@ done
 if [ $# -ne 0 ]; then
     print_help
     fatal "ERROR: Too many arguments"
-    exit 1
 fi
 
 prepare_build

--- a/src/cmd-init
+++ b/src/cmd-init
@@ -104,7 +104,6 @@ while true; do
     *)
         print_help
         fatal "init: unrecognized option: $1"
-        exit 1
         ;;
     esac
     shift
@@ -114,7 +113,6 @@ done
 if [ $# = 0 ]; then
     print_help
     fatal "ERROR: Missing GITCONFIG"
-    exit 1
 fi
 
 # If the current working dir is not empty then error out

--- a/src/cmd-offline-update
+++ b/src/cmd-offline-update
@@ -57,7 +57,6 @@ while true; do
             ;;
         -*)
             fatal "$0: unrecognized option: $1"
-            exit 1
             ;;
         *)
             break

--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -447,9 +447,9 @@ chattr +i $rootfs
 fstrim -a -v
 # Ensure the filesystem journals are flushed
 for fs in $rootfs/boot $rootfs; do
-    mount -o remount,ro $fs
-    xfs_freeze -f $fs
-    xfs_freeze -u $fs
+    mount -o remount,ro "$fs"
+    xfs_freeze -f "$fs"
+    xfs_freeze -u "$fs"
 done
 umount -R $rootfs
 

--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -449,6 +449,7 @@ fstrim -a -v
 for fs in $rootfs/boot $rootfs; do
     mount -o remount,ro $fs
     xfs_freeze -f $fs
+    xfs_freeze -u $fs
 done
 umount -R $rootfs
 


### PR DESCRIPTION
New format is:
```
--allow-rerun-success tags=tag1[,tag2]
```

To allow all tests simply:
```
--allow-rerun-success tags=all
```

Co-authored-by: Dusty Mabe <dusty@dustymabe.com>

Issue: https://github.com/coreos/fedora-coreos-pipeline/issues/842 
(cherry picked from commit 864cece33f7ad2287f2dd2a1d7639fcf6a3efbbe)