### PR TITLE
Minor fixes: Fix FCOS version check and error return for `delete_gcp_image`

### DIFF
--- a/src/cmd-cloud-prune
+++ b/src/cmd-cloud-prune
@@ -272,7 +272,7 @@ def delete_gcp_image(build, cloud_config, dry_run):
     gcp = build.images.get("gcp")
     if not gcp:
         print(f"No GCP image for {build.id} for {build.arch}")
-        return
+        return errors
     gcp_image = gcp.get("image")
     json_key = cloud_config.get("gcp", {}).get("json-key")
     project = cloud_config.get("gcp", {}).get("project")

--- a/src/cosalib/cmdlib.py
+++ b/src/cosalib/cmdlib.py
@@ -344,7 +344,7 @@ def parse_fcos_version_to_timestamp_and_stream(version):
     Parses an FCOS build ID and verifies the versioning is accurate. Then
     it verifies that the parsed timestamp has %Y%m%d format and returns that.
     '''
-    m = re.match(r'^([0-9]{2})\.([0-9]{8})\.([0-9]+)\.([0-9]+)$', version)
+    m = re.match(r'^([0-9]{2})\.([0-9]{8})\.([0-9]+|dev)\.([0-9]+)$', version)
     if m is None:
         raise Exception(f"Incorrect versioning for FCOS build {version}")
     try:


### PR DESCRIPTION
We have few older [builds](https://builds.coreos.fedoraproject.org/prod/streams/testing-devel/builds/builds.json) for testing-devel which had .dev in their buildIDs. Fixed the version check to accept that. Also fixed the return statement in `delete_gcp_image` to return empty errors list instead on returning None as needed.