### PR TITLE
Revert "Revert "qemu: drop supportsIsoKargs check cause now all platfroms support it""

### DIFF
--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -104,6 +104,9 @@ var (
 		// "iso-offline-install.4k.s390fw",
 		"pxe-online-install.s390fw",
 		"pxe-offline-install.s390fw",
+		"miniso-install.s390fw",
+		"miniso-install.nm.s390fw",
+		"miniso-install.4k.nm.s390fw",
 	}
 	tests_ppc64le = []string{
 		"iso-live-login.ppcfw",

--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -1409,13 +1409,6 @@ func coreosInstallerSupportsISOKargs() (bool, error) {
 	return strings.Contains(out, "kargs"), nil
 }
 
-// supportsIsoKargs returns true if we support modifying ISO kargs on the
-// current arch. We could also auto-detect this, but would probably still want
-// some assertions that we detected as supported on !s390x.
-func (builder *QemuBuilder) supportsIsoKargs() bool {
-	return builder.architecture != "s390x"
-}
-
 func (builder *QemuBuilder) setupIso() error {
 	if err := builder.ensureTempdir(); err != nil {
 		return err
@@ -1460,11 +1453,9 @@ func (builder *QemuBuilder) setupIso() error {
 				return errors.Wrapf(err, "running `coreos-installer iso kargs modify`; old CoreOS ISO?")
 			}
 			// Only actually emit a warning if we expected it to be supported
-			if builder.supportsIsoKargs() {
-				stderr := stderrb.String()
-				plog.Warningf("running coreos-installer iso kargs modify: %v: %q", err, stderr)
-				plog.Warning("likely targeting an old CoreOS ISO; ignoring...")
-			}
+			stderr := stderrb.String()
+			plog.Warningf("running coreos-installer iso kargs modify: %v: %q", err, stderr)
+			plog.Warning("likely targeting an old CoreOS ISO; ignoring...")
 		}
 	} else if len(builder.AppendKernelArgs) > 0 {
 		return fmt.Errorf("coreos-installer does not support appending kernel args")


### PR DESCRIPTION
coreos-installer 0.18.0 was released, so we can enable tests again

This reverts commit 0c9789331e9ad27db64205a11364c94990e276ca.