### PR TITLE
Fixes for ppc64le boot mirroring tests

### DIFF
--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -1205,6 +1205,7 @@ ExecStart=%s
 
 	// Architectures using 64k pages use slightly more memory, ask for more than requested
 	// to make sure that we don't run out of it. Currently ppc64le and aarch64 use 64k pages.
+	// See similar logic in boot-mirror.go and luks.go.
 	switch coreosarch.CurrentRpmArch() {
 	case "ppc64le", "aarch64":
 		if targetMeta.MinMemory <= 4096 {

--- a/mantle/kola/tests/ignition/luks.go
+++ b/mantle/kola/tests/ignition/luks.go
@@ -164,7 +164,7 @@ func runTest(c cluster.TestCluster, tpm2 bool, threshold int, killTangAfterFirst
 	opts := platform.MachineOptions{
 		MinMemory: 4096,
 	}
-	// ppc64le and aarch64 use 64K pages
+	// ppc64le and aarch64 use 64K pages; see similar logic in harness.go and boot-mirror.go
 	switch coreosarch.CurrentRpmArch() {
 	case "ppc64le", "aarch64":
 		opts.MinMemory = 8192

--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -383,8 +383,8 @@ func (inst *QemuInstance) SwitchBootOrder() (err2 error) {
 }
 
 // RemovePrimaryBlockDevice deletes the primary device from a qemu instance
-// and sets the seconday device as primary. It expects that all block devices
-// are mirrors.
+// and sets the secondary device as primary. It expects that all block devices
+// with device name disk-<N> are mirrors.
 func (inst *QemuInstance) RemovePrimaryBlockDevice() (err2 error) {
 	var primaryDevice string
 	var secondaryDevicePath string
@@ -397,7 +397,7 @@ func (inst *QemuInstance) RemovePrimaryBlockDevice() (err2 error) {
 	// a `BackingFileDepth` parameter of a device and check if
 	// it is a removable and part of `virtio-blk-pci` devices.
 	for _, dev := range blkdevs.Return {
-		if !dev.Removable && strings.Contains(dev.DevicePath, "virtio-backend") {
+		if !dev.Removable && strings.HasPrefix(dev.Device, "disk-") {
 			if dev.Inserted.BackingFileDepth == 1 {
 				primaryDevice = dev.DevicePath
 			} else {
@@ -1131,7 +1131,7 @@ func (builder *QemuBuilder) addDiskImpl(disk *Disk, primary bool) error {
 		opts = "," + strings.Join(diskOpts, ",")
 	}
 
-	id := fmt.Sprintf("d%d", builder.diskID)
+	id := fmt.Sprintf("disk-%d", builder.diskID)
 
 	// Avoid file locking detection, and the disks we create
 	// here are always currently ephemeral.


### PR DESCRIPTION
These two commits together should fix both https://github.com/coreos/coreos-assembler/issues/2725 and https://github.com/coreos/coreos-assembler/issues/3360.