### PR TITLE
devshell: fix journal monitoring

### DIFF
--- a/ci/prow-rhcos.sh
+++ b/ci/prow-rhcos.sh
@@ -17,6 +17,6 @@ esac
 export COSA_SKIP_OVERLAY=1
 # Create a temporary cosa workdir
 cd "$(mktemp -d)"
-cosa init --variant scos --transient -b "${RHCOS_BRANCH}" https://github.com/openshift/os
+cosa init --transient -b "${RHCOS_BRANCH}" https://github.com/openshift/os
 # Use a COSA specifc test entry point to focus on tests relevant for COSA
 exec src/config/ci/prow-entrypoint.sh rhcos-cosa-prow-pr-ci

--- a/mantle/cmd/kola/devshell.go
+++ b/mantle/cmd/kola/devshell.go
@@ -430,7 +430,7 @@ func watchJournal(builder *platform.QemuBuilder, conf *conf.Conf, stateChan chan
 		},
 	}
 
-	r, err := builder.VirtioJournal(conf, "--system")
+	r, err := builder.VirtioJournal(conf, "-o json --system")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Commit 7b07ffe8a dropped the `-o json` argument to the journalctl query that the devshell code uses to monitor system boot and know when to SSH. Fix this by re-adding the argument but only for devshell so that the default is still to output traditional logs (as in the testiso case).

Fixes 7b07ffe8a ("mantle/platform/qemu: drop json formatting from journal output").