### PR TITLE
cmd-remote-build-container: enhance tag existence check

### DIFF
--- a/src/cmd-remote-build-container
+++ b/src/cmd-remote-build-container
@@ -97,8 +97,13 @@ def is_tag_in_registry(repo, tag):
     try:
         subprocess.check_output(cmd, stderr=subprocess.PIPE)
     except subprocess.CalledProcessError as e:
-        # yuck; check if it's because the tag doesn't exist
-        if b'manifest unknown' in e.stderr:
+        # yuck; check if it's because the tag doesn't exist. This
+        # handles two different kinds of failure:
+        # $ skopeo    inspect    --raw # docker://quay.io/coreos-assembler/staging:aarch64-706fa53
+        # FATA[0000] Error parsing image name "docker://quay.io/coreos-assembler/staging:aarch64-706fa53": reading manifest aarch64-706fa53 in quay.io/coreos-assembler/staging: manifest unknown
+        # $ skopeo    inspect    --raw docker://quay.io/coreos-assembler/staging:aarch64-706fa52
+        # FATA[0000] Error parsing image name "docker://quay.io/coreos-assembler/staging:aarch64-706fa52": reading manifest aarch64-706fa52 in quay.io/coreos-assembler/staging: unknown: Tag aarch64-706fa52 was deleted or has expired. To pull, revive via time machine
+        if b'manifest' in e.stderr and b'unknown' in e.stderr:
             return False
         # any other error is unexpected; fail
         logging.error(f" STDOUT: {e.stdout.decode()}")


### PR DESCRIPTION
We started seeing failures today like:

```
+ cosa remote-build-container --arch aarch64 --cache-ttl 24h --git-ref 706fa522579e5b1b95fe0b4cc160b2e70ebf39e1 --git-url https://github.com/coreos/coreos-assembler.git --repo quay.io/coreos-assembler/staging --push-to-registry --auth=****
notice: failed to look up uid in /etc/passwd; enabling workaround
2023-06-21 20:20:48,838 INFO - Translated https://github.com/coreos/coreos-assembler.git#706fa522579e5b1b95fe0b4cc160b2e70ebf39e1 into 706fa52
2023-06-21 20:20:48,838 INFO - Targetting a container image for quay.io/coreos-assembler/staging:aarch64-706fa52
2023-06-21 20:20:49,126 ERROR -  STDOUT:
2023-06-21 20:20:49,126 ERROR -  STDERR: time="2023-06-21T20:20:49Z" level=fatal msg="Error parsing image name \"docker://quay.io/coreos-assembler/staging:aarch64-706fa52\": reading manifest aarch64-706fa52 in quay.io/coreos-assembler/staging: unknown: Tag aarch64-706fa52 was deleted or has expired. To pull, revive via time machine"
```

So this failure isn't "manifest unkown", but a little bit more nuanced. Let's modify the check so it catches both cases.