### PR TITLE
Support `cosa build` on RISCV64

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -41,6 +41,8 @@ case $arch in
     "ppc64le") DEFAULT_TERMINAL="hvc0"           ;;
     "aarch64") DEFAULT_TERMINAL="ttyAMA0"        ;;
     "s390x")   DEFAULT_TERMINAL="ttysclp0"       ;;
+    # minimal support; the rest of cosa isn't yet riscv64-aware
+    "riscv64") DEFAULT_TERMINAL="ttyS0"          ;;
     *)         fatal "Architecture ${arch} not supported"
 esac
 export DEFAULT_TERMINAL


### PR DESCRIPTION
# Feature Request #

## Issue
[#3460](https://github.com/coreos/coreos-assembler/issues/3460)

## Motivation and Context
Enable RISCV64 architecture in dependencies in order to build coreos on RISCV64 CPU.

## How to test this PR?
Compile and run the test suite against a native RISCV64 board. Luckily, I have a board provided by RiscV International for qualification.