### PR TITLE
cmd-fetch: use `sudo du` for pkgcache size check

### DIFF
--- a/src/cmd-fetch
+++ b/src/cmd-fetch
@@ -8,7 +8,7 @@ dn=$(dirname "$0")
 FILE=cache/pkgcache-repo
 if [ -d "${FILE}" ]
 then
-        pkgcachesize=$(du --bytes --max-depth 0 "${FILE}" \
+        pkgcachesize=$(sudo du --bytes --max-depth 0 "${FILE}" \
                        | awk '{print $1; exit}')
         pkglimit=$((1024 * 1024 * 1024 * 5))
         if [[ "${pkgcachesize}" -gt "${pkglimit}" ]]


### PR DESCRIPTION
Right now we call `sudo cosa prune --pkgcache` if the pkgcache is higher
than 5G, but to check its size we run `du` unprivileged. This can fail
though if e.g. there's leftover rpm-ostree dirs from an aborted compose
with mode 700 that the user can't read.

Do the size check as root too.