### PR TITLE
cmdlib: also chown back `compose.json` in privileged path

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -566,6 +566,7 @@ runcompose_tree() {
         # with a consistent value, regardless of the environment
         (umask 0022 && sudo -E "$@")
         sudo chown -R -h "${USER}":"${USER}" "${tmprepo}"
+        sudo chown "${USER}":"${USER}" "${composejson}"
     else
         runvm_with_cache -- "$@" --repo "${repo}" --write-composejson-to "${composejson}"
     fi


### PR DESCRIPTION
Match what we do for the repo and chown back `compose.json` to the build user. This should fix `cosa build --force-image`.