### PR TITLE
mantle/kola: run basic nvme tests only on x86/aarch64

### DIFF
--- a/mantle/kola/tests/coretest/core.go
+++ b/mantle/kola/tests/coretest/core.go
@@ -87,6 +87,7 @@ func init() {
 		Platforms:   []string{"qemu"},
 		ClusterSize: 0,
 		NativeFuncs: nativeFuncs,
+		Architectures: []string{"x86_64", "aarch64"},
 	})
 	// TODO: Enable DockerPing/DockerEcho once fixed
 	// TODO: Only enable PodmanPing on non qemu. Needs:


### PR DESCRIPTION
On ppc64le it fails to boot with an error like:

```
Trying to load:  from: /pci@800000020000000/mass-storage@1 ...
E3404: Not a bootable device!
```

On s390x it appears qemu doesn't even support it as an option:

```
qemu-system-s390x: -device nvme,drive=disk-1,serial=primary-disk,bootindex=1: 'nvme' is not a valid device model name
```