### PR TITLE
OCPBUGS-13941: [RHCOS-4.13] s390x/Secure Execution: Set swiotlb to recommended value

### DIFF
--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -148,6 +148,7 @@ if [[ ${secure_execution} -eq 1 ]]; then
     SDPART=1
     BOOTVERITYHASHPN=5
     ROOTVERITYHASHPN=6
+    extrakargs="${extrakargs} swiotlb=262144"
 fi
 # Make the size relative
 if [ "${rootfs_size}" != "0" ]; then


### PR DESCRIPTION
The recommended value for swiotlob is swiotlb=262144. Set the value in the kernel cmdline during image creation.

Docs: https://www.ibm.com/docs/en/linux-on-systems?topic=ki-secure-execution

This fixes https://issues.redhat.com/browse/OCPBUGS-11574

Signed-off-by: Jan Schintag <jan.schintag@de.ibm.com>
(cherry picked from commit 44e7b4db8bd815a488fb5f6112dae393800eb62e)

s390x/Secure Execution: Move swiotlb kernel arg to bls-config

Currently the swiotlb argument is tied to the zipl call during image creation. Move the arg to the ostree call instead so it is written to bls-config and becomes persistent.

Signed-off-by: Jan Schintag <jan.schintag@de.ibm.com>
(cherry picked from commit 3bbe77a6dec613f3aacf13b10acc4f109243dcad)