### PR TITLE
cmd-init: run `git submodule update` when `--commit` is used

### DIFF
--- a/src/cmd-init
+++ b/src/cmd-init
@@ -169,6 +169,7 @@ mkdir -p src
             if [ -n "${COMMIT}" ]; then
                 git -C ./config fetch origin "$COMMIT"
                 git -C ./config reset --hard "$COMMIT"
+                git -C ./config submodule update --init --recursive
             fi
             (set +x; cd config && echo -n "Config commit: " && git describe --tags --always --abbrev=42)
             ;;


### PR DESCRIPTION
When building RHCOS, we first build for x86_64 on the latest commit
available on the stream's branch. When we trigger builds for other
arches, we want to make sure the same commit of the src config is used,
so we pass `--commit`.

However, `--commit` doesn't reset git submodule, so there's a race
condition where if a submodule bump landed between the x86_64 build and
the multi-arch builds, we would use the latest submodule, rather than
the older one.

Run `git submodule update` to fix this race.

