### PR TITLE
cmdlib: bump size of cache qcow2

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -599,7 +599,7 @@ runvm_with_cache_snapshot() {
     local snapshot=$1; shift
     # "cache2" has an explicit label so we can find it in qemu easily
     if [ ! -f "${workdir}"/cache/cache2.qcow2 ]; then
-        qemu-img create -f qcow2 cache2.qcow2.tmp 10G
+        qemu-img create -f qcow2 cache2.qcow2.tmp 16G
         (
          # shellcheck source=src/libguestfish.sh
          source /usr/lib/coreos-assembler/libguestfish.sh


### PR DESCRIPTION
Since we are now using the cache qcow2 for OSBuild we need it to be a little large to handle those duties as well as the tree compose ones. I'd like to drop the cache, but hit some trouble there; see https://github.com/coreos/coreos-assembler/pull/3720.