### PR TITLE
platform/qemu.go: fix device name check when switching bootorder

### DIFF
--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -339,7 +339,7 @@ func (inst *QemuInstance) SwitchBootOrder() (err2 error) {
 		switch dev.Device {
 		case "installiso":
 			bootdev = devpath
-		case "d1", "mpath10":
+		case "disk-1", "mpath10":
 			primarydev = devpath
 		case "mpath11":
 			secondarydev = devpath


### PR DESCRIPTION
Missed this when I changed the QEMU drive name to `disk-` instead of `d`.

Fixes 75945a30f ("platform/qemu: strengthen data block device checks").