### PR TITLE
kola/testiso: enable 4k images tests for s390x

### DIFF
--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -105,10 +105,8 @@ var (
 	tests_s390x = []string{
 		"iso-live-login.s390fw",
 		"iso-offline-install.s390fw",
-		// https://github.com/coreos/fedora-coreos-tracker/issues/1434
-		// "iso-offline-install.mpath.s390fw",
-		// https://github.com/coreos/fedora-coreos-tracker/issues/1261
-		// "iso-offline-install.4k.s390fw",
+		"iso-offline-install.mpath.s390fw",
+		"iso-offline-install.4k.s390fw",
 		"pxe-online-install.s390fw",
 		"pxe-offline-install.s390fw",
 		"miniso-install.s390fw",


### PR DESCRIPTION
```
$ cosa kola testiso -S --qemu-native-4k --qemu-multipath  --output-dir tmp/kola-testiso-metal

⏭️  Skipping kola test pattern "fcos.internet":
  👉 https://github.com/coreos/coreos-assembler/pull/1478
⏭️  Skipping kola test pattern "podman.workflow":
  👉 https://github.com/coreos/coreos-assembler/pull/1478
Ignoring verification of signature on metal image
Running test: iso-live-login.s390fw
PASS: iso-live-login.s390fw (13.86s)
Running test: iso-live-login.4k.s390fw
PASS: iso-live-login.4k.s390fw (13.245s)
Running test: iso-offline-install.s390fw
PASS: iso-offline-install.s390fw (46.925s)
Running test: iso-offline-install.4k.s390fw
PASS: iso-offline-install.4k.s390fw (45.83s)
Running test: iso-offline-install.mpath.s390fw
PASS: iso-offline-install.mpath.s390fw (47.561s)
Running test: pxe-online-install.s390fw
PASS: pxe-online-install.s390fw (35.406s)
Running test: pxe-online-install.4k.s390fw
PASS: pxe-online-install.4k.s390fw (40.085s)
Running test: pxe-offline-install.s390fw
PASS: pxe-offline-install.s390fw (48.966s)
Running test: pxe-offline-install.4k.s390fw
PASS: pxe-offline-install.4k.s390fw (48.873s)
Running test: miniso-install.s390fw
PASS: miniso-install.s390fw (47.588s)
Running test: miniso-install.4k.s390fw
PASS: miniso-install.4k.s390fw (47.149s)
Running test: miniso-install.nm.s390fw
PASS: miniso-install.nm.s390fw (51.022s)
Running test: miniso-install.4k.nm.s390fw
PASS: miniso-install.4k.nm.s390fw (51.009s)
+ rc=0
```

This [issue]( https://github.com/coreos/fedora-coreos-tracker/issues/1261) seems to be obsolete, but we still have to wait for a new `coreos-installer.rpm`

Depends on: https://github.com/ibm-s390-linux/s390-tools/pull/154