### PR TITLE
cmd-generate-release-meta: allow missing `base-oscontainer`

### DIFF
--- a/src/cmd-generate-release-meta
+++ b/src/cmd-generate-release-meta
@@ -143,9 +143,11 @@ def append_build(out, input_):
     arch_dict = {"media": {}}
     ensure_dup(input_, arch_dict, "ostree-commit", "commit")
 
-    # we always expect base-oscontainer so error out if missing
-    assert 'base-oscontainer' in input_
-    arch_dict['oci-image'] = populate_oci_image(input_['buildid'], input_['base-oscontainer'])
+    # within the CoreOS pipelines, we always expect base-oscontainer to be set,
+    # but this script is also currently used by OKD but they only care about
+    # bootimages
+    if 'base-oscontainer' in input_:
+        arch_dict['oci-image'] = populate_oci_image(input_['buildid'], input_['base-oscontainer'])
 
     platforms = ["aliyun", "applehv", "aws", "azure", "azurestack", "digitalocean", "exoscale", "gcp", "hyperv", "ibmcloud", "kubevirt", "metal", "nutanix", "openstack", "powervs", "qemu", "virtualbox", "vmware", "vultr", "qemu-secex"]
     for platform in platforms:


### PR DESCRIPTION
Commit 21802b618 ("cmd-generate-release-meta: inject `oci-image` key in release metadata") broke the OKD pipeline which builds the OCI image, but doesn't push it using cosa.

Down the line, this should resolve itself by having OKD and OCP's node image being built the same way as layered images.

But for now let's relax the check here and just inject the OCI image information if it's available.