### PR TITLE
[rhcos-4.13] mantle/kola: change URLs for coreos.tls.fetch-urls test

### DIFF
--- a/mantle/kola/tests/misc/tls.go
+++ b/mantle/kola/tests/misc/tls.go
@@ -21,8 +21,9 @@ import (
 
 var (
 	urlsToFetch = []string{
-		"https://www.example.com/",
-		"https://www.wikipedia.org/",
+		"https://cloud.google.com",
+		"https://aws.amazon.com/",
+		"https://azure.microsoft.com",
 		"https://start.fedoraproject.org/",
 	}
 )


### PR DESCRIPTION
These were changed to other URLs when the test moved to an external test in https://github.com/coreos/fedora-coreos-config/commit/41901c7dc5e604e0ee27ffcf60f87b1b6d7a723b

Let's update the URLs for older releases too to simplify our allow rules for external domains.