### PR TITLE
grub.cfg: Clarify relationship with bootupd in comments

### DIFF
--- a/src/grub.cfg
+++ b/src/grub.cfg
@@ -1,3 +1,6 @@
+# Changes in this file won't take affect, unless you also
+# update the Static GRUB configuration files in bootup
+# See: https://github.com/coreos/bootupd/pull/536
 # petitboot doesn't support -e and doesn't support an empty path part
 if [ -d (md/md-boot)/grub2 ]; then
   # fcct currently creates /boot RAID with superblock 1.0, which allows


### PR DESCRIPTION
- Add a comment explaining that changes to this config file (grub.cfg) do not directly affect the system's GRUB configuration.
- Bootupd uses this file as a reference to generate static GRUB config files, and the actual grub.cfg installed on the system comes from bootupd.
- This clarification helps avoid confusion for those expecting changes here to take immediate effect.