### PR TITLE
vmdeps: add python3-dnf for now

### DIFF
--- a/src/vmdeps.txt
+++ b/src/vmdeps.txt
@@ -38,6 +38,9 @@ podman
 
 # For running osbuild
 osbuild osbuild-ostree osbuild-selinux osbuild-tools python3-pyrsistent
+# remove this when osbuild-tools requires python3-dnf
+# https://github.com/osbuild/osbuild/pull/1908
+python3-dnf
 
 # For resetting the terminal inside supermin shell
 /usr/bin/reset


### PR DESCRIPTION
OSBuild dropped dnf as a dependency upstream [1] but osbuild-mpp still uses python3-dnf. Let's add the dep here until it's added as a dep on osbuild-tools upstream [2].

[1] https://github.com/osbuild/osbuild/pull/1896
[2] https://github.com/osbuild/osbuild/pull/1908