### PR TITLE
platform/qemu: fix usage of removed Mount9p

### DIFF
--- a/mantle/platform/machine/qemu/cluster.go
+++ b/mantle/platform/machine/qemu/cluster.go
@@ -125,7 +125,7 @@ func (qc *Cluster) NewMachineWithQemuOptions(userdata *conf.UserData, options pl
 	// reliably change the Ignition config here...
 	for _, path := range qc.flight.opts.BindRO {
 		destpathrel := strings.TrimLeft(path, "/")
-		builder.Mount9p(path, "/kola/host/"+destpathrel, true)
+		builder.MountHost(path, "/kola/host/"+destpathrel, true)
 	}
 
 	if qc.flight.opts.Memory != "" {


### PR DESCRIPTION
PR #3593 was written and opened before #3428 but merged after it. CI had passed but was not rerun, so this went in. This would be fixed by using a merge bot on this repo that reruns CI before merge (See also https://bors.tech/essay/2017/02/02/pitch/.)

Fixes: d812406d5 ("kola: Add `--qemu-bind-ro`")