### PR TITLE
Revert "cmdlib: workaround rofiles-fuse mounts leaking"

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -762,10 +762,7 @@ if [ -n "\${cachedev}" ]; then
     # XXX: brutal workaround for https://github.com/coreos/coreos-assembler/issues/3848
     killall rofiles-fuse || :
     /sbin/fstrim -v ${workdir}/cache
-    while ! mount -o remount,ro ${workdir}/cache; do
-        echo "failed to remount cache ro; retrying..." |& tee /dev/virtio-ports/cosa-cmdout
-        sleep 1
-    done
+    mount -o remount,ro ${workdir}/cache
     fsfreeze -f ${workdir}/cache
     fsfreeze -u ${workdir}/cache
     umount ${workdir}/cache

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -759,8 +759,6 @@ else
 fi
 echo \$rc > ${rc_file}
 if [ -n "\${cachedev}" ]; then
-    # XXX: brutal workaround for https://github.com/coreos/coreos-assembler/issues/3848
-    killall rofiles-fuse || :
     /sbin/fstrim -v ${workdir}/cache
     mount -o remount,ro ${workdir}/cache
     fsfreeze -f ${workdir}/cache


### PR DESCRIPTION
This reverts commit ba45b296ec11734bafcae7728915016f17137a3d.