### PR TITLE
Add tags argument parser for aws_cli

### DIFF
--- a/mantle/cmd/ore/aws/upload.go
+++ b/mantle/cmd/ore/aws/upload.go
@@ -41,7 +41,7 @@ After a successful run, the final line of output will be a line of JSON describi
 	  --ami-name="CoreOS-stable-1234.5.6" \
 	  --ami-description="CoreOS stable 1234.5.6" \
 	  --file="/home/.../coreos_production_ami_vmdk_image.vmdk" \
-	  --tags="machine=production"`,
+	  --tags=machine=production --tags=FedoraGroup=coreos"`,
 		RunE: runUpload,
 
 		SilenceUsage: true,

--- a/src/cosalib/aws.py
+++ b/src/cosalib/aws.py
@@ -154,6 +154,8 @@ def aws_run_ore(build, args):
         ore_args.extend(['--grant-user', user])
     for user in args.grant_user_snapshot:
         ore_args.extend(['--grant-user-snapshot', user])
+    for tag in args.tags:
+        ore_args.extend(['--tags', tag])
     if args.public:
         ore_args.extend(['--public'])
 
@@ -191,4 +193,6 @@ def aws_cli(parser):
     parser.add_argument("--grant-user-snapshot", help="Grant user snapshot volume permission",
                         nargs="*", default=[])
     parser.add_argument("--public", action="store_true", help="Mark images as publicly available")
+    parser.add_argument("--tags", help="list of key=value tags to attach to the AMI",
+                        action='append', default=[])
     return parser

--- a/src/cosalib/aws.py
+++ b/src/cosalib/aws.py
@@ -189,9 +189,9 @@ def aws_cli(parser):
                         default=os.environ.get("AWS_CONFIG_FILE"))
     parser.add_argument("--name-suffix", help="Suffix for name")
     parser.add_argument("--grant-user", help="Grant user launch permission",
-                        nargs="*", default=[])
+                        action='append', default=[])
     parser.add_argument("--grant-user-snapshot", help="Grant user snapshot volume permission",
-                        nargs="*", default=[])
+                        action='append', default=[])
     parser.add_argument("--public", action="store_true", help="Mark images as publicly available")
     parser.add_argument("--tags", help="list of key=value tags to attach to the AMI",
                         action='append', default=[])


### PR DESCRIPTION
Add the ability to add tags to AMIs when running `ore aws upload` with `--tags` flag.
Can be used as:
`cosa buildextend-aws --tags foo=bar,abc=xyz` or
`cosa buildextend-aws --tags=foo=bar --tags=abc=xyz`