### PR TITLE
build-fast: Use target/ if available

### DIFF
--- a/src/cmd-build-fast
+++ b/src/cmd-build-fast
@@ -90,16 +90,22 @@ echo "Basing on previous build: ${previous_build:-none}"
 
 if [ -n "${projectdir}" ]; then
     cd "${projectdir}"
-    rm _install -rf
+    instroot=_install
+    # Rust projects will already have a handy directory for build artifacts
+    if test -d target; then
+        instroot=target/cosa-build-fast
+    fi
+    instroot=$(pwd)/${instroot}  # Must be absolute for `make`
+    rm "${instroot}" -rf
     make
-    make install DESTDIR="$(pwd)/_install"
+    make install DESTDIR="${instroot}"
     fastref=cosa/fastbuild/"$(basename "${projectdir}")"
     version="$(git describe --tags --abbrev=10)"
     if ! git diff --quiet; then
         version="${version}+dirty"
     fi
     outdir=${projectdir}/.cosa
-    rootfsoverrides="${projectdir}/_install"
+    rootfsoverrides="${instroot}"
 else
     fastref=cosa/fastbuild/${name}
     version="$(date +"%s")"


### PR DESCRIPTION
This avoids my IDE from transiently seeing a ton of newly added files.  Same motivation as e.g.
https://github.com/coreos/cargo-vendor-filterer/pull/48/commits/aa4a3669704cf491c92158a354ed87156011d493