### PR TITLE
mantle/kola: allow custom coreos distributions in tests

### DIFF
--- a/mantle/platform/platform.go
+++ b/mantle/platform/platform.go
@@ -500,13 +500,19 @@ func CheckMachine(ctx context.Context, m Machine) error {
 
 	// ensure we're talking to a supported system
 	var distribution string
-	switch string(out) {
+	outstr := string(out)
+	switch outstr {
 	case `fedora-coreos`:
 		distribution = "fcos"
 	case `scos-`, `scos-coreos`, `rhcos-`, `rhcos-coreos`:
 		distribution = "rhcos"
 	default:
-		return fmt.Errorf("not a supported instance: %v", string(out))
+		// allow custom distriubtions as long as variant is coreos
+		if strings.HasSuffix(outstr, "-coreos") {
+			distribution = strings.Replace(outstr, "-coreos", "", -1)
+		} else {
+			return fmt.Errorf("not a supported instance: %v", outstr)
+		}
 	}
 
 	// check systemd version on host to see if we can use `busctl --json=short`


### PR DESCRIPTION
This change allows the platform.CheckMachine method to pass for customized CoreOS distributions as long as the machine is a  variant.

Built a `coreos-assembler-test` docker image and confirmed a normal `fedora-coreos` build continued to work.

```
$ cosa kola --skip-secure-boot run basic
+ docker run -it --rm --security-opt=label=disable --privileged -v=/home/philcali/coreos:/srv/ --device=/dev/kvm --device=/dev/fuse --tmpfs=/tmp -v=/var/tmp:/var/tmp --name=cosa -v=/home/philcali/.aws:/home/builder/.aws coreos-assmerbler-test kola --skip-secure-boot run basic
kola -p qemu run basic --output-dir tmp/kola
=== RUN   basic
=== RUN   basic/DbusPerms
=== RUN   basic/ServicesActive
=== RUN   basic/ReadOnly
=== RUN   basic/Useradd
=== RUN   basic/MachineID
=== RUN   basic/FCOSGrowpart
=== RUN   basic/PortSSH
--- PASS: basic (26.33s)
    --- PASS: basic/DbusPerms (0.17s)
    --- PASS: basic/ServicesActive (0.08s)
    --- PASS: basic/ReadOnly (0.07s)
    --- PASS: basic/Useradd (0.14s)
    --- PASS: basic/MachineID (0.07s)
    --- PASS: basic/FCOSGrowpart (0.10s)
    --- PASS: basic/PortSSH (0.08s)
PASS, output in tmp/kola
+ rc=0
+ set +x
```