### PR TITLE
build.sh: unfreeze grub2

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -42,14 +42,6 @@ install_rpms() {
     local builddeps
     local frozendeps=""
 
-    # freeze grub2 for https://github.com/coreos/fedora-coreos-tracker/issues/1886
-    case "${arch}" in
-        x86_64) frozendeps=$(echo grub2-{common,tools,tools-extra,tools-minimal,efi-x64,pc,pc-modules}-2.12-15.fc41);;
-        aarch64) frozendeps=$(echo grub2-{common,tools,tools-extra,tools-minimal,efi-aa64}-2.12-15.fc41);;
-        ppc64le) frozendeps=$(echo grub2-{common,tools,tools-extra,tools-minimal,ppc64le,ppc64le-modules}-2.12-15.fc41);;
-        *) ;;
-    esac
-
     # First, a general update; this is best practice.  We also hit an issue recently
     # where qemu implicitly depended on an updated libusbx but didn't have a versioned
     # requires https://bugzilla.redhat.com/show_bug.cgi?id=1625641


### PR DESCRIPTION
This issue in PXE tests on ppc64le is now fixed.

Closes https://github.com/coreos/fedora-coreos-tracker/issues/1886