### PR TITLE
osbuild: make building with OSBuild the default

### DIFF
--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -281,8 +281,8 @@ if [ "${image_type}" == "qemu" ] || [ "${image_type}" == "metal" ] || [ "${image
     fi
 fi
 
-# Run with OSBuild if it's supported and requested, otherwise use create_disk
-if [ "${OSBUILD_SUPPORTED:-}" != "" ] && [ "${COSA_USE_OSBUILD:-}" != "" ]; then
+# Run with OSBuild if it's supported, unless it is explicitly disabled with COSA_USE_OSBUILD=0
+if [ "${OSBUILD_SUPPORTED:-}" != "" ] && [ "${COSA_USE_OSBUILD:-}" != "0" ]; then
     # In the jenkins pipelines we build the qemu image first and that operation
     # will do a lot of the same work required for later artifacts (metal, metal4k, etc)
     # so we want the cached output from that run to persist. The later artifacts get


### PR DESCRIPTION
Now all of our streams are ready to be switched to OSBuild and RHCOS latest streams are also switched over. Let's make it the default so we don't have to set COSA_USE_OSBUILD=1 any longer. This also has the side effect of making all CI run with OSBUild now too.