### PR TITLE
cmd-generate-release-meta: fix kubevirt object in release metadata

### DIFF
--- a/src/cmd-generate-release-meta
+++ b/src/cmd-generate-release-meta
@@ -91,6 +91,18 @@ if os.path.exists(args.output) and os.stat(args.output).st_size > 0:
         print(f"Using existing release file {args.output}")
 
 
+def get_floating_tag(rel, tags):
+    found = ""
+    for tag in tags:
+        if rel not in tag:
+            if found != "":
+                raise f"multiple floating tags within: {tags}"
+            found = tag
+    if found == "":
+        raise f"failed to find floating tag within: {tags}"
+    return found
+
+
 # Append the coreos-assembler build json `input_` to `out`, the target release stream.
 def append_build(out, input_):
     arch = input_.get("coreos-assembler.basearch")
@@ -170,7 +182,11 @@ def append_build(out, input_):
     # KubeVirt specific additions: https://github.com/coreos/stream-metadata-go/pull/41
     if input_.get("kubevirt", None) is not None:
         arch_dict["media"].setdefault("kubevirt", {}).setdefault("image", {})
-        arch_dict["media"]["kubevirt"]["image"].update(input_.get("kubevirt", {}))
+        tag = get_floating_tag(input_["buildid"], input_["kubevirt"]["tags"])
+        arch_dict["media"]["kubevirt"]["image"] = {
+            "image": input_["kubevirt"]["image"] + f":{tag}",
+            "digest-ref": input_["kubevirt"]["image"] + "@" + input_["kubevirt"]["digest"],
+        }
 
     # Azure: https://github.com/coreos/stream-metadata-go/issues/13
     inputaz = input_.get("azure")


### PR DESCRIPTION
We're not currently setting all the fields of the `kubevirt` image in release metadata. Notably as per earlier discussions[[1]][[2]], we want the `image` field to use a floating tag and the `digest-ref` field to use a digest pullspec.

Determining the floating tag to use is a bit hacky right now, but safe: we find in the list of pushed tags the one which doesn't have a build ID reference to it. If we find multiple, we fail. In the future, we'll probably want to strengthen this to be more explicit.

[1]: https://github.com/coreos/stream-metadata-go/pull/46
[2]: https://github.com/coreos/fedora-coreos-tracker/pull/1172

Closes: #3456