### PR TITLE
osbuild: update coreos.platforms stage patch

### DIFF
--- a/src/0001-util-Add-bls-module.patch
+++ b/src/0001-util-Add-bls-module.patch
@@ -1,4 +1,4 @@
-From a16a27938627d0f16d7a9f09daa889ec29ec9740 Mon Sep 17 00:00:00 2001
+From 636d3810acaa2cf7ce33616a1d57a2eeed39797b Mon Sep 17 00:00:00 2001
 From: Renata Ravanelli <rravanel@redhat.com>
 Date: Mon, 19 Feb 2024 10:30:34 -0300
 Subject: [PATCH 1/2] util: Add bls module
@@ -8,20 +8,19 @@ Boot Loader Specification (BLS) as needed.
 
 Signed-off-by: Renata Ravanelli <rravanel@redhat.com>
 ---
- osbuild/util/bls.py                          | 38 ++++++++++++++++++++
+ osbuild/util/bls.py                          | 35 ++++++++++++++++++++
  stages/org.osbuild.kernel-cmdline.bls-append | 20 ++---------
- 2 files changed, 40 insertions(+), 18 deletions(-)
+ 2 files changed, 37 insertions(+), 18 deletions(-)
  create mode 100644 osbuild/util/bls.py
 
 diff --git a/osbuild/util/bls.py b/osbuild/util/bls.py
 new file mode 100644
-index 00000000..4168bd71
+index 00000000..f7ee6dad
 --- /dev/null
 +++ b/osbuild/util/bls.py
-@@ -0,0 +1,38 @@
+@@ -0,0 +1,35 @@
 +import glob
 +import os
-+import re
 +
 +"""
 +Function for appending parameters to
@@ -40,8 +39,6 @@ index 00000000..4168bd71
 +    kernel_arguments (list): A list of kernel arguments to be added.
 +
 +    """
-+    # There is unlikely to be more than one bls config, but just
-+    # in case we'll iterate over them.
 +    entries = []
 +    for entry in glob.glob(f"{root_path}/loader/entries/*.conf"):
 +        entries.append(entry)

--- a/src/0002-Add-coreos.platforms-stage.patch
+++ b/src/0002-Add-coreos.platforms-stage.patch
@@ -1,4 +1,4 @@
-From d26d29a9cfea000418ea1f24127e8697af88e351 Mon Sep 17 00:00:00 2001
+From 00edf67a4ec9a909919e8fa480f04c823b75ab63 Mon Sep 17 00:00:00 2001
 From: Renata Ravanelli <rravanel@redhat.com>
 Date: Wed, 7 Feb 2024 16:43:54 -0300
 Subject: [PATCH 2/2] Add coreos.platforms stage
@@ -25,7 +25,7 @@ Signed-off-by: Renata Ravanelli <rravanel@redhat.com>
 
 diff --git a/stages/org.osbuild.coreos.platform b/stages/org.osbuild.coreos.platform
 new file mode 100755
-index 00000000..9eceac0e
+index 00000000..f064fde0
 --- /dev/null
 +++ b/stages/org.osbuild.coreos.platform
 @@ -0,0 +1,115 @@
@@ -133,12 +133,12 @@ index 00000000..9eceac0e
 +        json_grub_args, json_kargs = process_platforms_json(platforms_dest_path, platform)
 +    if json_kargs:
 +        kernel_arguments.extend(json_kargs)
-+
 +    # Write out the GRUB2 console.cfg on all platforms where grub is being used
-+    if os.path.exists(os.dirname(grub_console_cfg_path)):
++    if os.path.exists(os.path.dirname(grub_console_cfg_path)):
++        # We add console.cfg file in grub.cfg, that's how the grubconfigs are added
 +        generate_console_settings_file(json_grub_args, grub_console_cfg_path)
 +    # Append kernel arguments in bls entries
-+    bls.options_append(f"{boot_path}", kernel_arguments)
++    bls.options_append(boot_path, kernel_arguments)
 +
 +if __name__ == "__main__":
 +    args = osbuild.api.arguments()


### PR DESCRIPTION
With the latest from upstream which fixes an os.dirname() bug (it should be os.path.dirname()).

https://github.com/osbuild/osbuild/pull/1589