### PR TITLE
cmd-init: Remove 'yumrepos-branch' argument

### DIFF
--- a/src/cmd-init
+++ b/src/cmd-init
@@ -11,7 +11,6 @@ BRANCH=""
 COMMIT=""
 TRANSIENT=0
 YUMREPOS=""
-YUMREPOS_BRANCH=""
 VARIANT=""
 
 print_help() {
@@ -19,8 +18,7 @@ print_help() {
 Usage: coreos-assembler init --help
        coreos-assembler init [--force] [--transient] [--branch BRANCH] 
                              [--commit COMMIT] [-V/--variant VARIANT]
-                             [--yumrepos GITREPO] [--yumrepos-branch BRANCH]
-                             GITCONFIG
+                             [--yumrepos GITREPO] GITCONFIG
 
   For example, you can use https://github.com/coreos/fedora-coreos-config
   as GITCONFIG, or fork it.  Another option useful for local development
@@ -31,8 +29,7 @@ Usage: coreos-assembler init --help
   Use `--yumrepos` for builds that need .repo files and a content_sets.yaml which
   are not in GITCONFIG. For example: files need to be hidden behind a firewall
   in GITREPO. Using this option will clone GITREPO alongside GITCONFIG, thus you
-  may need to configure certificates. Use `--yumrepos-branch` to choose a non-default
-  branch when cloning. Local paths are also supported. 
+  may need to configure certificates. Local paths are also supported.
 
   Use `--transient` for builds that will throw away all cached data on success/failure,
   and should hence not invoke `fsync()` for example.
@@ -55,7 +52,7 @@ EOF
 
 # Call getopt to validate the provided input.
 rc=0
-options=$(getopt --options hfb:c:V: --longoptions help,force,transient,branch:,commit:,yumrepos:,yumrepos-branch:,variant: -- "$@") || rc=$?
+options=$(getopt --options hfb:c:V: --longoptions help,force,transient,branch:,commit:,yumrepos:,variant: -- "$@") || rc=$?
 [ $rc -eq 0 ] || {
     print_help
     exit 1
@@ -97,15 +94,6 @@ while true; do
                 shift ;;
             *)
                 YUMREPOS="$2"
-                shift ;;
-        esac
-        ;;
-    --yumrepos-branch)
-        case "$2" in
-            "")
-                shift ;;
-            *)
-                YUMREPOS_BRANCH="$2"
                 shift ;;
         esac
         ;;
@@ -212,7 +200,7 @@ fi
 case "${YUMREPOS}" in
     "");;
     /*) ln -s "${YUMREPOS}" src/yumrepos;;
-    *) git clone ${YUMREPOS_BRANCH:+--branch=${YUMREPOS_BRANCH}} --depth=1 "${YUMREPOS}" src/yumrepos;;
+    *) git clone --depth=1 "${YUMREPOS}" src/yumrepos;;
 esac
 
 set +x


### PR DESCRIPTION
We don't use this argument anymore. All repos are expected to be in the main branch for all releases, under distinct names.