### PR TITLE
mantle/gcp:  support c3 metal instance types

### DIFF
--- a/mantle/platform/api/gcloud/compute.go
+++ b/mantle/platform/api/gcloud/compute.go
@@ -160,6 +160,12 @@ func (a *API) mkinstance(userdata, name string, keys []*agent.Key, opts platform
 	} else {
 		return nil, fmt.Errorf("Does not support confidential type %s, should be: sev, sev_snp\n", a.options.ConfidentialType)
 	}
+	// metal instances can only have a TERMINATE maintenance policy
+	if strings.HasSuffix(a.options.MachineType, "metal") {
+		instance.Scheduling = &compute.Scheduling{
+			OnHostMaintenance: "TERMINATE",
+		}
+	}
 	// attach aditional disk
 	for _, spec := range opts.AdditionalDisks {
 		plog.Debugf("Parsing disk spec %q\n", spec)

--- a/mantle/platform/api/gcloud/image.go
+++ b/mantle/platform/api/gcloud/image.go
@@ -86,6 +86,7 @@ func (a *API) CreateImage(spec *ImageSpec, overwrite bool) (*compute.Operation, 
 		}
 	}
 
+	// https://cloud.google.com/compute/docs/images/create-custom#guest-os-features
 	features := []*compute.GuestOsFeature{
 		// https://cloud.google.com/compute/docs/images/create-delete-deprecate-private-images
 		{
@@ -105,6 +106,10 @@ func (a *API) CreateImage(spec *ImageSpec, overwrite bool) (*compute.Operation, 
 		// https://cloud.google.com/blog/products/identity-security/rsa-snp-vm-more-confidential
 		{
 			Type: "SEV_SNP_CAPABLE",
+		},
+		// https://cloud.google.com/compute/docs/networking/using-idpf
+		{
+			Type: "IDPF",
 		},
 	}
 


### PR DESCRIPTION
This requires the IDPF guest OS feature flag to be set when creating GCP images and also a TERMINATE maintenance policy and hyperdisk storage. With this change, after uploading a disk you can then test with kola with something like:

```
cosa kola run -p=gcp                        \
    --gcp-json-key=key.json                 \
    --gcp-project=project                   \
    --gcp-machinetype=c3-highcpu-192-metal  \
    --gcp-zone=us-central1-c basic
```

Related to https://github.com/coreos/fedora-coreos-tracker/issues/1794