### PR TITLE
build-deps.txt: add shellcheck

### DIFF
--- a/src/build-deps.txt
+++ b/src/build-deps.txt
@@ -2,6 +2,8 @@
 time
 # Used by mantle
 golang
+# Used for syntax validation of manifests
+shellcheck
 # Use tmux for developer multi-arch builder access UX 
 #https://github.com/coreos/fedora-coreos-pipeline/issues/803
 tmux


### PR DESCRIPTION
CI was updated[0] to use coreos-assembler as a buildroot instead of the fcos-buildroot container and the openshift/os `validate` job[1] fails because shellcheck isn't installed in coreos-assembler. It cannot be installed using `sudo` when running on OpenShift so it needs to be installed directly in coreos-assembler.

[0] https://github.com/openshift/release/pull/59000/commits/68a7999da3e4fc98603b33b95cb83917b35e62d5
[1] https://github.com/openshift/os/blob/ce4da959eb3fc9477a0a96b69e6efd084a69b9ac/ci/prow-entrypoint.sh#L162