### PR TITLE
create_disk: run `bootupctl backend install` using bootupd from target system

### DIFF
--- a/src/create_disk.sh
+++ b/src/create_disk.sh
@@ -404,8 +404,7 @@ EOF
 install_uefi() {
     # https://github.com/coreos/fedora-coreos-tracker/issues/510
     # See also https://github.com/ostreedev/ostree/pull/1873#issuecomment-524439883
-    # Unshare mount ns to work around https://github.com/coreos/bootupd/issues/367
-    unshare -m /usr/bin/bootupctl backend install --src-root="${deploy_root}" "${rootfs}"
+    chroot_run bootupctl backend install --src-root="/" "/sysroot"
     # We have a "static" grub config file that basically configures grub to look
     # in the RAID called "md-boot", if it exists, or the partition labeled "boot".
     local target_efi="$rootfs/boot/efi"
@@ -460,7 +459,9 @@ chroot_run() {
     for mnt in dev proc sys run var tmp; do
         mount --rbind "/$mnt" "${deploy_root}/$mnt"
     done
+    mount --rbind "${rootfs}" "${deploy_root}/sysroot"
     chroot "${deploy_root}" "$@"
+    umount --recursive "${deploy_root}/sysroot"
     for mnt in dev proc sys run var tmp; do
         umount --recursive "${deploy_root}/$mnt"
     done


### PR DESCRIPTION
Just like most tools run in this script, we want to use the version of bootupd in the target system rather than whatever happens to be in cosa to ensure maximum compatibility.

This is already fixed in the osbuild flow. So this is just fixing it in the legacy flow until we've fully moved over to osbuild since it's easy to do. While we're here, drop the `unshare` workaround since it's no longer needed.

This bit us recently:

https://github.com/coreos/fedora-coreos-streams/issues/862#issuecomment-1992283167