### PR TITLE
mantle/kola: don't match on tag OR pattern

### DIFF
--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -547,8 +547,8 @@ func filterTests(tests map[string]*register.Test, patterns []string, pltfrm stri
 
 		if userTypedPattern {
 			// If the user explicitly typed a pattern, then the test *must*
-			// match by name or by tag. Otherwise, we skip it.
-			if !nameMatch && !tagMatch {
+			// have a name match. Otherwise, we skip it.
+			if !nameMatch {
 				continue
 			}
 		} else {


### PR DESCRIPTION
If a pattern (or patterns) were provided then we should match other tests (i.e. by tag).  This was causing all tests to get rerun if a tag was provided it would match all the tests with that tag and not the pattern provided that described what tests to rerun.

Fixes https://github.com/coreos/coreos-assembler/issues/3041