### PR TITLE
Add platforms JSON as part of the container

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -189,6 +189,7 @@ patch_osbuild() {
         /usr/lib/coreos-assembler/0002-stages-sgdisk-support-label-option.patch                   \
         /usr/lib/coreos-assembler/0001-stages-zipl.inst-improve-kernel-initrd-path-resoluti.patch \
         /usr/lib/coreos-assembler/0002-stages-zipl.inst-support-appending-kernel-options.patch    \
+        /usr/lib/coreos-assembler/0001-stages-copy-allow-copying-from-the-tree.patch              \
             | patch -d /usr/lib/osbuild -p1
 
     # And then move the files back; supermin appliance creation will need it back

--- a/src/0001-stages-copy-allow-copying-from-the-tree.patch
+++ b/src/0001-stages-copy-allow-copying-from-the-tree.patch
@@ -1,0 +1,72 @@
+From 3ecec2e2848a51803e4a9953b132a6eaf4e5043c Mon Sep 17 00:00:00 2001
+From: Dusty Mabe <dusty@dustymabe.com>
+Date: Thu, 1 Feb 2024 23:14:06 -0500
+Subject: [PATCH] stages(copy): allow copying from the tree
+
+It seems like an artifical limitation to prevent copying from one
+location in the tree to another. It just so happens we need this
+functionality when building CoreOS images because we want to take
+a file embedded in the OSTree at a location and copy it to another
+location in the tree. The particular example here is we want to copy
+/usr/share/coreos-assembler/platforms.json -> /boot/coreos/platforms.json
+See https://github.com/coreos/coreos-assembler/pull/3709
+
+Allowing to copy from/to the tree we can now do something like:
+
+```
+- type: org.osbuild.copy
+  options:
+    paths:
+      - from: tree:///usr/share/coreos-assembler/platforms.json
+        to: tree:///boot/coreos/platforms.json
+  mounts:
+    - name: ostree.deployment
+      type: org.osbuild.ostree.deployment
+      options:
+        deployment:
+          ref: ostree/1/1/0
+          osname:
+            fedora-coreos
+```
+---
+ stages/org.osbuild.copy | 17 +++++++++++++----
+ 1 file changed, 13 insertions(+), 4 deletions(-)
+
+diff --git a/stages/org.osbuild.copy b/stages/org.osbuild.copy
+index 3c137af5..d476efdb 100755
+--- a/stages/org.osbuild.copy
++++ b/stages/org.osbuild.copy
+@@ -45,9 +45,18 @@ SCHEMA_2 = r"""
+         "required": ["from", "to"],
+         "properties": {
+           "from": {
+-            "type": "string",
+-            "description": "The source",
+-            "pattern": "^input:\/\/[^\/]+\/"
++            "oneOf": [
++              {
++                "type": "string",
++                "description": "The source, if an input",
++                "pattern": "^input:\/\/[^\/]+\/"
++              },
++              {
++                "type": "string",
++                "description": "The source, if the tree",
++                "pattern": "^tree:\/\/\/"
++              }
++            ]
+           },
+           "to": {
+             "oneOf": [
+@@ -58,7 +67,7 @@ SCHEMA_2 = r"""
+               },
+               {
+                 "type": "string",
+-                "description": "The destination, if a tree",
++                "description": "The destination, if the tree",
+                 "pattern": "^tree:\/\/\/"
+               }
+             ]
+-- 
+2.43.0
+

--- a/src/coreos.osbuild.aarch64.mpp.yaml
+++ b/src/coreos.osbuild.aarch64.mpp.yaml
@@ -111,6 +111,12 @@ pipelines:
           paths:
             - path: /boot/efi
               mode: 448
+      # platforms.json will live here
+      - type: org.osbuild.mkdir
+        options:
+          paths:
+            - path: /boot/coreos
+              mode: 644
       - type: org.osbuild.ignition
       # Deploy via container if we have a container ociarchive, else from repo.
       - mpp-if: ociarchive != ''
@@ -168,6 +174,21 @@ pipelines:
             ref: ostree/1/1/0
             osname:
               mpp-format-string: '{osname}'
+      # Copy in the platforms.json that was baked into the OSTree into /boot
+      # so tools like coreos-installer can use the information.
+      - type: org.osbuild.copy
+        options:
+          paths:
+            - from: tree:///usr/share/coreos-assembler/platforms.json
+              to: tree:///boot/coreos/platforms.json
+        mounts:
+          - name: ostree.deployment
+            type: org.osbuild.ostree.deployment
+            options:
+              deployment:
+                ref: ostree/1/1/0
+                osname:
+                  mpp-format-string: '{osname}'
   - name: raw-image
     stages:
       - type: org.osbuild.truncate

--- a/src/coreos.osbuild.ppc64le.mpp.yaml
+++ b/src/coreos.osbuild.ppc64le.mpp.yaml
@@ -108,6 +108,12 @@ pipelines:
               bootloader: none
               # https://github.com/coreos/fedora-coreos-tracker/issues/1333
               bls-append-except-default: grub_users=""
+      # platforms.json will live here
+      - type: org.osbuild.mkdir
+        options:
+          paths:
+            - path: /boot/coreos
+              mode: 644
       - type: org.osbuild.ignition
       # Deploy via container if we have a container ociarchive, else from repo.
       - mpp-if: ociarchive != ''
@@ -178,6 +184,21 @@ pipelines:
             ref: ostree/1/1/0
             osname:
               mpp-format-string: '{osname}'
+      # Copy in the platforms.json that was baked into the OSTree into /boot
+      # so tools like coreos-installer can use the information.
+      - type: org.osbuild.copy
+        options:
+          paths:
+            - from: tree:///usr/share/coreos-assembler/platforms.json
+              to: tree:///boot/coreos/platforms.json
+        mounts:
+          - name: ostree.deployment
+            type: org.osbuild.ostree.deployment
+            options:
+              deployment:
+                ref: ostree/1/1/0
+                osname:
+                  mpp-format-string: '{osname}'
   - name: raw-image
     stages:
       - type: org.osbuild.truncate

--- a/src/coreos.osbuild.s390x.mpp.yaml
+++ b/src/coreos.osbuild.s390x.mpp.yaml
@@ -95,6 +95,12 @@ pipelines:
               bootloader: none
              ## no grub_users="" on s390x
              #bls-append-except-default: grub_users=""
+      # platforms.json will live here
+      - type: org.osbuild.mkdir
+        options:
+          paths:
+            - path: /boot/coreos
+              mode: 644
       - type: org.osbuild.ignition
       # Deploy via container if we have a container ociarchive, else from repo.
       - mpp-if: ociarchive != ''
@@ -176,6 +182,21 @@ pipelines:
             ref: ostree/1/1/0
             osname:
               mpp-format-string: '{osname}'
+      # Copy in the platforms.json that was baked into the OSTree into /boot
+      # so tools like coreos-installer can use the information.
+      - type: org.osbuild.copy
+        options:
+          paths:
+            - from: tree:///usr/share/coreos-assembler/platforms.json
+              to: tree:///boot/coreos/platforms.json
+        mounts:
+          - name: ostree.deployment
+            type: org.osbuild.ostree.deployment
+            options:
+              deployment:
+                ref: ostree/1/1/0
+                osname:
+                  mpp-format-string: '{osname}'
   - name: raw-image
     stages:
       - type: org.osbuild.truncate

--- a/src/coreos.osbuild.x86_64.mpp.yaml
+++ b/src/coreos.osbuild.x86_64.mpp.yaml
@@ -113,6 +113,12 @@ pipelines:
           paths:
             - path: /boot/efi
               mode: 448
+      # platforms.json will live here
+      - type: org.osbuild.mkdir
+        options:
+          paths:
+            - path: /boot/coreos
+              mode: 644
       - type: org.osbuild.ignition
       # Deploy via container if we have a container ociarchive, else from repo.
       - mpp-if: ociarchive != ''
@@ -170,6 +176,21 @@ pipelines:
             ref: ostree/1/1/0
             osname:
               mpp-format-string: '{osname}'
+      # Copy in the platforms.json that was baked into the OSTree into /boot
+      # so tools like coreos-installer can use the information.
+      - type: org.osbuild.copy
+        options:
+          paths:
+            - from: tree:///usr/share/coreos-assembler/platforms.json
+              to: tree:///boot/coreos/platforms.json
+        mounts:
+          - name: ostree.deployment
+            type: org.osbuild.ostree.deployment
+            options:
+              deployment:
+                ref: ostree/1/1/0
+                osname:
+                  mpp-format-string: '{osname}'
   - name: raw-image
     stages:
       - type: org.osbuild.truncate


### PR DESCRIPTION
 Incorporate the platforms JSON file into the container,
 as it is essential for our OSBuild requirements.