### PR TITLE
HTTP/S `buildfetch` streams in chunks

### DIFF
--- a/src/cmd-buildfetch
+++ b/src/cmd-buildfetch
@@ -226,12 +226,26 @@ class HTTPFetcher(Fetcher):
 
     @retry(stop=retry_stop, retry=retry_requests_exception, before_sleep=retry_callback)
     def fetch_impl(self, url, dest):
-        # notice we don't use `stream=True` here; the stuff we're fetching for
-        # now is super small
-        with requests.get(url) as r:
+        with requests.get(url, stream=True) as r:
             r.raise_for_status()
             with open(dest, mode='wb') as f:
-                f.write(r.content)
+                # Stream file data from the network to the file in these size chunks.
+                # 30 MiB is somewhat arbitrary but should be easily supported on most systems
+                # without transfer slowdown.
+                max_chunk_size = 30 * 1024 * 1024
+
+                # If the HTTP headers have encoded the file transfer as chunks already, respect those instead
+                # of our hardcoded max size.
+                if 'chunked' in r.headers.get('transfer-encoding', list()):
+                    max_chunk_size = None
+
+                # With stream=True above, read data from the network and write it to the file in chunks
+                # rather than trying to put it all in RAM and then write it all to disk.
+                # For large ociarchive files on lower-RAM systems, this can cause a crash, and the performance
+                # trade-off for chunking it is usually negligible unless the files are extra huge, the disk IO cache is
+                # very small, and the network pipe is very large.
+                for chunk in r.iter_content(chunk_size=max_chunk_size):
+                    f.write(chunk)
 
     @retry(stop=retry_stop, retry=retry_requests_exception, before_sleep=retry_callback)
     def exists_impl(self, url):


### PR DESCRIPTION
Keep RAM usage down when using `buildfetch`.  Existing code was downloading the entire file into RAM before writing it to disk, but now that ociarchive files are included that are usually 4-8 GiB that's no longer a good idea.  Lower-RAM systems choke on having too little RAM available to continue operating normally.

This instead sets a somewhat arbitrary 30 MiB chunk limit.  If the server itself is already chunk encoding it will use whatever that says instead, but in a lot (most?) cases the server probably isn't.  

---

It's confirmed to fix a problem with downloading 4 GiB ociarchive files as part of a `buildfetch` on a desktop system with only 8 GB of RAM.  The system was crashing every time during the download due to the OOM killing it for eating too much of the available RAM.  We ideally want the system to be able to do builds with ociarchives of up to 8 GiB.

---

Effect on download performance for existing uses should be relatively negligible.  It might slightly impact download time if you have a really huge network pipe, lots of RAM, slow disk IO, and small disk IO cache, but otherwise it won't affect much.

In one timing test on a system with a 1 Gbps network pipe, an NVMe disk, 64 GB of RAM, and a 4GB ociarchive file the timing results were:
```
chunked:
    0.58s user 0.47s system 0% cpu 4:05.30 total
unchunked/original:
    0.57s user 0.41s system 0% cpu 4:24.63 total
```

So the chunking pretty clearly doesn't have an impact since the unchunked (original) code actually took longer in the case where it should have been optimal, indicating the difference is within the margin of testing error.

/closes #3597 