### PR TITLE
cmdlib.sh: limit overrides/rpm repoquery to specific arches

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -450,7 +450,7 @@ EOF
         # the same RPMs: the `dnf repoquery` below is to pick the latest one
         dnf repoquery  --repofrompath=tmp,"file://${overridesdir}/rpm" \
             --disablerepo '*' --enablerepo tmp --refresh --latest-limit 1 \
-            --exclude '*.src' --qf 'pkg: %{name} %{evr} %{arch}\n' \
+            --arch "$arch,noarch" --qf 'pkg: %{name} %{evr} %{arch}\n' \
             --quiet > "${tmp_overridesdir}/pkgs.txt"
 
         # shellcheck disable=SC2002


### PR DESCRIPTION
It's useful to be able to just `koji download-build BUILDID` to populate `overrides/rpm` with the RPMs you want to test. Ideally you'd add e.g. `--arch x86_64 --arch noarch` to this to limit what gets downloaded.

But it should still work fine regardless if you forgot and there's a bunch of RPMs in there that are not for your arch. To handle this, limit the repoquery results to the relevant arches only. This also allows us to drop the `*.src` exclusion we had.