### PR TITLE
cmdlib.sh: copy all GPG keys into supermin VM

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -739,7 +739,7 @@ runvm() {
 EOF
 
     # and include all GPG keys
-    find /etc/pki/rpm-gpg/ -type f >> "${vmpreparedir}/hostfiles"
+    echo '/etc/pki/rpm-gpg/*' >> "${vmpreparedir}/hostfiles"
 
     # the reason we do a heredoc here is so that the var substition takes
     # place immediately instead of having to proxy them through to the VM


### PR DESCRIPTION
Currently, we're only copying files, but we want symlinks too.

Follow-up to 876c466ed ("build.sh: add CentOS Stream keys into `/etc/pki/rpm-gpg`").