### PR TITLE
Stop bumping aarch64 to 8G automatically

### DIFF
--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -1204,10 +1204,10 @@ ExecStart=%s
 	config.AddSystemdUnit(unitName, unit, conf.NoState)
 
 	// Architectures using 64k pages use slightly more memory, ask for more than requested
-	// to make sure that we don't run out of it. Currently ppc64le and aarch64 use 64k pages.
+	// to make sure that we don't run out of it. Currently, only ppc64le uses 64k pages by default.
 	// See similar logic in boot-mirror.go and luks.go.
 	switch coreosarch.CurrentRpmArch() {
-	case "ppc64le", "aarch64":
+	case "ppc64le":
 		if targetMeta.MinMemory <= 4096 {
 			targetMeta.MinMemory = targetMeta.MinMemory * 2
 		}

--- a/mantle/kola/tests/ignition/luks.go
+++ b/mantle/kola/tests/ignition/luks.go
@@ -164,9 +164,9 @@ func runTest(c cluster.TestCluster, tpm2 bool, threshold int, killTangAfterFirst
 	opts := platform.MachineOptions{
 		MinMemory: 4096,
 	}
-	// ppc64le and aarch64 use 64K pages; see similar logic in harness.go and boot-mirror.go
+	// ppc64le uses 64K pages; see similar logic in harness.go and boot-mirror.go
 	switch coreosarch.CurrentRpmArch() {
-	case "ppc64le", "aarch64":
+	case "ppc64le":
 		opts.MinMemory = 8192
 	}
 	m, err := c.NewMachineWithOptions(ignition, opts)

--- a/mantle/kola/tests/misc/boot-mirror.go
+++ b/mantle/kola/tests/misc/boot-mirror.go
@@ -100,9 +100,9 @@ func runBootMirrorTest(c cluster.TestCluster) {
 			MinMemory:       4096,
 		},
 	}
-	// ppc64le and aarch64 use 64K pages; see similar logic in harness.go and luks.go
+	// ppc64le uses 64K pages; see similar logic in harness.go and luks.go
 	switch coreosarch.CurrentRpmArch() {
-	case "ppc64le", "aarch64":
+	case "ppc64le":
 		options.MinMemory = 8192
 	}
 	// FIXME: for QEMU tests kola currently assumes the host CPU architecture
@@ -152,9 +152,9 @@ func runBootMirrorLUKSTest(c cluster.TestCluster) {
 			MinMemory:       4096,
 		},
 	}
-	// ppc64le and aarch64 use 64K pages; see similar logic in harness.go and luks.go
+	// ppc64le uses 64K pages; see similar logic in harness.go and luks.go
 	switch coreosarch.CurrentRpmArch() {
-	case "ppc64le", "aarch64":
+	case "ppc64le":
 		options.MinMemory = 8192
 	}
 	// FIXME: for QEMU tests kola currently assumes the host CPU architecture


### PR DESCRIPTION
The aarch64 RHEL8 kernel used a page size of 64K. In RHEL9, this was
lowered to the usual 4K and a separate kernel was added for 64K.

For testing, this now means that we no longer need to double the memory
for aarch64 by default like we do for ppc64le. If we write tests that
make use of the 64K kernel, we can have them request more memory as
needed.