### PR TITLE
build.sh: stop fast-tracking rpm-ostree/ostree from updates-testing

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -62,10 +62,6 @@ install_rpms() {
     # Process our base dependencies + build dependencies and install
     (echo "${builddeps}" && echo "${frozendeps}" && "${srcdir}"/src/print-dependencies.sh) | xargs yum -y install
 
-    # Add fast-tracked packages here.  We don't want to wait on bodhi for rpm-ostree
-    # as we want to enable fast iteration there.
-    yum -y --enablerepo=updates-testing upgrade rpm-ostree ostree
-
     # Delete file that only exists on ppc64le because it is causing
     # sudo to not work.
     # https://bugzilla.redhat.com/show_bug.cgi?id=2082149


### PR DESCRIPTION
If we want to fast-track these packages we can tag them into the fXX-coreos-continous tags like any other package. Right now the version of rpm-ostree in `updates-testing` is busted and we don't want it in our builds.

[1] https://bodhi.fedoraproject.org/updates/FEDORA-2025-95492f42d2#comment-3932487