### PR TITLE
osbuild manifests: treat SCOS and RHCOS the same

### DIFF
--- a/src/osbuild-manifests/coreos.osbuild.aarch64.mpp.yaml
+++ b/src/osbuild-manifests/coreos.osbuild.aarch64.mpp.yaml
@@ -244,7 +244,7 @@ pipelines:
           # defaults in the version of mkfs.ext4 in the build root.
           # This is mostly useful right now because COSA is based
           # on Fedora.
-          mpp-if: osname == 'rhcos'
+          mpp-if: osname in ['rhcos', 'scos']
           then:
             orphan_file: false
             metadata_csum_seed: true
@@ -415,7 +415,7 @@ pipelines:
           # defaults in the version of mkfs.ext4 in the build root.
           # This is mostly useful right now because COSA is based
           # on Fedora.
-          mpp-if: osname == 'rhcos'
+          mpp-if: osname in ['rhcos', 'scos']
           then:
             orphan_file: false
             metadata_csum_seed: true

--- a/src/osbuild-manifests/coreos.osbuild.ppc64le.mpp.yaml
+++ b/src/osbuild-manifests/coreos.osbuild.ppc64le.mpp.yaml
@@ -237,7 +237,7 @@ pipelines:
           # defaults in the version of mkfs.ext4 in the build root.
           # This is mostly useful right now because COSA is based
           # on Fedora.
-          mpp-if: osname == 'rhcos'
+          mpp-if: osname in ['rhcos', 'scos']
           then:
             orphan_file: false
             metadata_csum_seed: true
@@ -385,7 +385,7 @@ pipelines:
           # defaults in the version of mkfs.ext4 in the build root.
           # This is mostly useful right now because COSA is based
           # on Fedora.
-          mpp-if: osname == 'rhcos'
+          mpp-if: osname in ['rhcos', 'scos']
           then:
             orphan_file: false
             metadata_csum_seed: true

--- a/src/osbuild-manifests/coreos.osbuild.s390x.mpp.yaml
+++ b/src/osbuild-manifests/coreos.osbuild.s390x.mpp.yaml
@@ -234,7 +234,7 @@ pipelines:
           # defaults in the version of mkfs.ext4 in the build root.
           # This is mostly useful right now because COSA is based
           # on Fedora.
-          mpp-if: osname == 'rhcos'
+          mpp-if: osname in ['rhcos', 'scos']
           then:
             orphan_file: false
             metadata_csum_seed: true
@@ -353,7 +353,7 @@ pipelines:
           # defaults in the version of mkfs.ext4 in the build root.
           # This is mostly useful right now because COSA is based
           # on Fedora.
-          mpp-if: osname == 'rhcos'
+          mpp-if: osname in ['rhcos', 'scos']
           then:
             orphan_file: false
             metadata_csum_seed: true

--- a/src/osbuild-manifests/coreos.osbuild.x86_64.mpp.yaml
+++ b/src/osbuild-manifests/coreos.osbuild.x86_64.mpp.yaml
@@ -247,7 +247,7 @@ pipelines:
           # defaults in the version of mkfs.ext4 in the build root.
           # This is mostly useful right now because COSA is based
           # on Fedora.
-          mpp-if: osname == 'rhcos'
+          mpp-if: osname in ['rhcos', 'scos']
           then:
             orphan_file: false
             metadata_csum_seed: true
@@ -420,7 +420,7 @@ pipelines:
           # defaults in the version of mkfs.ext4 in the build root.
           # This is mostly useful right now because COSA is based
           # on Fedora.
-          mpp-if: osname == 'rhcos'
+          mpp-if: osname in ['rhcos', 'scos']
           then:
             orphan_file: false
             metadata_csum_seed: true


### PR DESCRIPTION
Otherwise, SCOS would get e.g. the `orphan_file` and `metadata_csum_seed` settings from FCOS which will break things.

This is of course a short-term fix to get CI working again (e.g. once c10s is up, it should probably match the current Fedora settings). The longer-term fix is tracked at:

https://github.com/coreos/coreos-assembler/issues/3801