### PR TITLE
[ppc64le] Remove P8 and P9 hack so tests pass for Power10

### DIFF
--- a/src/libguestfish.sh
+++ b/src/libguestfish.sh
@@ -11,14 +11,6 @@ export LIBGUESTFS_BACKEND=direct
 
 arch=$(uname -m)
 
-
-# Hack to run with a wrapper on older P8 hardware running RHEL7
-if [ "$arch" = "ppc64le" ] ; then
-    if [[ "$(uname -r)" =~ "el7" ]]; then
-        export LIBGUESTFS_HV="/usr/lib/coreos-assembler/libguestfs-ppc64le-wrapper.sh"
-    fi
-fi
-
 # Hack to give ppc64le more memory inside the libguestfs VM.
 # The compiled in default I see when running `guestfish get-memsize`
 # is 1280. We need this because we are seeing issues from

--- a/src/libguestfs-ppc64le-wrapper.sh
+++ b/src/libguestfs-ppc64le-wrapper.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-exec qemu-system-ppc64 "$@" -machine pseries,accel=kvm:tcg,vsmt=8,cap-fwnmi=off


### PR DESCRIPTION
008e04c322e99cdb769cdb36c010810c8625376b and a6d7bbbadc8f091afbd6732b18fd4aa5a25c4590 added and used the `libguestfs-ppc64le-wrapper.sh` in order to address some failing tests on ppc64le. Using a Power10 machine with KVM enabled, tests are passing with this script removed. There was a successful test run with: `cosa kola run --tag '!reprovision'`

If we are going to use p10 for CI going forward, I think we can remove this script entirely. Otherwise, we will have to distinguish between p10 and not p10 or possibly implement a better way than relying on using `uname -r ` output searching for `el7`.

Related to issue https://github.com/coreos/coreos-assembler/issues/2473