### PR TITLE
mantle/kola: increase reboot wait time for fcos.upgrade.basic

### DIFF
--- a/mantle/kola/tests/upgrade/basic.go
+++ b/mantle/kola/tests/upgrade/basic.go
@@ -343,7 +343,7 @@ func runFnAndWaitForRebootIntoVersion(c cluster.TestCluster, m platform.Machine,
 
 	fn()
 
-	if err := m.WaitForReboot(120*time.Second, oldBootId); err != nil {
+	if err := m.WaitForReboot(240*time.Second, oldBootId); err != nil {
 		c.Fatalf("failed waiting for machine reboot: %v", err)
 	}
 


### PR DESCRIPTION
We've been seeing this fail a lot more on AWS recently and we think it's because we're bumping up into this timeout. The truth is that we're not just waiting for a reboot here, but actually waiting for zincati to select the upgrade, for rpm-ostree to deploy it, finalize and reboot. Given all that I can see why this might be bumping up into the limit.

```
=== RUN   fcos.upgrade.basic
=== RUN   fcos.upgrade.basic/setup
=== RUN   fcos.upgrade.basic/upgrade-from-previous
=== RUN   fcos.upgrade.basic/upgrade-from-current
--- FAIL: fcos.upgrade.basic (495.26s)
    --- PASS: fcos.upgrade.basic/setup (204.18s)
            cluster.go:162: real	0m0.045s
            cluster.go:162: user	0m0.006s
            cluster.go:162: sys	0m0.012s
    --- FAIL: fcos.upgrade.basic/upgrade-from-previous (122.05s)
            basic.go:347: failed waiting for machine reboot: timed out after 2m0s waiting for machine to reboot
    --- SKIP: fcos.upgrade.basic/upgrade-from-current (0.00s)
            cluster.go:54: A previous test has already failed
```