### PR TITLE
osbuild: Allow deploy via container image

### DIFF
--- a/src/osbuild-manifests/coreos.osbuild.aarch64.mpp.yaml
+++ b/src/osbuild-manifests/coreos.osbuild.aarch64.mpp.yaml
@@ -4,6 +4,8 @@ mpp-vars:
   ociarchive: $ociarchive
   osname: $osname
   container_imgref: $container_imgref
+  container_repo: $container_repo
+  container_tag: $container_tag
   metal_image_size_mb: $metal_image_size_mb
   cloud_image_size_mb: $cloud_image_size_mb
   bios_boot_size_mb: 1
@@ -120,7 +122,7 @@ pipelines:
             - path: /boot/efi
               mode: 493
       - type: org.osbuild.ignition
-      # Deploy via container if we have a container ociarchive, else from repo.
+      # Deploy via container if we have a container ociarchive or an image, else from repo.
       - mpp-if: ociarchive != ''
         then:
           type: org.osbuild.ostree.deploy.container
@@ -142,6 +144,28 @@ pipelines:
               references:
                 name:oci-archive:
                   name: coreos.ociarchive
+      - mpp-if: container_repo != ''
+        then:
+          type: org.osbuild.ostree.deploy.container
+          options:
+            osname:
+              mpp-format-string: '{osname}'
+            target_imgref:
+              mpp-format-string: '{container_imgref}'
+            mounts:
+              - /boot
+              - /boot/efi
+            kernel_opts:
+              - rw
+              - '$ignition_firstboot'
+          inputs:
+            images:
+              type: org.osbuild.containers
+              origin: org.osbuild.source
+              mpp-resolve-images:
+                images:
+                  - source: $container_repo
+                    tag: $container_tag
         else:
           type: org.osbuild.ostree.deploy
           options:

--- a/src/osbuild-manifests/coreos.osbuild.ppc64le.mpp.yaml
+++ b/src/osbuild-manifests/coreos.osbuild.ppc64le.mpp.yaml
@@ -4,6 +4,8 @@ mpp-vars:
   ociarchive: $ociarchive
   osname: $osname
   container_imgref: $container_imgref
+  container_repo: $container_repo
+  container_tag: $container_tag
   metal_image_size_mb: $metal_image_size_mb
   cloud_image_size_mb: $cloud_image_size_mb
   bios_boot_size_mb: 1
@@ -115,7 +117,7 @@ pipelines:
               # will always work.
               bootprefix: true
       - type: org.osbuild.ignition
-      # Deploy via container if we have a container ociarchive, else from repo.
+      # Deploy via container if we have a container ociarchive or an image, else from repo.
       - mpp-if: ociarchive != ''
         then:
           type: org.osbuild.ostree.deploy.container
@@ -136,6 +138,28 @@ pipelines:
               references:
                 name:oci-archive:
                   name: coreos.ociarchive
+      - mpp-if: container_repo != ''
+        then:
+          type: org.osbuild.ostree.deploy.container
+          options:
+            osname:
+              mpp-format-string: '{osname}'
+            target_imgref:
+              mpp-format-string: '{container_imgref}'
+            mounts:
+              - /boot
+              - /boot/efi
+            kernel_opts:
+              - rw
+              - '$ignition_firstboot'
+          inputs:
+            images:
+              type: org.osbuild.containers
+              origin: org.osbuild.source
+              mpp-resolve-images:
+                images:
+                  - source: $container_repo
+                    tag: $container_tag
         else:
           type: org.osbuild.ostree.deploy
           options:

--- a/src/osbuild-manifests/coreos.osbuild.x86_64.mpp.yaml
+++ b/src/osbuild-manifests/coreos.osbuild.x86_64.mpp.yaml
@@ -4,6 +4,8 @@ mpp-vars:
   ociarchive: $ociarchive
   osname: $osname
   container_imgref: $container_imgref
+  container_repo: $container_repo
+  container_tag: $container_tag
   metal_image_size_mb: $metal_image_size_mb
   cloud_image_size_mb: $cloud_image_size_mb
   bios_boot_size_mb: 1
@@ -120,7 +122,7 @@ pipelines:
             - path: /boot/efi
               mode: 493
       - type: org.osbuild.ignition
-      # Deploy via container if we have a container ociarchive, else from repo.
+      # Deploy via container if we have a container ociarchive or an image, else from repo.
       - mpp-if: ociarchive != ''
         then:
           type: org.osbuild.ostree.deploy.container
@@ -142,6 +144,28 @@ pipelines:
               references:
                 name:oci-archive:
                   name: coreos.ociarchive
+      - mpp-if: container_repo != ''
+        then:
+          type: org.osbuild.ostree.deploy.container
+          options:
+            osname:
+              mpp-format-string: '{osname}'
+            target_imgref:
+              mpp-format-string: '{container_imgref}'
+            mounts:
+              - /boot
+              - /boot/efi
+            kernel_opts:
+              - rw
+              - '$ignition_firstboot'
+          inputs:
+            images:
+              type: org.osbuild.containers
+              origin: org.osbuild.source
+              mpp-resolve-images:
+                images:
+                  - source: $container_repo
+                    tag: $container_tag
         else:
           type: org.osbuild.ostree.deploy
           options:

--- a/src/runvm-osbuild
+++ b/src/runvm-osbuild
@@ -54,7 +54,8 @@ deploy_via_container=$(getconfig_def "deploy-via-container" "")
 metal_image_size_mb=$(getconfig "metal-image-size")
 cloud_image_size_mb=$(getconfig "cloud-image-size")
 container_imgref=$(getconfig "container-imgref")
-
+container_repo=$(getconfig "container-repo")
+container_tag=$(getconfig "container-tag")
 # If we are deploying via container let's go ahead and pull
 # the oci archive path from the config
 ostree_container=""
@@ -83,6 +84,8 @@ osbuild-mpp                                             \
     -D ociarchive=\""${ostree_container}"\"             \
     -D osname=\""${osname}"\"                           \
     -D container_imgref=\""${container_imgref}"\"       \
+    -D container_repo=\""${container_repo}"\"       \
+    -D container_tag=\""${container_tag}"\"       \
     -D metal_image_size_mb="${metal_image_size_mb}"     \
     -D cloud_image_size_mb="${cloud_image_size_mb}"     \
     "${mppyaml}" "${processed_json}"


### PR DESCRIPTION
 - Allow osbuild image creation to use also a container image. It is part of the efforce to enable podman to use osbuild.