### PR TITLE
osbuild: Fix changes done causing podman to fail 

### DIFF
--- a/src/osbuild-manifests/coreos.osbuild.aarch64.mpp.yaml
+++ b/src/osbuild-manifests/coreos.osbuild.aarch64.mpp.yaml
@@ -227,13 +227,13 @@ pipelines:
                 - '$ignition_firstboot'
                 - mpp-format-string: '{extra_kargs}'
             inputs:
-            images:
-              type: org.osbuild.containers
-              origin: org.osbuild.source
-              mpp-resolve-images:
-                images:
-                  - source: $container_repo
-                    tag: $container_tag
+              images:
+                type: org.osbuild.containers
+                origin: org.osbuild.source
+                mpp-resolve-images:
+                  images:
+                    - source: $container_repo
+                      tag: $container_tag
       - type: org.osbuild.ostree.aleph
         options:
           coreos_compat: true

--- a/src/osbuild-manifests/coreos.osbuild.ppc64le.mpp.yaml
+++ b/src/osbuild-manifests/coreos.osbuild.ppc64le.mpp.yaml
@@ -221,13 +221,13 @@ pipelines:
                 - '$ignition_firstboot'
                 - mpp-format-string: '{extra_kargs}'
             inputs:
-            images:
-              type: org.osbuild.containers
-              origin: org.osbuild.source
-              mpp-resolve-images:
-                images:
-                  - source: $container_repo
-                    tag: $container_tag
+              images:
+                type: org.osbuild.containers
+                origin: org.osbuild.source
+                mpp-resolve-images:
+                  images:
+                    - source: $container_repo
+                      tag: $container_tag
       # Drop the immutable bit here (we add it back later) because it
       # causes failures when cleaning up tmp dirs.
       - type: org.osbuild.chattr

--- a/src/osbuild-manifests/coreos.osbuild.s390x.mpp.yaml
+++ b/src/osbuild-manifests/coreos.osbuild.s390x.mpp.yaml
@@ -211,13 +211,13 @@ pipelines:
                #- '$ignition_firstboot'
                 - mpp-format-string: '{extra_kargs}'
             inputs:
-            images:
-              type: org.osbuild.containers
-              origin: org.osbuild.source
-              mpp-resolve-images:
-                images:
-                  - source: $container_repo
-                    tag: $container_tag
+              images:
+                type: org.osbuild.containers
+                origin: org.osbuild.source
+                mpp-resolve-images:
+                  images:
+                    - source: $container_repo
+                      tag: $container_tag
       # Drop the immutable bit here (we add it back later) because it
       # causes failures when cleaning up tmp dirs.
       - type: org.osbuild.chattr

--- a/src/osbuild-manifests/coreos.osbuild.x86_64.mpp.yaml
+++ b/src/osbuild-manifests/coreos.osbuild.x86_64.mpp.yaml
@@ -229,13 +229,13 @@ pipelines:
                 - '$ignition_firstboot'
                 - mpp-format-string: '{extra_kargs}'
             inputs:
-            images:
-              type: org.osbuild.containers
-              origin: org.osbuild.source
-              mpp-resolve-images:
-                images:
-                  - source: $container_repo
-                    tag: $container_tag
+              images:
+                type: org.osbuild.containers
+                origin: org.osbuild.source
+                mpp-resolve-images:
+                  images:
+                    - source: $container_repo
+                      tag: $container_tag
       - type: org.osbuild.ostree.aleph
         options:
           coreos_compat: true


### PR DESCRIPTION
Fix changes done in https://github.com/coreos/coreos-assembler/pull/3808 causing the podman CI to fail https://jenkins-fedora-coreos-pipeline.apps.ocp.fedoraproject.org/job/build-podman-os/63/