### PR TITLE
devshell: Don't output status if not on a tty

### DIFF
--- a/mantle/cmd/kola/devshell.go
+++ b/mantle/cmd/kola/devshell.go
@@ -50,7 +50,10 @@ func stripControlCharacters(s string) string {
 	}, s)
 }
 
-func displayStatusMsg(status, msg string, termMaxWidth int) {
+func displayStatusMsg(ontty bool, status, msg string, termMaxWidth int) {
+	if !ontty {
+		return
+	}
 	s := strings.TrimSpace(msg)
 	if s == "" {
 		return
@@ -63,8 +66,11 @@ func displayStatusMsg(status, msg string, termMaxWidth int) {
 }
 
 func runDevShellSSH(ctx context.Context, builder *platform.QemuBuilder, conf *conf.Conf, sshCommand string) error {
-	if !term.IsTerminal(0) {
-		return fmt.Errorf("stdin is not a tty")
+	ontty := term.IsTerminal(0)
+	if sshCommand == "" {
+		if !ontty {
+			return fmt.Errorf("stdin is not a tty")
+		}
 	}
 	termMaxWidth, _, err := term.GetSize(0)
 	if err != nil {
@@ -170,6 +176,7 @@ func runDevShellSSH(ctx context.Context, builder *platform.QemuBuilder, conf *co
 
 	// Start the SSH client
 	sc := newSshClient(ip, agent.Socket, sshCommand)
+	sc.ontty = ontty
 	go sc.controlStartStop()
 
 	ready := false
@@ -187,7 +194,7 @@ func runDevShellSSH(ctx context.Context, builder *platform.QemuBuilder, conf *co
 		// a status message on the console.
 		case serialMsg := <-serialChan:
 			if !ready {
-				displayStatusMsg(statusMsg, serialMsg, termMaxWidth)
+				displayStatusMsg(ontty, statusMsg, serialMsg, termMaxWidth)
 			}
 			lastMsg = serialMsg
 		// monitor the err channel
@@ -201,7 +208,7 @@ func runDevShellSSH(ctx context.Context, builder *platform.QemuBuilder, conf *co
 
 		// monitor the instance state
 		case <-qemuWaitChan:
-			displayStatusMsg("DONE", "QEMU instance terminated", termMaxWidth)
+			displayStatusMsg(ontty, "DONE", "QEMU instance terminated", termMaxWidth)
 			return nil
 
 		// monitor the machine state events from console/serial logs
@@ -232,17 +239,17 @@ func runDevShellSSH(ctx context.Context, builder *platform.QemuBuilder, conf *co
 					statusMsg = "QEMU guest is booting"
 				}
 			}
-			displayStatusMsg(fmt.Sprintf("EVENT | %s", statusMsg), lastMsg, termMaxWidth)
+			displayStatusMsg(ontty, fmt.Sprintf("EVENT | %s", statusMsg), lastMsg, termMaxWidth)
 
 		// monitor the SSH connection
 		case err := <-sc.errChan:
 			if err == nil {
 				sc.controlChan <- sshNotReady
-				displayStatusMsg("SESSION", "Clean exit from SSH, terminating instance", termMaxWidth)
+				displayStatusMsg(ontty, "SESSION", "Clean exit from SSH, terminating instance", termMaxWidth)
 				return nil
 			} else if sshCommand != "" {
 				sc.controlChan <- sshNotReady
-				displayStatusMsg("SESSION", "SSH command exited, terminating instance", termMaxWidth)
+				displayStatusMsg(ontty, "SESSION", "SSH command exited, terminating instance", termMaxWidth)
 				return err
 			}
 			if ready {
@@ -455,6 +462,7 @@ type sshClient struct {
 	port        string
 	agent       string
 	cmd         string
+	ontty       bool
 	controlChan chan sshControlMessage
 	errChan     chan error
 	sshCmd      *exec.Cmd
@@ -511,8 +519,10 @@ func (sc *sshClient) start() {
 	if sc.cmd != "" {
 		sshArgs = append(sshArgs, "--", sc.cmd)
 	}
-	fmt.Printf("\033[2K\r")                // clear serial console line
-	fmt.Printf("[SESSION] Starting SSH\r") // and stage a status msg which will be erased
+	if sc.ontty {
+		fmt.Printf("\033[2K\r")                // clear serial console line
+		fmt.Printf("[SESSION] Starting SSH\r") // and stage a status msg which will be erased
+	}
 	sshCmd := exec.Command(sshArgs[0], sshArgs[1:]...)
 	sshCmd.Stdin = os.Stdin
 	sshCmd.Stdout = os.Stdout
@@ -531,7 +541,7 @@ func (sc *sshClient) start() {
 		for scanner.Scan() {
 			msg := scanner.Text()
 			if strings.Contains(msg, "Connection to 127.0.0.1 closed") {
-				displayStatusMsg("SSH", "connection closed", 0)
+				displayStatusMsg(sc.ontty, "SSH", "connection closed", 0)
 			}
 		}
 	}()


### PR DESCRIPTION
This is just better behavior for the case of e.g.
`cosa run -x "somecmd" > out.txt` to execute a command and capture the output - we don't want to intermix status stuff in there.

Further, this makes it easier to test the code when not on a tty (in e.g. CI).