### PR TITLE
bump cache qcow size; skip compression on manifest.json

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -571,9 +571,10 @@ cat > tmp/images.json <<EOF
         "skip-compression": true
     },
     "oci-manifest": {
-      "path": "${ostree_oci_manifest_path}",
-      "sha256": "${ostree_oci_manifest_sha256}",
-      "size": ${ostree_oci_manifest_size}
+        "path": "${ostree_oci_manifest_path}",
+        "sha256": "${ostree_oci_manifest_sha256}",
+        "size": ${ostree_oci_manifest_size},
+        "skip-compression": true
     }
   }
 }

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -602,7 +602,7 @@ runcompose_extensions() {
 # the cache disk. `runvm_with_cache_snapshot on` will set snapshotting to on.
 runvm_with_cache_snapshot() {
     local snapshot=$1; shift
-    local cache_size=${RUNVM_CACHE_SIZE:-20G}
+    local cache_size=${RUNVM_CACHE_SIZE:-30G}
     # "cache2" has an explicit label so we can find it in qemu easily
     if [ ! -f "${workdir}"/cache/cache2.qcow2 ]; then
         qemu-img create -f qcow2 cache2.qcow2.tmp "$cache_size"


### PR DESCRIPTION
- cmdlib: bump cache size to 30G
- cmd-build: skip-compression on manifest json