### PR TITLE
kola/testiso: combine `fromram` test with `4k` instead

### DIFF
--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -107,9 +107,9 @@ var (
 	}
 	tests_ppc64le = []string{
 		"iso-live-login.ppcfw",
-		"iso-offline-install-fromram.ppcfw",
+		"iso-offline-install.ppcfw",
 		"iso-offline-install.mpath.ppcfw",
-		"iso-offline-install.4k.ppcfw",
+		"iso-offline-install-fromram.4k.ppcfw",
 		"miniso-install.ppcfw",
 		"miniso-install.nm.ppcfw",
 		"miniso-install.4k.ppcfw",
@@ -120,9 +120,9 @@ var (
 	tests_aarch64 = []string{
 		"iso-live-login.uefi",
 		"iso-live-login.4k.uefi",
-		"iso-offline-install-fromram.uefi",
+		"iso-offline-install.uefi",
 		"iso-offline-install.mpath.uefi",
-		"iso-offline-install.4k.uefi",
+		"iso-offline-install-fromram.4k.uefi",
 		"miniso-install.uefi",
 		"miniso-install.nm.uefi",
 		"miniso-install.4k.uefi",


### PR DESCRIPTION
The `iso-offline-install.$firmware` tests are the most common, "default", path that users installing CoreOS will use. Let's keep that test untouched so we make sure we always have coverage for it.

To keep the number of tests the same, combine it with the `4k` test instead, since it differs from the default path in an orthogonal way to how `fromram` differs.

Follow-up to 095510153 ("mantle/kola/testiso: support testing coreos.liveiso.fromram installs").