### PR TITLE
mantle/journal: Prefer systemd unit over syslog identifier

### DIFF
--- a/mantle/network/journal/format.go
+++ b/mantle/network/journal/format.go
@@ -65,7 +65,13 @@ func (s *shortWriter) WriteEntry(entry Entry) error {
 	var buf bytes.Buffer
 	buf.WriteString(realtime.In(s.tz).Format(time.StampMicro))
 
-	if identifier, ok := entry[FIELD_SYSLOG_IDENTIFIER]; ok {
+	// Default to equivalent of journalctl -o with-unit, because its value is
+	// trusted, and the syslog identifier (commonly when executing bash via ExecStart)
+	// can be garbage.
+	if unit, ok := entry[FIELD_SYSTEMD_UNIT]; ok {
+		buf.WriteByte(' ')
+		buf.WriteString(string(unit))
+	} else if identifier, ok := entry[FIELD_SYSLOG_IDENTIFIER]; ok {
 		buf.WriteByte(' ')
 		buf.Write(identifier)
 	} else {

--- a/mantle/network/journal/format_test.go
+++ b/mantle/network/journal/format_test.go
@@ -171,8 +171,8 @@ func TestFormatShortFromExport(t *testing.T) {
 	const expect = `Jul 17 16:01:01.413961 gdm-password][587]: AccountsService-DEBUG(+): ActUserManager: ignoring unspecified session '8' since it's not graphical: Success
 Jul 17 16:01:01.416351 /USR/SBIN/CROND[8278]: (root) CMD (run-parts /etc/cron.hourly)
 -- Reboot --
-Feb 14 20:15:16.372858 python3[16853]: foo
-                                       bar
+Feb 14 20:15:16.372858 session-35898.scope[16853]: foo
+                                                   bar
 `
 	if d := diff.Diff(buf.String(), expect); d != "" {
 		t.Errorf("unexpected output:\n%s", d)


### PR DESCRIPTION
Same rationale as https://github.com/openshift/installer/pull/7371/commits/948df48aada21e47e9bb0d0a53366871aa21b40a

Before systemd was created, syslog was the dominant Unix logging system.

Later, systemd introduced the journal whose output intentionally exactly matched that of syslog for compatibility.

In systemd, the "unit" is the technical heart of things; yet the syslog output only includes the "syslog identifier" which might or might not look like the unit.

For many of our units that just run shell script, the syslog identifier is just "bash".

This makes it hard to distinguish what's going on.  With this patch the output will change from e.g.:

```
Jul 26 21:15:00 cvrzlbtm-bbcf1-t58lf-bootstrap release-image-download.sh[1995]: 2c5e0f38687f7acf45adf9de5e841a46bbbda574d121d71d92bfb929826dfa27
```

to

```
Jul 26 21:15:00 cvrzlbtm-bbcf1-t58lf-bootstrap release-image.service[1995]: 2c5e0f38687f7acf45adf9de5e841a46bbbda574d121d71d92bfb929826dfa27
```

And that creates a stronger connection with the code; we can reliably find what `release-image.service` is.