### PR TITLE
[rhcos-4.14] vmdeps: include deps needed for push-container-manifest

### DIFF
--- a/src/vmdeps.txt
+++ b/src/vmdeps.txt
@@ -35,3 +35,8 @@ tar
 
 # needed for extensions container build
 podman
+
+# Needed for cosa push-container-manifest. In later releases the
+# supermin build pulls in these deps but for some reason not in Fedora 38.
+python3-jsonschema
+python3-pyrsistent


### PR DESCRIPTION
Followon to https://github.com/coreos/fedora-coreos-pipeline/pull/1047

For some reason in older releases these deps don't get pulled in in the supermin build and push-container-manifest is failing.