### PR TITLE
Various patches to build extensions container using `podman build` in production

### DIFF
--- a/src/build-extensions-container.sh
+++ b/src/build-extensions-container.sh
@@ -37,5 +37,11 @@ img=localhost/extensions-container
     --volume "${workdir}"/tmp/extensions.json:/tmp/extensions.json \
     -t "${img}" -f extensions/Dockerfile "${ctx_dir}")
 
+# In newer openshift/os, extensions.json is now part of the image itself. If our
+# bind-mounted one is empty, it means we're dealing with the new kind.
+if [ ! -s "${workdir}"/tmp/extensions.json ]; then
+    (set -x; podman run --rm "${img}" cat /usr/share/rpm-ostree/extensions.json > "${workdir}/tmp/extensions.json")
+fi
+
 # Call skopeo to export it from the container storage to an oci-archive.
 (set -x; skopeo copy "containers-storage:${img}" oci-archive:"$filename")

--- a/src/cmd-remote-build-container
+++ b/src/cmd-remote-build-container
@@ -15,12 +15,13 @@ logging.basicConfig(level=logging.INFO,
                     format="%(asctime)s %(levelname)s - %(message)s")
 
 
-def build_container_image(labels, buildDir, fromimage, cacheTTL,
+def build_container_image(labels, buildDir, containerfile, fromimage, cacheTTL,
                           repo, tag, secret, mount_ca, security_opt):
     '''
     Build the image  using podman remote and push to the registry
     @param labels list labels to add to image
     @param buildDir str the location of the directory to build from
+    @param containerfile str the location of the containerfile relative to buildDir
     @param fromimage str value to pass to `podman build --from=`
     @param cacheTTL str value to pass to `podman build --cache-ttl=`
     @param repo str registry repository
@@ -31,6 +32,8 @@ def build_container_image(labels, buildDir, fromimage, cacheTTL,
         cmd.extend([f"--label={label}"])
     if fromimage:
         cmd.extend([f"--from={fromimage}"])
+    if containerfile:
+        cmd.extend([f"--file={containerfile}"])
     if secret:
         for s in secret:
             cmd.append(f"--secret={s}")
@@ -180,10 +183,10 @@ def main():
         if needbuild:
             logging.info("Building container via podman")
             builddir = os.path.join(gitdir, args.git_sub_dir)
-            build_container_image(args.labels, builddir, args.fromimage,
-                                  args.cache_ttl, args.repo, args.tag,
-                                  args.secret, args.mount_host_ca_certs,
-                                  args.security_opt)
+            build_container_image(args.labels, builddir, args.git_containerfile,
+                                  args.fromimage, args.cache_ttl,
+                                  args.repo, args.tag, args.secret,
+                                  args.mount_host_ca_certs, args.security_opt)
 
     # Push to the registry if needed, else save the image to a file
     if args.push_to_registry:
@@ -239,6 +242,9 @@ Examples:
     parser.add_argument(
         '--git-sub-dir', default='', required=False,
         help='Git sub directory to use for container build')
+    parser.add_argument(
+        '--git-containerfile', default='', required=False,
+        help='Path to Containerfile (relative to git clone and sub dir, if specified)')
     parser.add_argument(
         '--label', dest="labels", default=[], action='append',
         required=False, help='Add image label(s)')

--- a/src/cmd-remote-build-container
+++ b/src/cmd-remote-build-container
@@ -150,6 +150,8 @@ def main():
         runcmd(cmd, quiet=True, capture_output=True)
         cmd = ["git", "-C", gitdir, "checkout", "FETCH_HEAD"]
         runcmd(cmd, quiet=True, capture_output=True)
+        cmd = ["git", "-C", gitdir, "submodule", "update", "--recursive", "--init"]
+        runcmd(cmd, quiet=True, capture_output=True)
         cmd = ["git", "-C", gitdir, "rev-parse", "FETCH_HEAD"]
         commit = runcmd(cmd, quiet=True, capture_output=True).stdout.strip().decode()
         shortcommit = commit[0:7]

--- a/src/cosalib/container_manifest.py
+++ b/src/cosalib/container_manifest.py
@@ -26,8 +26,8 @@ def local_container_manifest_or_image_exists(repo, tag):
     @param repo str registry repository
     @param tag str tag
     '''
-    cmds = [["podman", "manifest", "exists", f"{repo}:{tag}"],
-            ["podman", "image", "exists", f"{repo}:{tag}"]]
+    cmds = [["podman", "image", "exists", f"{repo}:{tag}"],
+            ["podman", "manifest", "exists", f"{repo}:{tag}"]]
     for cmd in cmds:
         cp = runcmd(cmd, check=False)
         # The commands returns 0 (exists), 1 (doesn't exist), 125 (other error)

--- a/src/supermin-init-prelude.sh
+++ b/src/supermin-init-prelude.sh
@@ -8,6 +8,11 @@ mount -t sysfs /sys /sys
 mount -t cgroup2 cgroup2 -o rw,nosuid,nodev,noexec,relatime,seclabel,nsdelegate,memory_recursiveprot /sys/fs/cgroup
 mount -t devtmpfs devtmpfs /dev
 
+# this is also normally set up by systemd in early boot
+ln -s /proc/self/fd/0 /dev/stdin
+ln -s /proc/self/fd/1 /dev/stdout
+ln -s /proc/self/fd/2 /dev/stderr
+
 # need /dev/shm for podman
 mkdir -p /dev/shm
 mount -t tmpfs tmpfs /dev/shm


### PR DESCRIPTION
We're getting ready to build the extensions container in production as part of the layered node image work. To be able to build it using `podman build` directly and not via `cosa build-extensions-container`, a few adjustments are needed.

See individual commit messages.