### PR TITLE
use container images from coreos-assembler org

### DIFF
--- a/mantle/cmd/kola/resources/iscsi_butane_setup.yaml
+++ b/mantle/cmd/kola/resources/iscsi_butane_setup.yaml
@@ -19,7 +19,7 @@ storage:
             Wants=network-online.target
             OnFailure=emergency.target
             [Container]
-            Image=quay.io/jbtrystram/targetcli:latest
+            Image=quay.io/coreos-assembler/targetcli:latest
             ContainerName=targetd
             Network=host
             Volume=/dev/disk/by-id/virtio-target:/dev/disk/by-id/virtio-target

--- a/mantle/kola/tests/ignition/luks.go
+++ b/mantle/kola/tests/ignition/luks.go
@@ -91,12 +91,7 @@ func setupTangMachine(c cluster.TestCluster) ut.TangServer {
 		c.Fatal(err)
 	}
 
-	// TODO: move container image to centralized namespace
-	// container source: https://github.com/mike-nguyen/tang-docker-container/
-	containerImage := "quay.io/mike_nguyen/tang"
-	if coreosarch.CurrentRpmArch() != "x86_64" {
-		containerImage = "quay.io/multi-arch/tang:" + coreosarch.CurrentRpmArch()
-	}
+	containerImage := "quay.io/coreos-assembler/tang:latest"
 
 	containerID, errMsg, err := m.SSH("sudo podman run -d -p 80:80 " + containerImage)
 	if err != nil {


### PR DESCRIPTION
Point test that requires containers to use images from the coreos-assembler org.

Following https://github.com/coreos/coreos-assembler/pull/3727

See  https://github.com/coreos/fedora-coreos-tracker/issues/1639
This will fail CI until this one is in :  https://github.com/coreos/fedora-coreos-pipeline/pull/959