### PR TITLE
tests/kdump.crash.ssh: increase logging verbosity

### DIFF
--- a/mantle/kola/tests/ignition/kdump.go
+++ b/mantle/kola/tests/ignition/kdump.go
@@ -161,6 +161,11 @@ systemd:
   units:
     - name: kdump.service
       enabled: true
+      dropins:
+        - name: debug.conf
+          contents: |
+            [Service]
+            Environment="debug=1"
 kernel_arguments:
     should_exist:
       - crashkernel=512M`,


### PR DESCRIPTION
This increase the log verbosity by quite a log but is often required to investigate kdump failures.
Logs are discared on successful tests so it's not a big deal.