### PR TITLE
harness: don't require cosa build for `--oscontainer`

### DIFF
--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -1840,9 +1840,6 @@ func runTest(h *harness.H, t *register.Test, pltfrm string, flight platform.Flig
 	}
 
 	if Options.OSContainer != "" {
-		if CosaBuild == nil {
-			h.Fatalf("Requested oscontainer pivot, but no cosa build found")
-		}
 		rebase_arg := Options.OSContainer
 		// if it looks like a path to an OCI archive, then copy it into the system
 		if strings.HasSuffix(Options.OSContainer, ".ociarchive") {


### PR DESCRIPTION
The `--oscontainer` switch takes either a filename to an OCI archive or a pullspec. In neither case is a cosa directory required.

Fixes b8f70e813 ("kola: handle `--oscontainer` imperatively") which mistakenly cargo culted that bit from surrounding code.