### PR TITLE
mantle/util/distros: Add case for SCOS disk artifacts

### DIFF
--- a/mantle/util/distros.go
+++ b/mantle/util/distros.go
@@ -26,7 +26,7 @@ import (
 // the path to an artifact (usually a disk image).
 func TargetDistroFromName(artifact string) string {
 	basename := filepath.Base(artifact)
-	if strings.HasPrefix(basename, "rhcos-") {
+	if strings.HasPrefix(basename, "rhcos-") || strings.HasPrefix(basename, "scos-") {
 		return "rhcos"
 	}
 	// For now, just assume fcos


### PR DESCRIPTION
Make sure to use the SCOS (aliased to RHCOS) distribution for tests when called on an SCOS disk image.