### PR TITLE
cmdlib.sh: add env var to sleep before killing `tail`

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -845,6 +845,10 @@ EOF
     fi
     rc="$(cat "${rc_file}")"
 
+    # XXX: this is for debugging temporarily
+    if [ -n "${TAIL_SLEEP:-}" ]; then
+        sleep "${TAIL_SLEEP}"
+    fi
     # cleanup tail before nuking dir containing file it's following
     kill "$tail_pid"
 


### PR DESCRIPTION
I can't reproduce this locally, but I have a suspicion that `tail` can exit too quickly in some circumstances, causing truncated output:

https://github.com/openshift/os/pull/1498#issuecomment-2096598277 https://github.com/coreos/coreos-assembler/pull/3785#discussion_r1591387449

Rather than having an unconditional `sleep`, let's make it easier to test that theory by having an env var we can use to make it optional. Then we'll test that in CI.

Mid-term, I'd like to revert 79b15c89d soon so we can go back to virtio-serial which is just so much cleaner.