### PR TITLE
cmd-coreos-prune: fix skipping of images action

### DIFF
--- a/src/cmd-coreos-prune
+++ b/src/cmd-coreos-prune
@@ -410,10 +410,11 @@ def prune_images(s3, build, images_to_keep, dry_run, bucket, prefix):
                     s3.delete_object(Bucket=bucket, Key=image_prefix)
                     print(f"\t\t\tPruned {name} image for {build.id} for {build.arch}")
                 except botocore.exceptions.ClientError as e:
-                    if e.response['Error']['Code'] == 'NoSuchKey':
-                        print(f"\t\t\t{bucket}/{image_prefix} already pruned.")
-                    else:
-                        errors.append(e)
+                    # Note that even if the object doesn't exist the delete_object()
+                    # will still return Success (`204 Success (No Content)`) so we
+                    # don't need to handle that error case here.
+                    # https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObject.html#API_DeleteObject_RequestSyntax
+                    errors.append(e)
     if errors:
         print(f"\t\t\tFound errors when pruning images for {build.id}:")
         for e in errors:

--- a/src/cmd-coreos-prune
+++ b/src/cmd-coreos-prune
@@ -148,16 +148,15 @@ def main():
 
                     # Skip if the action has been handled previously for the build
                     if action in previous_cleanup:
-                        # If we are in here then there has been some previous cleanup of
-                        # this type run for this build. For all types except `images` we
-                        # can just continue.
-                        if action != "images":
-                            print(f"\t\tBuild {build_id} has already had {action} pruning completed")
-                            continue
+                        print(f"\t\tBuild {build_id} has already had {action} pruning completed")
+                        continue
+                    # We have to handle the "images" action separately because the key in the previous
+                    # cleanup is "images-kept" and not "images"
+                    if action == 'images' and 'images-kept' in previous_cleanup:
                         # OK `images` has been pruned before, but we need to check
                         # that all the images were pruned that match the current policy.
                         # i.e. there may be additional images we need prune
-                        elif set(images_to_keep) == set(previous_cleanup.get("images-kept", [])):
+                        if set(images_to_keep) == set(previous_cleanup.get("images-kept", [])):
                             print(f"\t\tBuild {build_id} has already had {action} pruning completed")
                             continue
 


### PR DESCRIPTION
This detection wasn't working properly and causing the `images` action to get run even for builds where the images had already been pruned.
