### PR TITLE
[rhcos-4.13] koji-upload: Change artifact used to store the rpm list

### DIFF
--- a/src/cmd-koji-upload
+++ b/src/cmd-koji-upload
@@ -582,7 +582,7 @@ class Upload(_KojiBase):
         for _, value in (self.build).get_artifacts():
             file_output = self.get_file_meta(value)
             if file_output is not None:
-                if "qcow2" in value['upload_path']:
+                if "commitmeta.json" in value['upload_path']:
                     file_output["components"] = self.build.get_rpm_list()
                 outputs.append(file_output)
         self._image_files = outputs


### PR DESCRIPTION
 - To store the rpm list in Brew we need to link it to an artifact, let's change it from qemu (1 GB) to the
commitmeta.json (60 KB) due the size.
 - The rpm list is also generated from commitmeta.json, what make sense to have it instead.

Signed-off-by: Renata Ravanelli <rravanel@redhat.com>
(cherry picked from commit dd7315e13ef86bd2ec39a74147f58c1ba8ccc100)