### PR TITLE
mantle/kola: trim newline from kernel warning match

### DIFF
--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -1954,6 +1954,7 @@ func CheckConsole(output []byte, t *register.Test) (bool, []string) {
 			if len(match) > 1 {
 				// include first subexpression
 				badline += fmt.Sprintf(" (%s)", match[1])
+				badline = strings.TrimSpace(badline) // trim potential newline
 			}
 			badlines = append(badlines, badline)
 			if !check.warnOnly {


### PR DESCRIPTION
This way we can stop printing newlines in our error messages like:

```
[2025-03-18T00:15:50.235Z] === RUN   ext.config.root-reprovision.raid1
[2025-03-18T00:19:56.607Z] --- FAIL: ext.config.root-reprovision.raid1 (244.32s)
[2025-03-18T00:19:56.607Z]         harness.go:1740: Found kernel warning (arch/powerpc/net/bpf_jit_comp.c:961 __arch_prepare_bpf_trampoline.isra.0+0xe18/0x10a0
[2025-03-18T00:19:56.607Z] ) on machine bbfae284-54af-4005-95a4-58740c49ca4b console
[2025-03-18T00:19:56.607Z] FAIL, output in /home/jenkins/agent/workspace/build-arch/tmp/kola-N7agh/kola-reprovision/rerun
```