### PR TITLE
ore/aws: Handle missing `SnapshotID`

### DIFF
--- a/mantle/cmd/ore/aws/delete-image.go
+++ b/mantle/cmd/ore/aws/delete-image.go
@@ -57,6 +57,18 @@ func runDeleteImage(cmd *cobra.Command, args []string) {
 	}
 
 	if snapshotID != "" {
+		if snapshotID == "detectFromAMI" && amiID != "" {
+			// Let's try to extract the snapshotID from AMI
+			snapshot, err := API.FindSnapshot(amiID)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: Encountered error when searching for snapshot for %s: %s. Continuing..\n", amiID, err)
+				os.Exit(0)
+			} else if snapshot == nil {
+				fmt.Fprintf(os.Stdout, "No valid snapshot found for %s.\n", amiID)
+				os.Exit(0)
+			}
+			snapshotID = snapshot.SnapshotID
+		}
 		err := API.RemoveBySnapshotTag(snapshotID, allowMissing)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Could not delete %v: %v\n", snapshotID, err)

--- a/src/cmd-cloud-prune
+++ b/src/cmd-cloud-prune
@@ -324,7 +324,9 @@ def deregister_aws_amis(build, cloud_config, dry_run):
     for ami in amis:
         region_name = ami.get("name")
         ami_id = ami.get("hvm")
-        snapshot_id = ami.get("snapshot")
+        # If we are dealing with an old manifest where the snapshot ID isn't stored
+        # then let's instruct ore to detect the snapshot ID from the AMI.
+        snapshot_id = ami.get("snapshot", "detectFromAMI")
         if dry_run:
             print(f"Would delete {ami_id} and {snapshot_id} for {build.id}")
             continue


### PR DESCRIPTION
Added a check for when the `snapshotID` is None in the `RemoveBySnapshotTag` function. If `snapshotID` is None, the function now attempts to extract the snapshot ID from the associated AMI. If the AMI cannot be described, it is logged as pruned, and the function returns without error.