### PR TITLE
src/cmd-push-container-manifest: fix allowing for missing architectures

### DIFF
--- a/src/cmd-push-container-manifest
+++ b/src/cmd-push-container-manifest
@@ -69,7 +69,7 @@ def main():
             builddir = builds.get_build_dir(build_id=args.build, basearch=arch)
             buildmeta = GenericBuildMeta(build=args.build, basearch=arch,
                                          workdir=os.path.abspath(os.getcwd()))
-            if not buildmeta['images'][args.artifact]:
+            if not buildmeta['images'].get(args.artifact):
                 print(f"No artifact {args.artifact} in {args.build}/{arch}")
                 if allow_missing_arches:
                     continue


### PR DESCRIPTION
We need to use .get() here because if the key doesn't exist (which is what we are checking for) then we'll get a KeyError. Fixes a8bfe8f.