### PR TITLE
runvm-osbuild: fix handling of `container-(repo|tag)` fields

### DIFF
--- a/src/osbuild-manifests/coreos.osbuild.aarch64.mpp.yaml
+++ b/src/osbuild-manifests/coreos.osbuild.aarch64.mpp.yaml
@@ -144,49 +144,50 @@ pipelines:
               references:
                 name:oci-archive:
                   name: coreos.ociarchive
-      - mpp-if: container_repo != ''
-        then:
-          type: org.osbuild.ostree.deploy.container
-          options:
-            osname:
-              mpp-format-string: '{osname}'
-            target_imgref:
-              mpp-format-string: '{container_imgref}'
-            mounts:
-              - /boot
-              - /boot/efi
-            kernel_opts:
-              - rw
-              - '$ignition_firstboot'
-          inputs:
-            images:
-              type: org.osbuild.containers
-              origin: org.osbuild.source
-              mpp-resolve-images:
-                images:
-                  - source: $container_repo
-                    tag: $container_tag
         else:
-          type: org.osbuild.ostree.deploy
-          options:
-            osname:
-              mpp-format-string: '{osname}'
-            remote: fedora
-            mounts:
-              - /boot
-              - /boot/efi
-            kernel_opts:
-              - rw
-              - '$ignition_firstboot'
-          inputs:
-            commits:
-              type: org.osbuild.ostree
-              origin: org.osbuild.source
-              mpp-resolve-ostree-commits:
-                commits:
-                  - ref: $ref
-                    remote:
-                      url: $repourl
+          mpp-if: container_repo != ''
+          then:
+            type: org.osbuild.ostree.deploy.container
+            options:
+              osname:
+                mpp-format-string: '{osname}'
+              target_imgref:
+                mpp-format-string: '{container_imgref}'
+              mounts:
+                - /boot
+                - /boot/efi
+              kernel_opts:
+                - rw
+                - '$ignition_firstboot'
+            inputs:
+              images:
+                type: org.osbuild.containers
+                origin: org.osbuild.source
+                mpp-resolve-images:
+                  images:
+                    - source: $container_repo
+                      tag: $container_tag
+          else:
+            type: org.osbuild.ostree.deploy
+            options:
+              osname:
+                mpp-format-string: '{osname}'
+              remote: fedora
+              mounts:
+                - /boot
+                - /boot/efi
+              kernel_opts:
+                - rw
+                - '$ignition_firstboot'
+            inputs:
+              commits:
+                type: org.osbuild.ostree
+                origin: org.osbuild.source
+                mpp-resolve-ostree-commits:
+                  commits:
+                    - ref: $ref
+                      remote:
+                        url: $repourl
       - type: org.osbuild.ostree.aleph
         options:
           coreos_compat: true

--- a/src/osbuild-manifests/coreos.osbuild.ppc64le.mpp.yaml
+++ b/src/osbuild-manifests/coreos.osbuild.ppc64le.mpp.yaml
@@ -138,48 +138,49 @@ pipelines:
               references:
                 name:oci-archive:
                   name: coreos.ociarchive
-      - mpp-if: container_repo != ''
-        then:
-          type: org.osbuild.ostree.deploy.container
-          options:
-            osname:
-              mpp-format-string: '{osname}'
-            target_imgref:
-              mpp-format-string: '{container_imgref}'
-            mounts:
-              - /boot
-              - /boot/efi
-            kernel_opts:
-              - rw
-              - '$ignition_firstboot'
-          inputs:
-            images:
-              type: org.osbuild.containers
-              origin: org.osbuild.source
-              mpp-resolve-images:
-                images:
-                  - source: $container_repo
-                    tag: $container_tag
-        else:
-          type: org.osbuild.ostree.deploy
-          options:
-            osname:
-              mpp-format-string: '{osname}'
-            remote: fedora
-            mounts:
-              - /boot
-            kernel_opts:
-              - rw
-              - '$ignition_firstboot'
-          inputs:
-            commits:
-              type: org.osbuild.ostree
-              origin: org.osbuild.source
-              mpp-resolve-ostree-commits:
-                commits:
-                  - ref: $ref
-                    remote:
-                      url: $repourl
+        else
+          mpp-if: container_repo != ''
+          then:
+            type: org.osbuild.ostree.deploy.container
+            options:
+              osname:
+                mpp-format-string: '{osname}'
+              target_imgref:
+                mpp-format-string: '{container_imgref}'
+              mounts:
+                - /boot
+                - /boot/efi
+              kernel_opts:
+                - rw
+                - '$ignition_firstboot'
+            inputs:
+              images:
+                type: org.osbuild.containers
+                origin: org.osbuild.source
+                mpp-resolve-images:
+                  images:
+                    - source: $container_repo
+                      tag: $container_tag
+          else:
+            type: org.osbuild.ostree.deploy
+            options:
+              osname:
+                mpp-format-string: '{osname}'
+              remote: fedora
+              mounts:
+                - /boot
+              kernel_opts:
+                - rw
+                - '$ignition_firstboot'
+            inputs:
+              commits:
+                type: org.osbuild.ostree
+                origin: org.osbuild.source
+                mpp-resolve-ostree-commits:
+                  commits:
+                    - ref: $ref
+                      remote:
+                        url: $repourl
       # Drop the immutable bit here (we add it back later) because it
       # causes failures when cleaning up tmp dirs.
       - type: org.osbuild.chattr

--- a/src/osbuild-manifests/coreos.osbuild.ppc64le.mpp.yaml
+++ b/src/osbuild-manifests/coreos.osbuild.ppc64le.mpp.yaml
@@ -149,7 +149,6 @@ pipelines:
                 mpp-format-string: '{container_imgref}'
               mounts:
                 - /boot
-                - /boot/efi
               kernel_opts:
                 - rw
                 - '$ignition_firstboot'

--- a/src/osbuild-manifests/coreos.osbuild.s390x.mpp.yaml
+++ b/src/osbuild-manifests/coreos.osbuild.s390x.mpp.yaml
@@ -125,26 +125,48 @@ pipelines:
                 name:oci-archive:
                   name: coreos.ociarchive
         else:
-          type: org.osbuild.ostree.deploy
-          options:
-            osname:
-              mpp-format-string: '{osname}'
-            remote: fedora
-            mounts:
-              - /boot
-            kernel_opts:
-              - rw
-             ## '$ignition_firstboot' only works with GRUB, not available on s390x
-             #- '$ignition_firstboot'
-          inputs:
-            commits:
-              type: org.osbuild.ostree
-              origin: org.osbuild.source
-              mpp-resolve-ostree-commits:
-                commits:
-                  - ref: $ref
-                    remote:
-                      url: $repourl
+          mpp-if: container_repo != ''
+          then:
+            type: org.osbuild.ostree.deploy.container
+            options:
+              osname:
+                mpp-format-string: '{osname}'
+              target_imgref:
+                mpp-format-string: '{container_imgref}'
+              mounts:
+                - /boot
+              kernel_opts:
+                - rw
+                - '$ignition_firstboot'
+            inputs:
+              images:
+                type: org.osbuild.containers
+                origin: org.osbuild.source
+                mpp-resolve-images:
+                  images:
+                    - source: $container_repo
+                      tag: $container_tag
+          else:
+            type: org.osbuild.ostree.deploy
+            options:
+              osname:
+                mpp-format-string: '{osname}'
+              remote: fedora
+              mounts:
+                - /boot
+              kernel_opts:
+                - rw
+               ## '$ignition_firstboot' only works with GRUB, not available on s390x
+               #- '$ignition_firstboot'
+            inputs:
+              commits:
+                type: org.osbuild.ostree
+                origin: org.osbuild.source
+                mpp-resolve-ostree-commits:
+                  commits:
+                    - ref: $ref
+                      remote:
+                        url: $repourl
       # Drop the immutable bit here (we add it back later) because it
       # causes failures when cleaning up tmp dirs.
       - type: org.osbuild.chattr

--- a/src/osbuild-manifests/coreos.osbuild.x86_64.mpp.yaml
+++ b/src/osbuild-manifests/coreos.osbuild.x86_64.mpp.yaml
@@ -144,49 +144,50 @@ pipelines:
               references:
                 name:oci-archive:
                   name: coreos.ociarchive
-      - mpp-if: container_repo != ''
-        then:
-          type: org.osbuild.ostree.deploy.container
-          options:
-            osname:
-              mpp-format-string: '{osname}'
-            target_imgref:
-              mpp-format-string: '{container_imgref}'
-            mounts:
-              - /boot
-              - /boot/efi
-            kernel_opts:
-              - rw
-              - '$ignition_firstboot'
-          inputs:
-            images:
-              type: org.osbuild.containers
-              origin: org.osbuild.source
-              mpp-resolve-images:
-                images:
-                  - source: $container_repo
-                    tag: $container_tag
         else:
-          type: org.osbuild.ostree.deploy
-          options:
-            osname:
-              mpp-format-string: '{osname}'
-            remote: fedora
-            mounts:
-              - /boot
-              - /boot/efi
-            kernel_opts:
-              - rw
-              - '$ignition_firstboot'
-          inputs:
-            commits:
-              type: org.osbuild.ostree
-              origin: org.osbuild.source
-              mpp-resolve-ostree-commits:
-                commits:
-                  - ref: $ref
-                    remote:
-                      url: $repourl
+          mpp-if: container_repo != ''
+          then:
+            type: org.osbuild.ostree.deploy.container
+            options:
+              osname:
+                mpp-format-string: '{osname}'
+              target_imgref:
+                mpp-format-string: '{container_imgref}'
+              mounts:
+                - /boot
+                - /boot/efi
+              kernel_opts:
+                - rw
+                - '$ignition_firstboot'
+            inputs:
+              images:
+                type: org.osbuild.containers
+                origin: org.osbuild.source
+                mpp-resolve-images:
+                  images:
+                    - source: $container_repo
+                      tag: $container_tag
+          else:
+            type: org.osbuild.ostree.deploy
+            options:
+              osname:
+                mpp-format-string: '{osname}'
+              remote: fedora
+              mounts:
+                - /boot
+                - /boot/efi
+              kernel_opts:
+                - rw
+                - '$ignition_firstboot'
+            inputs:
+              commits:
+                type: org.osbuild.ostree
+                origin: org.osbuild.source
+                mpp-resolve-ostree-commits:
+                  commits:
+                    - ref: $ref
+                      remote:
+                        url: $repourl
       - type: org.osbuild.ostree.aleph
         options:
           coreos_compat: true

--- a/src/runvm-osbuild
+++ b/src/runvm-osbuild
@@ -54,8 +54,8 @@ deploy_via_container=$(getconfig_def "deploy-via-container" "")
 metal_image_size_mb=$(getconfig "metal-image-size")
 cloud_image_size_mb=$(getconfig "cloud-image-size")
 container_imgref=$(getconfig "container-imgref")
-container_repo=$(getconfig "container-repo")
-container_tag=$(getconfig "container-tag")
+container_repo=$(getconfig_def "container-repo" "")
+container_tag=$(getconfig_def "container-tag" "")
 # If we are deploying via container let's go ahead and pull
 # the oci archive path from the config
 ostree_container=""


### PR DESCRIPTION
Those fields are optional so we need to use `getconfig_def` instead.

Fixes b74e2f986 ("osbuild: Allow deploy via container image").