### PR TITLE
mantle/kola/tests/crio: update tests for new cri-tools

### DIFF
--- a/mantle/kola/tests/crio/crio.go
+++ b/mantle/kola/tests/crio/crio.go
@@ -32,6 +32,8 @@ import (
 	"github.com/coreos/coreos-assembler/mantle/lang/worker"
 	"github.com/coreos/coreos-assembler/mantle/platform"
 	"github.com/coreos/coreos-assembler/mantle/platform/conf"
+
+	"github.com/google/uuid"
 )
 
 // simplifiedCrioInfo represents the results from crio info
@@ -51,7 +53,8 @@ const overrideCrioOperationTimeoutSeconds = "300s"
 var crioPodTemplate = `{
 	"metadata": {
 		"name": "rhcos-crio-pod-%s",
-		"namespace": "redhat.test.crio"
+		"namespace": "redhat.test.crio",
+		"uid": "%s"
 	},
 	"image": {
 			"image": "localhost/%s:latest"
@@ -220,7 +223,7 @@ func crioBaseTests(c cluster.TestCluster) {
 // generateCrioConfig generates a crio pod/container configuration
 // based on the input name and arguments returning the path to the generated configs.
 func generateCrioConfig(podName, imageName string, command []string) (string, string, error) {
-	fileContentsPod := fmt.Sprintf(crioPodTemplate, podName, imageName)
+	fileContentsPod := fmt.Sprintf(crioPodTemplate, podName, uuid.New().String(), imageName)
 
 	tmpFilePod, err := os.CreateTemp("", podName+"Pod")
 	if err != nil {


### PR DESCRIPTION
Cri-tools 1.29[0] now pre-validates container metadata before running with crictl[1]. The required uid field was missing in our test causing the following failure.

```
load podSandboxConfig: name, namespace or uid is not in metadata \"&PodSandboxMetadata{Name:rhcos-crio-pod-restart-test,Uid:,Namespace:redhat.test.crio,Attempt:0,}\
```

[0] https://github.com/kubernetes-sigs/cri-tools/releases/tag/v1.29.0
[1] https://github.com/kubernetes-sigs/cri-tools/pull/1274

Fixes: https://github.com/openshift/os/issues/1407