### PR TITLE
Revert "create_disk: add version field to aleph file"

### DIFF
--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -174,7 +174,7 @@ StandardError=kmsg+console
 ExecStart=/bin/sh -c "journalctl -t coreos-installer-service | /usr/bin/awk '/[Dd]ownload/ {exit 1}'"
 ExecStart=/bin/sh -c "/usr/bin/udevadm settle"
 ExecStart=/bin/sh -c "/usr/bin/mount /dev/disk/by-label/root /mnt"
-ExecStart=/bin/sh -c "/usr/bin/jq -er '.[\"version\"] == \"%s\"' /mnt/.coreos-aleph-version.json"
+ExecStart=/bin/sh -c "/usr/bin/jq -er '.[\"build\"] == \"%s\"' /mnt/.coreos-aleph-version.json"
 ExecStart=/bin/sh -c "/usr/bin/jq -er '.[\"ostree-commit\"] == \"%s\"' /mnt/.coreos-aleph-version.json"
 [Install]
 RequiredBy=coreos-installer.target

--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -386,11 +386,6 @@ test -d "${deploy_root}" || (echo "failed to find $deploy_root"; exit 1)
 #
 # build:         The coreos-assembler build ID; today we support
 #                having the same ostree commit in different image builds.
-# version:       same value as build for now, even though version is
-#                not exactly the same as build ID, this will ease
-#                transition to using osbuild where it's defined
-#                appropriately and build: isn't there:
-#                https://github.com/osbuild/osbuild/pull/1475
 # ref:           The ostree ref used; useful for cross-checking.
 # ostree-commit: Similar to `ref`; one can derive this from looking
 #                at the coreos-assembler builds, but it's very
@@ -400,7 +395,6 @@ test -d "${deploy_root}" || (echo "failed to find $deploy_root"; exit 1)
 cat > $rootfs/.coreos-aleph-version.json << EOF
 {
 	"build": "${buildid}",
-	"version": "${buildid}",
 	"ref": "${ref}",
 	"ostree-commit": "${commit}",
 	"imgid": "${imgid}"


### PR DESCRIPTION
This reverts commit c2d37f4005e0e7c98d24c5f561c149ab7fd4dfce.

We found an issue with this and need to revert it for now: https://github.com/coreos/bootupd/pull/585#issuecomment-1861130612