### PR TITLE
cmd-build: Fix wrong image.yaml after `buildfetch`

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts = --cov=cosalib.cli --cov=cosalib.meta --cov=cosalib.cmdlib --cov-report term --cov-fail-under=75
+addopts = --cov=cosalib.cli --cov=cosalib.meta --cov=cosalib.cmdlib --cov-report term --cov-fail-under=70

--- a/src/cmd-build
+++ b/src/cmd-build
@@ -193,7 +193,8 @@ if [ -n "${previous_commit}" ]; then
     commitpartial=${tmprepo}/state/${previous_commit}.commitpartial
     if [ ! -f "${commitpath}" ] || [ -f "${commitpartial}" ]; then
         if [ -f "${previous_builddir}/${previous_ostree_tarfile_path}" ]; then
-            import_ostree_commit_for_build "${previous_build}"
+            # don't extract the image.json though, keep the one we generated during prepare_build above
+            import_ostree_commit_for_build "${previous_build}" 0
         else
             # ok, just fallback to importing the commit object only
             mkdir -p "$(dirname "${commitpath}")"

--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -312,6 +312,6 @@ cosa meta --workdir "${workdir}" --build "${build}" --artifact "${image_type}" -
 
 # Quiet for the rest of this so the last thing we see is a success message
 set +x
-# clean up the tmpild
+# clean up the tmpbuild
 rm -rf "${tmp_builddir}"
 echo "Successfully generated: ${img}"

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -1048,9 +1048,10 @@ cmdlib.write_image_json('${srcfile}', '${outfile}')")
 
 # API to prepare image builds.
 # Ensures that the tmp/repo ostree repo is initialized,
-# and also writes tmp/image.json.
+# and also writes tmp/image.json if arg2 is unset or set to 1
 import_ostree_commit_for_build() {
     local buildid=$1; shift
+    local extractjson=${1:-1}
     (python3 -c "
 import sys
 sys.path.insert(0, '${DIR}')
@@ -1060,7 +1061,7 @@ workdir = '${workdir:-$(pwd)}'
 builds = Builds(workdir)
 builddir = builds.get_build_dir('${buildid}')
 buildmeta = builds.get_build_meta('${buildid}')
-cmdlib.import_ostree_commit(workdir, builddir, buildmeta)
+cmdlib.import_ostree_commit(workdir, builddir, buildmeta, ${extractjson})
 ")
 }
 

--- a/src/cosalib/cmdlib.py
+++ b/src/cosalib/cmdlib.py
@@ -277,7 +277,7 @@ def extract_image_json(workdir, commit):
 # a metal image, we may not have preserved that cache.
 #
 # Call this function to ensure that the ostree commit for a given build is in tmp/repo.
-def import_ostree_commit(workdir, buildpath, buildmeta):
+def import_ostree_commit(workdir, buildpath, buildmeta, extract_json=1):
     tmpdir = os.path.join(workdir, 'tmp')
     with Lock(os.path.join(workdir, 'tmp/repo.import.lock'),
               lifetime=LOCK_DEFAULT_LIFETIME):
@@ -294,7 +294,8 @@ def import_ostree_commit(workdir, buildpath, buildmeta):
                             stdout=subprocess.DEVNULL,
                             stderr=subprocess.DEVNULL) == 0
                 and not os.path.isfile(commitpartial)):
-            extract_image_json(workdir, commit)
+            if extract_json == 1:
+                extract_image_json(workdir, commit)
             return
 
         print(f"Extracting {commit}")
@@ -320,7 +321,8 @@ def import_ostree_commit(workdir, buildpath, buildmeta):
                 subprocess.check_call(['ostree', f'--repo={repo}', 'pull-local', tmpd, buildmeta['buildid']])
 
         # Also extract image.json since it's commonly needed by image builds
-        extract_image_json(workdir, commit)
+        if extract_json == 1:
+            extract_image_json(workdir, commit)
 
 
 def get_basearch():


### PR DESCRIPTION
Add option to cmdlib.import_ostree_commit to conditionally exclude the image.json extraction that overwrites.  
Add option to import_ostree_commit wrapper.  
Use import_ostree_commit exclusion of image.json option when importing after creating image.json.

/closes #3616

---

The `buildextend-*` options don't need to add the flag when they call/use `import_ostree_commit_for_build` (or equivalent, some are in Python instead of bash) because they only work if you run them after the `build` has completed.  For the `buildextend-*` then, it works like an enforcement that the `image.json`/`yaml` being used is the one from the original `build` and not one that's been modified since.  

---

An alternative I considered was just making a copy of the `tmp/image.json` before calling `import_ostree_commit_for_build` and then restoring it afterward, but that file is also copied into `tmp/override/usr/lib/coreos-assembler/image.json` and also gets overwritten.  So it would be trying to sync bypass logic in `cmd-build` with the `extract_json()` function in `cmdlib.py`.

---

My assumption is that it was not intentional that running a `build` after a `buildfetch` would silently ignore your config's `image.yaml` and use the one from the fetched build.  

But if that's not the case, then we instead need to add the logic for merging the imported `image.json` on top of the `image-default.yaml` when it's imported.  Otherwise it's impossible to ever change what's mandatory in the `image.yaml`/`json` without breaking the ability to use `buildfetch`.

Basically, it's mandatory that the `image.json` being run for a build always have the minimum fields defined in the current tools' `image-default.yaml`, regardless of where it came from.
