### PR TITLE
[rhcos-4.16] mantle/kola: use volume for testisocompletion device

### DIFF
--- a/mantle/cmd/kola/resources/iscsi_butane_setup.yaml
+++ b/mantle/cmd/kola/resources/iscsi_butane_setup.yaml
@@ -104,7 +104,7 @@ storage:
           # makes it so we don't have to pull down COSA from quay
           Rootfs=/var/cosaroot
           Volume=/srv/boot.ipxe:/srv/boot.ipxe
-          AddDevice=/dev/virtio-ports/testisocompletion:/dev/virtio-ports/testisocompletion
+          Volume=/dev/virtio-ports/testisocompletion:/dev/virtio-ports/testisocompletion
           # Create a few writable directories from empty volumes. We
           # must use named volumes for now so we can pass :nocopy.
           # https://github.com/containers/podman/issues/25176


### PR DESCRIPTION
For some reason in OCP 4.16 with podman-4.9.4-16.el9_4 AddDevice (--device /dev/virtio-ports/testisocompletion) doesn't seem to be mapping into the container correctly. Switch to Volume here.