### PR TITLE
kola/qemuexec: Add a wwn option for scsis disks

### DIFF
--- a/docs/cosa/run.md
+++ b/docs/cosa/run.md
@@ -87,10 +87,15 @@ Additional disks CLI arguments support optional flags using the `--add-disk
 
 - `mpath`: enables multipathing for the disk (see below for details).
 - `4k`: sets the disk as 4Kn (4096 physical sector size)
-- `channel=CHANNEL`: set the channel type (e.g. `virtio`, `nvme`)
+- `channel=CHANNEL`: set the channel type (e.g. `virtio`, `nvme`, `scsi`)
 - `serial=NAME`: sets the disk serial; this can then be used to customize the
   default `diskN` naming documented above (e.g. `serial=foobar` will make the
   device show up as `/dev/disk/by-id/virtio-foobar`)
+- `wwn=ID`: sets the disk WWN identifier. Must be an integer. This will only
+  be used in with `channel=scsi` or `mpath`. Note that the link will be
+  created with the number converted to it's hexadecimal representation.
+  (e.g. `wwn=11` will make the device show up as
+  `/dev/disk/by-id/wwn-0x000000000000000b`)
 
 ## Additional kernel arguments
 


### PR DESCRIPTION
Add a customizable WWN option for kola DiskSpec to have reliable links under `/dev/disk/by-id/`. With this change kola qemuxec can be run like: `kola qemuexec -D "5G:channel=scsi,wwn=007"`

Resulting in the following links:
```
[core@localhost ~]$ rpm -qa sg3_utils
sg3_utils-1.48-1.fc40.x86_64
[core@localhost ~]$ ls -l /dev/disk/by-id
total 0
lrwxrwxrwx. 1 root root  9 Apr  5 09:05 scsi-30000000000000007 -> ../../sda
lrwxrwxrwx. 1 root root  9 Apr  5 09:05 wwn-0x0000000000000007 -> ../../sda
```

This is motivated by recent changes in sg3_utils [1] which removed some udev links.
At least one of our tests [2] relying on this started failing. This patch was suggested by @jlebon [3]

[1] https://listman.redhat.com/archives/dm-devel/2023-March/053645.html
[2] https://github.com/coreos/fedora-coreos-tracker/issues/1670
[3] https://github.com/coreos/fedora-coreos-tracker/issues/1670#issuecomment-2037725303