### PR TITLE
mantle/platform: bump Azure API timeout to 10m for instance creation

### DIFF
--- a/mantle/platform/api/azure/instance.go
+++ b/mantle/platform/api/azure/instance.go
@@ -166,7 +166,7 @@ func (a *API) CreateInstance(name, userdata, sshkey, resourceGroup, storageAccou
 
 	vmParams := a.getVMParameters(name, userdata, sshkey, fmt.Sprintf("https://%s.blob.core.windows.net/", storageAccount), ip, nic)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 	poller, err := a.compClient.BeginCreateOrUpdate(ctx, resourceGroup, name, vmParams, nil)
 	if err != nil {
@@ -174,7 +174,7 @@ func (a *API) CreateInstance(name, userdata, sshkey, resourceGroup, storageAccou
 	}
 	_, err = poller.PollUntilDone(ctx, nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("waiting on instance creation failed: %w", err)
 	}
 
 	err = util.WaitUntilReady(5*time.Minute, 10*time.Second, func() (bool, error) {


### PR DESCRIPTION
Looks like we're bumping up into this again regularly. I suspect it's Azure just having trouble and will resolve itself in a few weeks. I think bumping it a few more minutes won't be a big deal but wouldn't want to go over 10.

Let's also disambiguate the error message generated from BeginCreateOrUpdate versus PollUntilDone.