### PR TITLE
cmd-cloud-prune: remove the unneeded exception

### DIFF
--- a/src/cmd-cloud-prune
+++ b/src/cmd-cloud-prune
@@ -225,8 +225,6 @@ def get_supported_images(meta_json):
             raise Exception(f"The platform {key} is not supported")
         if key in SUPPORTED:
             images[key] = meta_json[key]
-        else:
-            raise Exception(f"The platform {key} is neither in supported nor unsupported artifacts.")
     return images
 
 


### PR DESCRIPTION
This exception was not supposed to be added there since that check was just added to make sure there isn't any build
artifacts in `meta.json` top-level keys that is in unsupported list. So far, we only prune aws and gcp. There are many top-level keys that are not artifacts-related so this check would throw the exception when not needed.