### PR TITLE
cmd-coreos-prune: Ensure action completion of each build

### DIFF
--- a/src/cmd-coreos-prune
+++ b/src/cmd-coreos-prune
@@ -125,6 +125,7 @@ def main():
     for build in reversed(builds):
         build_id = build["id"]
         build_date = parse_fcos_version_to_timestamp(build_id)
+        actions_completed = []
 
         # For each build, iterate over arches first to minimize downloads of meta.json per arch
         for arch in build["arches"]:
@@ -188,20 +189,14 @@ def main():
                                         prune_container(tag, args.dry_run, container_repo, args.registry_auth_file)
                                 else:
                                     print(f"No container tags to prune for build {build_id}.")
-        # Update policy-cleanup after pruning actions for the architecture
+                    actions_completed.append(action)  # Append action to completed list
+        # Update policy-cleanup for completed actions
         policy_cleanup = build.setdefault("policy-cleanup", {})
-        for action in policy[stream].keys():  # Only update actions specified in policy[stream]
-            match action:
-                case "cloud-uploads":
-                    if "cloud-uploads" not in policy_cleanup:
-                        policy_cleanup["cloud-uploads"] = True
-                case "images":
-                    if "images" not in policy_cleanup:
-                        policy_cleanup["images"] = True
-                    policy_cleanup["images-kept"] = images_to_keep
-                case "containers":
-                    if "containers" not in policy_cleanup:
-                        policy_cleanup["containers"] = True
+        for action in actions_completed:
+            if action == "images":
+                policy_cleanup["images-kept"] = images_to_keep
+            else:
+                policy_cleanup[action] = True
 
     if pruned_build_ids:
         if "tombstone-builds" not in builds_json_data:


### PR DESCRIPTION
Refactor policy-cleanup updates to ensure action completion across all arches. Modified to track completed actions
per arch. This bug came after we refactored the code to to iterate by build, arch, then action.

With the current code, it tries to update the builds.json for every build in the stream having the respective action in `gc-policy.yaml` not taking into consideration the datetime for eg. if the script will prune all containers that are 2weeks ago, the script will try to update every build in that stream with `"containers": true` no matter if the pruning ran on that build or not.