### PR TITLE
cmdlib: use BTRFS for the cache2.qcow2

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -608,7 +608,9 @@ runvm_with_cache_snapshot() {
         (
          # shellcheck source=src/libguestfish.sh
          source /usr/lib/coreos-assembler/libguestfish.sh
-         virt-format --filesystem=ext4 --label=cosa-cache -a cache2.qcow2.tmp)
+         # XXX switch back to XFS here when XFS bugfix has been backported
+         # https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=4b2f459d86252619448455013f581836c8b1b7da
+         virt-format --filesystem=btrfs --label=cosa-cache -a cache2.qcow2.tmp)
         mv -T cache2.qcow2.tmp "${workdir}"/cache/cache2.qcow2
     fi
     # And remove the old one


### PR DESCRIPTION
We switched to ext4 to get away from using reflinks (see [1]) but the problem was actually specific to XFS. It's now been fixed upstream in [2], but we need to wait for it to get back backported to stable branches. Let's switch to BTRFS for now so we can still get the space savings of reflinks, while avoiding the reflink bug in XFS.

[1] https://github.com/coreos/coreos-assembler/issues/3728
[2] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=4b2f459d86252619448455013f581836c8b1b7da