### PR TITLE
mantle/kola/testiso: support testing coreos.liveiso.fromram installs

### DIFF
--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -773,6 +773,14 @@ func testLiveIso(ctx context.Context, inst platform.Install, outdir string, mini
 		isoKernelArgs = append(isoKernelArgs, liveISOFromRAMKarg)
 	}
 
+	// Sometimes the logs that stream from various virtio streams can be
+	// incomplete because they depend on services inside the guest.
+	// When you are debugging earlyboot/initramfs issues this can be
+	// problematic. Let's add a hook here to enable more debugging.
+	if _, ok := os.LookupEnv("COSA_TESTISO_DEBUG"); ok {
+		isoKernelArgs = append(isoKernelArgs, "systemd.log_color=0 systemd.log_level=debug systemd.log_target=console")
+	}
+
 	mach, err := inst.InstallViaISOEmbed(isoKernelArgs, liveConfig, targetConfig, outdir, isOffline, minimal)
 	if err != nil {
 		return 0, errors.Wrapf(err, "running iso install")

--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -223,6 +223,8 @@ ExecStart=/bin/bash -c '[[ $(findmnt -nvro SOURCE /sysroot) == /dev/mapper/mpath
 [Install]
 RequiredBy=multi-user.target`
 
+// This test is broken. Please fix!
+// https://github.com/coreos/coreos-assembler/issues/3554
 var verifyNoEFIBootEntry = `[Unit]
 Description=TestISO Verify No EFI Boot Entry
 OnFailure=emergency.target


### PR DESCRIPTION
In https://github.com/coreos/fedora-coreos-config/pull/2544 we added a new `coreos.liveiso.fromram` kernel argument to instruct the ISO image to boot completely from memory in order to facilitate installs back to the same disk the ISO was booted from in iso-as-disk mode (i.e. dd the ISO file to a hard drive or partition on a hard drive).

Let's test here that we can boot completely from memory and that /run/media/iso is not mounted.

Currently this doesn't actually do an install to the same disk that we booted from (actually the iso-as-disk tests don't actually do installs at all, but just verify they can boot), but rather just verifies the ISO isn't mounted after the live system boots up, which should be sufficient.
