### PR TITLE
build: freeze grub2 due to ppc64le PXE test failures

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -42,7 +42,13 @@ install_rpms() {
     local builddeps
     local frozendeps
 
-    frozendeps=""
+    # freeze grub2 for https://github.com/coreos/fedora-coreos-tracker/issues/1886
+    case "${arch}" in
+        x86_64) frozendeps=$(echo grub2-{common,tools,tools-extra,tools-minimal,efi-x64,pc,pc-modules}-2.12-15.fc41);;
+        aarch64) frozendeps=$(echo grub2-{common,tools,tools-extra,tools-minimal,efi-aa64}-2.12-15.fc41);;
+        ppc64le) frozendeps=$(echo grub2-{common,tools,tools-extra,tools-minimal,ppc64le,ppc64le-modules}-2.12-15.fc41);;
+        *) ;;
+    esac
 
     # First, a general update; this is best practice.  We also hit an issue recently
     # where qemu implicitly depended on an updated libusbx but didn't have a versioned


### PR DESCRIPTION
some PXE tests are failing in ppc64le because they use the grub2 package from cosa to set up the environment. Freeze to the last working version for now.

See: https://github.com/coreos/fedora-coreos-tracker/issues/1886