### PR TITLE
workaround selinux issues with osbuild

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -173,7 +173,11 @@ patch_osbuild() {
     mv /usr/bin/osbuild-mpp /usr/lib/osbuild/tools/
 
     # Now all the software is under the /usr/lib/osbuild dir and we can patch
-    patch -d /usr/lib/osbuild -p1 < /usr/lib/coreos-assembler/0001-stages-dmverity-make-device-objects-more-generic.patch
+    cat /usr/lib/coreos-assembler/0001-stages-dmverity-make-device-objects-more-generic.patch     \
+        /usr/lib/coreos-assembler/0001-stages-coreos.platform-use-shutil.copy.patch               \
+        /usr/lib/coreos-assembler/0001-stages-selinux-don-t-require-file_contexts-if-labels.patch \
+        /usr/lib/coreos-assembler/0001-hacks-for-coreos-selinux-issues.patch                      \
+            | patch -d /usr/lib/osbuild -p1
 
     # And then move the files back; supermin appliance creation will need it back
     # in the places delivered by the RPM.

--- a/src/0001-hacks-for-coreos-selinux-issues.patch
+++ b/src/0001-hacks-for-coreos-selinux-issues.patch
@@ -1,0 +1,44 @@
+From 9faf7e2566cd9460ac51ff508c192bdc839ad2ef Mon Sep 17 00:00:00 2001
+From: Dusty Mabe <dusty@dustymabe.com>
+Date: Tue, 17 Sep 2024 12:27:37 -0400
+Subject: [PATCH 3/3] hacks for coreos selinux issues
+
+context in https://github.com/coreos/fedora-coreos-tracker/issues/1771#issuecomment-2348607969
+---
+ osbuild/mounts.py | 13 ++++++++++++-
+ 1 file changed, 12 insertions(+), 1 deletion(-)
+
+diff --git a/osbuild/mounts.py b/osbuild/mounts.py
+index 42b556ba..9b6c0804 100644
+--- a/osbuild/mounts.py
++++ b/osbuild/mounts.py
+@@ -178,7 +178,12 @@ class FileSystemMountService(MountService):
+ 
+         options = self.translate_options(options)
+ 
+-        os.makedirs(mountpoint, exist_ok=True)
++        if not os.path.exists(mountpoint):
++            os.makedirs(mountpoint)
++            # Tactical fix for https://github.com/coreos/fedora-coreos-tracker/issues/1771
++            if target == '/boot' or target == "/boot/efi":
++                subprocess.run(["chcon", "-v", "-t", 'boot_t', mountpoint], check=True)
++
+         self.mountpoint = mountpoint
+ 
+         print(f"mounting {source} -> {mountpoint}")
+@@ -198,6 +203,12 @@ class FileSystemMountService(MountService):
+             msg = e.stdout.strip()
+             raise RuntimeError(f"{msg} (code: {code})") from e
+ 
++        # Tactical fix for https://github.com/coreos/fedora-coreos-tracker/issues/1771
++        # After the mount, let's make sure the lost+found directory has the right label
++        lostfounddir = os.path.join(mountpoint, 'lost+found')
++        if os.path.exists(lostfounddir):
++            subprocess.run(["chcon", "-v", "-t", 'lost_found_t', lostfounddir], check=True)
++
+         self.check = True
+         return mountpoint
+ 
+-- 
+2.46.0
+

--- a/src/0001-stages-coreos.platform-use-shutil.copy.patch
+++ b/src/0001-stages-coreos.platform-use-shutil.copy.patch
@@ -1,0 +1,31 @@
+From 6b48c91e26efb448b2f2121b4179a1b79e15ce6d Mon Sep 17 00:00:00 2001
+From: Dusty Mabe <dusty@dustymabe.com>
+Date: Tue, 17 Sep 2024 12:18:45 -0400
+Subject: [PATCH 1/3] stages/coreos.platform: use shutil.copy
+
+Switch from shutil.copy2 so that we don't copy over the
+SELinux labels from the source file.
+---
+ stages/org.osbuild.coreos.platform | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/stages/org.osbuild.coreos.platform b/stages/org.osbuild.coreos.platform
+index a88951cc..7e66c26c 100755
+--- a/stages/org.osbuild.coreos.platform
++++ b/stages/org.osbuild.coreos.platform
+@@ -52,8 +52,10 @@ def main(paths, options):
+     json_grub_args, json_kargs = None, None
+     if os.path.exists(platforms_source_path):
+         os.makedirs(os.path.dirname(platforms_dest_path), mode=0o755, exist_ok=True)
+-        # Copy platforms.json to the boot partition
+-        shutil.copy2(platforms_source_path, platforms_dest_path)
++        # Copy platforms.json to the boot partition. Use shutil.copy here and not
++        # shutil.copy2 because we don't want the selinux labels from the source
++        # to be copied over, but rather the defaults for the destination.
++        shutil.copy(platforms_source_path, platforms_dest_path)
+         json_grub_args, json_kargs = process_platforms_json(platforms_dest_path, platform)
+     if json_kargs:
+         kernel_arguments.extend(json_kargs)
+-- 
+2.46.0
+

--- a/src/0001-stages-selinux-don-t-require-file_contexts-if-labels.patch
+++ b/src/0001-stages-selinux-don-t-require-file_contexts-if-labels.patch
@@ -1,0 +1,65 @@
+From 281b0795fb4cc43ea05039627ebb5ff7130d70e9 Mon Sep 17 00:00:00 2001
+From: Dusty Mabe <dusty@dustymabe.com>
+Date: Tue, 17 Sep 2024 12:22:16 -0400
+Subject: [PATCH 2/3] stages/selinux: don't require file_contexts if labels
+ passed
+
+With the labels option the user is specifying the exact context
+they want to set on the path so it's not necessary to supply a
+context here. This can be also useful in the case where you want
+to set some labels and you haven't yet populated the tree yet.
+---
+ stages/org.osbuild.selinux           | 11 +++++++----
+ stages/org.osbuild.selinux.meta.json | 13 +++++++++++--
+ 2 files changed, 18 insertions(+), 6 deletions(-)
+
+diff --git a/stages/org.osbuild.selinux b/stages/org.osbuild.selinux
+index bb45298d..563d827b 100755
+--- a/stages/org.osbuild.selinux
++++ b/stages/org.osbuild.selinux
+@@ -8,11 +8,14 @@ from osbuild.util import selinux
+ 
+ 
+ def main(tree, options):
+-    file_contexts = os.path.join(f"{tree}", options["file_contexts"])
++    file_contexts = options.get("file_contexts")
+     exclude_paths = options.get("exclude_paths")
+-    if exclude_paths:
+-        exclude_paths = [os.path.join(tree, p.lstrip("/")) for p in exclude_paths]
+-    selinux.setfiles(file_contexts, os.fspath(tree), "", exclude_paths=exclude_paths)
++
++    if file_contexts:
++        file_contexts = os.path.join(f"{tree}", options["file_contexts"])
++        if exclude_paths:
++            exclude_paths = [os.path.join(tree, p.lstrip("/")) for p in exclude_paths]
++        selinux.setfiles(file_contexts, os.fspath(tree), "", exclude_paths=exclude_paths)
+ 
+     labels = options.get("labels", {})
+     for path, label in labels.items():
+diff --git a/stages/org.osbuild.selinux.meta.json b/stages/org.osbuild.selinux.meta.json
+index ea1bb3ef..151839e5 100644
+--- a/stages/org.osbuild.selinux.meta.json
++++ b/stages/org.osbuild.selinux.meta.json
+@@ -20,8 +20,17 @@
+   "schema_2": {
+     "options": {
+       "additionalProperties": false,
+-      "required": [
+-        "file_contexts"
++      "oneOf": [
++        {
++          "required": [
++            "file_contexts"
++          ]
++        },
++        {
++          "required": [
++            "labels"
++          ]
++        }
+       ],
+       "properties": {
+         "file_contexts": {
+-- 
+2.46.0
+

--- a/src/osbuild-manifests/coreos.osbuild.aarch64.mpp.yaml
+++ b/src/osbuild-manifests/coreos.osbuild.aarch64.mpp.yaml
@@ -139,6 +139,12 @@ pipelines:
       mpp-format-string: '{buildroot}'
     source-epoch: 1659397331
     stages:
+      # Set the context of the root of the tree so that we avoid unlabeled_t files.
+      # https://github.com/coreos/fedora-coreos-tracker/issues/1772
+      - type: org.osbuild.selinux
+        options:
+          labels:
+            /: system_u:object_r:root_t:s0
       - type: org.osbuild.ostree.init-fs
       - type: org.osbuild.ostree.os-init
         options:

--- a/src/osbuild-manifests/coreos.osbuild.ppc64le.mpp.yaml
+++ b/src/osbuild-manifests/coreos.osbuild.ppc64le.mpp.yaml
@@ -141,6 +141,12 @@ pipelines:
       mpp-format-string: '{buildroot}'
     source-epoch: 1659397331
     stages:
+      # Set the context of the root of the tree so that we avoid unlabeled_t files.
+      # https://github.com/coreos/fedora-coreos-tracker/issues/1772
+      - type: org.osbuild.selinux
+        options:
+          labels:
+            /: system_u:object_r:root_t:s0
       - type: org.osbuild.ostree.init-fs
       - type: org.osbuild.ostree.os-init
         options:

--- a/src/osbuild-manifests/coreos.osbuild.s390x.mpp.yaml
+++ b/src/osbuild-manifests/coreos.osbuild.s390x.mpp.yaml
@@ -169,6 +169,12 @@ pipelines:
       mpp-format-string: '{buildroot}'
     source-epoch: 1659397331
     stages:
+      # Set the context of the root of the tree so that we avoid unlabeled_t files.
+      # https://github.com/coreos/fedora-coreos-tracker/issues/1772
+      - type: org.osbuild.selinux
+        options:
+          labels:
+            /: system_u:object_r:root_t:s0
       - type: org.osbuild.ostree.init-fs
       - type: org.osbuild.ostree.os-init
         options:

--- a/src/osbuild-manifests/coreos.osbuild.x86_64.mpp.yaml
+++ b/src/osbuild-manifests/coreos.osbuild.x86_64.mpp.yaml
@@ -141,6 +141,12 @@ pipelines:
       mpp-format-string: '{buildroot}'
     source-epoch: 1659397331
     stages:
+      # Set the context of the root of the tree so that we avoid unlabeled_t files.
+      # https://github.com/coreos/fedora-coreos-tracker/issues/1772
+      - type: org.osbuild.selinux
+        options:
+          labels:
+            /: system_u:object_r:root_t:s0
       - type: org.osbuild.ostree.init-fs
       - type: org.osbuild.ostree.os-init
         options:

--- a/src/vmdeps.txt
+++ b/src/vmdeps.txt
@@ -38,3 +38,7 @@ podman
 
 # For running osbuild
 osbuild osbuild-ostree osbuild-selinux osbuild-tools python3-pyrsistent
+
+# For resetting the terminal inside supermin shell
+/usr/bin/reset
+/usr/bin/clear


### PR DESCRIPTION
We have a few issues right now where files in our images
don't have any selinux context (i.e. end up unlabeled_t).
Here we workaround the hidden mountpoints issue [1] with
a patch to OSBuild to hardcode some chcon calls. We
workaround the "bunch of files under /sysroot are unlabeled"
issue [2] by backported a proposed upstream change to
the org.osbuild.selinux stage [3] and then using it to
explicitly set the context on the root of the tree to
`root_t`. We also add a fix [4] for another issue where
'/boot/coreos/platforms.json' would end up with the
wrong label.

[1] https://github.com/coreos/fedora-coreos-tracker/issues/1771
[2] https://github.com/coreos/fedora-coreos-tracker/issues/1772
[3] https://github.com/osbuild/osbuild/pull/1889
[4] https://github.com/osbuild/osbuild/pull/1888
