### PR TITLE
gf-set-platform: use console.cfg for preferred file name

### DIFF
--- a/src/gf-set-platform
+++ b/src/gf-set-platform
@@ -70,9 +70,9 @@ fi
 coreos_gf upload "${tmpd}"/bls.conf "${blscfg_path}"
 
 if [ -n "$rewrite_grub_cmds" ]; then
-    # Use the new console config written out by bootupd if it exists
-    if [ "$(coreos_gf exists /boot/grub2/30_console.cfg)" = "true" ]; then
-        grub_console_config_path='/boot/grub2/30_console.cfg'
+    # Use the new console config written out by OSBuild coreos.platform stage if it exists
+    if [ "$(coreos_gf exists /boot/grub2/console.cfg)" = "true" ]; then
+        grub_console_config_path='/boot/grub2/console.cfg'
     else
         grub_console_config_path='/boot/grub2/grub.cfg'
     fi


### PR DESCRIPTION
In https://github.com/coreos/fedora-coreos-tracker/issues/1671 we decided to have this file be `console.cfg` and not `30_console.cfg`.