### PR TITLE
cmd-diff: support passing in the architecture

### DIFF
--- a/src/cmd-diff
+++ b/src/cmd-diff
@@ -22,9 +22,9 @@ class DiffBuildTarget:
     meta: dict
 
     @staticmethod
-    def from_build(builds, build):
-        return DiffBuildTarget(build, builds.get_build_dir(build),
-                               builds.get_build_meta(build))
+    def from_build(builds, build, arch):
+        return DiffBuildTarget(build, builds.get_build_dir(build, arch),
+                               builds.get_build_meta(build, arch))
 
 
 @dataclass
@@ -66,8 +66,8 @@ def main():
     if args.diff_from == args.diff_to:
         raise Exception("from and to builds are the same")
 
-    diff_from = DiffBuildTarget.from_build(builds, args.diff_from)
-    diff_to = DiffBuildTarget.from_build(builds, args.diff_to)
+    diff_from = DiffBuildTarget.from_build(builds, args.diff_from, args.arch)
+    diff_to = DiffBuildTarget.from_build(builds, args.diff_to, args.arch)
 
     # get activated differs
     active_differs = []
@@ -96,6 +96,8 @@ def parse_args():
     parser.add_argument("--from", dest='diff_from', help="First build ID")
     parser.add_argument("--to", dest='diff_to', help="Second build ID")
     parser.add_argument("--gc", action='store_true', help="Delete cached diff content")
+    parser.add_argument("--arch", dest='arch', help="Architecture of builds")
+
     for differ in DIFFERS:
         parser.add_argument("--" + differ.name, action='store_true', default=False,
                             help=differ.description)


### PR DESCRIPTION
This adds '--arch' argument to pass architecture you want to get information about. By default current arch is used.

```
$ uname -m
x86_64
$ cosa diff --arch=s390x --from=41.20250101.20.0 --to=41.20250114.20.0 --rpms
ostree diff commit from: c3fe29653cf0ebd1d093b1a55cf9ac79a386373e71f64c67769f904332ba0ca6
ostree diff commit to:   988aa49471f406354274bc013c1102004dad25000862df68472d6058fcb00f8b
Upgraded:
  audit 4.0.2-1.fc41 -> 4.0.3-1.fc41
  audit-libs 4.0.2-1.fc41 -> 4.0.3-1.fc41
  ...
```

Issue: https://github.com/coreos/coreos-assembler/issues/3987