### PR TITLE
mantle/platform/gcloud: fix confidential compute check

### DIFF
--- a/mantle/cmd/kola/kola.go
+++ b/mantle/cmd/kola/kola.go
@@ -17,7 +17,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"math/rand"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -25,7 +24,6 @@ import (
 	"sort"
 	"strings"
 	"text/tabwriter"
-	"time"
 
 	"github.com/coreos/pkg/capnslog"
 	"github.com/pkg/errors"
@@ -160,8 +158,6 @@ func init() {
 }
 
 func main() {
-	// initialize global state
-	rand.Seed(time.Now().UnixNano())
 	cli.Execute(root)
 }
 

--- a/mantle/platform/api/azure/api.go
+++ b/mantle/platform/api/azure/api.go
@@ -16,8 +16,8 @@
 package azure
 
 import (
+	"crypto/rand"
 	"fmt"
-	"math/rand"
 	"os"
 	"strings"
 	"time"
@@ -27,9 +27,12 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage"
+	"github.com/coreos/pkg/capnslog"
 
 	"github.com/coreos/coreos-assembler/mantle/auth"
 )
+
+var plog = capnslog.NewPackageLogger("github.com/coreos/coreos-assembler/mantle", "platform/api/azure")
 
 type API struct {
 	azIdCred   *azidentity.DefaultAzureCredential
@@ -116,7 +119,9 @@ func (a *API) SetupClients() error {
 
 func randomName(prefix string) string {
 	b := make([]byte, 5)
-	rand.Read(b)
+	if _, err := rand.Read(b); err != nil {
+		plog.Errorf("randomName: failed to generate a random name: %v", err)
+	}
 	return fmt.Sprintf("%s-%x", prefix, b)
 }
 

--- a/mantle/platform/api/gcloud/compute.go
+++ b/mantle/platform/api/gcloud/compute.go
@@ -147,18 +147,20 @@ func (a *API) mkinstance(userdata, name string, keys []*agent.Key, opts platform
 		})
 	}
 	// create confidential instance
-	ConfidentialType := strings.ToUpper(a.options.ConfidentialType)
-	ConfidentialType = strings.Replace(ConfidentialType, "-", "_", -1)
-	if ConfidentialType == "SEV" || ConfidentialType == "SEV_SNP" {
-		fmt.Printf("Using confidential type for confidential computing %s\n", ConfidentialType)
-		instance.ConfidentialInstanceConfig = &compute.ConfidentialInstanceConfig{
-			ConfidentialInstanceType: ConfidentialType,
+	if a.options.ConfidentialType != "" {
+		ConfidentialType := strings.ToUpper(a.options.ConfidentialType)
+		ConfidentialType = strings.Replace(ConfidentialType, "-", "_", -1)
+		if ConfidentialType == "SEV" || ConfidentialType == "SEV_SNP" {
+			fmt.Printf("Using confidential type for confidential computing %s\n", ConfidentialType)
+			instance.ConfidentialInstanceConfig = &compute.ConfidentialInstanceConfig{
+				ConfidentialInstanceType: ConfidentialType,
+			}
+			instance.Scheduling = &compute.Scheduling{
+				OnHostMaintenance: "TERMINATE",
+			}
+		} else {
+			return nil, fmt.Errorf("Does not support confidential type %s, should be: sev, sev_snp\n", a.options.ConfidentialType)
 		}
-		instance.Scheduling = &compute.Scheduling{
-			OnHostMaintenance: "TERMINATE",
-		}
-	} else {
-		return nil, fmt.Errorf("Does not support confidential type %s, should be: sev, sev_snp\n", a.options.ConfidentialType)
 	}
 	// attach aditional disk
 	for _, spec := range opts.AdditionalDisks {

--- a/mantle/platform/machine/azure/cluster.go
+++ b/mantle/platform/machine/azure/cluster.go
@@ -15,9 +15,9 @@
 package azure
 
 import (
+	"crypto/rand"
 	"errors"
 	"fmt"
-	"math/rand"
 	"os"
 	"path/filepath"
 
@@ -35,7 +35,9 @@ type cluster struct {
 
 func (ac *cluster) vmname() string {
 	b := make([]byte, 5)
-	rand.Read(b)
+	if _, err := rand.Read(b); err != nil {
+		plog.Errorf("failed to generate a random vmname: %v", err)
+	}
 	return fmt.Sprintf("%s-%x", ac.Name()[0:13], b)
 }
 

--- a/mantle/platform/machine/esx/cluster.go
+++ b/mantle/platform/machine/esx/cluster.go
@@ -15,9 +15,9 @@
 package esx
 
 import (
+	"crypto/rand"
 	"errors"
 	"fmt"
-	"math/rand"
 	"os"
 	"path/filepath"
 
@@ -32,7 +32,9 @@ type cluster struct {
 
 func (ec *cluster) vmname() string {
 	b := make([]byte, 5)
-	rand.Read(b)
+	if _, err := rand.Read(b); err != nil {
+		plog.Errorf("failed to generate a random vmname: %v", err)
+	}
 	return fmt.Sprintf("%s-%x", ec.Name(), b)
 }
 


### PR DESCRIPTION
In db803c3 we add support for ConfidentialType but we made it so that we always execute this code where we don't want to do that if the user didn't specify any ConfidentialType for GCP.

The way the code is now we can't run any GCP tests on non confidential instances.

```
failed to create instance "kola-dd144aac7413f66c85e9":
    Does not support confidential type , should be: sev, sev_snp
```