### PR TITLE
cmdlib.sh: only chown `compose.json` if it exists

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -566,7 +566,9 @@ runcompose_tree() {
         # with a consistent value, regardless of the environment
         (umask 0022 && sudo -E "$@")
         sudo chown -R -h "${USER}":"${USER}" "${tmprepo}"
-        sudo chown "${USER}":"${USER}" "${composejson}"
+        if [ -f "${composejson}" ]; then
+            sudo chown "${USER}":"${USER}" "${composejson}"
+        fi
     else
         runvm_with_cache -- "$@" --repo "${repo}" --write-composejson-to "${composejson}"
     fi


### PR DESCRIPTION
It only gets actually written in `cosa build`, so we need to handle the `cosa fetch` case where this path is also taken.

Fixes 40a2027e8 ("cmdlib: also chown back `compose.json` in privileged path").