### PR TITLE
build.sh: remove edk2-ovmf version freeze 

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -43,13 +43,6 @@ install_rpms() {
 
     frozendeps=""
 
-    # freeze edk2 for https://github.com/coreos/coreos-assembler/issues/3815
-    case "${arch}" in
-      x86_64|aarch64) frozendeps=$(echo edk2-{ovmf,aarch64}-20240214-7.fc40);;
-      *) ;;
-    esac
-
-
     # First, a general update; this is best practice.  We also hit an issue recently
     # where qemu implicitly depended on an updated libusbx but didn't have a versioned
     # requires https://bugzilla.redhat.com/show_bug.cgi?id=1625641


### PR DESCRIPTION
We temporarily froze updates to that version due to issues with the FCOS PXE 4K UEFI tests. You can check it here: https://github.com/coreos/coreos-assembler/pull/3816. 

Now that we had a update to fix it, we can switch back to the latest version.