### PR TITLE
cmd: fix cmd-init detection failure when processing local sources dir

### DIFF
--- a/src/cmd-init
+++ b/src/cmd-init
@@ -179,7 +179,7 @@ mkdir -p src
 # Default paths for manifest.yaml & image.yaml
 manifest="src/config/manifest.yaml"
 image="src/config/image.yaml"
-if [[ ! -f "${manifest}" ]] || [[ ! -f "${image}" ]]; then
+if [[ ! -f $(readlink -f "${manifest}") ]] || [[ ! -f $(readlink -f "${image}") ]]; then
     echo 1>&2 "Could not find default manifests (${manifest} & ${image})"
     fatal "If you are using a custom configuration, be sure it has a manifest.yaml & image.yaml."
 fi
@@ -188,7 +188,7 @@ fi
 if [[ -n "${VARIANT}" ]] && [[ "${VARIANT}" != "default" ]]; then
     manifest="src/config/manifest-${VARIANT}.yaml"
     image="src/config/image-${VARIANT}.yaml"
-    if [[ ! -f "${manifest}" ]] || [[ ! -f "${image}" ]]; then
+    if [[ ! -f $(readlink -f "${manifest}") ]] || [[ ! -f $(readlink -f "${image}") ]]; then
         fatal "Could not find the manifests (${manifest} & ${image}) for the '${VARIANT}' variant"
     fi
     echo "Using variant: '${VARIANT}'"


### PR DESCRIPTION
The '- f' option of the shell will give the opposite result as expected when a soft link is included in the path