### PR TITLE
cosalib/kubevirt: add the version=buildID label to the kubevirt ociarchive

### DIFF
--- a/src/cosalib/kubevirt.py
+++ b/src/cosalib/kubevirt.py
@@ -37,6 +37,7 @@ class KubeVirtImage(QemuVariantImage):
                 '-chardev', f'file,id=ociarchiveout,path={final_img}',
                 '-device', 'virtserialport,chardev=ociarchiveout,name=ociarchiveout',
                 '--', 'podman', 'build', '--disable-compression=false',
+                '--label', f'version={self.build_id}',
                 '--tag=oci-archive:/dev/virtio-ports/ociarchiveout', ctxdir])
 
 


### PR DESCRIPTION
Downstream RHCOS tooling uses this and it's probably a good idea to have it anyway.