### PR TITLE
kola: add support for simulating 512e disks and add support for `primaryDisk` key 

### DIFF
--- a/docs/cosa/run.md
+++ b/docs/cosa/run.md
@@ -87,6 +87,7 @@ Additional disks CLI arguments support optional flags using the `--add-disk
 
 - `mpath`: enables multipathing for the disk (see below for details).
 - `4k`: sets the disk as 4Kn (4096 physical sector size)
+- `512e`: sets the disk as 512e (4096 physical sector size, 512 logical sector size)
 - `channel=CHANNEL`: set the channel type (e.g. `virtio`, `nvme`, `scsi`)
 - `serial=NAME`: sets the disk serial; this can then be used to customize the
   default `diskN` naming documented above (e.g. `serial=foobar` will make the

--- a/docs/kola/external-tests.md
+++ b/docs/kola/external-tests.md
@@ -231,7 +231,9 @@ In the example above, the test would only run if `--tag special` was provided.
 
 The `additionalDisks` key has the same semantics as the `--add-disk` argument
 to `qemuexec`. It is currently only supported on `qemu`. The `primaryDisk` key
-also supports the same syntax and controls the primary boot disk.
+also supports the same syntax and controls the primary boot disk. Only for the
+`primaryDisk` key, the size can be omitted (e.g. `:mpath`), in which case the
+qcow2 will not be resized.
 
 The `injectContainer` boolean if set will cause the framework to inject
 the ostree base image container into the target system; the path can be

--- a/docs/kola/external-tests.md
+++ b/docs/kola/external-tests.md
@@ -191,6 +191,7 @@ Here's an example `kola.json`:
     "platforms": "qemu",
     "tags": "sometagname needs-internet skip-base-checks othertag",
     "requiredTag": "special",
+    "primaryDisk": ["20G:mpath"],
     "additionalDisks": [ "5G" ],
     "minMemory": 4096,
     "minDisk": 15,
@@ -229,7 +230,8 @@ If a test has a `requiredTag`, it is run only if the required tag is specified.
 In the example above, the test would only run if `--tag special` was provided.
 
 The `additionalDisks` key has the same semantics as the `--add-disk` argument
-to `qemuexec`. It is currently only supported on `qemu`.
+to `qemuexec`. It is currently only supported on `qemu`. The `primaryDisk` key
+also supports the same syntax and controls the primary boot disk.
 
 The `injectContainer` boolean if set will cause the framework to inject
 the ostree base image container into the target system; the path can be

--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -157,6 +157,7 @@ func init() {
 	bv(&kola.QEMUOptions.NbdDisk, "qemu-nbd-socket", false, "Present the disks over NBD socket to qemu")
 	bv(&kola.QEMUOptions.MultiPathDisk, "qemu-multipath", false, "Enable multiple paths for the main disk")
 	bv(&kola.QEMUOptions.Native4k, "qemu-native-4k", false, "Force 4k sectors for main disk")
+	bv(&kola.QEMUOptions.Disk512e, "qemu-512e", false, "Force 512e layout for main disk")
 	bv(&kola.QEMUOptions.Nvme, "qemu-nvme", false, "Use NVMe for main disk")
 	bv(&kola.QEMUOptions.Swtpm, "qemu-swtpm", true, "Create temporary software TPM")
 	ssv(&kola.QEMUOptions.BindRO, "qemu-bind-ro", nil, "Inject a host directory; this does not automatically mount in the guest")

--- a/mantle/cmd/kola/qemuexec.go
+++ b/mantle/cmd/kola/qemuexec.go
@@ -139,8 +139,12 @@ func buildDiskFromOptions() *platform.Disk {
 		channel = "nvme"
 	}
 	sectorSize := 0
+	logicalSectorSize := 0
 	if kola.QEMUOptions.Native4k {
 		sectorSize = 4096
+	} else if kola.QEMUOptions.Disk512e {
+		sectorSize = 4096
+		logicalSectorSize = 512
 	}
 	options := []string{}
 	if kola.QEMUOptions.DriveOpts != "" {
@@ -155,13 +159,14 @@ func buildDiskFromOptions() *platform.Disk {
 	// Build the disk definition. Note that if kola.QEMUOptions.DiskImage is
 	// "" we'll just end up with a blank disk image, which is what we want.
 	disk := &platform.Disk{
-		BackingFile:   kola.QEMUOptions.DiskImage,
-		Channel:       channel,
-		Size:          size,
-		SectorSize:    sectorSize,
-		DriveOpts:     options,
-		MultiPathDisk: kola.QEMUOptions.MultiPathDisk,
-		NbdDisk:       kola.QEMUOptions.NbdDisk,
+		BackingFile:       kola.QEMUOptions.DiskImage,
+		Channel:           channel,
+		Size:              size,
+		SectorSize:        sectorSize,
+		LogicalSectorSize: logicalSectorSize,
+		DriveOpts:         options,
+		MultiPathDisk:     kola.QEMUOptions.MultiPathDisk,
+		NbdDisk:           kola.QEMUOptions.NbdDisk,
 	}
 	return disk
 }

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -1020,6 +1020,7 @@ type externalTestMeta struct {
 	Tags                      string   `json:"tags,omitempty"                      yaml:"tags,omitempty"`
 	RequiredTag               string   `json:"requiredTag,omitempty"               yaml:"requiredTag,omitempty"`
 	AdditionalDisks           []string `json:"additionalDisks,omitempty"           yaml:"additionalDisks,omitempty"`
+	PrimaryDisk               string   `json:"primaryDisk,omitempty"               yaml:"primaryDisk,omitempty"`
 	InjectContainer           bool     `json:"injectContainer,omitempty"           yaml:"injectContainer,omitempty"`
 	MinMemory                 int      `json:"minMemory,omitempty"                 yaml:"minMemory,omitempty"`
 	MinDiskSize               int      `json:"minDisk,omitempty"                   yaml:"minDisk,omitempty"`
@@ -1233,6 +1234,7 @@ ExecStart=%s
 		Tags:          []string{"external"},
 
 		AdditionalDisks:           targetMeta.AdditionalDisks,
+		PrimaryDisk:               targetMeta.PrimaryDisk,
 		InjectContainer:           targetMeta.InjectContainer,
 		MinMemory:                 targetMeta.MinMemory,
 		MinDiskSize:               targetMeta.MinDiskSize,
@@ -1752,6 +1754,7 @@ func runTest(h *harness.H, t *register.Test, pltfrm string, flight platform.Flig
 
 		options := platform.MachineOptions{
 			MultiPathDisk:             t.MultiPathDisk,
+			PrimaryDisk:               t.PrimaryDisk,
 			AdditionalDisks:           t.AdditionalDisks,
 			MinMemory:                 t.MinMemory,
 			MinDiskSize:               t.MinDiskSize,

--- a/mantle/kola/register/register.go
+++ b/mantle/kola/register/register.go
@@ -70,7 +70,7 @@ type Test struct {
 	RequiredTag          string        // if specified, test is filtered by default unless tag is provided -- defaults to none
 	Description          string        // test description
 
-	// Whether the primary disk is multipathed.
+	// Whether the primary disk is multipathed. Deprecated in favour of PrimaryDisk.
 	MultiPathDisk bool
 
 	// Sizes of additional empty disks to attach to the node, followed by
@@ -78,13 +78,18 @@ type Test struct {
 	// "5G:mpath,foo,bar"]) -- defaults to none.
 	AdditionalDisks []string
 
+	// Size of primary disk to attach to the node, followed by
+	// comma-separated list of optional options (e.g. "20G:mpath"]).
+	PrimaryDisk string
+
 	// InjectContainer will cause the ostree base image to be injected into the target
 	InjectContainer bool
 
 	// Minimum amount of memory in MB required for test.
 	MinMemory int
 
-	// Minimum amount of primary disk in GB required for test.
+	// Minimum amount of primary disk in GB required for test. Deprecated in favour
+	// of PrimaryDisk.
 	MinDiskSize int
 
 	// Additional amount of NICs required for test.

--- a/mantle/platform/api/gcloud/compute.go
+++ b/mantle/platform/api/gcloud/compute.go
@@ -38,7 +38,7 @@ func (a *API) vmname() string {
 func ParseDisk(spec string, zone string) (*compute.AttachedDisk, error) {
 	var diskInterface string
 
-	size, diskmap, err := util.ParseDiskSpec(spec)
+	size, diskmap, err := util.ParseDiskSpec(spec, false)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse disk spec %q: %w", spec, err)
 	}

--- a/mantle/platform/machine/qemu/cluster.go
+++ b/mantle/platform/machine/qemu/cluster.go
@@ -145,8 +145,12 @@ func (qc *Cluster) NewMachineWithQemuOptions(userdata *conf.UserData, options pl
 		channel = "nvme"
 	}
 	sectorSize := 0
+	logicalSectorSize := 0
 	if qc.flight.opts.Native4k {
 		sectorSize = 4096
+	} else if qc.flight.opts.Disk512e {
+		sectorSize = 4096
+		logicalSectorSize = 512
 	}
 	multiPathDisk := options.MultiPathDisk || qc.flight.opts.MultiPathDisk
 	var diskSize string
@@ -156,11 +160,12 @@ func (qc *Cluster) NewMachineWithQemuOptions(userdata *conf.UserData, options pl
 		diskSize = qc.flight.opts.DiskSize
 	}
 	primaryDisk := platform.Disk{
-		BackingFile:   qc.flight.opts.DiskImage,
-		Channel:       channel,
-		Size:          diskSize,
-		SectorSize:    sectorSize,
-		MultiPathDisk: multiPathDisk,
+		BackingFile:       qc.flight.opts.DiskImage,
+		Channel:           channel,
+		Size:              diskSize,
+		SectorSize:        sectorSize,
+		LogicalSectorSize: logicalSectorSize,
+		MultiPathDisk:     multiPathDisk,
 	}
 
 	if options.OverrideBackingFile != "" {

--- a/mantle/platform/machine/qemu/cluster.go
+++ b/mantle/platform/machine/qemu/cluster.go
@@ -143,7 +143,7 @@ func (qc *Cluster) NewMachineWithQemuOptions(userdata *conf.UserData, options pl
 	var primaryDisk platform.Disk
 	if options.PrimaryDisk != "" {
 		var diskp *platform.Disk
-		if diskp, err = platform.ParseDisk(options.PrimaryDisk); err != nil {
+		if diskp, err = platform.ParseDisk(options.PrimaryDisk, true); err != nil {
 			return nil, errors.Wrapf(err, "parsing primary disk spec '%s'", options.PrimaryDisk)
 		}
 		primaryDisk = *diskp

--- a/mantle/platform/machine/qemu/flight.go
+++ b/mantle/platform/machine/qemu/flight.go
@@ -41,6 +41,7 @@ type Options struct {
 	NbdDisk       bool
 	MultiPathDisk bool
 	Native4k      bool
+	Disk512e      bool
 	Nvme          bool
 
 	//Option to create a temporary software TPM - true by default

--- a/mantle/platform/platform.go
+++ b/mantle/platform/platform.go
@@ -155,6 +155,7 @@ type Flight interface {
 
 type MachineOptions struct {
 	MultiPathDisk             bool
+	PrimaryDisk               string
 	AdditionalDisks           []string
 	MinMemory                 int
 	MinDiskSize               int


### PR DESCRIPTION
kola/qemu: add support for simulating 512e disks

It's come up a few times now that we need to dig into 512e-specific
behaviours (most recently in OCPBUGS-35410). Let's add a knob for this
in the qemu platform just like the one we have for 4Kn.

---

kola: add support for `primaryDisk` key

Just like we have `additionalDisks`, add a new `primaryDisk` key which
takes the same "diskspec" format. This immediately unlocks all the same
knobs available to additional disks to the primary disk itself from
external tests.

E.g. with this, we can now migrate multipath tests to external tests
that use `primaryDisk: 20G:mpath`.

My immediate motivation for this however is to be able to use the
new `512e` disk option from an external test as part of fixing
OCPBUGS-35410.