### PR TITLE
cmdlib: only do overlayfs check in privileged path

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -157,8 +157,8 @@ prepare_build() {
         fatal "No ${workdir}/builds found; did you run coreos-assembler init?"
     fi
 
-    if [ "$(stat -f --printf="%T" .)" = "overlayfs" ] && [ -z "${COSA_SKIP_OVERLAY:-}" ]; then
-        fatal "${workdir} must be a volume"
+    if has_privileges && [ "$(stat -f --printf="%T" .)" = "overlayfs" ] && [ -z "${COSA_SKIP_OVERLAY:-}" ]; then
+        fatal "${workdir} must be a volume when privileged"
     fi
 
     if test '!' -w "${workdir}"; then


### PR DESCRIPTION
It's only in the privileged path where we're composing directly to the filesystem that we care about whether we're on overlayfs or not. In the unprivileged path, the compose happens on a real filesystem on the cache qcow2 within supermin, so there's no need to restrict what filesystem the workdir itself on the outside is sitting on.