### PR TITLE
kola: return 77 on warning and use different colors to highlight tests results

### DIFF
--- a/mantle/cli/cli.go
+++ b/mantle/cli/cli.go
@@ -15,6 +15,7 @@
 package cli
 
 import (
+	"errors"
 	"os"
 
 	"github.com/coreos/pkg/capnslog"
@@ -39,6 +40,8 @@ var (
 	logLevel   = capnslog.NOTICE
 
 	plog = capnslog.NewPackageLogger("github.com/coreos/coreos-assembler/mantle", "cli")
+
+	ErrExitWarning77 = errors.New("A test marked as warn:true failed. Exiting with 77 as exit code")
 )
 
 // Execute sets up common features that all mantle commands should share
@@ -65,7 +68,12 @@ func Execute(main *cobra.Command) {
 	})
 
 	if err := main.Execute(); err != nil {
-		plog.Fatal(err)
+		if err == ErrExitWarning77 {
+			plog.Warning(err)
+			os.Exit(77)
+		} else {
+			plog.Fatal(err)
+		}
 	}
 	os.Exit(0)
 }

--- a/mantle/cmd/kola/kola.go
+++ b/mantle/cmd/kola/kola.go
@@ -276,7 +276,7 @@ func kolaRunPatterns(patterns []string, rerun bool) error {
 		return err
 	}
 
-	runErr := kola.RunTests(patterns, runMultiply, rerun, rerunSuccessTags, kolaPlatform, outputDir, !kola.Options.NoTestExitError)
+	runErr := kola.RunTests(patterns, runMultiply, rerun, rerunSuccessTags, kolaPlatform, outputDir)
 
 	// needs to be after RunTests() because harness empties the directory
 	if err := writeProps(); err != nil {
@@ -714,7 +714,7 @@ func runRunUpgrade(cmd *cobra.Command, args []string) error {
 		patterns = args
 	}
 
-	runErr := kola.RunUpgradeTests(patterns, runRerunFlag, kolaPlatform, outputDir, !kola.Options.NoTestExitError)
+	runErr := kola.RunUpgradeTests(patterns, runRerunFlag, kolaPlatform, outputDir)
 
 	// needs to be after RunTests() because harness empties the directory
 	if err := writeProps(); err != nil {

--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -57,6 +57,7 @@ func init() {
 	root.PersistentFlags().StringVarP(&kolaParallelArg, "parallel", "j", "1", "number of tests to run in parallel, or \"auto\" to match CPU count")
 	sv(&kola.TAPFile, "tapfile", "", "file to write TAP results to")
 	root.PersistentFlags().BoolVarP(&kola.Options.NoTestExitError, "no-test-exit-error", "T", false, "Don't exit with non-zero if tests fail")
+	root.PersistentFlags().BoolVarP(&kola.Options.UseWarnExitCode77, "on-warn-failure-exit-77", "", false, "Exit with code 77 if 'warn: true' tests fail")
 	sv(&kola.Options.BaseName, "basename", "kola", "Cluster name prefix")
 	ss("debug-systemd-unit", []string{}, "full-unit-name.service to enable SYSTEMD_LOG_LEVEL=debug on. Can be specified multiple times.")
 	ssv(&kola.DenylistedTests, "denylist-test", []string{}, "Test pattern to add to denylist. Can be specified multiple times.")

--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -56,7 +56,6 @@ func init() {
 	root.PersistentFlags().StringVarP(&kola.Options.Distribution, "distro", "b", "", "Distribution: "+strings.Join(kolaDistros, ", "))
 	root.PersistentFlags().StringVarP(&kolaParallelArg, "parallel", "j", "1", "number of tests to run in parallel, or \"auto\" to match CPU count")
 	sv(&kola.TAPFile, "tapfile", "", "file to write TAP results to")
-	root.PersistentFlags().BoolVarP(&kola.Options.NoTestExitError, "no-test-exit-error", "T", false, "Don't exit with non-zero if tests fail")
 	root.PersistentFlags().BoolVarP(&kola.Options.UseWarnExitCode77, "on-warn-failure-exit-77", "", false, "Exit with code 77 if 'warn: true' tests fail")
 	sv(&kola.Options.BaseName, "basename", "kola", "Cluster name prefix")
 	ss("debug-systemd-unit", []string{}, "full-unit-name.service to enable SYSTEMD_LOG_LEVEL=debug on. Can be specified multiple times.")

--- a/mantle/harness/harness.go
+++ b/mantle/harness/harness.go
@@ -624,7 +624,7 @@ func (t *H) report() {
 
 	status := t.status()
 	if status == testresult.Fail || t.suite.opts.Verbose {
-		t.flushToParent(format, status, t.name, dstr)
+		t.flushToParent(format, status.Display(), t.name, dstr)
 	}
 
 	// TODO: store multiple buffers for subtests without indentation

--- a/mantle/harness/harness_test.go
+++ b/mantle/harness/harness_test.go
@@ -76,6 +76,9 @@ func TestContextCancel(t *testing.T) {
 }
 
 func TestSubTests(t *testing.T) {
+	// When TERM is set, we add colors to highlight tests results: '--- FAIL' will be in red '--- \033[31mFAIL\033[0m'
+	// Let's unset it here for simplicity
+	os.Unsetenv("TERM")
 	realTest := t
 	testCases := []struct {
 		desc   string

--- a/mantle/harness/testresult/status.go
+++ b/mantle/harness/testresult/status.go
@@ -14,6 +14,8 @@
 
 package testresult
 
+import "os"
+
 const (
 	Fail TestResult = "FAIL"
 	Warn TestResult = "WARN"
@@ -22,3 +24,25 @@ const (
 )
 
 type TestResult string
+
+func (s TestResult) Display() string {
+	if term, has_term := os.LookupEnv("TERM"); !has_term || term == "" {
+		return string(s)
+	}
+
+	red := "\033[31m"
+	yellow := "\033[33m"
+	blue := "\033[34m"
+	green := "\033[32m"
+	reset := "\033[0m"
+
+	if s == Fail {
+		return red + string(s) + reset
+	} else if s == Warn {
+		return yellow + string(s) + reset
+	} else if s == Skip {
+		return blue + string(s) + reset
+	} else {
+		return green + string(s) + reset
+	}
+}

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -33,6 +33,7 @@ import (
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 
+	"github.com/coreos/coreos-assembler/mantle/cli"
 	"github.com/coreos/coreos-assembler/mantle/harness"
 	"github.com/coreos/coreos-assembler/mantle/harness/reporters"
 	"github.com/coreos/coreos-assembler/mantle/kola/cluster"
@@ -869,7 +870,8 @@ func runProvidedTests(testsBank map[string]*register.Test, patterns []string, mu
 
 	// Ignore the error when only denied tests with Warn:true feature failed
 	if runErr != nil && allFailedTestsAreWarnOnError(testResults.getResults()) {
-		return nil
+		return cli.ErrExitWarning77
+
 	}
 
 	// If the intial run failed and the rerun passed, we still return an error

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -685,7 +685,7 @@ func filterDenylistedTests(tests map[string]*register.Test) (map[string]*registe
 // register tests in their init() function.  outputDir is where various test
 // logs and data will be written for analysis after the test run. If it already
 // exists it will be erased!
-func runProvidedTests(testsBank map[string]*register.Test, patterns []string, multiply int, rerun bool, rerunSuccessTags []string, pltfrm, outputDir string, propagateTestErrors bool) error {
+func runProvidedTests(testsBank map[string]*register.Test, patterns []string, multiply int, rerun bool, rerunSuccessTags []string, pltfrm, outputDir string) error {
 	var versionStr string
 
 	// Avoid incurring cost of starting machine in getClusterSemver when
@@ -832,10 +832,6 @@ func runProvidedTests(testsBank map[string]*register.Test, patterns []string, mu
 	handleSuiteErrors := func(outputDir string, suiteErr error) error {
 		caughtTestError := suiteErr != nil
 
-		if !propagateTestErrors {
-			suiteErr = nil
-		}
-
 		if TAPFile != "" {
 			src := filepath.Join(outputDir, "test.tap")
 			err := system.CopyRegularFile(src, TAPFile)
@@ -861,7 +857,7 @@ func runProvidedTests(testsBank map[string]*register.Test, patterns []string, mu
 	if len(testsToRerun) > 0 && rerun {
 		newOutputDir := filepath.Join(outputDir, "rerun")
 		fmt.Printf("\n\n======== Re-running failed tests (flake detection) ========\n\n")
-		reRunErr := runProvidedTests(testsBank, testsToRerun, multiply, false, rerunSuccessTags, pltfrm, newOutputDir, propagateTestErrors)
+		reRunErr := runProvidedTests(testsBank, testsToRerun, multiply, false, rerunSuccessTags, pltfrm, newOutputDir)
 
 		// Return the results from the rerun if rerun success allowed
 		if allTestsAllowRerunSuccess(testsBank, testsToRerun, rerunSuccessTags) {
@@ -979,12 +975,12 @@ func getRerunnable(tests []*harness.H) []string {
 	return testsToRerun
 }
 
-func RunTests(patterns []string, multiply int, rerun bool, rerunSuccessTags []string, pltfrm, outputDir string, propagateTestErrors bool) error {
-	return runProvidedTests(register.Tests, patterns, multiply, rerun, rerunSuccessTags, pltfrm, outputDir, propagateTestErrors)
+func RunTests(patterns []string, multiply int, rerun bool, rerunSuccessTags []string, pltfrm, outputDir string) error {
+	return runProvidedTests(register.Tests, patterns, multiply, rerun, rerunSuccessTags, pltfrm, outputDir)
 }
 
-func RunUpgradeTests(patterns []string, rerun bool, pltfrm, outputDir string, propagateTestErrors bool) error {
-	return runProvidedTests(register.UpgradeTests, patterns, 0, rerun, nil, pltfrm, outputDir, propagateTestErrors)
+func RunUpgradeTests(patterns []string, rerun bool, pltfrm, outputDir string) error {
+	return runProvidedTests(register.UpgradeTests, patterns, 0, rerun, nil, pltfrm, outputDir)
 }
 
 // externalTestMeta is parsed from kola.json in external tests

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -33,7 +33,6 @@ import (
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 
-	"github.com/coreos/coreos-assembler/mantle/cli"
 	"github.com/coreos/coreos-assembler/mantle/harness"
 	"github.com/coreos/coreos-assembler/mantle/harness/reporters"
 	"github.com/coreos/coreos-assembler/mantle/kola/cluster"
@@ -237,6 +236,8 @@ var (
 			match: regexp.MustCompile(`(/.*/system-generators/.*) (failed with exit status|terminated by signal|failed due to unknown reason)`),
 		},
 	}
+
+	ErrWarnOnTestFail = errors.New("A test marked as warn:true failed.")
 )
 
 const (
@@ -870,8 +871,7 @@ func runProvidedTests(testsBank map[string]*register.Test, patterns []string, mu
 
 	// Ignore the error when only denied tests with Warn:true feature failed
 	if runErr != nil && allFailedTestsAreWarnOnError(testResults.getResults()) {
-		return cli.ErrExitWarning77
-
+		return ErrWarnOnTestFail
 	}
 
 	// If the intial run failed and the rerun passed, we still return an error

--- a/mantle/platform/platform.go
+++ b/mantle/platform/platform.go
@@ -182,7 +182,6 @@ type Options struct {
 	CosaBuildId   string
 	CosaBuildArch string
 
-	NoTestExitError   bool
 	UseWarnExitCode77 bool
 
 	AppendButane   string

--- a/mantle/platform/platform.go
+++ b/mantle/platform/platform.go
@@ -182,7 +182,8 @@ type Options struct {
 	CosaBuildId   string
 	CosaBuildArch string
 
-	NoTestExitError bool
+	NoTestExitError   bool
+	UseWarnExitCode77 bool
 
 	AppendButane   string
 	AppendIgnition string


### PR DESCRIPTION
```
=== RUN   ext.config.ntp.timesyncd.dhcp-propagation                                                                                                                                                                                            
=== RUN   ext.config.ntp.chrony.coreos-platform-chrony-config                                                                                                                                                                                  
=== RUN   ext.config.ntp.chrony.dhcp-propagation                                                                                                                                                                                               
--- PASS: ext.config.ntp.chrony.coreos-platform-chrony-config (27.13s) 
--- WARN: ext.config.ntp.chrony.dhcp-propagation (410.37s)
+ rc=77                                                                                                                                                                                                                                        
+ set +x
```