### PR TITLE
Expose optional `COSA_SUPERMIN_SIZE`  to set rootfs image partition size

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -770,8 +770,10 @@ umount ${workdir}
 EOF
     chmod a+x "${vmpreparedir}"/init
     (cd "${vmpreparedir}" && tar -czf init.tar.gz --remove-files init)
+
+    size_default=10G
     # put the supermin output in a separate file since it's noisy
-    if ! supermin --build "${vmpreparedir}" --size 10G -f ext2 -o "${vmbuilddir}" \
+    if ! supermin --build "${vmpreparedir}" --size "${COSA_SUPERMIN_SIZE:-${size_default}}" -f ext2 -o "${vmbuilddir}" \
             &> "${tmp_builddir}/supermin.out"; then
         cat "${tmp_builddir}/supermin.out"
         fatal "Failed to run: supermin --build"


### PR DESCRIPTION
When 'supermin --build ...' generates the rootfs, kernel, and initrd, it's passed a size to use for the rootfs.  That sets the upper bound on the ostree that can be added to the rootfs of the images cosa generates.  It was hardcoded to 10G, which is a reasonable starting point, but different use conditions can easily exceed that. For now, follow the COSA_SUPERMIN_MEMORY example and expose an optional COSA_SUPERMIN_SIZE environment variable that allows a caller to override the rootfs size in case they need the rootfs to be bigger or smaller than the default 10G.

/close #3955 

----

There's already a `COSA_SUPERMIN_MEMORY` environment variable that's used to optionally configure how much RAM is allocated to the `kola qemuexec` call when it generates the actual qcow2 disk image file from the supermin kernel, initrd, and rootfs.

At some point in the future we could consider expanding the change here to either be specified via the `image.yaml` file, or (even better) calculate the size of the ostree we're going to put into the rootfs and use that to decide what size to make the rootfs.