### PR TITLE
Add support for composefs

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -326,6 +326,16 @@ fi
 if [ ! -f "${workdir}"/builds/builds.json ] && [ ! -f "${fetch_stamp}" ] ; then
     fatal "Must fetch before building"
 fi
+composefs="$(jq -r .composefs < "${image_json}")"
+case "${composefs}" in
+    false) 
+    ;;
+    true)
+        ostree config --repo="${tmprepo}" set ex-integrity.composefs "true"
+    ;;
+    *) fatal "Unhandled composefs setting: ${composefs}" ;;
+esac
+
 # --cache-only is here since `fetch` is a separate verb
 # shellcheck disable=SC2086
 if test -n "${previous_commit}"; then

--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -118,6 +118,7 @@ esac
 rootfs_args=$(getconfig_def "rootfs-args" "")
 
 bootfs=$(getconfig "bootfs")
+composefs=$(getconfig_def "composefs" "")
 grub_script=$(getconfig "grub-script")
 ostree_container=$(getconfig "ostree-container")
 commit=$(getconfig "ostree-commit")
@@ -310,11 +311,14 @@ ostree config --repo $rootfs/ostree/repo set sysroot.bootloader none
 # Opt-in to https://github.com/ostreedev/ostree/pull/1767 AKA
 # https://github.com/ostreedev/ostree/issues/1265
 ostree config --repo $rootfs/ostree/repo set sysroot.readonly true
+if test -n "${composefs}"; then
+    ostree config --repo $rootfs/ostree/repo set ex-integrity.composefs true
+fi
 # Initialize the "stateroot"
 ostree admin os-init "$os_name" --sysroot $rootfs
 
 # Propagate flags into target repository
-if [ "${rootfs_type}" = "ext4verity" ]; then
+if [ "${rootfs_type}" = "ext4verity" ] && [ -z "${composefs}" ]; then
     ostree config --repo=$rootfs/ostree/repo set ex-fsverity.required 'true'
 fi
 

--- a/src/image-default.yaml
+++ b/src/image-default.yaml
@@ -4,6 +4,8 @@ bootfs: "ext4"
 rootfs: "xfs"
 # Add arguments here that will be passed to e.g. mkfs.xfs
 rootfs-args: ""
+# Set to "true" to enable composefs
+composefs: false
 
 # Additional default kernel arguments injected into disk images
 extra-kargs: []


### PR DESCRIPTION
This pairs with https://github.com/ostreedev/ostree/pull/2640

It's all off by default (to state the obvious).  But one can do e.g.:

```
$ cat >> src/config/image.yaml << EOF
composefs: true
EOF
```

To test out the fsverity bits, you also want
`rootfs: ext4verity`

More in https://github.com/ostreedev/ostree/issues/2867

