### PR TITLE
cmd-kola: print `kola` command on stderr instead

### DIFF
--- a/src/cmd-kola
+++ b/src/cmd-kola
@@ -90,10 +90,10 @@ elif args.upgrades:
         os.makedirs('tmp/kola-qemu-cache', exist_ok=True)
         kolaargs.extend(['--qemu-image-dir', 'tmp/kola-qemu-cache'])
     kolaargs.extend(['-v', '--find-parent-image'])
-    print(subprocess.list2cmdline(kolaargs), flush=True)
+    print(subprocess.list2cmdline(kolaargs), flush=True, file=sys.stderr)
     os.execvp('kola', kolaargs)
 else:
     kolaargs.extend(['--output-dir', outputdir])
     # flush before exec; see https://docs.python.org/3.7/library/os.html#os.execvpe
-    print(subprocess.list2cmdline(kolaargs), flush=True)
+    print(subprocess.list2cmdline(kolaargs), flush=True, file=sys.stderr)
     os.execvp('kola', kolaargs)


### PR DESCRIPTION
Otherwise this breaks `kola list --json` because now the output is no longer purely just JSON and so e.g. piping it to `jq .` fails.