### PR TITLE
runvm-osbuild: checkpoint deployed-tree pipeline

### DIFF
--- a/src/runvm-osbuild
+++ b/src/runvm-osbuild
@@ -117,7 +117,7 @@ osbuild \
     --out "$outdir"              \
     --store "$storedir"          \
     --cache-max-size 14GiB       \
-    --checkpoint build           \
+    --checkpoint deployed-tree   \
     --checkpoint tree            \
     --checkpoint raw-image       \
     ${platforms[@]/#/--export=}  \


### PR DESCRIPTION
The `build` pipeline was renamed to `deployed-tree` in 3a91ec2 and this should have been updated in that commit as well.