### PR TITLE
qemu: drop supportsIsoKargs check cause now all platfroms support it

### DIFF
--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -99,6 +99,9 @@ var (
 		// "iso-offline-install.4k.s390fw",
 		"pxe-online-install.s390fw",
 		"pxe-offline-install.s390fw",
+		"miniso-install.s390fw",
+		"miniso-install.nm.s390fw",
+		"miniso-install.4k.nm.s390fw",
 	}
 	tests_ppc64le = []string{
 		"iso-live-login.ppcfw",

--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -1396,13 +1396,6 @@ func coreosInstallerSupportsISOKargs() (bool, error) {
 	return strings.Contains(out, "kargs"), nil
 }
 
-// supportsIsoKargs returns true if we support modifying ISO kargs on the
-// current arch. We could also auto-detect this, but would probably still want
-// some assertions that we detected as supported on !s390x.
-func (builder *QemuBuilder) supportsIsoKargs() bool {
-	return builder.architecture != "s390x"
-}
-
 func (builder *QemuBuilder) setupIso() error {
 	if err := builder.ensureTempdir(); err != nil {
 		return err
@@ -1447,11 +1440,9 @@ func (builder *QemuBuilder) setupIso() error {
 				return errors.Wrapf(err, "running `coreos-installer iso kargs modify`; old CoreOS ISO?")
 			}
 			// Only actually emit a warning if we expected it to be supported
-			if builder.supportsIsoKargs() {
-				stderr := stderrb.String()
-				plog.Warningf("running coreos-installer iso kargs modify: %v: %q", err, stderr)
-				plog.Warning("likely targeting an old CoreOS ISO; ignoring...")
-			}
+			stderr := stderrb.String()
+			plog.Warningf("running coreos-installer iso kargs modify: %v: %q", err, stderr)
+			plog.Warning("likely targeting an old CoreOS ISO; ignoring...")
 		}
 	} else if len(builder.AppendKernelArgs) > 0 {
 		return fmt.Errorf("coreos-installer does not support appending kernel args")


### PR DESCRIPTION
After https://github.com/coreos/coreos-installer/pull/1230 being merged this became obsolete

```
$ cosa kola testiso -S --output-dir tmp/kola-testiso-metal
Ignoring verification of signature on metal image
Running test: iso-live-login.s390fw
PASS: iso-live-login.s390fw (13.395s)
Running test: iso-offline-install.s390fw
PASS: iso-offline-install.s390fw (45.608s)
Running test: pxe-online-install.s390fw
PASS: pxe-online-install.s390fw (34.957s)
Running test: pxe-offline-install.s390fw
PASS: pxe-offline-install.s390fw (48.485s)
Running test: miniso-install.s390fw
PASS: miniso-install.s390fw (48.38s)
Running test: miniso-install.nm.s390fw
PASS: miniso-install.nm.s390fw (51.278s)
Running test: miniso-install.4k.nm.s390fw
PASS: miniso-install.4k.nm.s390fw (50.6s)
+ rc=0
```