### PR TITLE
deps: add python3-fedfind

### DIFF
--- a/src/deps.txt
+++ b/src/deps.txt
@@ -71,6 +71,7 @@ fedora-messaging
 python3-resultsdb_api
 python3-resultsdb_conventions
 python3-resultsdb_conventions-fedora
+python3-fedfind
 
 # For debugging running processes in the pipelines
 strace


### PR DESCRIPTION
This is a new dep of python3-resultsdb_conventions-fedora in f39, but for some reason is undeclared. Add it manually for now until the package is fixed.