### PR TITLE
GCP: Mark images as `TDX_CAPABLE`

### DIFF
--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -125,7 +125,7 @@ func init() {
 	sv(&kola.GCPOptions.ServiceAcct, "gcp-service-account", "", "GCP service account to attach to instance (default project default)")
 	bv(&kola.GCPOptions.ServiceAuth, "gcp-service-auth", false, "for non-interactive auth when running within GCP")
 	sv(&kola.GCPOptions.JSONKeyFile, "gcp-json-key", "", "use a service account's JSON key for authentication (default \"~/"+auth.GCPConfigPath+"\")")
-	sv(&kola.GCPOptions.ConfidentialType, "gcp-confidential-type", "", "create confidential instances: sev, sev_snp")
+	sv(&kola.GCPOptions.ConfidentialType, "gcp-confidential-type", "", "create confidential instances: sev, sev_snp, tdx")
 
 	// openstack-specific options
 	sv(&kola.OpenStackOptions.ConfigPath, "openstack-config-file", "", "Path to a clouds.yaml formatted OpenStack config file. The underlying library defaults to ./clouds.yaml")
@@ -250,7 +250,11 @@ func syncOptionsImpl(useCosa bool) error {
 			if kola.GCPOptions.ConfidentialType != "" {
 				// https://cloud.google.com/compute/confidential-vm/docs/locations
 				fmt.Printf("Setting instance type for confidential computing\n")
-				kola.GCPOptions.MachineType = "n2d-standard-2"
+				if kola.GCPOptions.ConfidentialType == "tdx" {
+					kola.GCPOptions.MachineType = "c3-standard-4"
+				} else {
+					kola.GCPOptions.MachineType = "n2d-standard-2"
+				}
 			} else {
 				kola.GCPOptions.MachineType = "n1-standard-1"
 			}

--- a/mantle/platform/api/gcloud/compute.go
+++ b/mantle/platform/api/gcloud/compute.go
@@ -150,7 +150,7 @@ func (a *API) mkinstance(userdata, name string, keys []*agent.Key, opts platform
 	if a.options.ConfidentialType != "" {
 		ConfidentialType := strings.ToUpper(a.options.ConfidentialType)
 		ConfidentialType = strings.Replace(ConfidentialType, "-", "_", -1)
-		if ConfidentialType == "SEV" || ConfidentialType == "SEV_SNP" {
+		if ConfidentialType == "SEV" || ConfidentialType == "SEV_SNP" || ConfidentialType == "TDX" {
 			fmt.Printf("Using confidential type for confidential computing %s\n", ConfidentialType)
 			instance.ConfidentialInstanceConfig = &compute.ConfidentialInstanceConfig{
 				ConfidentialInstanceType: ConfidentialType,
@@ -159,7 +159,7 @@ func (a *API) mkinstance(userdata, name string, keys []*agent.Key, opts platform
 				OnHostMaintenance: "TERMINATE",
 			}
 		} else {
-			return nil, fmt.Errorf("Does not support confidential type %s, should be: sev, sev_snp\n", a.options.ConfidentialType)
+			return nil, fmt.Errorf("Does not support confidential type %s, should be: sev, sev_snp, tdx\n", a.options.ConfidentialType)
 		}
 	}
 	// metal instances can only have a TERMINATE maintenance policy

--- a/mantle/platform/api/gcloud/image.go
+++ b/mantle/platform/api/gcloud/image.go
@@ -111,6 +111,10 @@ func (a *API) CreateImage(spec *ImageSpec, overwrite bool) (*compute.Operation, 
 		{
 			Type: "IDPF",
 		},
+		// https://cloud.google.com/blog/products/identity-security/confidential-vms-on-intel-cpus-your-datas-new-intelligent-defense
+		{
+			Type: "TDX_CAPABLE",
+		},
 	}
 
 	if spec.Architecture == "" {


### PR DESCRIPTION
I manually marked `rhcos-419-96-202501191959-0-gcp-x86-64` on GCP as `TDX_CAPABLE`, and booted a TDX confidential VM instance. Serial port sample:
```
[    0.000000] tdx: Guest detected
...
[    1.444597] process: using TDX aware idle routine
...
[    1.524482] Memory Encryption Features active: Intel TDX
...
[    3.661927] systemd[1]: Detected virtualization kvm.
[    3.661938] systemd[1]: Detected confidential virtualization tdx.
[    3.661942] systemd[1]: Detected architecture x86-64.
[    3.661945] systemd[1]: Running in initrd.
...
```

Previous work: https://github.com/coreos/coreos-assembler/pull/3547
Previous work: https://github.com/coreos/coreos-assembler/pull/3871
Fixes: https://github.com/coreos/fedora-coreos-tracker/issues/1814
Fixes: https://issues.redhat.com/browse/COS-3111