### PR TITLE
cmd-cloud-prune: set default project when unspecified

### DIFF
--- a/src/cmd-cloud-prune
+++ b/src/cmd-cloud-prune
@@ -347,7 +347,7 @@ def delete_gcp_image(build, cloud_config, dry_run):
         print(f"No GCP image to prune for {build.id} for {build.arch}")
         return errors
     gcp_image = gcp.get("image")
-    project = gcp.get("project")
+    project = gcp.get("project") or "fedora-coreos-cloud"
     json_key = cloud_config.get("gcp", {}).get("json-key")
     if dry_run:
         print(f"Would delete {gcp_image} GCP image for {build.id}")


### PR DESCRIPTION
Updated the project assignment to default to `fedora-coreos-cloud` when `gcp.get("project")` returns None or an empty value. We have a few builds where the project is not specified. This ensures a fallback project is always available.
Example: 31.20200517.20.0 [meta.json](https://builds.coreos.fedoraproject.org/prod/streams/testing-devel/builds/31.20200517.20.0/x86_64/meta.json).