### PR TITLE
kola: Two zincati fixes

### DIFF
--- a/mantle/platform/cluster.go
+++ b/mantle/platform/cluster.go
@@ -282,6 +282,8 @@ After=network-online.target
 
 [Service]
 Type=oneshot
+# Newer zincati more explicitly fails on containers; fully disable it
+ExecStart=systemctl mask --now zincati
 ExecStart=rpm-ostree rebase --experimental %s
 ExecStart=touch /etc/kola-rebase-done
 ExecStart=systemctl reboot

--- a/mantle/platform/cluster.go
+++ b/mantle/platform/cluster.go
@@ -269,8 +269,7 @@ func (bc *BaseCluster) RenderUserData(userdata *platformConf.UserData, ignitionV
 
 	// disable Zincati by default
 	if bc.Distribution() == "fcos" {
-		conf.AddFile("/etc/zincati/config.d/90-disable-auto-updates.toml", `[updates]
-enabled = false`, 0644)
+		conf.DisableAutomaticUpdates()
 	}
 
 	if bc.bf.baseopts.OSContainer != "" {


### PR DESCRIPTION
The new zincati broke the bootc CI.

---

kola: Use centralized drop-in to disable zincati

Just a drive by cleanup.

---

kola: Explicitly mask zincati

The newer zincati errors out instead of retrying; mask it
explicitly.

---

