### PR TITLE
tests: update podman.workflow and remove fcos.internet

### DIFF
--- a/mantle/kola/tests/coretest/core.go
+++ b/mantle/kola/tests/coretest/core.go
@@ -16,7 +16,6 @@ import (
 	"github.com/coreos/coreos-assembler/mantle/kola/register"
 	"github.com/coreos/coreos-assembler/mantle/platform"
 	"github.com/coreos/coreos-assembler/mantle/platform/machine/qemu"
-	"github.com/coreos/coreos-assembler/mantle/util"
 )
 
 const (
@@ -91,21 +90,6 @@ func init() {
 		// only work on x86_64 and aarch64.
 		Architectures: []string{"x86_64", "aarch64"},
 	})
-	// TODO: Enable DockerPing/DockerEcho once fixed
-	// TODO: Only enable PodmanPing on non qemu. Needs:
-	// https://github.com/coreos/mantle/issues/1132
-	register.RegisterTest(&register.Test{
-		Name:        "fcos.internet",
-		Description: "Verify that podman echo and get head work.",
-		Run:         InternetTests,
-		ClusterSize: 1,
-		Tags:        []string{kola.NeedsInternetTag},
-		NativeFuncs: map[string]register.NativeFuncWrap{
-			"PodmanEcho":     register.CreateNativeFuncWrap(TestPodmanEcho),
-			"PodmanWgetHead": register.CreateNativeFuncWrap(TestPodmanWgetHead),
-		},
-		Distros: []string{"fcos"},
-	})
 	register.RegisterTest(&register.Test{
 		Name:        "rootfs.uuid",
 		Description: "Verify that the root disk's GUID was set to a random one on first boot.",
@@ -177,31 +161,6 @@ func TestPortSsh() error {
 		return err
 	}
 	return nil
-}
-
-func TestDockerEcho() error {
-	//t.Parallel()
-	return util.RunCmdTimeout(DockerTimeout, "docker", "run", "busybox", "echo")
-}
-
-func TestDockerPing() error {
-	//t.Parallel()
-	return util.RunCmdTimeout(DockerTimeout, "docker", "run", "busybox", "ping", "-c4", "coreos.com")
-}
-
-func TestPodmanEcho() error {
-	//t.Parallel()
-	return util.RunCmdTimeout(DockerTimeout, "podman", "run", "busybox", "echo")
-}
-
-func TestPodmanPing() error {
-	//t.Parallel()
-	return util.RunCmdTimeout(DockerTimeout, "podman", "run", "busybox", "ping", "-c4", "coreos.com")
-}
-
-func TestPodmanWgetHead() error {
-	//t.Parallel()
-	return util.RunCmdTimeout(DockerTimeout, "podman", "run", "busybox", "wget", "--spider", "http://fedoraproject.org/static/hotspot.txt")
 }
 
 // This execs gdbus, because we need to change uses to test perms.

--- a/mantle/kola/tests/podman/podman.go
+++ b/mantle/kola/tests/podman/podman.go
@@ -129,8 +129,8 @@ func podmanWorkflow(c cluster.TestCluster) {
 	m := c.Machines()[0]
 
 	// Test: Verify container can run with volume mount and port forwarding
-	image := "docker.io/library/nginx"
-	wwwRoot := "/usr/share/nginx/html"
+	image := "quay.io/fedora/fedora"
+	wwwRoot := "/var/html"
 	var id string
 
 	c.Run("run", func(c cluster.TestCluster) {
@@ -138,7 +138,8 @@ func podmanWorkflow(c cluster.TestCluster) {
 		cmd := fmt.Sprintf("echo TEST PAGE > %s/index.html", string(dir))
 		c.RunCmdSync(m, cmd)
 
-		cmd = fmt.Sprintf("sudo podman run -d -p 80:80 -v %s/index.html:%s/index.html:z %s", string(dir), wwwRoot, image)
+		webServerCmd := fmt.Sprintf("sh -c 'dnf install -y python3 && python3 -m http.server -d %s 80'", wwwRoot)
+		cmd = fmt.Sprintf("sudo podman run -d -p 80:80 -v %s/index.html:%s/index.html:z %s %s", string(dir), wwwRoot, image, webServerCmd)
 		out := c.MustSSH(m, cmd)
 		id = string(out)[0:64]
 


### PR DESCRIPTION
These two tests have been denylisted in FCOS for quite some time due to rate limiting issues with the containers they are pulling.
For `podman.workflow`: use the `quay.io/fedora/fedora` container and a Python HTTP server instead of the nginx container.
For `fcos.internet`: remove it altogether as there are other tests within FCOS that test this functionality.

See: https://issues.redhat.com/browse/COS-2094