### PR TITLE
host containerFiles needed for kola tests

### DIFF
--- a/tests/containers/README.md
+++ b/tests/containers/README.md
@@ -1,0 +1,4 @@
+This contains containerFiles to build images used by the CoreOS assembler tests.
+
+Create a folder for each image, with a README linking to the kola test that uses the image
+

--- a/tests/containers/tang/Containerfile
+++ b/tests/containers/tang/Containerfile
@@ -1,0 +1,8 @@
+FROM registry.fedoraproject.org/fedora-minimal:39
+
+RUN microdnf -y install tang && microdnf clean all && rm -rf /var/cache/yum
+EXPOSE 80
+
+RUN systemctl enable tangd.socket
+
+CMD ["/sbin/init"]

--- a/tests/containers/tang/README.md
+++ b/tests/containers/tang/README.md
@@ -1,0 +1,3 @@
+# Tang Container
+
+This is used by the luks tests in `luks.*`

--- a/tests/containers/targetcli/Containerfile
+++ b/tests/containers/targetcli/Containerfile
@@ -1,0 +1,9 @@
+FROM quay.io/centos/centos:stream9
+
+RUN dnf install -y targetcli kmod && dnf clean all
+RUN systemctl enable target
+
+EXPOSE 3260
+
+HEALTHCHECK --start-period=10s CMD targetcli pwd
+CMD [ "/sbin/init" ]

--- a/tests/containers/targetcli/README.md
+++ b/tests/containers/targetcli/README.md
@@ -1,0 +1,4 @@
+# targetcli container
+
+This is used by the iSCSI setup tested in `iso-offline-install-iscsi.bios`
+


### PR DESCRIPTION
Some kola tests requires additionnal images to work (isci, luks). Until now these images have been maintained by indivudual members of the coreOS team. This moves the images under coreos-assembler for sharing the maintainership, and allowing the images to be periodically rebuilt.

See https://github.com/coreos/fedora-coreos-tracker/issues/1639#issuecomment-1875832998