### PR TITLE
create_disk.sh: fix Secure Execution build

### DIFF
--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -213,7 +213,14 @@ rootfs_size_mb="$(jq '."estimate-mb".final' "$PWD/tmp/ostree-size.json")"
 # the size set in the configs since some of them have minimum sizes that
 # the platforms require and we want a "default" disk size that has some
 # free space.
-metal_image_size_mb="$(( rootfs_size_mb + 513 ))"
+nonroot_partition_sizes=513
+# In the Secure Execution case, we need to also include the sizes of the verity
+# partitions so that they don't "eat into" the 35% buffer (though note this is
+# all blown away on first boot anyway).
+if [[ $secure_execution -eq "1" ]]; then
+    nonroot_partition_sizes=$((nonroot_partition_sizes + 128 + 256 + 1))
+fi
+metal_image_size_mb="$(( rootfs_size_mb + nonroot_partition_sizes ))"
 cloud_image_size_mb="$(jq -r ".size*1024" < "${image_json}")"
 echo "Disk sizes: metal: ${metal_image_size_mb}M (estimated), cloud: ${cloud_image_size_mb}M"
 

--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -173,14 +173,19 @@ case "$arch" in
         ;;
     s390x)
         sgdisk_args=()
+        rootp_end=0
         if [[ ${secure_execution} -eq 1 ]]; then
             # shellcheck disable=SC2206
             sgdisk_args+=(-n ${SDPART}:0:+200M -c ${SDPART}:se -t ${SDPART}:0FC63DAF-8483-4772-8E79-3D69D8477DE4)
+            # we need to leave space for the verity hash partitions (and add 1MB otherwise sgdisk can't fit them for some reason)
+            rootp_end=-$((128+256+1))M
         fi
+
         # shellcheck disable=SC2206
         sgdisk_args+=(-n ${BOOTPN}:0:+384M -c ${BOOTPN}:boot \
-                      -n ${ROOTPN}:0:0 -c ${ROOTPN}:root -t ${ROOTPN}:0FC63DAF-8483-4772-8E79-3D69D8477DE4)
+                      -n ${ROOTPN}:0:${rootp_end} -c ${ROOTPN}:root -t ${ROOTPN}:0FC63DAF-8483-4772-8E79-3D69D8477DE4)
         if [[ ${secure_execution} -eq 1 ]]; then
+            # note these length values are hardcoded in both rootp_end above and in `cmd-buildextend-metal`
             # shellcheck disable=SC2206
             sgdisk_args+=(-n ${BOOTVERITYHASHPN}:0:+128M -c ${BOOTVERITYHASHPN}:boothash \
                           -n ${ROOTVERITYHASHPN}:0:+256M -c ${ROOTVERITYHASHPN}:roothash)


### PR DESCRIPTION
In 84ce8dca0, we broke the Secure Execution build because the root filesystem takes up all the remaining space, which leaves no space for the verity partitions that need to come after.

Hack around this by making the root partition end 384M before the end of the disk (that's the sum of the sizes of the verity partitions).

Fixes 84ce8dca0 ("buildextend-metal: rework image size and rootfs size handling").