### PR TITLE
buildextend-metal: rework image size and rootfs size handling

### DIFF
--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -208,23 +208,15 @@ echo "Estimating disk size..."
 # and doing so has apparently negative performance implications.
 /usr/lib/coreos-assembler/estimate-commit-disk-size ${BLKSIZE:+--blksize ${BLKSIZE}} --repo "$ostree_repo" "$commit" --add-percent 35 > "$PWD/tmp/ostree-size.json"
 rootfs_size="$(jq '."estimate-mb".final' "$PWD/tmp/ostree-size.json")"
-# extra size is the non-ostree partitions, see create_disk.sh
-image_size="$(( rootfs_size + 513 ))M"
-echo "Disk size estimated to ${image_size}"
-
-# For bare metal and dasd images, we use the estimated image size. For IaaS/virt, we get it from
-# image.yaml because we want a "default" disk size that has some free space.
-case "${image_type}" in
-    metal*|dasd)
-        # Unset the root size, which will inherit from the image size
-        rootfs_size=0
-        ;;
-    qemu)
-        image_size="$(jq -r ".size" < "${image_json}")G"
-        rootfs_size="${rootfs_size}M"
-        ;;
-    *) fatal "unreachable image_type ${image_type}";;
-esac
+# The minimum size of a disk image we'll need will be the rootfs_size
+# estimate plus the size of the non-root partitions. We'll use this
+# size for the metal/dasd images, but for the IaaS/virt image we'll use
+# the size set in the configs since some of them have minimum sizes that
+# the platforms require and we want a "default" disk size that has some
+# free space.
+metal_image_size="$(( rootfs_size + 513 ))M"
+cloud_image_size="$(jq -r ".size" < "${image_json}")G"
+echo "Disk sizes: metal: ${metal_image_size} (estimated), cloud: ${cloud_image_size}"
 
 if [ "${image_type}" == metal4k ]; then
     disk_args+=("--no-x86-bios-bootloader")
@@ -234,7 +226,7 @@ set -x
 kargs="$(python3 -c 'import sys, json; args = json.load(sys.stdin)["extra-kargs"]; print(" ".join(args))' < "${image_json}")"
 kargs="$kargs ignition.platform.id=$ignition_platform_id"
 
-qemu-img create -f ${image_format} "${path}.tmp" "${image_size}"
+qemu-img create -f ${image_format} "${path}.tmp" "${metal_image_size}"
 
 extra_target_device_opts=""
 # we need 4096 block size for ECKD DASD and (obviously) metal4k
@@ -247,7 +239,6 @@ qemu_args+=("-drive" "if=none,id=target,format=${image_format},file=${path}.tmp,
 # Generate the JSON describing the disk we want to build
 cat >image-dynamic.json << EOF
 {
-    "rootfs-size": "${rootfs_size}",
     "osname": "${name}",
     "buildid": "${build}",
     "imgid": "${img}",
@@ -281,6 +272,12 @@ else
                 --platform "${ignition_platform_id}" \
                 --platforms-json "${platforms_json}" \
                 "${disk_args[@]}"
+
+    # Now that we've created the image let's resize it to the desired
+    # size for qemu (and all images based on it).
+    if [[ $image_type == qemu ]]; then
+        qemu-img resize "${path}.tmp" "${cloud_image_size}"
+    fi
 fi
 
 if [[ $secure_execution -eq "1" && -z "${hostkey}" ]]; then

--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -128,7 +128,6 @@ remote_name=$(getconfig_def "ostree-remote" "")
 deploy_via_container=$(getconfig "deploy-via-container" "")
 container_imgref=$(getconfig "container-imgref" "")
 os_name=$(getconfig "osname")
-rootfs_size=$(getconfig "rootfs-size")
 buildid=$(getconfig "buildid")
 imgid=$(getconfig "imgid")
 
@@ -150,11 +149,6 @@ if [[ ${secure_execution} -eq 1 ]]; then
     ROOTVERITYHASHPN=6
     extrakargs="${extrakargs} swiotlb=262144"
 fi
-# Make the size relative
-if [ "${rootfs_size}" != "0" ]; then
-    rootfs_size="+${rootfs_size}"
-fi
-
 # shellcheck disable=SC2031
 case "$arch" in
     x86_64)
@@ -164,7 +158,7 @@ case "$arch" in
         -n 1:0:+1M -c 1:BIOS-BOOT -t 1:21686148-6449-6E6F-744E-656564454649 \
         -n ${EFIPN}:0:+127M -c ${EFIPN}:EFI-SYSTEM -t ${EFIPN}:C12A7328-F81F-11D2-BA4B-00A0C93EC93B \
         -n ${BOOTPN}:0:+384M -c ${BOOTPN}:boot \
-        -n ${ROOTPN}:0:"${rootfs_size}" -c ${ROOTPN}:root -t ${ROOTPN}:0FC63DAF-8483-4772-8E79-3D69D8477DE4
+        -n ${ROOTPN}:0:0 -c ${ROOTPN}:root -t ${ROOTPN}:0FC63DAF-8483-4772-8E79-3D69D8477DE4
         ;;
     aarch64)
         RESERVEDPN=1
@@ -174,7 +168,7 @@ case "$arch" in
         -n ${RESERVEDPN}:0:+1M -c ${RESERVEDPN}:reserved -t ${RESERVEDPN}:8DA63339-0007-60C0-C436-083AC8230908 \
         -n ${EFIPN}:0:+127M -c ${EFIPN}:EFI-SYSTEM -t ${EFIPN}:C12A7328-F81F-11D2-BA4B-00A0C93EC93B \
         -n ${BOOTPN}:0:+384M -c ${BOOTPN}:boot \
-        -n ${ROOTPN}:0:"${rootfs_size}" -c ${ROOTPN}:root -t ${ROOTPN}:0FC63DAF-8483-4772-8E79-3D69D8477DE4
+        -n ${ROOTPN}:0:0 -c ${ROOTPN}:root -t ${ROOTPN}:0FC63DAF-8483-4772-8E79-3D69D8477DE4
         ;;
     s390x)
         sgdisk_args=()
@@ -184,7 +178,7 @@ case "$arch" in
         fi
         # shellcheck disable=SC2206
         sgdisk_args+=(-n ${BOOTPN}:0:+384M -c ${BOOTPN}:boot \
-                      -n ${ROOTPN}:0:"${rootfs_size}" -c ${ROOTPN}:root -t ${ROOTPN}:0FC63DAF-8483-4772-8E79-3D69D8477DE4)
+                      -n ${ROOTPN}:0:0 -c ${ROOTPN}:root -t ${ROOTPN}:0FC63DAF-8483-4772-8E79-3D69D8477DE4)
         if [[ ${secure_execution} -eq 1 ]]; then
             # shellcheck disable=SC2206
             sgdisk_args+=(-n ${BOOTVERITYHASHPN}:0:+128M -c ${BOOTVERITYHASHPN}:boothash \
@@ -205,7 +199,7 @@ case "$arch" in
         -n ${PREPPN}:0:+4M -c ${PREPPN}:PowerPC-PReP-boot -t ${PREPPN}:9E1A2D38-C612-4316-AA26-8B49521E5A8B \
         -n ${RESERVEDPN}:0:+1M -c ${RESERVEDPN}:reserved -t ${RESERVEDPN}:8DA63339-0007-60C0-C436-083AC8230908 \
         -n ${BOOTPN}:0:+384M -c ${BOOTPN}:boot \
-        -n ${ROOTPN}:0:"${rootfs_size}" -c ${ROOTPN}:root -t ${ROOTPN}:0FC63DAF-8483-4772-8E79-3D69D8477DE4
+        -n ${ROOTPN}:0:0 -c ${ROOTPN}:root -t ${ROOTPN}:0FC63DAF-8483-4772-8E79-3D69D8477DE4
         ;;
 esac
 


### PR DESCRIPTION
This patch changes the strategy to create the disk initially with the smaller disk size and then resize the disk at the end if needed to the larger disk size.

This simplifies things a bit since we don't need to pass down the rootfs size into create_disk.sh.

This is prep for some later patches that add osbuild support for dynamically setting the disk size and should simplify things since for both create_disk.sh and osbuild we won't need to pass in the rootfs size.