### PR TITLE
[rhcos-4.16]: mantle/kola: make iscsi tests use virtiofs mounted COSA rootfs

### DIFF
--- a/mantle/cmd/kola/resources/iscsi_butane_setup.yaml
+++ b/mantle/cmd/kola/resources/iscsi_butane_setup.yaml
@@ -57,7 +57,7 @@ storage:
             # Will return 0 if the discovery yield a valid portal
             iscsiadm --mode discovery --type sendtargets --portal 127.0.0.1 | \
               grep iqn.2024-05.com.coreos
-    - path: /var/boot.ipxe
+    - path: /srv/boot.ipxe
       mode: 0644
       contents:
         inline: |
@@ -87,16 +87,6 @@ storage:
             -i /var/nested-ign.json
           # Unmount the disk
           iscsiadm --mode node --logoutall=all
-    # Use a separate unit to pull the image so it can be downloading
-    # in the background while the `coreos-installer install` is running.
-    - path: /etc/containers/systemd/coreos-assembler.image
-      contents:
-        inline: |
-          [Image]
-          Image=quay.io/coreos-assembler/coreos-assembler
-          [Service]
-          # Extend start time. COSA is a large image we are pulling from quay.
-          TimeoutStartSec=600
     - path: /etc/containers/systemd/coreos-iscsi-vm.container
       contents:
         inline: |
@@ -108,14 +98,23 @@ storage:
           OnFailure=emergency.target
           OnFailureJobMode=isolate
           [Container]
-          Image=coreos-assembler.image
           ContainerName=iscsiboot
-          Volume=/var/boot.ipxe:/var/boot.ipxe
-          Volume=/dev/virtio-ports/testisocompletion:/mnt/serial
+          # Use the read-only virtiofs shared rootfs from COSA. This
+          # saves us pulling 4+ GiB COSA container from quay.
+          # makes it so we don't have to pull down COSA from quay
+          Rootfs=/var/cosaroot
+          Volume=/srv/boot.ipxe:/srv/boot.ipxe
+          AddDevice=/dev/virtio-ports/testisocompletion:/dev/virtio-ports/testisocompletion
+          # Create a few writable directories from empty volumes. We
+          # must use named volumes for now so we can pass :nocopy.
+          # https://github.com/containers/podman/issues/25176
+          Volume=root:/root/:nocopy
+          Volume=vartmp:/var/tmp/:nocopy
+          WorkingDir=/root
           PodmanArgs=--privileged
           Network=host
           LogDriver=passthrough
-          Exec=shell -- kola qemuexec --netboot /var/boot.ipxe --usernet-addr 10.0.3.0/24 -- -device virtio-serial -chardev file,id=iscsi-completion-virtio,path=/mnt/serial,append=on -device virtserialport,chardev=iscsi-completion-virtio,name=testisocompletion
+          Exec=kola qemuexec --netboot /srv/boot.ipxe --qemu-swtpm=false --usernet-addr 10.0.3.0/24 -- -device virtio-serial -chardev file,id=iscsi-completion-virtio,path=/dev/virtio-ports/testisocompletion,append=on -device virtserialport,chardev=iscsi-completion-virtio,name=testisocompletion
           [Install]
           # Start by default on boot
           WantedBy=multi-user.target

--- a/mantle/cmd/kola/resources/iscsi_butane_setup.yaml
+++ b/mantle/cmd/kola/resources/iscsi_butane_setup.yaml
@@ -110,6 +110,8 @@ storage:
           # Start by default on boot
           WantedBy=multi-user.target
           [Service]
+          # Extend start time. COSA is a large image we are pulling from quay.
+          TimeoutStartSec=600
           # fix permissions on the serial device before passing it as a volume
           ExecStartPre=chmod 777 /dev/virtio-ports/testisocompletion
           # Pipe the logs to a virtio port so kola saves them

--- a/mantle/cmd/kola/resources/iscsi_butane_setup.yaml
+++ b/mantle/cmd/kola/resources/iscsi_butane_setup.yaml
@@ -87,6 +87,16 @@ storage:
             -i /var/nested-ign.json
           # Unmount the disk
           iscsiadm --mode node --logoutall=all
+    # Use a separate unit to pull the image so it can be downloading
+    # in the background while the `coreos-installer install` is running.
+    - path: /etc/containers/systemd/coreos-assembler.image
+      contents:
+        inline: |
+          [Image]
+          Image=quay.io/coreos-assembler/coreos-assembler
+          [Service]
+          # Extend start time. COSA is a large image we are pulling from quay.
+          TimeoutStartSec=600
     - path: /etc/containers/systemd/coreos-iscsi-vm.container
       contents:
         inline: |
@@ -98,7 +108,7 @@ storage:
           OnFailure=emergency.target
           OnFailureJobMode=isolate
           [Container]
-          Image=quay.io/coreos-assembler/coreos-assembler
+          Image=coreos-assembler.image
           ContainerName=iscsiboot
           Volume=/var/boot.ipxe:/var/boot.ipxe
           Volume=/dev/virtio-ports/testisocompletion:/mnt/serial
@@ -110,8 +120,6 @@ storage:
           # Start by default on boot
           WantedBy=multi-user.target
           [Service]
-          # Extend start time. COSA is a large image we are pulling from quay.
-          TimeoutStartSec=600
           # fix permissions on the serial device before passing it as a volume
           ExecStartPre=chmod 777 /dev/virtio-ports/testisocompletion
           # Pipe the logs to a virtio port so kola saves them

--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -1091,6 +1091,12 @@ func testLiveInstalliscsi(ctx context.Context, inst platform.Install, outdir str
 
 	builder.SetConfig(config)
 
+	// Bind mount in the COSA rootfs into the VM so we can use it as a
+	// read-only rootfs for quickly starting the container to kola
+	// qemuexec the nested VM for the test. See resources/iscsi_butane_setup.yaml
+	builder.MountHost("/", "/var/cosaroot", true)
+	config.MountHost("/var/cosaroot", true)
+
 	mach, err := builder.Exec()
 	if err != nil {
 		return 0, errors.Wrapf(err, "running iso")


### PR DESCRIPTION
Backport https://github.com/coreos/coreos-assembler/pull/4013 to `rhcos-4.16`.

In this case we'll run the podman container with --rootfs instead
of pulling a full 4+ GiB COSA image from quay for kola qemuexec.

This saves us quite a bit of time and bandwidth usage during a
pipeline run because we have more than 1 iscsi test.

This should also take care of https://github.com/coreos/fedora-coreos-tracker/issues/1866
because we are no longer pulling this particular container from quay.