### PR TITLE
kola: update ignition version for luks.cex

### DIFF
--- a/mantle/kola/tests/ignition/luks.go
+++ b/mantle/kola/tests/ignition/luks.go
@@ -204,7 +204,7 @@ func runCexTest(c cluster.TestCluster) {
 
 	ignition := conf.Ignition(`{
 		"ignition": {
-			"version": "3.5.0-experimental"
+			"version": "3.5.0"
 		},
 		"kernelArguments": {
 			"shouldExist": [


### PR DESCRIPTION
Update the ignition version for kola test luks.cex. The test fails with panic due to ignition version mismatch.

```
[coreos-assembler]$ kola run luks.cex
⏭️  Skipping kola test pattern "ext.config.version.rhaos-pkgs-match-openshift":
  👉 https://issues.redhat.com/browse/OCPBUGS-42688
⏭️  Skipping kola test pattern "*kdump*":
  👉 https://gitlab.com/redhat/centos-stream/containers/bootc/-/issues/1169
⏭️  Skipping kola test pattern "ostree.sync":
  👉 https://github.com/openshift/os/issues/1720
=== RUN   luks.cex
--- FAIL: luks.cex (6.60s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x73c4ca]

goroutine 131 [running]:
github.com/coreos/coreos-assembler/mantle/harness.tRunner.func1()
	/root/containerbuild/mantle/harness/harness.go:519 +0x34e
panic({0x211bc40, 0x3df9ae0})
	/usr/lib/golang/src/runtime/panic.go:785 +0x11a
github.com/coreos/coreos-assembler/mantle/platform.InstallFile({0x2b77c20, 0xc000982038}, {0x0, 0x0}, {0xc000500480, 0x1c})
	/root/containerbuild/mantle/platform/platform.go:294 +0xca
github.com/coreos/coreos-assembler/mantle/kola.ScpKolet({0xc000d51ad8, 0x1, 0x1})
	/root/containerbuild/mantle/kola/harness.go:1925 +0x53c
github.com/coreos/coreos-assembler/mantle/kola/tests/ignition.runCexTest({0xc000572c00, {0x2b99d40, 0xc000aae1c0}, {0xc000b94150, 0x1, 0x1}, 0x0, 0x0})
	/root/containerbuild/mantle/kola/tests/ignition/luks.go:250 +0x150
github.com/coreos/coreos-assembler/mantle/kola.runTest(0xc000572c00, 0xc0006718c8, {0x272d2aa, 0x4}, {0x2b96ac0, 0xc000b94070})
	/root/containerbuild/mantle/kola/harness.go:1893 +0x10ec
github.com/coreos/coreos-assembler/mantle/kola.runProvidedTests.func1(0xc000572c00)
	/root/containerbuild/mantle/kola/harness.go:828 +0x88
github.com/coreos/coreos-assembler/mantle/harness.tRunner(0xc000572c00, 0xc000a4e0f0)
	/root/containerbuild/mantle/harness/harness.go:561 +0x170
created by github.com/coreos/coreos-assembler/mantle/harness.(*H).RunTimeout in goroutine 1
	/root/containerbuild/mantle/harness/harness.go:607 +0x430
```