### PR TITLE
cmd-buildupload: log all args passed to `s3_client.upload_file`

### DIFF
--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -229,6 +229,8 @@ def generate_iso():
         raise Exception("Live image generation requires `metal` image")
     img_metal = os.path.join(builddir, img_metal_obj['path'])
     img_metal_checksum = img_metal_obj['sha256']
+    img_metal4k = None
+    img_metal4k_checksum = None
     img_metal4k_obj = buildmeta.get_artifact_meta("metal4k", unmerged=True)["images"].get("metal4k")
     if not img_metal4k_obj:
         if not args.fast:
@@ -319,6 +321,8 @@ def generate_iso():
             '--description', pretty_name, '--checksum', img_metal_checksum,
             '--output', '/var/tmp/coreos-installer-output'] + fast_arg)
     if img_metal4k_obj:
+        assert img_metal4k
+        assert img_metal4k_checksum
         tmp_osmet4k = os.path.join(tmpinitrd_rootfs, img_metal4k_obj['path'] + '.osmet')
         print('Generating osmet file for 4k metal image')
         runcmd(['/usr/lib/coreos-assembler/runvm-coreos-installer',
@@ -695,7 +699,7 @@ boot
     # Write out the igninfo.json file. This is used by coreos-installer to know
     # how to embed the Ignition config.
     with open(os.path.join(tmpisocoreos, igninfo_file), 'w') as fh:
-        json.dump(igninfo_json, fh, indent=2, sort_keys=True)
+        json.dump(igninfo_json, fh, indent=2, sort_keys=True)  # pylint: disable=E0601
         fh.write('\n')
 
     # Define inputs and outputs

--- a/src/cmd-buildupload
+++ b/src/cmd-buildupload
@@ -238,7 +238,7 @@ def s3_copy(s3_client, src, bucket, key, max_age, acl, extra_args={}, dry_run=Fa
     upload_args.update(extra_args)
 
     print((f"{'Would upload' if dry_run else 'Uploading'} {src} to "
-           f"s3://{bucket}/{key} {extra_args if len(extra_args) else ''}"))
+           f"s3://{bucket}/{key} with args {upload_args}"))
 
     if dry_run:
         return

--- a/src/cmd-compress
+++ b/src/cmd-compress
@@ -121,7 +121,7 @@ def compress_one_builddir(builddir):
                 elif args.compressor == 'zstd':
                     runcmd(['zstd', '-19', '-c', f'-T{t}', filepath], stdout=f)
                 else:
-                    runcmd(['gzip', f'-{gzip_level}', '-c', filepath], stdout=f)
+                    runcmd(['gzip', f'-{gzip_level}', '-c', filepath], stdout=f)  # pylint: disable=E0606
             file_with_ext = file + ext
             filepath_with_ext = filepath + ext
             compressed_size = os.path.getsize(tmpfile)

--- a/src/cmd-koji-upload
+++ b/src/cmd-koji-upload
@@ -169,10 +169,9 @@ class Build(_Build):
             ftype = (os.path.splitext(base)[1]).replace(".", "")
             ctype = f"{ftype}.{x}"
             if ctype not in KOJI_CG_TYPES and ftype in KOJI_CG_TYPES:
-                if x == "gz":
-                    compressor = gzip
-                elif x == "xz":
+                if x != "gz":
                     raise Exception("not supported yet")
+                compressor = gzip
 
                 new_path = os.path.join(self._tmpdir, base)
                 try:


### PR DESCRIPTION
Notably, this includes the `CacheControl` and `ACL` args. This allows us to more easily cross-check the value of those keys with what was set higher up in the stack.