### PR TITLE
cmd-prune: don't prune the ostree repo if non-existant

### DIFF
--- a/src/cmd-prune
+++ b/src/cmd-prune
@@ -176,7 +176,8 @@ error_during_pruning = False
 for build in builds_to_delete:
     print(f"Pruning build {build.id}")
     try:
-        subprocess.check_call(['ostree', '--repo=tmp/repo', 'refs', '--delete', build.id])
+        if os.path.exists('tmp/repo'):
+            subprocess.check_call(['ostree', '--repo=tmp/repo', 'refs', '--delete', build.id])
         rmtree(os.path.join(builds_dir, build.id))
     except Exception as e:
         error_during_pruning = True


### PR DESCRIPTION
In cases where we buildfetch a bunch of different builds if we then want to clean some of them up easily with `cosa prune` it will fail if there is no ostree repo at `tmp/repo`. Let's just check and if nothing is there then let's not try to clean it up.