### PR TITLE
test containers: add systemd to tang image

### DIFF
--- a/tests/containers/tang/Containerfile
+++ b/tests/containers/tang/Containerfile
@@ -1,6 +1,6 @@
 FROM registry.fedoraproject.org/fedora-minimal:41
 
-RUN dnf -y install tang && dnf clean all && rm -rf /var/cache/yum
+RUN dnf -y install systemd tang && dnf clean all && rm -rf /var/cache/yum
 EXPOSE 80
 
 RUN systemctl enable tangd.socket


### PR DESCRIPTION
In the F41 fedora-minimal image, systemctl stopped working. We need to enable tang.service in the container so we need systemd in the container.

Adding systemd in the container.