### PR TITLE
kola/tests/boot-mirror: bump sleep hack to 60s

### DIFF
--- a/mantle/kola/tests/misc/boot-mirror.go
+++ b/mantle/kola/tests/misc/boot-mirror.go
@@ -245,7 +245,9 @@ func detachPrimaryBlockDevice(c cluster.TestCluster, m platform.Machine) {
 		// that rebooting too quickly after ripping out the primary device can trigger
 		// a kernel panic on ppc64le. This may be memory-related since the same panic
 		// happens more easily if memory is lowered to 4G.
-		time.Sleep(30 * time.Second)
+		if coreosarch.CurrentRpmArch() == "ppc64le" {
+			time.Sleep(60 * time.Second)
+		}
 
 		err := m.Reboot()
 		if err != nil {


### PR DESCRIPTION
Follow-up to https://github.com/coreos/coreos-assembler/pull/3611.

We're still noticing occasional kernel panics with 30s on ppc64le. Bump it to 60s to see if that helps as a last ditch effort before re-disabling these tests until someone has time to dig into it properly.

While we're here, make it specific to ppc64le.