### PR TITLE
Revert "qemu: drop supportsIsoKargs check cause now all platfroms support it"

### DIFF
--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -99,9 +99,6 @@ var (
 		// "iso-offline-install.4k.s390fw",
 		"pxe-online-install.s390fw",
 		"pxe-offline-install.s390fw",
-		"miniso-install.s390fw",
-		"miniso-install.nm.s390fw",
-		"miniso-install.4k.nm.s390fw",
 	}
 	tests_ppc64le = []string{
 		"iso-live-login.ppcfw",


### PR DESCRIPTION
Reverts coreos/coreos-assembler#3572

This needs to wait for a new coreos-installer upstream release that includes https://github.com/coreos/coreos-installer/pull/1230 to make it into our RPMs available to us in FCOS/RHCOS. 