### PR TITLE
kola: really make `requiredTag` required

### DIFF
--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -539,8 +539,10 @@ func filterTests(tests map[string]*register.Test, patterns []string, pltfrm stri
 		}
 
 		if t.RequiredTag != "" && // if the test has a required tag...
-			!HasString(t.RequiredTag, positiveTags) && // and that tag was not provided by the user...
-			(!userTypedPattern || !nameMatch) { // and the user didn't request it by name...
+			!HasString(t.RequiredTag, positiveTags) { // and that tag was not provided by the user
+			if userTypedPattern && nameMatch {
+				fmt.Printf("⏭️  Skipping kola test \"%s\" with required tag \"%s\"\n", t.Name, t.RequiredTag)
+			}
 			continue // then skip it
 		}
 


### PR DESCRIPTION
Before, even though a test had a required tag, explicitly passing a pattern which matched that test name would still include it. I thought that would be convenient, but it makes the logic less predictable. Since we don't use many required tags today, let's instead opt for being more explicit and always actually require the tag.

Motivated by https://github.com/coreos/rpm-ostree/pull/4806#issuecomment-1918756297.