### PR TITLE
gcloud: Enable `SEV_SNP_CAPABLE`

### DIFF
--- a/mantle/platform/api/gcloud/image.go
+++ b/mantle/platform/api/gcloud/image.go
@@ -132,6 +132,10 @@ func (a *API) CreateImage(spec *ImageSpec, overwrite bool) (*compute.Operation, 
 		{
 			Type: "UEFI_COMPATIBLE",
 		},
+		// https://cloud.google.com/blog/products/identity-security/rsa-snp-vm-more-confidential
+		{
+			Type: "SEV_SNP_CAPABLE",
+		},
 	}
 
 	image := &compute.Image{


### PR DESCRIPTION
See: https://github.com/coreos/coreos-assembler/pull/3243
See: https://cloud.google.com/blog/products/identity-security/rsa-snp-vm-more-confidential
Fixes: https://issues.redhat.com/browse/COS-2343