### PR TITLE
Revert "set sysroot.bootprefix true in OSTree config"

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -188,6 +188,7 @@ patch_osbuild() {
         /usr/lib/coreos-assembler/0004-fscache-add-eviction-log-statement.patch                   \
         /usr/lib/coreos-assembler/0001-support-user-defined-partition-numbers-for-GPT-disks.patch \
         /usr/lib/coreos-assembler/0002-stages-sgdisk-support-label-option.patch                   \
+        /usr/lib/coreos-assembler/0001-stages-zipl.inst-improve-kernel-initrd-path-resoluti.patch \
         /usr/lib/coreos-assembler/0002-stages-zipl.inst-support-appending-kernel-options.patch    \
         /usr/lib/coreos-assembler/0001-stages-copy-allow-copying-from-the-tree.patch              \
         /usr/lib/coreos-assembler/0001-stages-qemu-don-t-use-internal-compression-for-now.patch   \

--- a/src/0001-stages-zipl.inst-improve-kernel-initrd-path-resoluti.patch
+++ b/src/0001-stages-zipl.inst-improve-kernel-initrd-path-resoluti.patch
@@ -1,0 +1,39 @@
+From f3e725766e5fe0a646bb5555a329574dddcdd309 Mon Sep 17 00:00:00 2001
+From: Nikita Dubrovskii <nikita@linux.ibm.com>
+Date: Tue, 30 Jan 2024 08:54:51 +0100
+Subject: [PATCH 1/2] stages(zipl.inst): improve kernel/initrd path resolution
+
+If /boot is a separate filesystem then the path inside the blscfg
+won't have the rootfs prefix on it and we need to add it here.
+
+Co-authored-by: Dusty Mabe <dusty@dustymabe.com>
+---
+ stages/org.osbuild.zipl.inst | 12 ++++++++++--
+ 1 file changed, 10 insertions(+), 2 deletions(-)
+
+diff --git a/stages/org.osbuild.zipl.inst b/stages/org.osbuild.zipl.inst
+index a9bea045..92dfd33e 100755
+--- a/stages/org.osbuild.zipl.inst
++++ b/stages/org.osbuild.zipl.inst
+@@ -74,8 +74,16 @@ def find_kernel(root, kernel: str):
+         if version != kernel:
+             continue
+ 
+-        linux = root + params["linux"]
+-        initrd = root + params["initrd"]
++        # Find the prefix that needs to be added to get the full path to
++        # the kernel/initrd. If /boot is a separate filesystem then the
++        # path inside the blscfg won't have that prefix on it and we need
++        # to add it here.
++        prefix = root
++        if os.path.ismount(os.path.join(root, "boot")):
++            prefix = os.path.join(root, "boot")
++
++        linux = os.path.join(prefix, params["linux"].lstrip("/"))
++        initrd = os.path.join(prefix, params["initrd"].lstrip("/"))
+         options = params.get("options", "")
+         return linux, initrd, options
+ 
+-- 
+2.43.0
+

--- a/src/coreos.osbuild.aarch64.mpp.yaml
+++ b/src/coreos.osbuild.aarch64.mpp.yaml
@@ -106,12 +106,6 @@ pipelines:
               bootloader: none
               # https://github.com/coreos/fedora-coreos-tracker/issues/1333
               bls-append-except-default: grub_users=""
-              # Opt-in to https://github.com/ostreedev/ostree/pull/2705 which will
-              # add /boot as the prefix on top of BLS config entries. This is OK
-              # because there is a symlink that is created in the root of the boot
-              # filesystem by OSTree (boot -> .) that makes it so that /boot paths
-              # will always work.
-              bootprefix: true
       - type: org.osbuild.mkdir
         options:
           paths:

--- a/src/coreos.osbuild.ppc64le.mpp.yaml
+++ b/src/coreos.osbuild.ppc64le.mpp.yaml
@@ -108,12 +108,6 @@ pipelines:
               bootloader: none
               # https://github.com/coreos/fedora-coreos-tracker/issues/1333
               bls-append-except-default: grub_users=""
-              # Opt-in to https://github.com/ostreedev/ostree/pull/2705 which will
-              # add /boot as the prefix on top of BLS config entries. This is OK
-              # because there is a symlink that is created in the root of the boot
-              # filesystem by OSTree (boot -> .) that makes it so that /boot paths
-              # will always work.
-              bootprefix: true
       # platforms.json will live here
       - type: org.osbuild.mkdir
         options:

--- a/src/coreos.osbuild.s390x.mpp.yaml
+++ b/src/coreos.osbuild.s390x.mpp.yaml
@@ -95,12 +95,6 @@ pipelines:
               bootloader: none
              ## no grub_users="" on s390x
              #bls-append-except-default: grub_users=""
-              # Opt-in to https://github.com/ostreedev/ostree/pull/2705 which will
-              # add /boot as the prefix on top of BLS config entries. This is OK
-              # because there is a symlink that is created in the root of the boot
-              # filesystem by OSTree (boot -> .) that makes it so that /boot paths
-              # will always work.
-              bootprefix: true
       - type: org.osbuild.ignition
       # Deploy via container if we have a container ociarchive, else from repo.
       - mpp-if: ociarchive != ''

--- a/src/coreos.osbuild.x86_64.mpp.yaml
+++ b/src/coreos.osbuild.x86_64.mpp.yaml
@@ -108,12 +108,6 @@ pipelines:
               bootloader: none
               # https://github.com/coreos/fedora-coreos-tracker/issues/1333
               bls-append-except-default: grub_users=""
-              # Opt-in to https://github.com/ostreedev/ostree/pull/2705 which will
-              # add /boot as the prefix on top of BLS config entries. This is OK
-              # because there is a symlink that is created in the root of the boot
-              # filesystem by OSTree (boot -> .) that makes it so that /boot paths
-              # will always work.
-              bootprefix: true
       - type: org.osbuild.mkdir
         options:
           paths:

--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -316,12 +316,6 @@ ostree config --repo $rootfs/ostree/repo set sysroot.bootloader none
 # Opt-in to https://github.com/ostreedev/ostree/pull/1767 AKA
 # https://github.com/ostreedev/ostree/issues/1265
 ostree config --repo $rootfs/ostree/repo set sysroot.readonly true
-# Opt-in to https://github.com/ostreedev/ostree/pull/2705 which will
-# add /boot as the prefix on top of BLS config entries. This is OK
-# because there is a symlink that is created in the root of the boot
-# filesystem by OSTree (boot -> .) that makes it so that /boot paths
-# will always work.
-ostree config --repo $rootfs/ostree/repo set sysroot.bootprefix true
 if test -n "${composefs}"; then
     ostree config --repo $rootfs/ostree/repo set ex-integrity.composefs true
 fi


### PR DESCRIPTION
This reverts commit f5677a36abbe506a04210d15f2151c9056bef454.

We're seeing some related problems. Tracked in
https://github.com/coreos/fedora-coreos-tracker/issues/1667