### PR TITLE
kola: add `--extend-timeout-percentage` switch

### DIFF
--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -71,6 +71,8 @@ func init() {
 	sv(&kola.Options.CosaBuildArch, "arch", coreosarch.CurrentRpmArch(), "The target architecture of the build")
 	sv(&kola.Options.AppendButane, "append-butane", "", "Path to Butane config which is merged with test code")
 	sv(&kola.Options.AppendIgnition, "append-ignition", "", "Path to Ignition config which is merged with test code")
+	// we make this a percentage to avoid having to deal with floats
+	root.PersistentFlags().UintVar(&kola.Options.ExtendTimeoutPercent, "extend-timeout-percentage", 0, "Extend all test timeouts by N percent")
 	// rhcos-specific options
 	sv(&kola.Options.OSContainer, "oscontainer", "", "oscontainer image pullspec for pivot (RHCOS only)")
 

--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -135,7 +135,7 @@ var (
 )
 
 const (
-	installTimeout = 10 * time.Minute
+	installTimeoutMins = 10
 	// https://github.com/coreos/fedora-coreos-config/pull/2544
 	liveISOFromRAMKarg = "coreos.liveiso.fromram"
 )
@@ -589,8 +589,9 @@ func awaitCompletion(ctx context.Context, inst *platform.QemuInstance, outdir st
 	start := time.Now()
 	errchan := make(chan error)
 	go func() {
-		time.Sleep(installTimeout)
-		errchan <- fmt.Errorf("timed out after %v", installTimeout)
+		timeout := (time.Duration(installTimeoutMins*(100+kola.Options.ExtendTimeoutPercent)) * time.Minute) / 100
+		time.Sleep(timeout)
+		errchan <- fmt.Errorf("timed out after %v", timeout)
 	}()
 	if !console {
 		go func() {

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -826,7 +826,7 @@ func runProvidedTests(testsBank map[string]*register.Test, patterns []string, mu
 			// At the end of the test, its cluster is destroyed
 			runTest(h, test, pltfrm, flight)
 		}
-		htests.Add(test.Name, run, test.Timeout)
+		htests.Add(test.Name, run, (test.Timeout*time.Duration(100+(Options.ExtendTimeoutPercent)))/100)
 	}
 
 	handleSuiteErrors := func(outputDir string, suiteErr error) error {

--- a/mantle/platform/platform.go
+++ b/mantle/platform/platform.go
@@ -194,6 +194,8 @@ type Options struct {
 	OSContainer string
 
 	SSHOnTestFailure bool
+
+	ExtendTimeoutPercent uint
 }
 
 // RuntimeConfig contains cluster-specific configuration.


### PR DESCRIPTION
This switch that allows extending all test timeouts by a given percentage. For example, `--extend-timeout-percentage 50` will increase all timeouts by 50%.

This can be useful in contexts where one is running tests in an environment much slower than the baseline (e.g. without KVM).