### PR TITLE
kola: Add `--qemu-bind-ro`

### DIFF
--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -157,6 +157,7 @@ func init() {
 	bv(&kola.QEMUOptions.Native4k, "qemu-native-4k", false, "Force 4k sectors for main disk")
 	bv(&kola.QEMUOptions.Nvme, "qemu-nvme", false, "Use NVMe for main disk")
 	bv(&kola.QEMUOptions.Swtpm, "qemu-swtpm", true, "Create temporary software TPM")
+	ssv(&kola.QEMUOptions.BindRO, "qemu-bind-ro", nil, "Inject a host directory; this does not automatically mount in the guest")
 
 	sv(&kola.QEMUIsoOptions.IsoPath, "qemu-iso", "", "path to CoreOS ISO image")
 	bv(&kola.QEMUIsoOptions.AsDisk, "qemu-iso-as-disk", false, "attach ISO image as regular disk")

--- a/mantle/platform/machine/qemu/cluster.go
+++ b/mantle/platform/machine/qemu/cluster.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	"sync"
 	"time"
@@ -119,6 +120,13 @@ func (qc *Cluster) NewMachineWithQemuOptions(userdata *conf.UserData, options pl
 	builder.Swtpm = qc.flight.opts.Swtpm
 	builder.Hostname = fmt.Sprintf("qemu%d", qc.BaseCluster.AllocateMachineSerial())
 	builder.ConsoleFile = qm.consolePath
+
+	// This one doesn't support configuring the path because we can't
+	// reliably change the Ignition config here...
+	for _, path := range qc.flight.opts.BindRO {
+		destpathrel := strings.TrimLeft(path, "/")
+		builder.Mount9p(path, "/kola/host/"+destpathrel, true)
+	}
 
 	if qc.flight.opts.Memory != "" {
 		memory, err := strconv.ParseInt(qc.flight.opts.Memory, 10, 32)

--- a/mantle/platform/machine/qemu/flight.go
+++ b/mantle/platform/machine/qemu/flight.go
@@ -46,6 +46,9 @@ type Options struct {
 	//Option to create a temporary software TPM - true by default
 	Swtpm bool
 
+	// Array of $hostpath
+	BindRO []string
+
 	//IBM Secure Execution
 	SecureExecution               bool
 	SecureExecutionIgnitionPubKey string


### PR DESCRIPTION
I'm trying to debug
`kola run --ssh-on-test-failure ext.rpm-ostree.destructive.container-image` interactively but one problem is that because the test is classified as disconnected, we run qemu with no networking.  This makes it impossible to get remote debug tools.

With this I can `--qemu-bind-ro /usr` to get access to the debug tools in my dev container's `/usr`.  But one needs to manually mount inside the VM, because injecting the mount into the Ignition config in kola is a bit trickier.

For reference it looks like e.g.
`mount -t 9p -o trans=virtio,version=9p2000.L /kola/usr /run/hostusr` in the ssh shell.