### PR TITLE
[4.9] kola: add stub for '--allow-rerun-success <string>'

### DIFF
--- a/mantle/cmd/kola/kola.go
+++ b/mantle/cmd/kola/kola.go
@@ -106,6 +106,7 @@ This can be useful for e.g. serving locally built OSTree repos to qemu.
 	runExternals []string
 	runMultiply  int
 	runRerunFlag bool
+	_stub        string
 )
 
 func init() {
@@ -113,6 +114,7 @@ func init() {
 	cmdRun.Flags().StringArrayVarP(&runExternals, "exttest", "E", nil, "Externally defined tests (will be found in DIR/tests/kola)")
 	cmdRun.Flags().IntVar(&runMultiply, "multiply", 0, "Run the provided tests N times (useful to find race conditions)")
 	cmdRun.Flags().BoolVar(&runRerunFlag, "rerun", false, "re-run failed tests once")
+	cmdRun.Flags().StringVar(&_stub, "allow-rerun-success", "", "stub added for compatibility with pipeline")
 
 	root.AddCommand(cmdList)
 	cmdList.Flags().StringArrayVarP(&runExternals, "exttest", "E", nil, "Externally defined tests in directory")


### PR DESCRIPTION
Future cosa releases support this option. For older releases it's error-prone to backport the feature, so just add a stub.

(cherry picked from commit e6f70bb8b67639a7c5cc117933e8ee663ff01aa4)