### PR TITLE
Qemu memory improvements

### DIFF
--- a/mantle/cmd/kola/qemuexec.go
+++ b/mantle/cmd/kola/qemuexec.go
@@ -338,15 +338,15 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 	builder.Hostname = hostname
 	// for historical reasons, both --memory and --qemu-memory are supported
 	if memory != 0 {
-		builder.Memory = memory
+		builder.MemoryMiB = memory
 	} else if kola.QEMUOptions.Memory != "" {
 		parsedMem, err := strconv.ParseInt(kola.QEMUOptions.Memory, 10, 32)
 		if err != nil {
 			return errors.Wrapf(err, "parsing memory option")
 		}
-		builder.Memory = int(parsedMem)
+		builder.MemoryMiB = int(parsedMem)
 	} else if kola.QEMUOptions.SecureExecution {
-		builder.Memory = 4096 // SE needs at least 4GB
+		builder.MemoryMiB = 4096 // SE needs at least 4GB
 	}
 	if err = builder.AddDisksFromSpecs(addDisks); err != nil {
 		return err

--- a/mantle/kola/tests/ignition/qemufailure.go
+++ b/mantle/kola/tests/ignition/qemufailure.go
@@ -63,7 +63,7 @@ func ignitionFailure(c cluster.TestCluster) error {
 	if err != nil {
 		return err
 	}
-	builder.Memory = 1024
+	builder.MemoryMiB = 1024
 	builder.Firmware = kola.QEMUOptions.Firmware
 	inst, err := builder.Exec()
 	if err != nil {

--- a/mantle/platform/machine/qemu/cluster.go
+++ b/mantle/platform/machine/qemu/cluster.go
@@ -125,11 +125,11 @@ func (qc *Cluster) NewMachineWithQemuOptions(userdata *conf.UserData, options pl
 		if err != nil {
 			return nil, errors.Wrapf(err, "parsing memory option")
 		}
-		builder.Memory = int(memory)
+		builder.MemoryMiB = int(memory)
 	} else if options.MinMemory != 0 {
-		builder.Memory = options.MinMemory
+		builder.MemoryMiB = options.MinMemory
 	} else if qc.flight.opts.SecureExecution {
-		builder.Memory = 4096 // SE needs at least 4GB
+		builder.MemoryMiB = 4096 // SE needs at least 4GB
 	}
 
 	channel := "virtio"

--- a/mantle/platform/machine/qemuiso/cluster.go
+++ b/mantle/platform/machine/qemuiso/cluster.go
@@ -112,7 +112,7 @@ func (qc *Cluster) NewMachineWithQemuOptions(userdata *conf.UserData, options pl
 		if err != nil {
 			return nil, errors.Wrapf(err, "parsing memory option")
 		}
-		builder.Memory = int(memory)
+		builder.MemoryMiB = int(memory)
 	}
 
 	if err := builder.AddIso(qc.flight.opts.IsoPath, "", qc.flight.opts.AsDisk); err != nil {

--- a/mantle/platform/metal.go
+++ b/mantle/platform/metal.go
@@ -73,7 +73,7 @@ func NewMetalQemuBuilderDefault() *QemuBuilder {
 	builder := NewQemuBuilder()
 	// https://github.com/coreos/fedora-coreos-tracker/issues/388
 	// https://github.com/coreos/fedora-coreos-docs/pull/46
-	builder.Memory = 4096
+	builder.MemoryMiB = 4096
 	return builder
 }
 

--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -434,8 +434,8 @@ type QemuBuilder struct {
 
 	// If set, use QEMU full emulation for the target architecture
 	architecture string
-	// Memory defaults to 1024 on most architectures, others it may be 2048
-	Memory int
+	// MemoryMiB defaults to 1024 on most architectures, others it may be 2048
+	MemoryMiB int
 	// Processors < 0 means to use host count, unset means 1, values > 1 are directly used
 	Processors int
 	UUID       string
@@ -1246,7 +1246,7 @@ func (builder *QemuBuilder) finalize() {
 	if builder.finalized {
 		return
 	}
-	if builder.Memory == 0 {
+	if builder.MemoryMiB == 0 {
 		// FIXME; Required memory should really be a property of the tests, and
 		// let's try to drop these arch-specific overrides.  ARM was bumped via
 		// commit 09391907c0b25726374004669fa6c2b161e3892f
@@ -1264,7 +1264,7 @@ func (builder *QemuBuilder) finalize() {
 		case "aarch64", "s390x", "ppc64le":
 			memory = 2048
 		}
-		builder.Memory = memory
+		builder.MemoryMiB = memory
 	}
 	builder.finalized = true
 }
@@ -1595,7 +1595,7 @@ func (builder *QemuBuilder) Exec() (*QemuInstance, error) {
 	if err != nil {
 		return nil, err
 	}
-	argv = append(argv, "-m", fmt.Sprintf("%d", builder.Memory))
+	argv = append(argv, "-m", fmt.Sprintf("%d", builder.MemoryMiB))
 
 	if builder.Processors < 0 {
 		nproc, err := system.GetProcessors()

--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -1595,6 +1595,8 @@ func (builder *QemuBuilder) Exec() (*QemuInstance, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Allocate a shared memory object, which is needed for virtiofs
+	argv = append(argv, "-object", fmt.Sprintf("memory-backend-memfd,id=mem,size=%dM,share=on", builder.MemoryMiB))
 	argv = append(argv, "-m", fmt.Sprintf("%d", builder.MemoryMiB))
 
 	if builder.Processors < 0 {


### PR DESCRIPTION
qemu: Clarify `Memory` as `MemoryMiB`

It's generally a good idea for variable names include their units.

---

qemu: Default to allocating sharable memfd for RAM

This is needed for virtiofs.  Also, unlike the current
README, we want to use a memfd instead of `/dev/shm` because that
might be too small in e.g. a default docker/podman container configuration
which uses 64MiB.

---

