### PR TITLE
src/cosalib/aliyun.py: save replication progress in meta.json

### DIFF
--- a/src/cosalib/aliyun.py
+++ b/src/cosalib/aliyun.py
@@ -89,8 +89,11 @@ def aliyun_run_ore_replicate(build, args):
             } for region, val in ore_data.items()
         ])
 
-    build.meta['aliyun'] = aliyun_img_data
-    build.meta_write()
+        # Record the images that have been replicated as they happen
+        # otherwise re-running the replication will fail with
+        # InvalidImageName.Duplicated because the image already exists
+        build.meta['aliyun'] = aliyun_img_data
+        build.meta_write()
 
     # we've successfully replicated to *some* of the regions, so exit early.
     # if `cosa aliyun-replicate` is ran again with the same arguments, it will


### PR DESCRIPTION
Previously meta.json would only be written if replication was successful in all regions. If there were any errors during replication meta.json would not be written. Subsequent replication runs would start over from scratch which would not be a problem except Aliyun will error out if there is already an image with the same name. Re-running the operation on the same build was not possible without deleting the images before hand.

Lets write meta.json after every region replication so we can keep track of the replicated regions and allow re-runs.