### PR TITLE
buildextend-legacy-oscontainer: stop using virtio-serial hack

### DIFF
--- a/src/buildextend-legacy-oscontainer.sh
+++ b/src/buildextend-legacy-oscontainer.sh
@@ -8,8 +8,6 @@ final_outfile=$(realpath "$1"); shift
 IMAGE_TYPE=legacy-oscontainer
 prepare_build
 tmp_outfile=${tmp_builddir}/legacy-oscontainer.ociarchive
-runvm -chardev "file,id=ociarchiveout,path=${tmp_outfile}" \
-    -device "virtserialport,chardev=ociarchiveout,name=ociarchiveout" -- \
-    /usr/lib/coreos-assembler/buildextend-legacy-oscontainer.py \
-        --output "/dev/virtio-ports/ociarchiveout" "$@"
+runvm -- /usr/lib/coreos-assembler/buildextend-legacy-oscontainer.py \
+    --output "${tmp_outfile}" "$@"
 /usr/lib/coreos-assembler/finalize-artifact "${tmp_outfile}" "${final_outfile}"


### PR DESCRIPTION
Now that we're on virtiofs, we can undo this hack.