### PR TITLE
[rhcos-4.11] Backport Brew changes

### DIFF
--- a/src/cmd-koji-upload
+++ b/src/cmd-koji-upload
@@ -406,6 +406,40 @@ class _KojiBase():
         return session
 
 
+class Search(_KojiBase):
+    """
+    Search for builds
+    """
+
+    def __init__(self, profile):
+        """
+        Creates a new instance for search.
+
+        :param profile: Koji profile name in /etc/koji.conf.d
+        :type str
+        """
+        super().__init__(profile)
+
+    def get_state(self, nvr):
+        """
+        Return the build state.
+        :param nvr: The nvr name from Brew
+
+        For more about build state see:
+          https://pagure.io/koji/blob/master/f/www/kojiweb/builds.chtml#_27
+          https://pagure.io/koji/blob/master/f/tests/test_cli/test_import.py#_73
+        """
+
+        info = self.session.getBuild(nvr, strict=False)
+        if (info):
+            return (info['state'])
+
+        # Don't return anything else if no build was found.
+        # Since the build states are describe as numbers from 0
+        # to 4, let's get an empty return
+        return ""
+
+
 class Reserve(_KojiBase):
     """
     Reserves a place in Koji for later archival.
@@ -821,6 +855,11 @@ Examples:
         --keytab keytab \
         --owner me@FEDORA.COM \
         --profile koji
+    $ cmd-koji-upload search \
+        --nvr nvr \
+        --keytab keytab \
+        --owner me@FEDORA.COM \
+        --profile koji
 
 Environment variables are supported:
     - KOJI_USERNAME will set the owner
@@ -867,6 +906,9 @@ Environment variables are supported:
     upload_cmd = sub_commands.add_parser(
         "upload", help="Uploads to koji", parents=[parent_parser], add_help=False)
 
+    search_cmd = sub_commands.add_parser(
+        "search", help="Search for a build", parents=[parent_parser], add_help=False)
+
     sub_commands.add_parser(
         "reserve-id", help="Reserves a koji id", parents=[parent_parser], add_help=False)
 
@@ -899,6 +941,10 @@ Environment variables are supported:
         '--s3-url', required=False,
         help='Store url information in meta.json')
 
+    search_cmd.add_argument(
+        '--nvr',  required=True,
+        help='NVR to look for')
+
     args, extra_args = parser.parse_known_args()
     set_logger(args.log_level)
 
@@ -915,7 +961,8 @@ Environment variables are supported:
 
     if args.auth:
         kinit(args.keytab, args.owner)
-
+    if args._command == 'search':
+        print(Search(args.profile).get_state(args.nvr))
     if args._command == 'upload':
 
         upload = Upload(build, args.owner, args.tag, args.profile)

--- a/src/cmd-koji-upload
+++ b/src/cmd-koji-upload
@@ -463,12 +463,21 @@ class Reserve(_KojiBase):
         """
         log.info("Reserving a unique koji id")
 
-        release = datetime.datetime.utcnow().strftime("%H%M%S")
-
+        # The koji/brew NVR is constructed like so:
+        # Name = "rhcos-$arch", like `rhcos-x86_64`
+        # Version = Everything before `-` in RHCOS version
+        # Release = Everything after `-` in RHCOS version
+        #
+        # Example: RHCOS Build ID: 414.92.202307170903-0 for x86_64
+        #   Name = rhcos-x86_64
+        #   Version = 414.92.202307170903
+        #   Release = 0
+        #   NVR = rhcos-x86_64-414.92.202307170903-0
+        version, release = build.build_id.split('-')
         data = {
             "name": f"{build.build_name}-{build.basearch}",
             "release": release,
-            "version": f"{build.build_id.replace('-', '.')}",
+            "version": version,
             "cg": "coreos-assembler",
         }
 
@@ -529,7 +538,6 @@ class Upload(_KojiBase):
         self._session = None
         self._tag = tag
         self._image_files = None
-        self._release = None
         self._reserve_id_file = None
         self._retry_attempts = 2
         self._uploaded = False
@@ -632,7 +640,6 @@ class Upload(_KojiBase):
 
         now = datetime.datetime.utcnow()
         stamp = now.strftime("%s")
-        self.release = now.strftime("%H%M%S")
 
         """
         Koji has a couple of checks to ensure the reservation data (build_Id, release, name
@@ -675,6 +682,17 @@ class Upload(_KojiBase):
             "meta", self.build.ckey("container-config-git"))
 
         log.debug(f"Preparing manifest for {(len(self.image_files))} files")
+        # The koji/brew NVR is constructed like so:
+        # Name = "rhcos-$arch", like `rhcos-x86_64`
+        # Version = Everything before `-` in RHCOS version
+        # Release = Everything after `-` in RHCOS version
+        #
+        # Example: RHCOS Build ID: 414.92.202307170903-0 for x86_64
+        #   Name = rhcos-x86_64
+        #   Version = 414.92.202307170903
+        #   Release = 0
+        #   NVR = rhcos-x86_64-414.92.202307170903-0
+        version, release = self.build.build_id.split('-')
         self._manifest = {
             "metadata_version": 0,
             "build": {
@@ -688,14 +706,11 @@ class Upload(_KojiBase):
                     }
                 },
                 "name": f"{self.build.build_name}-{self.build.basearch}",
-                "release": self._release,
+                "release": release,
                 "owner": self._owner,
                 "source": source['origin'],
                 "start_time": stamp,
-                # RHCOS wants to be semver-compatible, but Koji doesn't
-                # accept `-`.  See
-                # https://github.com/openshift/oc/pull/209#issuecomment-564876535
-                "version": f"{self.build.build_id.replace('-', '.')}"
+                "version": version
             },
             "buildroots": [{
                 "id": 1,


### PR DESCRIPTION
koji: Add search function
 - Add search function to look for builds by nvr;
 - We need this feature to ensure an update was
complete successfully, and we don't need to reupload it. An
example is if some fail occurs in the release job.

Signed-off-by: Renata Ravanelli <rravanel@redhat.com>
(cherry picked from commit https://github.com/coreos/coreos-assembler/commit/0eb550a5fcae30a738b5f19212a1be71e7988560)

_____________________________________________________________

koji: Change release number for NVR
 - The release number doesn't need to be random.
It makes things difficult when we need to search for
a NVR name.
 - Let's add our "release" version number as release number to
make things easier to search for a NVR when we need to.
Example:
  Our full version number is: 413.92.202302162021.0
  The Brew version is now: 412.86.202302162021 and
the release number is: 0

Signed-off-by: Renata Ravanelli <rravanel@redhat.com>
(cherry picked from commit https://github.com/coreos/coreos-assembler/commit/f33be694065e316098c1c67dde2a2e0722f1563a)