### PR TITLE
create_disk: Use fsfreeze

### DIFF
--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -539,8 +539,8 @@ fstrim -a -v
 # Ensure the filesystem journals are flushed
 for fs in $rootfs/boot $rootfs; do
     mount -o remount,ro "$fs"
-    xfs_freeze -f "$fs"
-    xfs_freeze -u "$fs"
+    fsfreeze -f "$fs"
+    fsfreeze -u "$fs"
 done
 
 umount -R $rootfs


### PR DESCRIPTION
It's the generic fs-independent tool.  No strong motivation, just pointed someone else at this code.

We made the equivalent change in bootc
https://github.com/containers/bootc/pull/102/commits/15de723ac2a9707523967aa4ee5c29875b94baa8