### PR TITLE
runvm: Implement optional cache size parameter for 'runvm'

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -601,9 +601,10 @@ runcompose_extensions() {
 # the cache disk. `runvm_with_cache_snapshot on` will set snapshotting to on.
 runvm_with_cache_snapshot() {
     local snapshot=$1; shift
+    local cache_size=${RUNVM_CACHE_SIZE:-16G}
     # "cache2" has an explicit label so we can find it in qemu easily
     if [ ! -f "${workdir}"/cache/cache2.qcow2 ]; then
-        qemu-img create -f qcow2 cache2.qcow2.tmp 16G
+        qemu-img create -f qcow2 cache2.qcow2.tmp "$cache_size"
         (
          # shellcheck source=src/libguestfish.sh
          source /usr/lib/coreos-assembler/libguestfish.sh


### PR DESCRIPTION
 - The current cache size for aarch64 during podman-related operations is insufficient. We require a method to expand it to enable the utilization of the cache feature by runvm. By implementing this, we can conveniently adjust the cache size as needed by passing it as a parameter.