### PR TITLE
mantle: fix offline detection in testiso tests

### DIFF
--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -513,7 +513,10 @@ func runTestIso(cmd *cobra.Command, args []string) error {
 		} else if kola.HasString("uefi", components) {
 			enableUefi = true
 		}
-		if kola.HasString("offline", components) {
+		// For offline it is a part of the first component. i.e. for
+		// iso-offline-install.bios we need to search for 'offline' in
+		// iso-offline-install, which is currently in components[0].
+		if kola.HasString("offline", strings.Split(components[0], "-")) {
 			isOffline = true
 		}
 


### PR DESCRIPTION
The offline detection in our testiso tests is not working properly meaning we are never running offline tests today. Let's fix that here by parsing it properly.

Fixes f98481f.