### PR TITLE
Only check for default manifest.yaml/image.yaml if used

### DIFF
--- a/src/cmd-init
+++ b/src/cmd-init
@@ -179,10 +179,6 @@ mkdir -p src
 # Default paths for manifest.yaml & image.yaml
 manifest="src/config/manifest.yaml"
 image="src/config/image.yaml"
-if [[ ! -f "${manifest}" ]] || [[ ! -f "${image}" ]]; then
-    echo 1>&2 "Could not find default manifests (${manifest} & ${image})"
-    fatal "If you are using a custom configuration, be sure it has a manifest.yaml & image.yaml."
-fi
 
 # Select the variant if requested
 if [[ -n "${VARIANT}" ]] && [[ "${VARIANT}" != "default" ]]; then
@@ -197,6 +193,9 @@ if [[ -n "${VARIANT}" ]] && [[ "${VARIANT}" != "default" ]]; then
   "coreos-assembler.config-variant": "${VARIANT}"
 }
 EOF
+elif [[ ! -f "${manifest}" ]] || [[ ! -f "${image}" ]]; then
+    echo 1>&2 "Could not find default manifests (${manifest} & ${image})"
+    fatal "If you are using a custom configuration, be sure it has a manifest.yaml & image.yaml."
 fi
 
 mkdir -p cache


### PR DESCRIPTION
The default manifest.yaml and image.yaml were checked to confirm they exist before it was even known whether they were the right files to use or not.  Move the check to occur after we know we're not using a VARIANT that points to different files.

----

This is a minor fix, but it allows custom OS users to conditionally generate `manifest{,-$variant}.yaml` and/or `image{,-$variant}.yaml` files.  As it is right now, the default `manifest.yaml` and `image.yaml` must always exist, even if they're never going to be use by the build (i.e. `VARIANT` was set with the `--variant` option).