### PR TITLE
build: Remove ENV container=oci

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 # When rebasing to new Fedora, also update openshift/release:
 # https://github.com/openshift/release/tree/master/ci-operator/config/coreos/coreos-assembler/coreos-coreos-assembler-main.yaml
 FROM quay.io/fedora/fedora:40
-# Work around for https://bugzilla.redhat.com/show_bug.cgi?id=2278652
-ENV container=oci
 WORKDIR /root/containerbuild
 
 # Keep this Dockerfile idempotent for local development rebuild use cases.


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2278652 was fixed and the fedora container base image now has the container=oci environment variabled defined.