### PR TITLE
[rhcos-4.18] build.sh: Fix coreos repo link

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -35,7 +35,7 @@ configure_yum_repos() {
     # Add continuous tag for latest build tools and mark as required so we
     # can depend on those latest tools being available in all container
     # builds.
-    echo -e "[f${version_id}-coreos-continuous]\nenabled=1\nmetadata_expire=1m\nbaseurl=https://kojipkgs.fedoraproject.org/repos-dist/f${version_id}-coreos-continuous/latest/\$basearch/\ngpgcheck=0\nskip_if_unavailable=False\n" > /etc/yum.repos.d/coreos.repo
+    echo -e "[f${version_id}-coreos-continuous]\nenabled=1\nmetadata_expire=1m\nbaseurl=https://kojipkgs.fedoraproject.org/repos-dist/f${version_id}-coreos-continuous/5333830/\$basearch/\ngpgcheck=0\nskip_if_unavailable=False\n" > /etc/yum.repos.d/coreos.repo
 }
 
 install_rpms() {

--- a/build.sh
+++ b/build.sh
@@ -162,28 +162,27 @@ write_archive_info() {
 }
 
 patch_osbuild() {
+    return # we have no patches right now
     # Add a few patches that either haven't made it into a release or
     # that will be obsoleted with other work that will be done soon.
 
     # To make it easier to apply patches we'll move around the osbuild
     # code on the system first:
-    rmdir /usr/lib/osbuild/osbuild
-    mv /usr/lib/python3.12/site-packages/osbuild /usr/lib/osbuild/
-    mkdir /usr/lib/osbuild/tools
-    mv /usr/bin/osbuild-mpp /usr/lib/osbuild/tools/
+    # rmdir /usr/lib/osbuild/osbuild
+    # mv /usr/lib/python3.12/site-packages/osbuild /usr/lib/osbuild/
+    # mkdir /usr/lib/osbuild/tools
+    # mv /usr/bin/osbuild-mpp /usr/lib/osbuild/tools/
 
     # Now all the software is under the /usr/lib/osbuild dir and we can patch
-    cat /usr/lib/coreos-assembler/0001-parsing-add-parse_location_into_parts.patch                \
-        /usr/lib/coreos-assembler/0002-parsing-treat-locations-without-scheme-as-belonging-.patch \
-        /usr/lib/coreos-assembler/0003-org.osbuild.selinux-support-operating-on-mounts.patch      \
-        /usr/lib/coreos-assembler/0004-org.osbuild.selinux-support-for-specifying-where-fil.patch \
-            | patch -d /usr/lib/osbuild -p1
+    #cat patch1.patch \
+    #    patch2.patch \
+    #        | patch -d /usr/lib/osbuild -p1
 
     # And then move the files back; supermin appliance creation will need it back
     # in the places delivered by the RPM.
-    mv /usr/lib/osbuild/tools/osbuild-mpp /usr/bin/osbuild-mpp
-    mv /usr/lib/osbuild/osbuild /usr/lib/python3.12/site-packages/osbuild
-    mkdir /usr/lib/osbuild/osbuild
+    # mv /usr/lib/osbuild/tools/osbuild-mpp /usr/bin/osbuild-mpp
+    # mv /usr/lib/osbuild/osbuild /usr/lib/python3.12/site-packages/osbuild
+    # mkdir /usr/lib/osbuild/osbuild
 }
 
 if [ $# -ne 0 ]; then


### PR DESCRIPTION
 - The latest repository is no longer available, likely due to an issue with the Koji repositories. As a workaround, this change forces the use of specific repository number to allow the cosa builds to work.