### PR TITLE
mantle/qemu: neuter virtiofsd seccomp filtering

### DIFF
--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -1594,6 +1594,9 @@ func createVirtiofsCmd(directory, socketPath string) exec.Cmd {
 	if os.Getuid() == 0 {
 		args = append(args, "--modcaps=-mknod:-setfcap")
 	}
+	// We don't need seccomp filtering; we trust our workloads. This incidentally
+	// works around issues like https://gitlab.com/virtio-fs/virtiofsd/-/merge_requests/200.
+	args = append(args, "--seccomp=none")
 	cmd := exec.Command("/usr/libexec/virtiofsd", args...)
 	// This sets things up so that the `.` we passed in the arguments is the target directory
 	cmd.Dir = directory


### PR DESCRIPTION
By default, `virtiofsd` uses seccomp to allow only some syscalls to be proxied from the guest. In the theme of `--sandbox=none`, let's also neuter seccomp filtering for our virtiofs usage; the workloads we run in the supermin/dev VMs are trusted.

Incidentally, this avoids issues like #3635, where some syscalls were accidentally missing from the allow list. In this case, new libostree code[[1]] running in the supermin VM when building the legacy oscontainer calls out to `fstatfs` over virtiofs, which maps to the blocked `fstatfs64` syscall on ppc64le. (I've opened an upstream patch[[2]] to fix this, but we don't strictly need it.)

Closes: #3635

[1]: https://github.com/ostreedev/ostree/commit/ba9c9dedffb953738c609fda6502b9b37ee1b6ba
[2]: https://gitlab.com/virtio-fs/virtiofsd/-/merge_requests/200