### PR TITLE
Update to f39

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # When rebasing to new Fedora, also update openshift/release:
 # https://github.com/openshift/release/tree/master/ci-operator/config/coreos/coreos-assembler/coreos-coreos-assembler-main.yaml
-FROM registry.fedoraproject.org/fedora:39
+FROM quay.io/fedora/fedora:39
 WORKDIR /root/containerbuild
 
 # Keep this Dockerfile idempotent for local development rebuild use cases.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # When rebasing to new Fedora, also update openshift/release:
 # https://github.com/openshift/release/tree/master/ci-operator/config/coreos/coreos-assembler/coreos-coreos-assembler-main.yaml
-FROM registry.fedoraproject.org/fedora:38
+FROM registry.fedoraproject.org/fedora:39
 WORKDIR /root/containerbuild
 
 # Keep this Dockerfile idempotent for local development rebuild use cases.

--- a/build.sh
+++ b/build.sh
@@ -172,7 +172,7 @@ write_archive_info() {
 patch_osbuild() {
     # A few patches that either haven't made it into a release or
     # that will be obsoleted with other work that will be done soon.
-    cat /usr/lib/coreos-assembler/*.patch | patch -p1 -d /usr/lib/python3.11/site-packages/
+    cat /usr/lib/coreos-assembler/*.patch | patch -p1 -d /usr/lib/python3.12/site-packages/
 }
 
 if [ $# -ne 0 ]; then

--- a/build.sh
+++ b/build.sh
@@ -44,14 +44,6 @@ install_rpms() {
 
     frozendeps=""
 
-    # freeze grub2 for https://github.com/coreos/coreos-assembler/issues/3370
-    case "${arch}" in
-        x86_64) frozendeps=$(echo grub2-{common,tools,tools-extra,tools-minimal,efi-x64,pc,pc-modules}-1:2.06-76.fc38);;
-        aarch64) frozendeps=$(echo grub2-{common,tools,tools-extra,tools-minimal,efi-aa64}-1:2.06-76.fc38);;
-        ppc64le) frozendeps=$(echo grub2-{common,tools,tools-extra,tools-minimal,ppc64le,ppc64le-modules}-1:2.06-76.fc38);;
-        *) ;;
-    esac
-
     # First, a general update; this is best practice.  We also hit an issue recently
     # where qemu implicitly depended on an updated libusbx but didn't have a versioned
     # requires https://bugzilla.redhat.com/show_bug.cgi?id=1625641

--- a/tests/test_cosalib_meta.py
+++ b/tests/test_cosalib_meta.py
@@ -143,13 +143,13 @@ def test_merge_meta(tmpdir):
             m = meta.GenericBuildMeta(_create_test_files(tmpdir, meta_data=td),
                                       '1.2.3')
 
+            # create working copies
             w = meta.GenericBuildMeta(_create_test_files(tmpdir, meta_data=td),
                                       '1.2.3')
-            # create working copies
             if x is None:
-                x = copy.deepcopy(m)
+                x = w
             else:
-                y = copy.deepcopy(m)
+                y = w
 
             # add the stamp
             m.write()


### PR DESCRIPTION
Update to f39

Today the ostree CI relies on the buildroot container, cosa and FCOS
all being on the same major.

---

build: Unfreeze grub2

We will just have to stop testing ppc64le with PXE boot.

HOWEVER: An important thing we could try to do going forward
is again do a build of coreos-assembler using RHEL 9 (or CentOS Stream 9).
We're not actually that far away from this last I tried, particularly
using EPEL content.

---

