### PR TITLE
osbuild: set sysroot.bootprefix=true for aarch64 too

### DIFF
--- a/src/osbuild-manifests/coreos.osbuild.aarch64.mpp.yaml
+++ b/src/osbuild-manifests/coreos.osbuild.aarch64.mpp.yaml
@@ -113,9 +113,7 @@ pipelines:
               # because there is a symlink that is created in the root of the boot
               # filesystem by OSTree (boot -> .) that makes it so that /boot paths
               # will always work.
-              # XXX disabled for now because of file length BLS issue only observed on aarch64
-              # https://github.com/coreos/fedora-coreos-tracker/issues/1667#issuecomment-1967779592
-              #bootprefix: true
+              bootprefix: true
       - type: org.osbuild.mkdir
         options:
           paths:


### PR DESCRIPTION
We were blocked by https://github.com/coreos/fedora-coreos-tracker/issues/1647 but the 6.9 kernel series doesn't appear to have the same problem. The 6.8 kernel does have the problem but our kernel filenames in stable releases of Fedora (i.e. not `rawhide`) won't be long enough to trigger the bug so we should be able to safely remove this since `rawhide` has moved on to 6.9 rc kernels.

This should be the final piece to close out
https://github.com/coreos/fedora-coreos-tracker/issues/1667