### PR TITLE
kola/tests: add `openshift` tag to OCP tests

### DIFF
--- a/mantle/kola/tests/crio/crio.go
+++ b/mantle/kola/tests/crio/crio.go
@@ -197,7 +197,7 @@ func init() {
 		Distros:     []string{"rhcos"},
 		UserData:    enableCrioIgn,
 		// crio pods require fetching a kubernetes pause image
-		Tags: []string{"crio", kola.NeedsInternetTag},
+		Tags: []string{"crio", kola.NeedsInternetTag, "openshift"},
 	})
 	register.RegisterTest(&register.Test{
 		Run:         crioNetwork,
@@ -207,7 +207,7 @@ func init() {
 		Distros:     []string{"rhcos"},
 		UserData:    enableCrioIgn,
 		// this test requires net connections outside the host
-		Tags: []string{"crio", kola.NeedsInternetTag},
+		Tags: []string{"crio", kola.NeedsInternetTag, "openshift"},
 		// qemu machines cannot communicate between each other
 		ExcludePlatforms: []string{"qemu"},
 	})

--- a/mantle/kola/tests/misc/network.go
+++ b/mantle/kola/tests/misc/network.go
@@ -69,6 +69,7 @@ func init() {
 		Timeout:     40 * time.Minute,
 		Distros:     []string{"rhcos"},
 		Platforms:   []string{"qemu"},
+		Tags:        []string{"openshift"},
 	})
 }
 


### PR DESCRIPTION
This is part of https://github.com/openshift/os/pull/1445.

Those tests are all actually testing OCP components. In the new model,
they should be run against an OCP layered image instead. Add a tag on
them so that we'll be able to run them separately.