### PR TITLE
Add support for devcontainers[1]

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,17 @@
+{
+    "image": "quay.io/coreos-assembler/coreos-assembler",
+    "workspaceMount": "",
+    "workspaceFolder": "/srv",
+    "runArgs": [
+              "--volume=${localWorkspaceFolder}:/srv/:Z", 
+              "--uidmap=1000:0:1", "--uidmap=0:1:1000", "--uidmap=1001:1001:64536",
+              "--device=/dev/kvm", "--device=/dev/fuse",  "--security-opt=label=disable", "--privileged",
+              "--tmpfs=/tmp", "-v=/var/tmp:/var/tmp"
+            ],      
+    "remoteUser": "builder",
+    "customizations": {
+        "vscode": {
+          "extensions": ["golang.Go", "ms-vsliveshare.vsliveshare"]
+        }
+      }
+}


### PR DESCRIPTION
This allows VSCode or any other devconatainer compliant IDE to automatically spin up a container containing the necessary dependencies.
This uses quay.io/coreos-assembler/coreos-assembler.

Requires the remotecontainer extension to be installed on VSCode [2]

With the flatpak version, set up podman remote first [3]

[1] https://containers.dev/
[2] https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers
[3] https://gist.github.com/FilBot3/4424d312a87f7b4178722d3b5eb20212