### PR TITLE
osbuild: fix ppc64le mpp syntax error

### DIFF
--- a/src/osbuild-manifests/coreos.osbuild.ppc64le.mpp.yaml
+++ b/src/osbuild-manifests/coreos.osbuild.ppc64le.mpp.yaml
@@ -138,7 +138,7 @@ pipelines:
               references:
                 name:oci-archive:
                   name: coreos.ociarchive
-        else
+        else:
           mpp-if: container_repo != ''
           then:
             type: org.osbuild.ostree.deploy.container


### PR DESCRIPTION
Fixes 38df1c876 ("osbuild: only deploy a single deployment").