### PR TITLE
osbuild: backport and use coreos.platforms stage

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -179,6 +179,8 @@ patch_osbuild() {
     cat /usr/lib/coreos-assembler/0004-fscache-add-eviction-log-statement.patch                   \
         /usr/lib/coreos-assembler/0001-stages-zipl.inst-improve-kernel-initrd-path-resoluti.patch \
         /usr/lib/coreos-assembler/0001-stages-qemu-sanity-check-created-image.patch               \
+        /usr/lib/coreos-assembler/0001-util-Add-bls-module.patch                                  \
+        /usr/lib/coreos-assembler/0002-Add-coreos.platforms-stage.patch                           \
             | patch -d /usr/lib/osbuild -p1
 
     # And then move the files back; supermin appliance creation will need it back

--- a/src/0001-util-Add-bls-module.patch
+++ b/src/0001-util-Add-bls-module.patch
@@ -1,0 +1,100 @@
+From a16a27938627d0f16d7a9f09daa889ec29ec9740 Mon Sep 17 00:00:00 2001
+From: Renata Ravanelli <rravanel@redhat.com>
+Date: Mon, 19 Feb 2024 10:30:34 -0300
+Subject: [PATCH 1/2] util: Add bls module
+
+ - Add functions for appending kernel parameters to the
+Boot Loader Specification (BLS) as needed.
+
+Signed-off-by: Renata Ravanelli <rravanel@redhat.com>
+---
+ osbuild/util/bls.py                          | 38 ++++++++++++++++++++
+ stages/org.osbuild.kernel-cmdline.bls-append | 20 ++---------
+ 2 files changed, 40 insertions(+), 18 deletions(-)
+ create mode 100644 osbuild/util/bls.py
+
+diff --git a/osbuild/util/bls.py b/osbuild/util/bls.py
+new file mode 100644
+index 00000000..4168bd71
+--- /dev/null
++++ b/osbuild/util/bls.py
+@@ -0,0 +1,38 @@
++import glob
++import os
++import re
++
++"""
++Function for appending parameters to
++Boot Loader Specification (BLS).
++"""
++
++def options_append(root_path, kernel_arguments):
++    """
++    Add kernel arguments to the Boot Loader Specification (BLS) configuration files.
++    There is unlikely to be more than one BLS config, but just in case, we'll iterate over them.
++
++    Parameters
++    ----------
++
++    root_path (str): The root path for locating BLS configuration files.
++    kernel_arguments (list): A list of kernel arguments to be added.
++
++    """
++    # There is unlikely to be more than one bls config, but just
++    # in case we'll iterate over them.
++    entries = []
++    for entry in glob.glob(f"{root_path}/loader/entries/*.conf"):
++        entries.append(entry)
++        # Read in the file and then append to the options line.
++        with open(entry, encoding="utf8") as f:
++            lines = f.read().splitlines()
++        with open(entry, "w", encoding="utf8") as f:
++            for line in lines:
++                if line.startswith('options '):
++                    f.write(f"{line} {' '.join(kernel_arguments)}\n")
++                else:
++                    f.write(f"{line}\n")
++    assert len(entries) != 0
++    print(f"Added {','.join(kernel_arguments)} to: {','.join(entries)}")
++    return 0
+diff --git a/stages/org.osbuild.kernel-cmdline.bls-append b/stages/org.osbuild.kernel-cmdline.bls-append
+index dd166624..7404032d 100755
+--- a/stages/org.osbuild.kernel-cmdline.bls-append
++++ b/stages/org.osbuild.kernel-cmdline.bls-append
+@@ -10,6 +10,7 @@ the tree or in a mount.
+ import glob
+ import sys
+ from urllib.parse import urlparse
++from osbuild.util import bls
+ 
+ import osbuild.api
+ 
+@@ -60,24 +61,7 @@ def main(paths, tree, options):
+ 
+     assert url.path.startswith("/")
+     bootroot = root + url.path
+-
+-    # There is unlikely to be more than one bls config, but just
+-    # in case we'll iterate over them.
+-    entries = []
+-    for entry in glob.glob(f"{bootroot}/loader/entries/*.conf"):
+-        entries.append(entry)
+-        # Read in the file and then append to the options line.
+-        with open(entry, encoding="utf8") as f:
+-            lines = f.read().splitlines()
+-        with open(entry, "w", encoding="utf8") as f:
+-            for line in lines:
+-                if line.startswith('options '):
+-                    f.write(f"{line} {' '.join(kopts)}\n")
+-                else:
+-                    f.write(f"{line}\n")
+-    assert len(entries) != 0
+-    print(f"Added {','.join(kopts)} to: {','.join(entries)}")
+-    return 0
++    bls.options_append(bootroot, kopts)
+ 
+ 
+ if __name__ == '__main__':
+-- 
+2.43.0
+

--- a/src/0002-Add-coreos.platforms-stage.patch
+++ b/src/0002-Add-coreos.platforms-stage.patch
@@ -1,0 +1,149 @@
+From d26d29a9cfea000418ea1f24127e8697af88e351 Mon Sep 17 00:00:00 2001
+From: Renata Ravanelli <rravanel@redhat.com>
+Date: Wed, 7 Feb 2024 16:43:54 -0300
+Subject: [PATCH 2/2] Add coreos.platforms stage
+
+ - Process all necessary operations related to CoreOS
+platforms is crucial and specific to CoreOS. This step
+is essential for CoreOS exclusively.
+
+- Our approach to handling 'platforms.json' may change as we
+advance with the OSBuild work. However, we don't have a clear
+vision about how it will be in the future yet, particularly as
+we also manage similar components within the osbuild composer
+to configure cloud parameters. We probably will know better
+when we start working with the cloud artifacts.
+
+As a summary, let's add it know to unblock us, and if we find a
+better approach in the future, we can always go back and remove it.
+
+Signed-off-by: Renata Ravanelli <rravanel@redhat.com>
+---
+ stages/org.osbuild.coreos.platform | 115 +++++++++++++++++++++++++++++
+ 1 file changed, 115 insertions(+)
+ create mode 100755 stages/org.osbuild.coreos.platform
+
+diff --git a/stages/org.osbuild.coreos.platform b/stages/org.osbuild.coreos.platform
+new file mode 100755
+index 00000000..9eceac0e
+--- /dev/null
++++ b/stages/org.osbuild.coreos.platform
+@@ -0,0 +1,115 @@
++#!/usr/bin/python3
++"""
++In CoreOS we have the concept of a platform (i.e. AWS, GCP, Metal, QEMU)
++where each platform has its own provided disk image with slightly
++differing settings/behavior. This stage will perform the necessary
++configuration for the given platform. This configuration boils down to
++a few steps:
++1. Locate the source of platform specific information that is provided
++   in the CoreOS filesystem tree already (the platforms.json).
++2. Copy the platforms.json file into the /boot/ partition, which is
++   sometimes used by coreos-installer.
++3. Read the platforms.json to fetch and platform specific kernel
++   arguments or grub configuration to set. These arguments/config
++   are primarily console settings.
++4. Apply any platform specific kernel arguments along with the
++   `ignition.platform.id={platform-name}` kernel argument.
++5. Create the grub console.cfg file and apply any platform
++   specific grub console configuration.
++This stage is highly CoreOS specific and subject to change in the
++future if/when we change the way platform specific information is
++defined in our broader efforts to share more defaults with OSBuild.
++"""
++SCHEMA_2 = r"""
++"options": {
++  "additionalProperties": false,
++  "properties": {
++    "platform": {
++      "description": "The target platform name/ID",
++      "type": "string"
++    }
++  }
++},
++"devices": {
++  "type": "object",
++  "additionalProperties": true
++},
++"mounts": {
++  "type": "array"
++}
++"""
++import json
++import os
++import osbuild.api
++import shutil
++import sys
++
++from osbuild.util import bls
++
++# Constants
++#For console.cfg see https://github.com/coreos/bootupd/pull/620
++#For platforms.json see https://github.com/coreos/coreos-assembler/pull/3709
++GRUB_CONSOLE_CFG = "boot/grub2/console.cfg"
++PLATFORMS_JSON_DEST= "boot/coreos/platforms.json"
++PLATFORMS_JSON_SOURCE = "usr/share/coreos-assembler/platforms.json"
++
++def generate_console_settings_file(console_settings, file_path):
++    settings_content = ""
++    if console_settings is not None:
++        settings_content = "\n".join(console_settings)
++    file_content = f"""
++# Any non-default console settings will be inserted here.
++# CONSOLE-SETTINGS-START
++{settings_content}
++# CONSOLE-SETTINGS-END
++"""
++    with open(file_path, 'w') as file:
++        file.write(file_content)
++
++
++def process_platforms_json(json_file_path, platform):
++    keys = ["grub_commands", "kernel_arguments"]
++    result = {}
++    with open(json_file_path, 'r') as file:
++        data = json.load(file)
++        if platform in data:
++            for key in keys:
++                if key in data[platform]:
++                    result[key] = data[platform][key]
++
++    return result.get("grub_commands", []),\
++           result.get("kernel_arguments", [])
++
++
++def main(paths, tree, options):
++
++    deployment = options.get("deployment")
++    platform = options.get("platform")
++
++    root = args["paths"]["mounts"]
++    boot_path = os.path.join(root, "boot")
++    platforms_source_path = os.path.join(root, PLATFORMS_JSON_SOURCE.lstrip())
++    platforms_dest_path = os.path.join(root, PLATFORMS_JSON_DEST.lstrip())
++    grub_console_cfg_path = os.path.join(root, GRUB_CONSOLE_CFG.lstrip())
++
++    kernel_arguments = [f"ignition.platform.id={platform}"]
++
++    json_grub_args, json_kargs = None, None
++    if os.path.exists(platforms_source_path):
++        os.makedirs(os.path.dirname(platforms_dest_path), mode=0o755, exist_ok=True)
++        # Copy platforms.json to the boot partition
++        shutil.copy2(platforms_source_path, platforms_dest_path)
++        json_grub_args, json_kargs = process_platforms_json(platforms_dest_path, platform)
++    if json_kargs:
++        kernel_arguments.extend(json_kargs)
++
++    # Write out the GRUB2 console.cfg on all platforms where grub is being used
++    if os.path.exists(os.dirname(grub_console_cfg_path)):
++        generate_console_settings_file(json_grub_args, grub_console_cfg_path)
++    # Append kernel arguments in bls entries
++    bls.options_append(f"{boot_path}", kernel_arguments)
++
++if __name__ == "__main__":
++    args = osbuild.api.arguments()
++    r = main(args["paths"], args["tree"], args["options"])
++    sys.exit(r)
+-- 
+2.43.0
+

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -729,6 +729,13 @@ runvm() {
     # include COSA in the image
     find /usr/lib/coreos-assembler/ -type f > "${vmpreparedir}/hostfiles"
 
+    # Include new files from OSBuild patches.
+    # Can drop this once the upstream PRs are merged:
+    # https://github.com/osbuild/osbuild/pull/1589
+    # shellcheck disable=SC2129
+    echo /usr/lib/osbuild/stages/org.osbuild.coreos.platform >> "${vmpreparedir}/hostfiles"
+    echo /usr/lib/python3.12/site-packages/osbuild/util/bls.py >> "${vmpreparedir}/hostfiles"
+
     # and include all GPG keys
     find /etc/pki/rpm-gpg/ -type f >> "${vmpreparedir}/hostfiles"
 

--- a/src/osbuild-manifests/coreos.osbuild.aarch64.mpp.yaml
+++ b/src/osbuild-manifests/coreos.osbuild.aarch64.mpp.yaml
@@ -111,12 +111,6 @@ pipelines:
           paths:
             - path: /boot/efi
               mode: 493
-      # platforms.json will live here
-      - type: org.osbuild.mkdir
-        options:
-          paths:
-            - path: /boot/coreos
-              mode: 493
       - type: org.osbuild.ignition
       # Deploy via container if we have a container ociarchive, else from repo.
       - mpp-if: ociarchive != ''
@@ -170,19 +164,6 @@ pipelines:
         options:
           deployment:
             default: true
-      # Copy in the platforms.json that was baked into the OSTree into /boot
-      # so tools like coreos-installer can use the information.
-      - type: org.osbuild.copy
-        options:
-          paths:
-            - from: tree:///usr/share/coreos-assembler/platforms.json
-              to: tree:///boot/coreos/platforms.json
-        mounts:
-          - name: ostree.deployment
-            type: org.osbuild.ostree.deployment
-            options:
-              deployment:
-                default: true
   - name: raw-image
     stages:
       - type: org.osbuild.truncate
@@ -540,25 +521,34 @@ pipelines:
           paths:
             - from: input://tree/disk.img
               to: tree:///disk.img
-      - type: org.osbuild.kernel-cmdline.bls-append
+      - type: org.osbuild.coreos.platform
         options:
-          bootpath: mount:///
-          kernel_opts:
-            - ignition.platform.id=metal
+          platform: metal
         devices:
-          boot:
+          disk:
             type: org.osbuild.loopback
             options:
               filename: disk.img
-              start:
-                mpp-format-int: '{image.layout[''boot''].start}'
-              size:
-                mpp-format-int: '{image.layout[''boot''].size}'
+              partscan: true
         mounts:
-          - name: boot
-            type: org.osbuild.ext4
-            source: boot
-            target: /
+           - name: root
+             type: org.osbuild.xfs
+             source: disk
+             partition:
+               mpp-format-int: '{image.layout[''root''].partnum}'
+             target: /
+           - name: ostree.deployment
+             type: org.osbuild.ostree.deployment
+             options:
+               source: mount
+               deployment:
+                 default: true
+           - name: boot
+             type: org.osbuild.ext4
+             source: disk
+             partition:
+               mpp-format-int: '{image.layout[''boot''].partnum}'
+             target: /boot
   - name: raw-metal4k-image
     stages:
       - type: org.osbuild.copy
@@ -572,27 +562,36 @@ pipelines:
           paths:
             - from: input://tree/disk.img
               to: tree:///disk.img
-      - type: org.osbuild.kernel-cmdline.bls-append
+      - type: org.osbuild.coreos.platform
         options:
-          bootpath: mount:///
-          kernel_opts:
-            - ignition.platform.id=metal
+          platform: metal
         devices:
-          boot:
+          disk:
             type: org.osbuild.loopback
             options:
               filename: disk.img
-              start:
-                mpp-format-int: '{image4k.layout[''boot''].start}'
-              size:
-                mpp-format-int: '{image4k.layout[''boot''].size}'
+              partscan: true
               sector-size:
                   mpp-format-int: "{four_k_sector_size}"
         mounts:
-          - name: boot
-            type: org.osbuild.ext4
-            source: boot
-            target: /
+           - name: root
+             type: org.osbuild.xfs
+             source: disk
+             partition:
+               mpp-format-int: '{image4k.layout[''root''].partnum}'
+             target: /
+           - name: ostree.deployment
+             type: org.osbuild.ostree.deployment
+             options:
+               source: mount
+               deployment:
+                 default: true
+           - name: boot
+             type: org.osbuild.ext4
+             source: disk
+             partition:
+               mpp-format-int: '{image4k.layout[''boot''].partnum}'
+             target: /boot
   - name: raw-qemu-image
     stages:
       - type: org.osbuild.copy
@@ -612,25 +611,34 @@ pipelines:
           filename: disk.img
           size:
             mpp-format-string: "{cloud_image_size_mb * 1024 * 1024}"
-      - type: org.osbuild.kernel-cmdline.bls-append
+      - type: org.osbuild.coreos.platform
         options:
-          bootpath: mount:///
-          kernel_opts:
-            - ignition.platform.id=qemu
+          platform: qemu
         devices:
-          boot:
+          disk:
             type: org.osbuild.loopback
             options:
               filename: disk.img
-              start:
-                mpp-format-int: '{image.layout[''boot''].start}'
-              size:
-                mpp-format-int: '{image.layout[''boot''].size}'
+              partscan: true
         mounts:
-          - name: boot
-            type: org.osbuild.ext4
-            source: boot
-            target: /
+           - name: root
+             type: org.osbuild.xfs
+             source: disk
+             partition:
+               mpp-format-int: '{image.layout[''root''].partnum}'
+             target: /
+           - name: ostree.deployment
+             type: org.osbuild.ostree.deployment
+             options:
+               source: mount
+               deployment:
+                 default: true
+           - name: boot
+             type: org.osbuild.ext4
+             source: disk
+             partition:
+               mpp-format-int: '{image.layout[''boot''].partnum}'
+             target: /boot
   - name: metal
     stages:
       - type: org.osbuild.copy

--- a/src/osbuild-manifests/coreos.osbuild.ppc64le.mpp.yaml
+++ b/src/osbuild-manifests/coreos.osbuild.ppc64le.mpp.yaml
@@ -108,12 +108,6 @@ pipelines:
               bootloader: none
               # https://github.com/coreos/fedora-coreos-tracker/issues/1333
               bls-append-except-default: grub_users=""
-      # platforms.json will live here
-      - type: org.osbuild.mkdir
-        options:
-          paths:
-            - path: /boot/coreos
-              mode: 493
       - type: org.osbuild.ignition
       # Deploy via container if we have a container ociarchive, else from repo.
       - mpp-if: ociarchive != ''
@@ -178,19 +172,6 @@ pipelines:
         options:
           deployment:
             default: true
-      # Copy in the platforms.json that was baked into the OSTree into /boot
-      # so tools like coreos-installer can use the information.
-      - type: org.osbuild.copy
-        options:
-          paths:
-            - from: tree:///usr/share/coreos-assembler/platforms.json
-              to: tree:///boot/coreos/platforms.json
-        mounts:
-          - name: ostree.deployment
-            type: org.osbuild.ostree.deployment
-            options:
-              deployment:
-                default: true
   - name: raw-image
     stages:
       - type: org.osbuild.truncate
@@ -505,25 +486,35 @@ pipelines:
           paths:
             - from: input://tree/disk.img
               to: tree:///disk.img
-      - type: org.osbuild.kernel-cmdline.bls-append
+      - type: org.osbuild.coreos.platform
         options:
-          bootpath: mount:///
-          kernel_opts:
-            - ignition.platform.id=metal
+          platform: metal
         devices:
-          boot:
+          disk:
             type: org.osbuild.loopback
             options:
               filename: disk.img
-              start:
-                mpp-format-int: '{image.layout[''boot''].start}'
-              size:
-                mpp-format-int: '{image.layout[''boot''].size}'
+              partscan: true
         mounts:
-          - name: boot
-            type: org.osbuild.ext4
-            source: boot
-            target: /
+           - name: root
+             type: org.osbuild.xfs
+             source: disk
+             partition:
+               mpp-format-int: '{image.layout[''root''].partnum}'
+             target: /
+           - name: ostree.deployment
+             type: org.osbuild.ostree.deployment
+             options:
+               source: mount
+               deployment:
+                 default: true
+           - name: boot
+             type: org.osbuild.ext4
+             source: disk
+             partition:
+               mpp-format-int: '{image.layout[''boot''].partnum}'
+             target: /boot
+
   - name: raw-metal4k-image
     stages:
       - type: org.osbuild.copy
@@ -537,27 +528,36 @@ pipelines:
           paths:
             - from: input://tree/disk.img
               to: tree:///disk.img
-      - type: org.osbuild.kernel-cmdline.bls-append
+      - type: org.osbuild.coreos.platform
         options:
-          bootpath: mount:///
-          kernel_opts:
-            - ignition.platform.id=metal
+          platform: metal
         devices:
-          boot:
+          disk:
             type: org.osbuild.loopback
             options:
               filename: disk.img
-              start:
-                mpp-format-int: '{image4k.layout[''boot''].start}'
-              size:
-                mpp-format-int: '{image4k.layout[''boot''].size}'
+              partscan: true
               sector-size:
                   mpp-format-int: "{four_k_sector_size}"
         mounts:
-          - name: boot
-            type: org.osbuild.ext4
-            source: boot
-            target: /
+           - name: root
+             type: org.osbuild.xfs
+             source: disk
+             partition:
+               mpp-format-int: '{image4k.layout[''root''].partnum}'
+             target: /
+           - name: ostree.deployment
+             type: org.osbuild.ostree.deployment
+             options:
+               source: mount
+               deployment:
+                 default: true
+           - name: boot
+             type: org.osbuild.ext4
+             source: disk
+             partition:
+               mpp-format-int: '{image4k.layout[''boot''].partnum}'
+             target: /boot
   - name: raw-qemu-image
     stages:
       - type: org.osbuild.copy
@@ -577,27 +577,34 @@ pipelines:
           filename: disk.img
           size:
             mpp-format-string: "{cloud_image_size_mb * 1024 * 1024}"
-      - type: org.osbuild.kernel-cmdline.bls-append
+      - type: org.osbuild.coreos.platform
         options:
-          bootpath: mount:///
-          kernel_opts:
-            - console=hvc0
-            - console=tty0
-            - ignition.platform.id=qemu
+          platform: qemu
         devices:
-          boot:
+          disk:
             type: org.osbuild.loopback
             options:
               filename: disk.img
-              start:
-                mpp-format-int: '{image.layout[''boot''].start}'
-              size:
-                mpp-format-int: '{image.layout[''boot''].size}'
+              partscan: true
         mounts:
-          - name: boot
-            type: org.osbuild.ext4
-            source: boot
-            target: /
+           - name: root
+             type: org.osbuild.xfs
+             source: disk
+             partition:
+               mpp-format-int: '{image.layout[''root''].partnum}'
+             target: /
+           - name: ostree.deployment
+             type: org.osbuild.ostree.deployment
+             options:
+               source: mount
+               deployment:
+                 default: true
+           - name: boot
+             type: org.osbuild.ext4
+             source: disk
+             partition:
+               mpp-format-int: '{image.layout[''boot''].partnum}'
+             target: /boot
   - name: metal
     stages:
       - type: org.osbuild.copy

--- a/src/osbuild-manifests/coreos.osbuild.s390x.mpp.yaml
+++ b/src/osbuild-manifests/coreos.osbuild.s390x.mpp.yaml
@@ -423,26 +423,35 @@ pipelines:
           paths:
             - from: input://tree/disk.img
               to: tree:///disk.img
-      - type: org.osbuild.kernel-cmdline.bls-append
+      - type: org.osbuild.coreos.platform
         options:
-          bootpath: mount:///
-          kernel_opts:
-            - ignition.platform.id=metal
+          platform: metal
         devices:
-          boot:
+          disk:
             type: org.osbuild.loopback
             options:
               filename: disk.img
-              start:
-                mpp-format-int: '{image.layout[''boot''].start}'
-              size:
-                mpp-format-int: '{image.layout[''boot''].size}'
+              partscan: true
         mounts:
-          - name: boot
-            type: org.osbuild.ext4
-            source: boot
-            target: /
-      # Must run after setting ignition.platform.id above
+           - name: root
+             type: org.osbuild.xfs
+             source: disk
+             partition:
+               mpp-format-int: '{image.layout[''root''].partnum}'
+             target: /
+           - name: ostree.deployment
+             type: org.osbuild.ostree.deployment
+             options:
+               source: mount
+               deployment:
+                 default: true
+           - name: boot
+             type: org.osbuild.ext4
+             source: disk
+             partition:
+               mpp-format-int: '{image.layout[''boot''].partnum}'
+             target: /boot
+      # Must run after the coreos.platform stage, which sets kernel arguments
       - type: org.osbuild.zipl.inst
         options:
           kernel: "1"
@@ -482,28 +491,37 @@ pipelines:
           paths:
             - from: input://tree/disk.img
               to: tree:///disk.img
-      - type: org.osbuild.kernel-cmdline.bls-append
+      - type: org.osbuild.coreos.platform
         options:
-          bootpath: mount:///
-          kernel_opts:
-            - ignition.platform.id=metal
+          platform: metal
         devices:
-          boot:
+          disk:
             type: org.osbuild.loopback
             options:
               filename: disk.img
-              start:
-                mpp-format-int: '{image4k.layout[''boot''].start}'
-              size:
-                mpp-format-int: '{image4k.layout[''boot''].size}'
+              partscan: true
               sector-size:
                   mpp-format-int: "{four_k_sector_size}"
         mounts:
-          - name: boot
-            type: org.osbuild.ext4
-            source: boot
-            target: /
-      # Must run after setting ignition.platform.id above
+           - name: root
+             type: org.osbuild.xfs
+             source: disk
+             partition:
+               mpp-format-int: '{image4k.layout[''root''].partnum}'
+             target: /
+           - name: ostree.deployment
+             type: org.osbuild.ostree.deployment
+             options:
+               source: mount
+               deployment:
+                 default: true
+           - name: boot
+             type: org.osbuild.ext4
+             source: disk
+             partition:
+               mpp-format-int: '{image4k.layout[''boot''].partnum}'
+             target: /boot
+      # Must run after the coreos.platform stage, which sets kernel arguments
       - type: org.osbuild.zipl.inst
         options:
           kernel: "1"
@@ -551,26 +569,35 @@ pipelines:
           filename: disk.img
           size:
             mpp-format-string: "{cloud_image_size_mb * 1024 * 1024}"
-      - type: org.osbuild.kernel-cmdline.bls-append
+      - type: org.osbuild.coreos.platform
         options:
-          bootpath: mount:///
-          kernel_opts:
-            - ignition.platform.id=qemu
+          platform: qemu
         devices:
-          boot:
+          disk:
             type: org.osbuild.loopback
             options:
               filename: disk.img
-              start:
-                mpp-format-int: '{image.layout[''boot''].start}'
-              size:
-                mpp-format-int: '{image.layout[''boot''].size}'
+              partscan: true
         mounts:
-          - name: boot
-            type: org.osbuild.ext4
-            source: boot
-            target: /
-      # Must run after setting ignition.platform.id above
+           - name: root
+             type: org.osbuild.xfs
+             source: disk
+             partition:
+               mpp-format-int: '{image.layout[''root''].partnum}'
+             target: /
+           - name: ostree.deployment
+             type: org.osbuild.ostree.deployment
+             options:
+               source: mount
+               deployment:
+                 default: true
+           - name: boot
+             type: org.osbuild.ext4
+             source: disk
+             partition:
+               mpp-format-int: '{image.layout[''boot''].partnum}'
+             target: /boot
+      # Must run after the coreos.platform stage, which sets kernel arguments
       - type: org.osbuild.zipl.inst
         options:
           kernel: "1"

--- a/src/osbuild-manifests/coreos.osbuild.x86_64.mpp.yaml
+++ b/src/osbuild-manifests/coreos.osbuild.x86_64.mpp.yaml
@@ -113,12 +113,6 @@ pipelines:
           paths:
             - path: /boot/efi
               mode: 493
-      # platforms.json will live here
-      - type: org.osbuild.mkdir
-        options:
-          paths:
-            - path: /boot/coreos
-              mode: 493
       - type: org.osbuild.ignition
       # Deploy via container if we have a container ociarchive, else from repo.
       - mpp-if: ociarchive != ''
@@ -172,19 +166,6 @@ pipelines:
         options:
           deployment:
             default: true
-      # Copy in the platforms.json that was baked into the OSTree into /boot
-      # so tools like coreos-installer can use the information.
-      - type: org.osbuild.copy
-        options:
-          paths:
-            - from: tree:///usr/share/coreos-assembler/platforms.json
-              to: tree:///boot/coreos/platforms.json
-        mounts:
-          - name: ostree.deployment
-            type: org.osbuild.ostree.deployment
-            options:
-              deployment:
-                default: true
   - name: raw-image
     stages:
       - type: org.osbuild.truncate
@@ -544,25 +525,35 @@ pipelines:
           paths:
             - from: input://tree/disk.img
               to: tree:///disk.img
-      - type: org.osbuild.kernel-cmdline.bls-append
+      - type: org.osbuild.coreos.platform
         options:
-          bootpath: mount:///
-          kernel_opts:
-            - ignition.platform.id=metal
+          platform: metal
         devices:
-          boot:
+          disk:
             type: org.osbuild.loopback
             options:
               filename: disk.img
-              start:
-                mpp-format-int: '{image.layout[''boot''].start}'
-              size:
-                mpp-format-int: '{image.layout[''boot''].size}'
+              partscan: true
         mounts:
-          - name: boot
-            type: org.osbuild.ext4
-            source: boot
-            target: /
+           - name: root
+             type: org.osbuild.xfs
+             source: disk
+             partition:
+               mpp-format-int: '{image.layout[''root''].partnum}'
+             target: /
+           - name: ostree.deployment
+             type: org.osbuild.ostree.deployment
+             options:
+               source: mount
+               deployment:
+                 default: true
+           - name: boot
+             type: org.osbuild.ext4
+             source: disk
+             partition:
+               mpp-format-int: '{image.layout[''boot''].partnum}'
+             target: /boot
+
   - name: raw-metal4k-image
     stages:
       - type: org.osbuild.copy
@@ -576,27 +567,36 @@ pipelines:
           paths:
             - from: input://tree/disk.img
               to: tree:///disk.img
-      - type: org.osbuild.kernel-cmdline.bls-append
+      - type: org.osbuild.coreos.platform
         options:
-          bootpath: mount:///
-          kernel_opts:
-            - ignition.platform.id=metal
+          platform: metal
         devices:
-          boot:
+          disk:
             type: org.osbuild.loopback
             options:
               filename: disk.img
-              start:
-                mpp-format-int: '{image4k.layout[''boot''].start}'
-              size:
-                mpp-format-int: '{image4k.layout[''boot''].size}'
+              partscan: true
               sector-size:
                   mpp-format-int: "{four_k_sector_size}"
         mounts:
-          - name: boot
-            type: org.osbuild.ext4
-            source: boot
-            target: /
+           - name: root
+             type: org.osbuild.xfs
+             source: disk
+             partition:
+               mpp-format-int: '{image4k.layout[''root''].partnum}'
+             target: /
+           - name: ostree.deployment
+             type: org.osbuild.ostree.deployment
+             options:
+               source: mount
+               deployment:
+                 default: true
+           - name: boot
+             type: org.osbuild.ext4
+             source: disk
+             partition:
+               mpp-format-int: '{image4k.layout[''boot''].partnum}'
+             target: /boot
   - name: raw-qemu-image
     stages:
       - type: org.osbuild.copy
@@ -616,27 +616,34 @@ pipelines:
           filename: disk.img
           size:
             mpp-format-string: "{cloud_image_size_mb * 1024 * 1024}"
-      - type: org.osbuild.kernel-cmdline.bls-append
+      - type: org.osbuild.coreos.platform
         options:
-          bootpath: mount:///
-          kernel_opts:
-            - console=tty0
-            - console=ttyS0,115200n8
-            - ignition.platform.id=qemu
+          platform: qemu
         devices:
-          boot:
+          disk:
             type: org.osbuild.loopback
             options:
               filename: disk.img
-              start:
-                mpp-format-int: '{image.layout[''boot''].start}'
-              size:
-                mpp-format-int: '{image.layout[''boot''].size}'
+              partscan: true
         mounts:
-          - name: boot
-            type: org.osbuild.ext4
-            source: boot
-            target: /
+           - name: root
+             type: org.osbuild.xfs
+             source: disk
+             partition:
+               mpp-format-int: '{image.layout[''root''].partnum}'
+             target: /
+           - name: ostree.deployment
+             type: org.osbuild.ostree.deployment
+             options:
+               source: mount
+               deployment:
+                 default: true
+           - name: boot
+             type: org.osbuild.ext4
+             source: disk
+             partition:
+               mpp-format-int: '{image.layout[''boot''].partnum}'
+             target: /boot
   - name: metal
     stages:
       - type: org.osbuild.copy


### PR DESCRIPTION
This is a backport of the upstream PR [1]. This helps us close one of the final gaps when it comes to features needed for OSBuild [2]. It updates the GRUB console settings and also will update kernel arguments based on the platforms.json content.

[1] https://github.com/osbuild/osbuild/pull/1589
[2] https://github.com/coreos/fedora-coreos-tracker/issues/1654