### PR TITLE
cmdlib: Support old FCOS version in parsing

### DIFF
--- a/src/cosalib/cmdlib.py
+++ b/src/cosalib/cmdlib.py
@@ -343,8 +343,9 @@ def parse_fcos_version_to_timestamp(version):
     '''
     Parses an FCOS build ID and verifies the versioning is accurate. Then
     it verifies that the parsed timestamp has %Y%m%d format and returns that.
+    Also, parses older format for versions, for eg. 30.20190712.0
     '''
-    m = re.match(r'^([0-9]{2})\.([0-9]{8})\.([0-9]+|dev)\.([0-9]+)$', version)
+    m = re.match(r'^([0-9]{2})\.([0-9]{8})\.([0-9]+|dev)(?:\.([0-9]+))?$', version)
     if m is None:
         raise Exception(f"Incorrect versioning for FCOS build {version}")
     try:


### PR DESCRIPTION
Ensure compatibility with older and newer versions. We have a few builds in `testing` stream with a different format. An example is `30.20190712.0`