### PR TITLE
mantle/kola: use TimeoutStartSec for iscsi tests

### DIFF
--- a/mantle/cmd/kola/resources/iscsi_butane_setup.yaml
+++ b/mantle/cmd/kola/resources/iscsi_butane_setup.yaml
@@ -110,6 +110,8 @@ storage:
           # Start by default on boot
           WantedBy=multi-user.target
           [Service]
+          # Extend start time. COSA is a large image we are pulling from quay.
+          TimeoutStartSec=600
           # fix permissions on the serial device before passing it as a volume
           ExecStartPre=chmod 777 /dev/virtio-ports/testisocompletion
           # Pipe the logs to a virtio port so kola saves them


### PR DESCRIPTION
Pulling COSA from quay and running an install in a VM takes a good amount of time. Let's bump this so the service doesn't timeout like has been seen:

```
Jan 27 13:27:10 localhost systemd[1]: Starting Boot VM over iSCSI...
Jan 27 13:28:21 localhost chronyd[1116]: Can't synchronise: no selectable sources
Jan 27 13:28:21 localhost chronyd[1116]: Source 149.28.200.179 replaced with 67.217.246.204 (2.rhel.pool.ntp.org)
Jan 27 13:31:16 localhost systemd[1289]: Created slice User Background Tasks Slice.
Jan 27 13:31:16 localhost systemd[1289]: Starting Cleanup of User's Temporary Files and Directories...
Jan 27 13:31:16 localhost systemd[1289]: Finished Cleanup of User's Temporary Files and Directories.
Jan 27 13:31:26 localhost systemd[1]: coreos-iscsi-vm.service: start operation timed out. Terminating.
Jan 27 13:31:26 localhost systemd[1]: coreos-iscsi-vm.service: Main process exited, code=exited, status=1/FAILURE
Jan 27 13:31:26 localhost systemd[1]: coreos-iscsi-vm.service: Failed with result 'timeout'.
```