### PR TITLE
tests/crio: don't try to write to `/tmp`

### DIFF
--- a/mantle/kola/tests/crio/crio.go
+++ b/mantle/kola/tests/crio/crio.go
@@ -174,12 +174,6 @@ var enableCrioIgn = conf.Ignition(`{
   "ignition": {
     "version": "3.0.0"
   },
-  "storage": {
-	"directories": [{
-		"path": "/tmp/test",
-		"mode": 511
-	}]
-  },
   "systemd": {
     "units": [
       {


### PR DESCRIPTION
It's not really useful to write to `/tmp` from Ignition because a tmpfs gets mounted on top anyway in the real root which will mask all this. So this bit of the cri-o test's Ignition config actually had no effect. Just remove it.

Also note that when composefs lands in RHCOS, this would have become a hard error because `/tmp` would be read-only before switchroot.