### PR TITLE
build: pass roofs size to osbuild

### DIFF
--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -243,6 +243,9 @@ image-type: "${image_type}"
 ostree-repo: "${ostree_repo}"
 metal-image-size: "${metal_image_size_mb}"
 cloud-image-size: "${cloud_image_size_mb}"
+# Note: this is only used in the secex case; there, the rootfs is
+# not the last partition on the disk so we need to explicitly size it
+rootfs-size: "${rootfs_size_mb}"
 EOF
 yaml2json "${image_dynamic_yaml}" "${image_dynamic_json}"
 cat "${image_json}" "${image_dynamic_json}" | jq -s add > "${image_for_disk_json}"

--- a/src/osbuild-manifests/coreos.osbuild.s390x.mpp.yaml
+++ b/src/osbuild-manifests/coreos.osbuild.s390x.mpp.yaml
@@ -17,7 +17,8 @@ mpp-vars:
   efi_system_size_mb: 127
   se_size_mb:   200
   boot_size_mb: 384
-  root_size_mb: 1800
+  root_size_mb:
+    mpp-format-int: $rootfs_size_mb
   boot_verity_size_mb: 128
   root_verity_size_mb: 256
   sector_size: 512

--- a/src/runvm-osbuild
+++ b/src/runvm-osbuild
@@ -55,6 +55,7 @@ platform=$(getconfig "image-type")
 deploy_via_container=$(getconfig_def "deploy-via-container" "")
 metal_image_size_mb=$(getconfig "metal-image-size")
 cloud_image_size_mb=$(getconfig "cloud-image-size")
+rootfs_size_mb=$(getconfig "rootfs-size")
 container_imgref=$(getconfig "container-imgref")
 container_repo=$(getconfig_def "container-repo" "")
 container_tag=$(getconfig_def "container-tag" "")
@@ -100,6 +101,7 @@ osbuild-mpp                                             \
     -D extra_kargs=\""${extra_kargs}"\"                 \
     -D metal_image_size_mb="${metal_image_size_mb}"     \
     -D cloud_image_size_mb="${cloud_image_size_mb}"     \
+    -D rootfs_size_mb="${rootfs_size_mb}"               \
     -D qemu_secex=\""${secex}"\"                        \
     "${mppyaml}" "${processed_json}"
 


### PR DESCRIPTION
This fixes `No space left on device` issue when building CoreOS with `secex`
