### PR TITLE
powervs: make disk name in OVA more descriptive

### DIFF
--- a/src/cosalib/ibmcloud.py
+++ b/src/cosalib/ibmcloud.py
@@ -38,9 +38,7 @@ VARIANTS = {
         "image_suffix": "ova.gz",
         "platform": "powervs",
         "compression": "gzip",
-        "tar_members": [
-            "disk.raw"
-        ]
+        "tar_members": []  # disk image is added as part of write_ova() function.
     },
 }
 
@@ -99,6 +97,7 @@ class IBMCloudImage(QemuVariantImage):
         log.debug(ovf_xml)
         # OVF descriptor must come first, then the manifest, then the meta file
         self.tar_members.append(self.ovf_path)
+        self.tar_members.append(f'{ovf_params["image"]}-disk.raw')
 
 
 @retry(reraise=True, stop=stop_after_attempt(3))

--- a/src/powervs-template.xml
+++ b/src/powervs-template.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ovf:Envelope xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <ovf:References>
-    <ovf:File href="disk.raw" id="file1" size="{image_size}"/>
+    <ovf:File href="{image}-disk.raw" id="file1" size="{image_size}"/>
   </ovf:References>
   <ovf:DiskSection>
     <ovf:Info>Disk Section</ovf:Info>
@@ -24,7 +24,7 @@
         <ovf:Info>Storage resources</ovf:Info>
         <ovf:Item>
           <rasd:Description>Temporary clone for export</rasd:Description>
-          <rasd:ElementName>disk.raw</rasd:ElementName>
+          <rasd:ElementName>{image}-disk.raw</rasd:ElementName>
           <rasd:HostResource>ovf:/disk/disk1</rasd:HostResource>
           <rasd:InstanceID>1</rasd:InstanceID>
           <rasd:ResourceType>17</rasd:ResourceType>


### PR DESCRIPTION
Enhancing visibility of OS's in PowerVS "Volumes" view includes providing additional details. IBM i, for example, names their .raw files "IBMi-\<version>-img.raw".
Task ref: https://issues.redhat.com/browse/COS-2627