### PR TITLE
mantle: move kolet binary location to /usr/local/bin

### DIFF
--- a/docs/kola/external-tests.md
+++ b/docs/kola/external-tests.md
@@ -112,11 +112,10 @@ method is deprecated and will be removed at some point)
 
 ## HTTP Server
 
-The `kolet` binary is copied into the `core` user's home directory
-(`/var/home/core`) on the CoreOS system running the tests. Notably, it contains
-the built-in command `kolet httpd` for starting an HTTP file server to serve the
-contents of the file system.
-By default, it starts the server listening on port `80` and serves the contents of
+The `kolet` binary is copied into the `/usr/local/bin/` directory on the CoreOS
+system running the tests. Notably, it contains the built-in command `kolet httpd`
+for starting an HTTP file server to serve the contents of the file system. By
+default, it starts the server listening on port `80` and serves the contents of
 the file system at `./`; you can use the `--port` and `--path` flags to override
 the defaults.
 
@@ -124,7 +123,7 @@ For example, if you're using a bash script as your test, you can start an HTTP
 server to serve the contents at `/var/home/core` like this:
 ```
 echo testdata > /var/home/core/testdata.txt
-systemd-run /var/home/core/kolet httpd --path /var/home/core/
+systemd-run /usr/local/bin/kolet httpd --path /var/home/core/
 # It may take some time for the server to start.
 sleep 1
 curl localhost/testdata.txt
@@ -155,13 +154,13 @@ systemd:
         [Unit]
         Before=kola-runext.service
         [Path]
-        PathExists=/var/home/core/kolet
+        PathExists=/usr/local/bin/kolet
         [Install]
         WantedBy=kola-runext.service
     - name: kolet-httpd.service
       contents: |
         [Service]
-        ExecStart=/var/home/core/kolet httpd --path /var/www -v
+        ExecStart=/usr/local/bin/kolet httpd --path /var/www -v
         [Install]
         WantedBy=kola-runext.service
 storage:

--- a/mantle/cmd/kolet/kolet.go
+++ b/mantle/cmd/kolet/kolet.go
@@ -97,14 +97,14 @@ const (
 	autopkgTestRebootPath   = "/tmp/autopkgtest-reboot"
 	autopkgtestRebootScript = `#!/bin/bash
 set -xeuo pipefail
-~core/kolet reboot-request "$1"
+/usr/local/bin/kolet reboot-request "$1"
 reboot
 `
 	autopkgTestRebootPreparePath = "/tmp/autopkgtest-reboot-prepare"
 
 	autopkgtestRebootPrepareScript = `#!/bin/bash
 set -euo pipefail
-exec ~core/kolet reboot-request "$1"
+exec /usr/local/bin/kolet reboot-request "$1"
 `
 
 	// File used to communicate between the script and the kolet runner internally

--- a/mantle/kola/cluster/cluster.go
+++ b/mantle/kola/cluster/cluster.go
@@ -105,9 +105,8 @@ func (t *TestCluster) ListNativeFunctions() []string {
 	return t.NativeFuncs
 }
 
-// DropLabeledFile places file from localPath to ~/ on every machine in
-// cluster, potentially with a custom SELinux label.
-func DropLabeledFile(machines []platform.Machine, localPath, selabel string) error {
+// DropFile places file from localPath to ~/ on every machine in cluster
+func DropFile(machines []platform.Machine, localPath string) error {
 	in, err := os.Open(localPath)
 	if err != nil {
 		return err
@@ -125,21 +124,11 @@ func DropLabeledFile(machines []platform.Machine, localPath, selabel string) err
 		if err := platform.InstallFile(in, m, partial); err != nil {
 			return err
 		}
-		if selabel != "" {
-			if out, stderr, err := m.SSH(fmt.Sprintf("sudo chcon -t %s %s.partial", selabel, base)); err != nil {
-				return errors.Wrapf(err, "running chcon on %s.partial: %s: %s", base, out, stderr)
-			}
-		}
 		if out, stderr, err := m.SSH(fmt.Sprintf("mv %[1]s.partial %[1]s", base)); err != nil {
 			return errors.Wrapf(err, "running mv %[1]s.partial %[1]s: %s: %s", base, out, stderr)
 		}
 	}
 	return nil
-}
-
-// DropFile places file from localPath to ~/ on every machine in cluster
-func DropFile(machines []platform.Machine, localPath string) error {
-	return DropLabeledFile(machines, localPath, "")
 }
 
 // SSH runs a ssh command on the given machine in the cluster. It differs from

--- a/mantle/kola/cluster/cluster.go
+++ b/mantle/kola/cluster/cluster.go
@@ -74,7 +74,7 @@ func (t *TestCluster) RunLogged(name string, f func(c TestCluster)) bool {
 
 // RunNative runs a registered NativeFunc on a remote machine
 func (t *TestCluster) RunNative(funcName string, m platform.Machine) bool {
-	command := fmt.Sprintf("./kolet run %q %q", t.H.Name(), funcName)
+	command := fmt.Sprintf("/usr/local/bin/kolet run %q %q", t.H.Name(), funcName)
 	return t.Run(funcName, func(c TestCluster) {
 		client, err := m.SSHClient()
 		if err != nil {

--- a/mantle/kola/tests/ignition/resource.go
+++ b/mantle/kola/tests/ignition/resource.go
@@ -81,7 +81,7 @@ func init() {
 func resourceLocal(c cluster.TestCluster) {
 	server := c.Machines()[0]
 
-	c.RunCmdSyncf(server, "sudo systemd-run --quiet ./kolet run %s Serve", c.H.Name())
+	c.RunCmdSyncf(server, "sudo systemd-run --quiet /usr/local/bin/kolet run %s Serve", c.H.Name())
 
 	ip := server.PrivateIP()
 	if c.Platform() == packet.Platform {

--- a/mantle/kola/tests/ignition/security.go
+++ b/mantle/kola/tests/ignition/security.go
@@ -95,7 +95,7 @@ EOF
 	publicKey := c.MustSSH(server, "sudo cat /var/tls/server.crt")
 
 	var conf *conf.UserData = localSecurityClient
-	c.RunCmdSyncf(server, "sudo systemd-run --quiet ./kolet run %s TLSServe", c.H.Name())
+	c.RunCmdSyncf(server, "sudo systemd-run --quiet /usr/local/bin/kolet run %s TLSServe", c.H.Name())
 
 	client, err := c.NewMachine(conf.Subst("$IP", ip).Subst("$KEY", dataurl.EncodeBytes(publicKey)))
 	if err != nil {

--- a/mantle/kola/tests/upgrade/basic.go
+++ b/mantle/kola/tests/upgrade/basic.go
@@ -80,11 +80,11 @@ func init() {
       {
         "name": "kolet-httpd.path",
         "enabled": true,
-        "contents": "[Path]\nPathExists=/var/home/core/kolet\n[Install]\nWantedBy=multi-user.target"
+        "contents": "[Path]\nPathExists=/usr/local/bin/kolet\n[Install]\nWantedBy=multi-user.target"
       },
       {
         "name": "kolet-httpd.service",
-        "contents": "[Service]\nExecStart=/var/home/core/kolet run fcos.upgrade.basic httpd -v\n[Install]\nWantedBy=multi-user.target"
+        "contents": "[Service]\nExecStart=/usr/local/bin/kolet run fcos.upgrade.basic httpd -v\n[Install]\nWantedBy=multi-user.target"
       }
     ]
   },


### PR DESCRIPTION
I'm writing a test that verifies files on the filesystem in CoreOS machinges match the SELinux policy. Placing kolet in `/var/home/core/kolet` with a `bin_t` context is a violation of this. Let's use /usr/local/bin/. This has the side effect of the file having the right `bin_t` context as soon as it is created.
