### PR TITLE
cmd-osbuild: fix format for disk image passed to qemu

### DIFF
--- a/src/cmd-osbuild
+++ b/src/cmd-osbuild
@@ -84,7 +84,7 @@ postprocess_qemu_secex() {
    # Basic qemu args:
    qemu_args=(); blk_size="512"
    [[ $platform == metal4k ]] && blk_size="4096"
-   qemu_args+=("-drive" "if=none,id=target,format=qcow,file=${imgpath},cache=unsafe" \
+   qemu_args+=("-drive" "if=none,id=target,format=qcow2,file=${imgpath},cache=unsafe" \
     "-device" "virtio-blk,serial=target,drive=target,physical_block_size=${blk_size},logical_block_size=${blk_size}")
 
    # SecureVM (holding Universal Key for all IBM Z Mainframes) requires scripts to execute genprotimg


### PR DESCRIPTION
Should have been qcow2 and not qcow.

Fixes 5509a8b