### PR TITLE
mantle/platform: allow `systemctl is-system-running` nonzero exit codes

### DIFF
--- a/mantle/platform/platform.go
+++ b/mantle/platform/platform.go
@@ -476,7 +476,10 @@ func CheckMachine(ctx context.Context, m Machine) error {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		out, stderr, err := m.SSH("systemctl is-system-running")
+		// By design, `systemctl is-system-running` returns nonzero codes based on its state.
+		// We want to explicitly accept some nonzero states and test instead by the string so
+		// add `|| :`.
+		out, stderr, err := m.SSH("systemctl is-system-running || :")
 		if !bytes.Contains([]byte("initializing starting running stopping"), out) {
 			return nil // stop retrying if the system went haywire
 		}


### PR DESCRIPTION
The `CheckMachine()` call tolerates `systemctl is-system-running` returning e.g. `starting` and `initializing` in addition to the usual `running`. But by design, the command returns a nonzero exit code in those cases.

Since we're explicitly checking the output string against the acceptable states, just ignore the command exit code so that we don't fail if the system is still starting.

Prep for adding a test in which we expect the system to still be `starting`.