### PR TITLE
mantle/podman.go: bump retry delay in podmanWorkflow test

### DIFF
--- a/mantle/kola/tests/podman/podman.go
+++ b/mantle/kola/tests/podman/podman.go
@@ -149,12 +149,12 @@ func podmanWorkflow(c cluster.TestCluster) {
 				return err
 			}
 			if !bytes.Contains(b, []byte("TEST PAGE")) {
-				return fmt.Errorf("nginx pod is not running %s", b)
+				return fmt.Errorf("Fedora container is not running %s", b)
 			}
 			return nil
 		}
 
-		if err := util.Retry(6, 5*time.Second, podIsRunning); err != nil {
+		if err := util.Retry(6, 10*time.Second, podIsRunning); err != nil {
 			c.Fatal("Pod is not running")
 		}
 	})


### PR DESCRIPTION
Bump the retry delay to `10*time.Seconds` which doubles the previous delay to allow for enough time to report success.
Update the container name in an error statement from nginx to Fedora which should have been done in https://github.com/coreos/coreos-assembler/pull/3939

fixes: https://github.com/coreos/fedora-coreos-tracker/issues/1835