### PR TITLE
cmdlib.sh: fix repoquery when building overrides lockfile

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -450,7 +450,7 @@ EOF
         # the same RPMs: the `dnf repoquery` below is to pick the latest one
         dnf repoquery  --repofrompath=tmp,"file://${overridesdir}/rpm" \
             --disablerepo '*' --enablerepo tmp --refresh --latest-limit 1 \
-            --exclude '*.src' --qf '%{name}\t%{evr}\t%{arch}' \
+            --exclude '*.src' --qf 'pkg: %{name} %{evr} %{arch}\n' \
             --quiet > "${tmp_overridesdir}/pkgs.txt"
 
         # shellcheck disable=SC2002
@@ -458,7 +458,9 @@ EOF
 import sys, json
 lockfile = {"packages": {}}
 for line in sys.stdin:
-    name, evr, arch = line.strip().split("\t")
+    if not line.startswith("pkg: "):
+        continue
+    _, name, evr, arch = line.strip().split()
     lockfile["packages"][name] = {"evra": f"{evr}.{arch}"}
 json.dump(lockfile, sys.stdout)' > "${local_overrides_lockfile}"
 


### PR DESCRIPTION
Fallout from the move to f41 and dnf5.

A few issues: first, looks like Looks like dnf5 repoquery's `--qf` acts
differently. Not only it no longer implicitly emits a newline, but also
it doesn't interpret `\t` anymore. This is tracked at:

rpm-software-management/dnf5#709

Second, `--quiet` is broken and still includes output from progress bar:

rpm-software-management/dnf5#1915

Work around this by using spaces instead of `\t`, adding `\n`, and
prefixing pkg entries with `pkg:`.