### PR TITLE
deps: drop `awscli`, install `awscli2` on x86_64 only

### DIFF
--- a/src/deps-x86_64.txt
+++ b/src/deps-x86_64.txt
@@ -1,2 +1,6 @@
 # For generating ISO images
 syslinux-nonlinux
+
+# For the pipeline and developers to interact with AWS. It's not needed by cosa
+# itself. This isn't available on s390x at least, so make it x86_64-only.
+awscli2

--- a/src/deps.txt
+++ b/src/deps.txt
@@ -40,7 +40,7 @@ podman buildah skopeo
 jq
 
 # For interacting with AWS/Aliyun/HTTP
-awscli golang-github-aliyun-cli python3-boto3 python3-requests
+golang-github-aliyun-cli python3-boto3 python3-requests
 
 # For python retries
 python3-tenacity


### PR DESCRIPTION
The package is noarch, but one of its dep isn't available on s390x.[[1]]
What's new in Fedora 39 is the AwsCli[[2]] change in which the `awscli`
was retired in favour of `awscli2`.

In fact, it turns out even on f38 we were pulling in `awscli2` on all
arches except s390x, where we still pulled `awscli`.

Anyway, cosa itself doesn't use the `aws` CLI but the Python/Go API
libraries directly, which *are* available on all arches.

The pipeline does use it in one spot[[3]], but that's only ever run from
the Jenkins controller, which is x86_64.

So let's just move the dep to be x86_64-specific and make it clear it's
not for cosa itself but for the pipeline and developer convenience.

[1]: https://src.fedoraproject.org/rpms/awscli2/blob/62f260a00a87/f/awscli2.spec#_41
[2]: https://fedoraproject.org/wiki/Changes/AwsCli
[3]: https://github.com/coreos/fedora-coreos-pipeline/blob/b2dc3c8a1c02e3838b933e09ed6bfc8d8dfe9153/utils.groovy#L214