### PR TITLE
cmdlib: Drop unsafety for cache disk

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -594,9 +594,6 @@ runvm_with_cache() {
     # And remove the old one
     rm -vf "${workdir}"/cache/cache.qcow2
     local cachedriveargs="discard=unmap"
-    if is_transient; then
-        cachedriveargs="cache=unsafe,discard=ignore"
-    fi
     cache_args+=("-drive" "if=none,id=cache,$cachedriveargs,file=${workdir}/cache/cache2.qcow2" \
                         "-device" "virtio-blk,drive=cache")
     runvm "${cache_args[@]}" "$@"


### PR DESCRIPTION
This can't really be safe here because we have to ensure that the stuff we write makes it to the filesystem image between a separated fetch + build process.

cc https://github.com/coreos/coreos-assembler/issues/3591 which I suspect this will fix, but didn't verify.