### PR TITLE
[rhcos-4.14] live-iso: Write kernel (and hmac) to /boot too

### DIFF
--- a/src/gf-mksquashfs
+++ b/src/gf-mksquashfs
@@ -36,8 +36,15 @@ coreos_gf_run_mount "${src}" --ro
 coreos_gf download /ostree/repo/config "${tmpd}/config"
 grep -v readonly=true "${tmpd}/config" > "${tmpd}/config.new"
 coreos_gf upload "${tmpd}/config.new" /ostree/repo/config
-coreos_gf mksquashfs / "${tmp_dest}" "compress:${compression}"
 
+# And ensure that the kernel binary and hmac file is in the place that dracut
+# expects it to be; xref https://issues.redhat.com/browse/OCPBUGS-15843
+kernel_binary=$(coreos_gf glob-expand /boot/ostree/*/vmlinuz*)
+kernel_hmac=$(coreos_gf glob-expand /boot/ostree/*/.*.hmac)
+coreos_gf ln "${kernel_hmac}" "/boot/$(basename "${kernel_hmac}")"
+coreos_gf ln "${kernel_binary}" "/boot/$(basename "${kernel_binary}")"
+
+coreos_gf mksquashfs / "${tmp_dest}" "compress:${compression}"
 coreos_gf_shutdown
 
 mv "${tmp_dest}" "${dest}"


### PR DESCRIPTION
Fixes the problem that we backported the FIPS test but not the enablement here.

---

This is useful in order to make the dracut FIPS module work. For ostree, we put the kernel stuff in `/boot/ostree` in order to namespace things.  But non-ostree systems tend to use `/boot` directly, and that's what the dracut module is hardcoded to do.

Now we did add some logic in the dracut module which scrapes the grub-injected `BOOT_IMAGE`, except this doesn't work for how we generate the CoreOS Live ISO today because the filenames of the kernel don't include versions etc.

In the case of the Live ISO though we don't really need to "ostree namespace" things, so just hardlink the kernel binary and the hmac file into the traditional places in `/boot`.

We *could* not do this, and do it in our dracut module in the initramfs in fips mode only for the Live ISO, but that'd be way more ugly.

xref https://issues.redhat.com/browse/OCPBUGS-15843

(cherry picked from commit 86943ca026b37dd1e359e4bb91a68a41529dc20b)