### PR TITLE
draft: move container images to coreos org

### DIFF
--- a/mantle/cmd/kola/resources/iscsi_butane_setup.yaml
+++ b/mantle/cmd/kola/resources/iscsi_butane_setup.yaml
@@ -19,6 +19,7 @@ storage:
             Wants=network-online.target
             OnFailure=emergency.target
             [Container]
+            #TODO: move container image to centralized namespace
             Image=quay.io/jbtrystram/targetcli:latest
             ContainerName=target
             Network=host

--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -1029,6 +1029,8 @@ func testLiveInstalliscsi(ctx context.Context, inst platform.Install, outdir str
 	// enable network
 	builder.EnableUsermodeNetworking([]platform.HostForwardPort{}, "")
 
+	// keep auto-login enabled for easier debug when running console
+	config.AddAutoLogin()
 	builder.SetConfig(config)
 
 	mach, err := builder.Exec()

--- a/mantle/kola/tests/ignition/luks.go
+++ b/mantle/kola/tests/ignition/luks.go
@@ -93,10 +93,7 @@ func setupTangMachine(c cluster.TestCluster) ut.TangServer {
 
 	// TODO: move container image to centralized namespace
 	// container source: https://github.com/mike-nguyen/tang-docker-container/
-	containerImage := "quay.io/mike_nguyen/tang"
-	if coreosarch.CurrentRpmArch() != "x86_64" {
-		containerImage = "quay.io/multi-arch/tang:" + coreosarch.CurrentRpmArch()
-	}
+	containerImage := "quay.io/jbtrystram/tang"
 
 	containerID, errMsg, err := m.SSH("sudo podman run -d -p 80:80 " + containerImage)
 	if err != nil {


### PR DESCRIPTION
Test commit, POC for https://github.com/coreos/fedora-coreos-tracker/issues/1639 This should be ammended once this repo is moved to the coreOS org