### PR TITLE
Fix --skip-config-archive.

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -633,7 +633,10 @@ loose_objs=()
 loose_objs+=("commitmeta.json" "ostree-commit-object")
 loose_objs+=("manifest-lock.generated.$basearch.json")
 # source metadata
-loose_objs+=("coreos-assembler-config-git.json" "coreos-assembler-config.tar.gz")
+loose_objs+=("coreos-assembler-config-git.json")
+if [ "${CONFIG_ARCHIVE}"  != 0 ]; then
+    loose_objs+=("coreos-assembler-config.tar.gz")
+fi
 mv -vt "${builddir}" "${loose_objs[@]}"
 # official more public artifacts; tracked by meta.json
 jq -r .images[].path meta.json | xargs mv -vt "${builddir}"


### PR DESCRIPTION
The `--skip-config-archive` skips creating the tar.gz of the src/config. However the changes to how files are collected failed to check this before hardcoding that the output file should be collected.

----

Looks like when the rework happened to use `loose_objs`, it missed the fact that the config archive may or may not exist.  If the `--skip-config-archive` is used, the build currently fails during the collection step.

/close #3972 