### PR TITLE
cp-reflink: re-enable it

### DIFF
--- a/src/cp-reflink
+++ b/src/cp-reflink
@@ -1,4 +1,2 @@
 #!/bin/bash
-# XXX: disable reflinks for now due to possible corruption:
-# https://github.com/coreos/coreos-assembler/pull/935
-exec cp -a --reflink=never "$@"
+exec cp -a --reflink=auto "$@"


### PR DESCRIPTION
It's been a while since we've disabled reflink. Let's re-enable it for space efficiency and we'll find out if the issue has been fixed or not.

Closes: #941