### PR TITLE
mantle/kola: run individual test without bucketing

### DIFF
--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -722,7 +722,11 @@ func runProvidedTests(testsBank map[string]*register.Test, patterns []string, mu
 		}
 	}
 
-	if len(nonExclusiveTests) > 0 {
+	if len(nonExclusiveTests) == 1 {
+		// If there is only one test then it can just be run by itself
+		// so add it back to the tests map.
+		tests[nonExclusiveTests[0].Name] = nonExclusiveTests[0]
+	} else if len(nonExclusiveTests) > 0 {
 		buckets := createTestBuckets(nonExclusiveTests)
 		numBuckets := len(buckets)
 		for i := 0; i < numBuckets; {


### PR DESCRIPTION
Fix #3479 

This PR introduces a new feature in coreos-assembler that makes sure when individual tests are run they are not bucketed

