### PR TITLE
[rhcos-4.13] support `cosa buildextend-qemu-secex`

### DIFF
--- a/src/cmd-buildextend-metal
+++ b/src/cmd-buildextend-metal
@@ -21,6 +21,11 @@ case "$(basename "$0")" in
         image_type=qemu
         image_suffix=-secex
         ;;
+    "cmd-buildextend-qemu-secex")
+        secure_execution=1
+        image_type=qemu
+        image_suffix=-secex
+        ;;
     *) fatal "called as unexpected name $0";;
 esac
 

--- a/src/cmd-buildextend-qemu-secex
+++ b/src/cmd-buildextend-qemu-secex
@@ -1,0 +1,1 @@
+./cmd-buildextend-metal


### PR DESCRIPTION
`qemu-secex` is the artifact name used in meta.json and elsewhere so let's support calling it that way like we do for other artifacts.

The `cmd-buildextend-secex` symlink is left in place for backwards compatibilty.

(cherry picked from commit 85931e4abf2ce0000ef09c57b73f30d6e9598d9b)