### PR TITLE
empty out deps-ppc64le.txt

### DIFF
--- a/src/deps-ppc64le.txt
+++ b/src/deps-ppc64le.txt
@@ -1,1 +1,0 @@
-# this file needs to exist even if empty


### PR DESCRIPTION
It was emptied out and just a comment left in dc22a02 but the way src/print-dependencies.sh works it fails if the grep to remove comments yields nothing. Let's just empty the file for now so the `if -s` check won't succeed.