### PR TITLE
Revert "mantle/kola: add detection for a kernel soft lockup"

### DIFF
--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -157,10 +157,6 @@ var (
 			match: regexp.MustCompile("Oops:"),
 		},
 		{
-			desc:  "kernel soft lockup",
-			match: regexp.MustCompile("watchdog: BUG: soft lockup - CPU"),
-		},
-		{
 			desc:  "kernel warning",
 			match: regexp.MustCompile(`WARNING: CPU: \d+ PID: \d+ at (.+)`),
 		},


### PR DESCRIPTION
This reverts commit a487f53c1fec5ef4a3e77ba717bf6a9da1a82b44.

This has been failing too much and as pointed out by others it doesn't mean the test won't eventually succeed.

What I'd like to do soon is re-instate this check, but allows a test that failed in this way to automatically have `--allow-rerun-success` capability.