### PR TITLE
testiso/iscsi: reduce VM memory to 2GB

### DIFF
--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -1047,7 +1047,7 @@ func testLiveInstalliscsi(ctx context.Context, inst platform.Install, outdir str
 	}
 
 	// We need more memory to start another VM within !
-	builder.MemoryMiB = 4096
+	builder.MemoryMiB = 2048
 
 	var iscsiTargetConfig = conf.Butane(iscsi_butane_config)
 


### PR DESCRIPTION
Openshift prow have a default limit to 3GB for the kola job
so reduce the memory for this test to 2GB, local testing showed
no issue with this amount.

See https://github.com/openshift/os/pull/1461#issuecomment-2022503532