### PR TITLE
fedmsg-broadcast: allow many basearches in `stream.release` msg

### DIFF
--- a/src/fedmsg-broadcast
+++ b/src/fedmsg-broadcast
@@ -52,7 +52,8 @@ def parse_args():
 
     stream_release = subparsers.add_parser('stream.release')
     stream_release.add_argument("--build", required=True)
-    stream_release.add_argument("--basearch", required=True)
+    stream_release.add_argument("--basearch", required=True,
+                                default=[], action='append')
     stream_release.add_argument("--stream", required=True)
     stream_release.set_defaults(func=msg_stream_release)
 
@@ -88,7 +89,7 @@ def msg_stream_release(args):
         environment=args.environment,
         body={
             "build_id": args.build,
-            "basearch": args.basearch,
+            "basearches": args.basearch,
             "stream": args.stream,
         },
     )


### PR DESCRIPTION
Right now, when a new build is released, we emit the `stream.release` message once per architecture. But an important part of the release job is to "integrate" all the different arches into a single release. So it seems much more appropriate to have it emit a single fedmsg and in it, we list out all the arches in that release.

Prep for adding a consumer to that message.