### PR TITLE
mantle/kola: add max_level_console=debug for COSA_TESTISO_DEBUG

### DIFF
--- a/mantle/platform/metal.go
+++ b/mantle/platform/metal.go
@@ -370,7 +370,9 @@ func renderInstallKargs(t *installerRun, offline bool) []string {
 // problematic. Let's add a hook here to enable more debugging.
 func renderCosaTestIsoDebugKargs() []string {
 	if _, ok := os.LookupEnv("COSA_TESTISO_DEBUG"); ok {
-		return []string{"systemd.log_color=0", "systemd.log_level=debug", "systemd.journald.forward_to_console=1"}
+		return []string{"systemd.log_color=0", "systemd.log_level=debug",
+			"systemd.journald.forward_to_console=1",
+			"systemd.journald.max_level_console=debug"}
 	} else {
 		return []string{}
 	}


### PR DESCRIPTION
Otherwise only `info` level messages will go to the console of the machine.

We were digging into a new instance of [1] and found that we weren't really getting debug messages on the console of the machine (which means no new clues as to why the tests are timing out). Turns out this is why we weren't getting those new debug messages we thought we would get.

[1] https://github.com/coreos/fedora-coreos-tracker/issues/1796