### PR TITLE
mantle/kola: extend testiso timeouts to 12 minutes

### DIFF
--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -155,7 +155,7 @@ var (
 )
 
 const (
-	installTimeoutMins = 10
+	installTimeoutMins = 12
 	// https://github.com/coreos/fedora-coreos-config/pull/2544
 	liveISOFromRAMKarg = "coreos.liveiso.fromram"
 )


### PR DESCRIPTION
For some reason the pxe-online-install.rootfs-appended.ppcfw test is taking 7 minutes just to transfer/load the combined initramfs plus rootfs. That's 7 minutes before the kernel even starts booting.

This means we're hitting timeouts a lot at 10 minutes. We should investigate why it's taking so long here, but for now let's bump it a little bit so we hopefully can get some stability in the pipeline.