### PR TITLE
testiso: add rw karg to iSCSI multipath test

### DIFF
--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -624,7 +624,7 @@ func runTestIso(cmd *cobra.Command, args []string) (err error) {
 			case "manual":
 				butane_config = strings.ReplaceAll(iscsi_butane_config, "COREOS_INSTALLER_KARGS", "--append-karg netroot=iscsi:10.0.2.15::::iqn.2024-05.com.coreos:0")
 			case "ibft-with-mpath":
-				butane_config = strings.ReplaceAll(iscsi_butane_config, "COREOS_INSTALLER_KARGS", "--append-karg rd.iscsi.firmware=1 --append-karg rd.multipath=default --append-karg root=/dev/disk/by-label/dm-mpath-root")
+				butane_config = strings.ReplaceAll(iscsi_butane_config, "COREOS_INSTALLER_KARGS", "--append-karg rd.iscsi.firmware=1 --append-karg rd.multipath=default --append-karg root=/dev/disk/by-label/dm-mpath-root --append-karg rw")
 			default:
 				plog.Fatalf("Unknown test name:%s", test)
 			}


### PR DESCRIPTION
This is required by ostree.

This sometimes worked I think because `ignition-remount-sysroot.service` has no ordering against `ostree-prepare-root.service` and so they'd race. But really, we shouldn't rely on that Ignition unit.

See also: https://github.com/coreos/coreos-assembler/pull/3789#discussion_r1591769493