### PR TITLE
[rhcos-4.9] Backport Brew changes

### DIFF
--- a/src/cmd-koji-upload
+++ b/src/cmd-koji-upload
@@ -432,12 +432,21 @@ class Reserve(_KojiBase):
         """
         log.debug("reserving a unique koji id")
 
-        release = datetime.datetime.utcnow().strftime("%H%M%S")
-
+        # The koji/brew NVR is constructed like so:
+        # Name = "rhcos-$arch", like `rhcos-x86_64`
+        # Version = Everything before `-` in RHCOS version
+        # Release = Everything after `-` in RHCOS version
+        #
+        # Example: RHCOS Build ID: 414.92.202307170903-0 for x86_64
+        #   Name = rhcos-x86_64
+        #   Version = 414.92.202307170903
+        #   Release = 0
+        #   NVR = rhcos-x86_64-414.92.202307170903-0
+        version, release = build.build_id.split('-')
         data = {
             "name": f"{build.build_name}-{build.basearch}",
             "release": release,
-            "version": f"{build.build_id.replace('-', '.')}",
+            "version": version,
             "cg": "coreos-assembler",
         }
 
@@ -497,7 +506,6 @@ class Upload(_KojiBase):
         self._session = None
         self._tag = tag
         self._image_files = None
-        self._release = None
         self._reserve_id_file = None
         self._retry_attempts = 2
         self._uploaded = False
@@ -597,7 +605,6 @@ class Upload(_KojiBase):
 
         now = datetime.datetime.utcnow()
         stamp = now.strftime("%s")
-        self.release = now.strftime("%H%M%S")
 
         """
         Koji has a couple of checks to ensure the reservation data (build_Id, release, name
@@ -640,6 +647,17 @@ class Upload(_KojiBase):
             "meta", self.build.ckey("container-config-git"))
 
         log.debug(f"Preparing manifest for {(len(self.image_files))} files")
+        # The koji/brew NVR is constructed like so:
+        # Name = "rhcos-$arch", like `rhcos-x86_64`
+        # Version = Everything before `-` in RHCOS version
+        # Release = Everything after `-` in RHCOS version
+        #
+        # Example: RHCOS Build ID: 414.92.202307170903-0 for x86_64
+        #   Name = rhcos-x86_64
+        #   Version = 414.92.202307170903
+        #   Release = 0
+        #   NVR = rhcos-x86_64-414.92.202307170903-0
+        version, release = self.build.build_id.split('-')
         self._manifest = {
             "metadata_version": 0,
             "build": {
@@ -653,14 +671,11 @@ class Upload(_KojiBase):
                     }
                 },
                 "name": f"{self.build.build_name}-{self.build.basearch}",
-                "release": self._release,
+                "release": release,
                 "owner": self._owner,
                 "source": source['origin'],
                 "start_time": stamp,
-                # RHCOS wants to be semver-compatible, but Koji doesn't
-                # accept `-`.  See
-                # https://github.com/openshift/oc/pull/209#issuecomment-564876535
-                "version": f"{self.build.build_id.replace('-', '.')}"
+                "version": version
             },
             "buildroots": [{
                 "id": 1,


### PR DESCRIPTION
koji: Add search function
 - Add search function to look for builds by nvr;
 - We need this feature to ensure an update was
complete successfully, and we don't need to reupload it. An
example is if some fail occurs in the release job.

Signed-off-by: Renata Ravanelli <rravanel@redhat.com>
(cherry picked from commit https://github.com/coreos/coreos-assembler/commit/0eb550a5fcae30a738b5f19212a1be71e7988560)

_____________________________________________________________

koji: Change release number for NVR
 - The release number doesn't need to be random.
It makes things difficult when we need to search for
a NVR name.
 - Let's add our "release" version number as release number to
make things easier to search for a NVR when we need to.
Example:
  Our full version number is: 413.92.202302162021.0
  The Brew version is now: 412.86.202302162021 and
the release number is: 0

Signed-off-by: Renata Ravanelli <rravanel@redhat.com>
(cherry picked from commit https://github.com/coreos/coreos-assembler/commit/f33be694065e316098c1c67dde2a2e0722f1563a)
_______________________________________________________________

Change cmd-koji-upload to add S3 information in meta.json
 - This change is needed due brew/compliance improvements where we need
to keep more information about where the artifacts are archived;
 - Add s3 parameters in order to update meta.json with
bucket, prefix and url information used in S3 upload.

Signed-off-by: Renata Ravanelli <rravanel@redhat.com>
(cherry picked from commit https://github.com/coreos/coreos-assembler/commit/253f9bbbb80fae55d4c77f1aaeec37375ffdec9b)