### PR TITLE
cmd-cloud-prune: Refactor the code and rename the script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ schema-check:
 	# Is the generated Go code synced with the schema?
 	grep -q "$(DIGEST)" pkg/builds/cosa_v1.go
 	grep -q "$(DIGEST)" pkg/builds/schema_doc.go
-	grep -q "$(DIGEST)" src/cmd-cloud-prune
+	grep -q "$(DIGEST)" src/cmd-coreos-prune
 
 install:
 	install -d $(DESTDIR)$(PREFIX)/lib/coreos-assembler

--- a/cmd/coreos-assembler.go
+++ b/cmd/coreos-assembler.go
@@ -16,7 +16,7 @@ var buildCommands = []string{"init", "fetch", "build", "osbuild", "run", "prune"
 var advancedBuildCommands = []string{"buildfetch", "buildupload", "oc-adm-release", "push-container"}
 var buildextendCommands = []string{"aliyun", "applehv", "aws", "azure", "digitalocean", "exoscale", "extensions-container", "gcp", "hyperv", "ibmcloud", "kubevirt", "live", "metal", "metal4k", "nutanix", "openstack", "qemu", "secex", "virtualbox", "vmware", "vultr"}
 
-var utilityCommands = []string{"aws-replicate", "cloud-prune", "compress", "copy-container", "koji-upload", "kola", "push-container-manifest", "remote-build-container", "remote-session", "sign", "tag", "update-variant"}
+var utilityCommands = []string{"aws-replicate", "coreos-prune", "compress", "copy-container", "koji-upload", "kola", "push-container-manifest", "remote-build-container", "remote-session", "sign", "tag", "update-variant"}
 var otherCommands = []string{"shell", "meta"}
 
 func init() {

--- a/docs/cosa.md
+++ b/docs/cosa.md
@@ -65,7 +65,7 @@ Those less commonly used commands are listed here:
 | [oc-adm-release](https://github.com/coreos/coreos-assembler/blob/main/src/cmd-oc-adm-release) | Publish an oscontainer as the machine-os-content in an OpenShift release series
 | [offline-update](https://github.com/coreos/coreos-assembler/blob/main/src/cmd-offline-update) | Given a disk image and a coreos-assembler build, use supermin to update the disk image to the target OSTree commit "offline"
 | [prune](https://github.com/coreos/coreos-assembler/blob/main/src/cmd-prune) | This script removes previous builds. DO NOT USE on production pipelines
-| [cloud-prune](https://github.com/coreos/coreos-assembler/blob/main/src/cmd-cloud-prune) | Prune resources as sepcified in policy.yaml
+| [coreos-prune](https://github.com/coreos/coreos-assembler/blob/main/src/cmd-coreos-prune) | Prune resources as sepcified in policy.yaml
 | [sign](https://github.com/coreos/coreos-assembler/blob/main/src/cmd-sign) | Implements signing with RoboSignatory via fedora-messaging
 | [supermin-shell](https://github.com/coreos/coreos-assembler/blob/main/src/cmd-supermin-shell) | Get a supermin shell
 | [tag](https://github.com/coreos/coreos-assembler/blob/main/src/cmd-tag) | Operate on the tags in `builds.json`

--- a/src/cmd-cloud-prune
+++ b/src/cmd-cloud-prune
@@ -49,7 +49,7 @@ from cosalib.gcp import remove_gcp_image
 from cosalib.aws import deregister_aws_resource
 from cosalib.builds import BUILDFILES
 from cosalib.s3 import s3_copy
-from cosalib.cmdlib import parse_fcos_version_to_timestamp_and_stream
+from cosalib.cmdlib import parse_fcos_version_to_timestamp
 from cosalib.cmdlib import convert_duration_to_days
 
 Build = collections.namedtuple("Build", ["id", "images", "arch", "meta_json"])
@@ -61,8 +61,6 @@ CACHE_MAX_AGE_METADATA = 60 * 5
 # is up to date.
 SUPPORTED = ["amis", "gcp"]
 UNSUPPORTED = ["aliyun", "azure", "ibmcloud", "powervs"]
-# list of known streams with containers
-STREAMS = {"next", "testing", "stable", "next-devel", "testing-devel", "rawhide", "branched"}
 
 
 def parse_args():
@@ -126,7 +124,7 @@ def main():
     # Iterate through builds from oldest to newest
     for build in reversed(builds):
         build_id = build["id"]
-        build_date, _ = parse_fcos_version_to_timestamp_and_stream(build_id)
+        build_date = parse_fcos_version_to_timestamp(build_id)
 
         # For each build, iterate over arches first to minimize downloads of meta.json per arch
         for arch in build["arches"]:

--- a/src/cmd-coreos-prune
+++ b/src/cmd-coreos-prune
@@ -64,7 +64,7 @@ UNSUPPORTED = ["aliyun", "azure", "ibmcloud", "powervs"]
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(prog="coreos-assembler cloud-prune")
+    parser = argparse.ArgumentParser(prog="coreos-assembler coreos-prune")
     parser.add_argument("--policy", required=True, type=str, help="Path to policy YAML file")
     parser.add_argument("--dry-run", help="Don't actually delete anything", action='store_true')
     parser.add_argument("--upload-builds-json", help="Push builds.json", action='store_true')

--- a/src/cosalib/cmdlib.py
+++ b/src/cosalib/cmdlib.py
@@ -339,7 +339,7 @@ def get_basearch():
         return get_basearch.saved
 
 
-def parse_fcos_version_to_timestamp_and_stream(version):
+def parse_fcos_version_to_timestamp(version):
     '''
     Parses an FCOS build ID and verifies the versioning is accurate. Then
     it verifies that the parsed timestamp has %Y%m%d format and returns that.
@@ -351,7 +351,7 @@ def parse_fcos_version_to_timestamp_and_stream(version):
         timestamp = datetime.datetime.strptime(m.group(2), '%Y%m%d')
     except ValueError:
         raise Exception(f"FCOS build {version} has incorrect date format. It should be in (%Y%m%d)")
-    return (timestamp, m.group(3))
+    return timestamp
 
 
 def convert_duration_to_days(duration_arg):


### PR DESCRIPTION
Refactor build parsing logic and remove unused variables. Rename `cmd-cloud-prune` to `cmd-coreos-prune` since it doesn't limit the garbage collection to just cloud resources but all other resources as well.