### PR TITLE
create_disk: update grub2-install invocation to match bootupd

### DIFF
--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -491,7 +491,7 @@ x86_64)
         chroot_run /sbin/grub2-install \
             --target i386-pc \
             --boot-directory $rootfs/boot \
-            --modules mdraid1x \
+            --modules "mdraid1x part_gpt" \
             "$disk"
     fi
     ;;


### PR DESCRIPTION
bootupd calls grub2-install with mdraid1x and part_gpt [1]. We are updating our grub2-install test to match what bootupd is doing for the grub2-install verification [2]. Let's also update create_disk.sh here so the test will pass regardless of whether a disk image was created with create_disk.sh or osbuild (which currently will use bootupd for the bootloader install).

[1] https://github.com/coreos/bootupd/blob/e1be3005d827fc3bacf82a2c2a98cd9c0706c65f/src/bios.rs#L66-L69
[2] https://github.com/coreos/fedora-coreos-config/pull/2810