### PR TITLE
Dockerfile: don't delete /go

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN ./build.sh patch_osbuild
 # clean up scripts (it will get cached in layers, but oh well)
 WORKDIR /srv/
 RUN chown builder: /srv
-RUN rm -rf /root/containerbuild /go
+RUN rm -rf /root/containerbuild
 
 # allow writing to /etc/passwd from arbitrary UID
 # https://docs.openshift.com/container-platform/4.8/openshift_images/create-images.html


### PR DESCRIPTION
We're creating `/go` and then deleting it later on, which doesn't make sense. Stop deleting it to fix the use case of Prow using the cosa image as a buildroot.