### PR TITLE
gcp: add `--confidential-vm` option to support confidential vm

### DIFF
--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -123,6 +123,7 @@ func init() {
 	sv(&kola.GCPOptions.ServiceAcct, "gcp-service-account", "", "GCP service account to attach to instance (default project default)")
 	bv(&kola.GCPOptions.ServiceAuth, "gcp-service-auth", false, "for non-interactive auth when running within GCP")
 	sv(&kola.GCPOptions.JSONKeyFile, "gcp-json-key", "", "use a service account's JSON key for authentication (default \"~/"+auth.GCPConfigPath+"\")")
+	bv(&kola.GCPOptions.Confidential, "gcp-confidential-vm", false, "create confidential instances")
 
 	// openstack-specific options
 	sv(&kola.OpenStackOptions.ConfigPath, "openstack-config-file", "", "Path to a clouds.yaml formatted OpenStack config file. The underlying library defaults to ./clouds.yaml")

--- a/mantle/platform/api/gcloud/api.go
+++ b/mantle/platform/api/gcloud/api.go
@@ -33,15 +33,16 @@ var (
 )
 
 type Options struct {
-	Image       string
-	Project     string
-	Zone        string
-	MachineType string
-	DiskType    string
-	Network     string
-	ServiceAcct string
-	JSONKeyFile string
-	ServiceAuth bool
+	Image        string
+	Project      string
+	Zone         string
+	MachineType  string
+	DiskType     string
+	Network      string
+	ServiceAcct  string
+	JSONKeyFile  string
+	ServiceAuth  bool
+	Confidential bool
 	*platform.Options
 }
 

--- a/mantle/platform/api/gcloud/compute.go
+++ b/mantle/platform/api/gcloud/compute.go
@@ -111,7 +111,15 @@ func (a *API) mkinstance(userdata, name string, keys []*agent.Key, useServiceAcc
 			Value: &userdata,
 		})
 	}
-
+	// create confidential instance
+	if a.options.Confidential {
+		instance.ConfidentialInstanceConfig = &compute.ConfidentialInstanceConfig{
+			EnableConfidentialCompute: true,
+		}
+		instance.Scheduling = &compute.Scheduling{
+			OnHostMaintenance: "TERMINATE",
+		}
+	}
 	return instance
 
 }


### PR DESCRIPTION
To run tests on confidential vm on gcp using kola, like:
`kola run -d -p gcp --gcp-image=projects/fedora-coreos-cloud/global/images/fedora-coreos-38-20230507-20-3-gcp-x86-64 --gcp-json-key=/srv/tool/gcp.json --gcp-machinetype n2d-standard-2 --gcp-confidential-vm basic`
Refer to https://github.com/coreos/fedora-coreos-tracker/issues/1457

Note:
Confidential VM supports the N2D series of machine types. See https://cloud.google.com/compute/docs/about-confidential-vm