### PR TITLE
cmdlib.sh: keep trying to remount after killall hack

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -761,7 +761,10 @@ if [ -n "\${cachedev}" ]; then
     # XXX: brutal workaround for https://github.com/coreos/coreos-assembler/issues/3848
     killall rofiles-fuse || :
     /sbin/fstrim -v ${workdir}/cache
-    mount -o remount,ro ${workdir}/cache
+    while ! mount -o remount,ro ${workdir}/cache; do
+        echo "failed to remount cache ro; retrying..." |& tee /dev/virtio-ports/cosa-cmdout
+        sleep 1
+    done
     fsfreeze -f ${workdir}/cache
     fsfreeze -u ${workdir}/cache
     umount ${workdir}/cache


### PR DESCRIPTION
Michael and I were debugging an issue where `cosa build` would still break on:

```
+ killall rofiles-fuse
+ /sbin/fstrim -v /home/jenkins/agent/workspace/bootupd_PR-706/cache
/home/jenkins/agent/workspace/bootupd_PR-706/cache: 17.8 GiB (19084976128 bytes) trimmed
+ mount -o remount,ro /home/jenkins/agent/workspace/bootupd_PR-706/cache
mount: /home/jenkins/agent/workspace/bootupd_PR-706/cache: mount point is busy.
```

which I think is because the rofiles-fuse processes haven't fully been cleaned up yet. Let's just spam retry to remount the cache, but notify the user when this is happening for more visibility.

We should be able to revert this once we fix
https://github.com/coreos/coreos-assembler/issues/3848