### PR TITLE
Allow `.dev` as `tag_stream` for fcos version

### DIFF
--- a/src/cmd-container-prune
+++ b/src/cmd-container-prune
@@ -102,7 +102,7 @@ def main():
         except Exception:
             print(f"WARNING: Ignoring unexpected tag: {tag}")
             continue
-        if stream_id != tag_stream:
+        if stream_id != int(tag_stream):
             if args.v:
                 print(f"Skipping tag {tag} not in {args.stream} stream")
             continue

--- a/src/cosalib/cmdlib.py
+++ b/src/cosalib/cmdlib.py
@@ -351,7 +351,7 @@ def parse_fcos_version_to_timestamp_and_stream(version):
         timestamp = datetime.datetime.strptime(m.group(2), '%Y%m%d')
     except ValueError:
         raise Exception(f"FCOS build {version} has incorrect date format. It should be in (%Y%m%d)")
-    return (timestamp, int(m.group(3)))
+    return (timestamp, m.group(3))
 
 
 def convert_duration_to_days(duration_arg):


### PR DESCRIPTION
For `testing-devel` stream, we have older [builds](https://builds.coreos.fedoraproject.org/prod/streams/testing-devel/builds/builds.json) with `.dev` (non-int) as `tag_stream`. Lets allow that to pass as a valid FCOS version through `parse_fcos_version_to_timestamp_and_stream`