### PR TITLE
tests/containers: add a NFS server containers

### DIFF
--- a/tests/containers/nfs/Containerfile
+++ b/tests/containers/nfs/Containerfile
@@ -1,0 +1,16 @@
+FROM registry.fedoraproject.org/fedora-minimal:41
+
+RUN dnf -y install /usr/bin/ps nfs-utils && dnf clean all && rm -rf /var/cache/yum
+
+ADD run_nfs.sh /usr/local/bin/
+
+# expose mountd 20048/tcp and nfsd 2049/tcp
+EXPOSE 2049/tcp 20048/tcp
+
+# Prepare mount point rw for everyone
+RUN mkdir /export && chmod 777 /export
+
+# mark /export as a mount point
+VOLUME /export
+ENTRYPOINT ["/usr/local/bin/run_nfs.sh"]
+CMD ["/export"]

--- a/tests/containers/nfs/README.md
+++ b/tests/containers/nfs/README.md
@@ -1,0 +1,10 @@
+# NFS Server Container
+
+This is used by the `kdump.crash.nfs` test.
+
+This image is forked from the [openshift e2e test image](https://github.com/openshift/kubernetes/tree/7ca9eb1e9e5ced974033c2b6f26560e22535244c/test/images/volume/nfs)
+
+See https://github.com/coreos/coreos-assembler/pull/3911 for the inital PR using it for more details on the test.
+
+It serves an empty `/` directory, writeable by anyone.
+Not for production use!

--- a/tests/containers/nfs/run_nfs.sh
+++ b/tests/containers/nfs/run_nfs.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+set -uxo  pipefail
+
+function start()
+{
+
+    # prepare /etc/exports
+    for i in "$@"; do
+        # fsid=0: needed for NFSv4
+        echo "$i *(rw,fsid=0,insecure,no_root_squash)" >> /etc/exports
+        echo "Serving $i"
+    done
+
+    # start rpcbind if it is not started yet
+    /usr/sbin/rpcinfo 127.0.0.1 > /dev/null; s=$?
+    if [ $s -ne 0 ]; then
+       echo "Starting rpcbind"
+       /usr/sbin/rpcbind -w
+    fi
+
+    mount -t nfsd nfsd /proc/fs/nfsd
+
+    # -V 3: enable NFSv3
+    /usr/sbin/rpc.mountd -N 2 -V 3
+
+    /usr/sbin/exportfs -r
+    # -G 10 to reduce grace time to 10 seconds (the lowest allowed)
+    /usr/sbin/rpc.nfsd -G 10 -V 3
+    /usr/sbin/rpc.statd --no-notify
+    echo "NFS started"
+}
+
+function stop()
+{
+    echo "Stopping NFS"
+
+    /usr/sbin/rpc.nfsd 0
+    /usr/sbin/exportfs -au
+    /usr/sbin/exportfs -f
+
+    kill "$( pidof rpc.mountd )"
+    umount /proc/fs/nfsd
+    echo > /etc/exports
+    exit 0
+}
+
+# rpc.statd has issues with very high ulimits
+ulimit -n 65535
+
+trap stop TERM
+
+start "$@"
+
+set +x
+# Ugly hack to do nothing and wait for SIGTERM
+while true; do
+    sleep 5
+done
+


### PR DESCRIPTION
This is prep work for enabling kdump over NFS testing. The previous attempt in https://github.com/coreos/coreos-assembler/pull/3911 used an image from openshift E2E tests, but I didn't pay attention to the image and the latest tag is not a multiarch manifest, so the pipeline tripped on that.

Building the image ourselves will fix that.