### PR TITLE
mantle/kola: use separate unit for pulling COSA in iscsi tests

### DIFF
--- a/mantle/cmd/kola/resources/iscsi_butane_setup.yaml
+++ b/mantle/cmd/kola/resources/iscsi_butane_setup.yaml
@@ -87,6 +87,16 @@ storage:
             -i /var/nested-ign.json
           # Unmount the disk
           iscsiadm --mode node --logoutall=all
+    # Use a separate unit to pull the image so it can be downloading
+    # in the background while the `coreos-installer install` is running.
+    - path: /etc/containers/systemd/coreos-assembler.image
+      contents:
+        inline: |
+          [Image]
+          Image=quay.io/coreos-assembler/coreos-assembler
+          [Service]
+          # Extend start time. COSA is a large image we are pulling from quay.
+          TimeoutStartSec=600
     - path: /etc/containers/systemd/coreos-iscsi-vm.container
       contents:
         inline: |
@@ -98,7 +108,7 @@ storage:
           OnFailure=emergency.target
           OnFailureJobMode=isolate
           [Container]
-          Image=quay.io/coreos-assembler/coreos-assembler
+          Image=coreos-assembler.image
           ContainerName=iscsiboot
           Volume=/var/boot.ipxe:/var/boot.ipxe
           Volume=/dev/virtio-ports/testisocompletion:/mnt/serial
@@ -110,8 +120,6 @@ storage:
           # Start by default on boot
           WantedBy=multi-user.target
           [Service]
-          # Extend start time. COSA is a large image we are pulling from quay.
-          TimeoutStartSec=600
           # fix permissions on the serial device before passing it as a volume
           ExecStartPre=chmod 777 /dev/virtio-ports/testisocompletion
           # Pipe the logs to a virtio port so kola saves them


### PR DESCRIPTION
We've seen errors in the RHCOS pipeline where the iSCSI tests are hitting the 10m timeout. We could bump the timeout, but first let's try pulling the COSA image in a separate unit so that it can happen in parallel with the install over iSCSI so that when we're ready to start the VM the image is already there.