### PR TITLE
cmdlib.sh: feed `/dev/zero` as qemu stdin

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -823,7 +823,7 @@ EOF
         if ! "${kola_args[@]}" -- "${base_qemu_args[@]}" \
             -device virtserialport,chardev=virtioserial0,name=cosa-cmdout \
             -chardev stdio,id=virtioserial0 \
-            "${qemu_args[@]}"; then
+            "${qemu_args[@]}" < /dev/zero; then # qemu hangs if it has nothing to read on stdin
                 cat "${runvm_console}"
                 fatal "Failed to run 'kola qemuexec'"
         fi

--- a/src/secex-genprotimgvm-scripts/runvm.sh
+++ b/src/secex-genprotimgvm-scripts/runvm.sh
@@ -56,7 +56,7 @@ else
 fi
 
 if ! "${kola_args[@]}" -- "${base_qemu_args[@]}" \
-    "${qemu_args[@]}" <&-; then # the <&- here closes stdin otherwise qemu waits forever
+    "${qemu_args[@]}" < /dev/zero; then # qemu hangs if it has nothing to read on stdin
     cat "${runvm_console}"
     echo "Failed to run 'kola qemuexec'"
     exit 1


### PR DESCRIPTION
This is a follow-up to 79b15c89d ("cmdlib.sh: go back to using `tail -F`
for command output") which was subsequently reverted.

To summarize, it seems like in QEMU v8.2 (in f40), the guest sometimes
would hang when writing over virtio-serial if the device is hooked up to
the QEMU's stdio.

In testing, removing the `<&-` hack to close QEMU's stdin fixed it for
CoreOS CI but not Prow:

https://github.com/coreos/coreos-assembler/pull/3785#issuecomment-2087342748

I think I've narrowed it down to CoreOS CI (i.e. Jenkins) allocating a
tty and Prow not. When stdin is not a tty, QEMU would immediately gets
EOF if it tries to read anything. I'm not sure exactly what happens, but
I think the virtio-serial hang is linked to this (even though there's no
userspace code in the guest trying to read from the virtio-serial port).

Work around this by explicitly feeding `/dev/zero` to QEMU's stdin.