### PR TITLE
tests/basic: only run basic.nvme on x86_64 and aarch64

### DIFF
--- a/mantle/kola/tests/coretest/core.go
+++ b/mantle/kola/tests/coretest/core.go
@@ -87,6 +87,9 @@ func init() {
 		Platforms:   []string{"qemu"},
 		ClusterSize: 0,
 		NativeFuncs: nativeFuncs,
+		// NVMe in theory is supported on all arches, but the way we test it seems to
+		// only work on x86_64 and aarch64.
+		Architectures: []string{"x86_64", "aarch64"},
 	})
 	// TODO: Enable DockerPing/DockerEcho once fixed
 	// TODO: Only enable PodmanPing on non qemu. Needs:


### PR DESCRIPTION
The original `--basic-qemu-scenarios` only ran it on x86_64. In testing, it seems to work at least in aarch64 so we might as well test it. On s390x, it seems like QEMU doesn't support it. On ppc64le, the bootloader complains it's "Not a bootable device!".

Follow-up to 6775ab126 ("mantle/kola: copy basic tests into formal kola
workflow") and 2f8a427b5 ("tests/basic: fix basic tests on multi-arch").