### PR TITLE
cmdlib: Drop cache qcow2, just use virtiofs

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -582,24 +582,9 @@ runcompose_extensions() {
 }
 
 runvm_with_cache() {
-    # "cache2" has an explicit label so we can find it in qemu easily
-    if [ ! -f "${workdir}"/cache/cache2.qcow2 ]; then
-        qemu-img create -f qcow2 cache2.qcow2.tmp 10G
-        (
-         # shellcheck source=src/libguestfish.sh
-         source /usr/lib/coreos-assembler/libguestfish.sh
-         virt-format --filesystem=xfs --label=cosa-cache -a cache2.qcow2.tmp)
-        mv -T cache2.qcow2.tmp "${workdir}"/cache/cache2.qcow2
-    fi
-    # And remove the old one
+    # Clean up old cache qcow2; we now always rely on virtiofs
     rm -vf "${workdir}"/cache/cache.qcow2
-    local cachedriveargs="discard=unmap"
-    if is_transient; then
-        cachedriveargs="cache=unsafe,discard=ignore"
-    fi
-    cache_args+=("-drive" "if=none,id=cache,$cachedriveargs,file=${workdir}/cache/cache2.qcow2" \
-                        "-device" "virtio-blk,drive=cache")
-    runvm "${cache_args[@]}" "$@"
+    runvm "$@"
 }
 
 # Strips out the digest field from lockfiles since they subtly conflict with


### PR DESCRIPTION
Another chunk of technical debt drops away; we went through a lot of gyrations in the initial development of doing rpm-ostree+qemu, but just using virtiofs to talk to the host seems to work fine here now.

An immediate motivation is https://github.com/coreos/rpm-ostree/issues/4565