### PR TITLE
cmdlib: don't use cache qcow for composes; use virtiofs

### DIFF
--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -1626,6 +1626,8 @@ func createVirtiofsCmd(directory, socketPath string) exec.Cmd {
 	// We don't need seccomp filtering; we trust our workloads. This incidentally
 	// works around issues like https://gitlab.com/virtio-fs/virtiofsd/-/merge_requests/200.
 	args = append(args, "--seccomp=none")
+	// OSTree composes use xattrs
+	args = append(args, "--xattr")
 	cmd := exec.Command("/usr/libexec/virtiofsd", args...)
 	// This sets things up so that the `.` we passed in the arguments is the target directory
 	cmd.Dir = directory

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -563,7 +563,7 @@ runcompose_tree() {
         (umask 0022 && sudo -E "$@")
         sudo chown -R -h "${USER}":"${USER}" "${tmprepo}"
     else
-        runvm_with_cache -- "$@" --repo "${repo}" --write-composejson-to "${composejson}"
+        runvm -- "$@" --repo "${repo}" --write-composejson-to "${composejson}"
     fi
 }
 
@@ -587,7 +587,7 @@ runcompose_extensions() {
         (umask 0022 && sudo -E "$@")
         sudo chown -R -h "${USER}":"${USER}" "${outputdir}"
     else
-        runvm_with_cache -- "$@"
+        runvm -- "$@"
     fi
 }
 


### PR DESCRIPTION
Now that our OSBuild workflow is using the cache we saw at least one case where the pipeline was running out of space. Since we had a previous proposal [1] to just drop the cahce altogether anyway let's try to at least remove it from the runcompose functions to eliminate the use of it there anyway.

[1] https://github.com/coreos/coreos-assembler/pull/3615