### PR TITLE
qemu: Support setting up a virtio console (hvc0)

### DIFF
--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -1899,7 +1899,17 @@ func (builder *QemuBuilder) Exec() (*QemuInstance, error) {
 	}
 
 	if builder.ConsoleFile != "" {
-		builder.Append("-display", "none", "-chardev", "file,id=log,path="+builder.ConsoleFile, "-serial", "chardev:log")
+		// If we're logging to a file, then we're headless
+		builder.Append("-display", "none")
+		builder.Append("-chardev", "file,id=log,path="+builder.ConsoleFile)
+		if _, useHvc := os.LookupEnv("COSA_QEMU_CONSOLE_HVC"); useHvc {
+			if builder.virtioSerialID == 0 {
+				builder.Append("-device", "virtio-serial")
+			}
+			builder.Append("-device", "virtconsole,chardev=log,id=console,name=console")
+		} else {
+			builder.Append("-serial", "chardev:log")
+		}
 	} else {
 		builder.Append("-serial", "mon:stdio")
 	}


### PR DESCRIPTION
The main motivation here is debugging issues with podman machine on Apple Virtualization, which only implements virtio, so we need to talk to hvc0.

However there's no reason for us not to also do this with qemu; we already have a few references to hvc0 in our console setup.

Turning this on by default will hence require a PR to f-c-c to add that.

But for now let's make it easier to test via an env var.