### PR TITLE
buildfetch: Add file parameter

### DIFF
--- a/src/cmd-buildfetch
+++ b/src/cmd-buildfetch
@@ -109,7 +109,8 @@ def main():
         assert builddir.startswith("builds/")
         builddir = builddir[len("builds/"):]
 
-        objects = ['meta.json', 'commitmeta.json', 'ostree-commit-object']
+        default_objects = ['meta.json', 'commitmeta.json', 'ostree-commit-object']
+        objects = default_objects + args.file
         for f in objects:
             fetcher.fetch(f'{builddir}/{f}')
 
@@ -159,6 +160,8 @@ def parse_args():
                         help="the target architecture(s)")
     parser.add_argument("--artifact", default=[], action='append',
                         help="Fetch given image artifact(s)", metavar="ARTIFACT")
+    parser.add_argument("--file", default=[], action='append',
+                        help="Fetch given non-artifact file(s)")
     parser.add_argument("--aws-config-file", metavar='CONFIG', default="",
                         help="Path to AWS config file")
     return parser.parse_args()


### PR DESCRIPTION
 - Allow fetch for non-artifact files such as:
	- coreos-assembler-yumrepos-git.json - coreos-assembler-config-git.json - manifest-lock.generated.x86_64.json
 - There are occasions where we may need to fetch locks/meta files, `--file` allows it.

Signed-off-by: Renata Ravanelli <rravanel@redhat.com>
(cherry picked from commit 2c8db986cd6525e1cb21fc9d0a9a53d460f04b28)