### PR TITLE
[rhcos-4.13] backport colors; add compat option

### DIFF
--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -57,6 +57,7 @@ func init() {
 	root.PersistentFlags().StringVarP(&kolaParallelArg, "parallel", "j", "1", "number of tests to run in parallel, or \"auto\" to match CPU count")
 	sv(&kola.TAPFile, "tapfile", "", "file to write TAP results to")
 	root.PersistentFlags().BoolVarP(&kola.Options.NoTestExitError, "no-test-exit-error", "T", false, "Don't exit with non-zero if tests fail")
+	root.PersistentFlags().BoolVarP(&kola.Options.UseWarnExitCode77, "on-warn-failure-exit-77", "", false, "NOOP compatibility convenience")
 	sv(&kola.Options.BaseName, "basename", "kola", "Cluster name prefix")
 	ss("debug-systemd-unit", []string{}, "full-unit-name.service to enable SYSTEMD_LOG_LEVEL=debug on. Can be specified multiple times.")
 	ssv(&kola.DenylistedTests, "denylist-test", []string{}, "Test pattern to add to denylist. Can be specified multiple times.")

--- a/mantle/harness/harness.go
+++ b/mantle/harness/harness.go
@@ -609,7 +609,7 @@ func (t *H) report() {
 
 	status := t.status()
 	if status == testresult.Fail || t.suite.opts.Verbose {
-		t.flushToParent(format, status, t.name, dstr)
+		t.flushToParent(format, status.Display(), t.name, dstr)
 	}
 
 	// TODO: store multiple buffers for subtests without indentation

--- a/mantle/harness/harness_test.go
+++ b/mantle/harness/harness_test.go
@@ -76,6 +76,9 @@ func TestContextCancel(t *testing.T) {
 }
 
 func TestSubTests(t *testing.T) {
+	// When TERM is set, we add colors to highlight tests results: '--- FAIL' will be in red '--- \033[31mFAIL\033[0m'
+	// Let's unset it here for simplicity
+	os.Unsetenv("TERM")
 	realTest := t
 	testCases := []struct {
 		desc   string

--- a/mantle/harness/testresult/status.go
+++ b/mantle/harness/testresult/status.go
@@ -14,6 +14,8 @@
 
 package testresult
 
+import "os"
+
 const (
 	Fail TestResult = "FAIL"
 	Skip TestResult = "SKIP"
@@ -21,3 +23,22 @@ const (
 )
 
 type TestResult string
+
+func (s TestResult) Display() string {
+	if term, has_term := os.LookupEnv("TERM"); !has_term || term == "" {
+		return string(s)
+	}
+
+	red := "\033[31m"
+	blue := "\033[34m"
+	green := "\033[32m"
+	reset := "\033[0m"
+
+	if s == Fail {
+		return red + string(s) + reset
+	} else if s == Skip {
+		return blue + string(s) + reset
+	} else {
+		return green + string(s) + reset
+	}
+}

--- a/mantle/platform/platform.go
+++ b/mantle/platform/platform.go
@@ -182,7 +182,8 @@ type Options struct {
 	CosaBuildId   string
 	CosaBuildArch string
 
-	NoTestExitError bool
+	NoTestExitError   bool
+	UseWarnExitCode77 bool
 
 	AppendButane   string
 	AppendIgnition string


### PR DESCRIPTION
```
commit 24f81930bfe785251a5b4ba56da77f8f8e294c8a
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Tue Aug 22 23:12:07 2023 -0400

    mantle/kola: add --on-warn-failure-exit-77 compat option
    
    It does nothing. This isn't a full backport. We just want to use
    the same code in the pipeline for all streams.

commit a3dd717c9753e901b942130beb6e08cbd4231c3e
Author: Nikita Dubrovskii <nikita@linux.ibm.com>
Date:   Fri Jul 28 08:51:42 2023 +0200

    mantle/kola: add colors to highlight tests results
    
    Removed the "Warn" parts from the cherry pick to make it compile
    because we didn't backport the warn:true stuff here.
    
    (cherry picked from commit a1917162844d5cd4af2b19a0e6a3a0401207f611)

```
