### PR TITLE
Fix sudo usage in cmd-*

### DIFF
--- a/src/cmd-fetch
+++ b/src/cmd-fetch
@@ -8,12 +8,12 @@ dn=$(dirname "$0")
 FILE=cache/pkgcache-repo
 if [ -d "${FILE}" ]
 then
-        pkgcachesize=$(sudo du --bytes --max-depth 0 "${FILE}" \
+        pkgcachesize=$(${SUDO} du --bytes --max-depth 0 "${FILE}" \
                        | awk '{print $1; exit}')
         pkglimit=$((1024 * 1024 * 1024 * 5))
         if [[ "${pkgcachesize}" -gt "${pkglimit}" ]]
         then
-                sudo cosa prune --pkgcache
+                ${SUDO} cosa prune --pkgcache
         fi
 fi
 

--- a/src/cmd-init
+++ b/src/cmd-init
@@ -147,7 +147,7 @@ source=$1; shift
 preflight
 
 if has_privileges; then
-    sudo chown "$USER:" .
+    ${SUDO} chown "$USER:" .
 elif [ ! -w . ]; then
     fatal "init: running unprivileged, and current directory not writable"
 fi


### PR DESCRIPTION
Sudo is being used directly all over the place, which doesn't work if the user is already root (something the `has_privileges` function checks for and supports). Add a `SUDO` and `SUDO_W_ENV` variable that evaluates to the equivalent `sudo` command when not root, but is blank when running as root.  
Also add a `sudo` (overlapping) and `sudo_w_env` alias that map to a `fake-root` function defined to just run the arguments passed without any actual sudo call. This makes sure any other tools called from the cmd-* shell scripts (like python scripts) won't call real sudo with their hardcoded commands when running as root.