### PR TITLE
Fix member path in `hyperv` ZIP

### DIFF
--- a/src/cosalib/qemuvariants.py
+++ b/src/cosalib/qemuvariants.py
@@ -324,7 +324,7 @@ class QemuVariantImage(_Build):
                 case "gzip":
                     rc = ['gzip', '-9c', uncompressed_path]
                 case "zip":
-                    rc = ['zip', '-9', "-", uncompressed_path]
+                    rc = ['zip', '-9j', "-", uncompressed_path]
                 case _:
                     raise ImageError(f"unsupported compression type: {self.compression}")
             with open(final_img, "wb") as fh:


### PR DESCRIPTION
The `hyperv` ZIP has two problems:

- The disk image should be at the root of the ZIP archive, but is nested inside a stack of intermediate directories.
- The disk image should have a `.vhdx` extension, but has `.vhdx.zip` instead.

Fix both issues.