### PR TITLE
cmd/remote-session: use `--init` instead of `dumb-init`

### DIFF
--- a/cmd/remote-session.go
+++ b/cmd/remote-session.go
@@ -227,7 +227,7 @@ func runSync(c *cobra.Command, args []string) error {
 		return fmt.Errorf("Must pass in a single arg with `:` prepended")
 	}
 	// build command and execute
-	rsyncargs := []string{"-ah", "--mkpath", "--blocking-io",
+	rsyncargs := []string{"-ah", "--no-owner", "--no-group", "--mkpath", "--blocking-io",
 		"--compress", "--rsh", "podman --remote exec -i"}
 	if !remoteSessionOpts.SyncQuiet {
 		rsyncargs = append(rsyncargs, "-v")

--- a/cmd/remote-session.go
+++ b/cmd/remote-session.go
@@ -144,8 +144,9 @@ func runCreate(c *cobra.Command, args []string) error {
 		"--volume=secex-data:/data.secex:ro",
 		"--uidmap=1000:0:1", "--uidmap=0:1:1000", "--uidmap=1001:1001:64536",
 		"--device=/dev/kvm", "--device=/dev/fuse", "--tmpfs=/tmp",
-		"--entrypoint=/usr/bin/dumb-init", remoteSessionOpts.CreateImage,
-		"sleep", remoteSessionOpts.CreateExpiration}
+		"--init", "--entrypoint=/usr/bin/sleep",
+		remoteSessionOpts.CreateImage,
+		remoteSessionOpts.CreateExpiration}
 	cmd := exec.Command("podman", podmanargs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
cmd/remote-session: use `--init` instead of `dumb-init`

I'd like to reuse the `cosa remote-session` bits to run non-cosa images
on remote builders. Since it's mostly a wrapper around `podman --remote`,
it has very few requirements on the target image.

One of the requirements I'd like to loosen is on `dumb-init`. That one
is easy to drop since podman has built-in support for making pid 1 an
init-like system. Use that instead.

---

cmd/remote-session: add `--no-{owner,group}` to `rsync` call

It's meaningless to try to retain ownership information between the
builder and the orchestrator pod. We don't really care about that stuff,
so tell `rsync` as much to avoid a bunch of `chown` warnings.

