### PR TITLE
devshell: Support `-S/--root-ssh-smbios`

### DIFF
--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -1071,6 +1071,8 @@ func (disk *Disk) prepare(builder *QemuBuilder) error {
 			// on our own.
 			if strings.HasSuffix(backingFile, "qcow2") {
 				format = "qcow2"
+			} else if strings.HasSuffix(backingFile, "raw") {
+				format = "raw"
 			}
 		}
 		if format != "" {


### PR DESCRIPTION
qemu: Detect raw format too

Raw format is fine to use on systems that have reflinks for example.

---

qemu: Support injecting SSH keys via systemd credentials over SMBIOS

Since it's in systemd it's available as a baseline way to
inject things like a SSH key.  That said, not all systems
support SMBIOS.  But for those that do let's support it.

---

devshell: Support `-S/--root-ssh-smbios`

We've built up a *lot* of generically useful qemu code, and
I am considering factoring it out into a Go package
suitable for sharing in particular with "podman machine"
and other use cases.

Related to this, I'm building systems now that don't use Ignition
by default.

We only need a small bit of code to inject a root ssh key
via systemd creds over SMBIOS; change things to support that.

Concretely with this I can now
`cosa run -S --qemu-image ~/build/centos-bootc.raw`

---

