### PR TITLE
mantle/aws: ami f39 changes

### DIFF
--- a/mantle/platform/api/aws/images.go
+++ b/mantle/platform/api/aws/images.go
@@ -331,14 +331,17 @@ func (a *API) CreateImportRole(bucket string) error {
 
 func (a *API) CreateHVMImage(snapshotID string, diskSizeGiB uint, name string, description string, architecture string) (string, error) {
 	var awsArch string
+	var bootmode string
 	if architecture == "" {
 		architecture = runtime.GOARCH
 	}
 	switch architecture {
 	case "amd64", "x86_64":
 		awsArch = ec2.ArchitectureTypeX8664
+		bootmode = "uefi-preferred"
 	case "arm64", "aarch64":
 		awsArch = ec2.ArchitectureTypeArm64
+		bootmode = "uefi"
 	default:
 		return "", fmt.Errorf("unsupported ec2 architecture %q", architecture)
 	}
@@ -366,6 +369,7 @@ func (a *API) CreateHVMImage(snapshotID string, diskSizeGiB uint, name string, d
 		},
 		EnaSupport:      aws.Bool(true),
 		SriovNetSupport: aws.String("simple"),
+		BootMode:        aws.String(bootmode),
 	})
 }
 

--- a/mantle/platform/api/aws/images.go
+++ b/mantle/platform/api/aws/images.go
@@ -344,11 +344,14 @@ func (a *API) CreateHVMImage(snapshotID string, diskSizeGiB uint, name string, d
 	if !set {
 		imdsSupport = "v2.0"
 	}
+	bootmode, set = os.LookupEnv("MANTLE_AWS_BOOT_MODE_x86_64")
 
 	switch architecture {
 	case "amd64", "x86_64":
 		awsArch = ec2.ArchitectureTypeX8664
-		bootmode = "uefi-preferred"
+		if !set {
+			bootmode = "uefi-preferred"
+		}
 	case "arm64", "aarch64":
 		awsArch = ec2.ArchitectureTypeArm64
 		bootmode = "uefi"

--- a/src/cosalib/aws.py
+++ b/src/cosalib/aws.py
@@ -119,7 +119,7 @@ def aws_run_ore(build, args):
     )
     os.environ["MANTLE_AWS_IMDS_SUPPORT"] = image_yaml['aws-imds-support']
     os.environ["MANTLE_AWS_VOLUME_TYPE"] = image_yaml['aws-volume-type']
-    os.environ["aws_boot_mode"] = image_yaml['aws-boot-mode']
+    os.environ["MANTLE_AWS_BOOT_MODE_x86_64"] = image_yaml['aws-boot-mode-x86-64']
 
     # First add the ore command to run before any options
     ore_args = ['ore', 'aws', 'upload']

--- a/src/image-default.yaml
+++ b/src/image-default.yaml
@@ -31,3 +31,4 @@ vmware-secure-boot: true
 # Defaults for AWS
 aws-imds-support: "v2.0"
 aws-volume-type: "gp3"
+aws-boot-mode-x86-64: "uefi-preferred"

--- a/src/image-default.yaml
+++ b/src/image-default.yaml
@@ -27,3 +27,7 @@ squashfs-compression: zstd
 vmware-hw-version: 13
 vmware-os-type: rhel7_64Guest
 vmware-secure-boot: true
+
+# Defaults for AWS
+aws-imds-support: "v2.0"
+aws-volume-type: "gp3"


### PR DESCRIPTION
Pulled in changes from https://github.com/coreos/coreos-assembler/pull/3402 

Fixes: https://github.com/coreos/fedora-coreos-tracker/issues/1502

Regarding documentation for the switch of the default from gp2 to gp3 is there a way to preload release notes for this repo? 
i.e
https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-plan-storage-compare-volume-types.html