### PR TITLE
kola/distros: introduce a `rhcos-base` variant

### DIFF
--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -41,7 +41,7 @@ var (
 	kolaParallelArg   string
 	kolaArchitectures = []string{"amd64"}
 	kolaPlatforms     = []string{"aws", "azure", "do", "esx", "gcp", "openstack", "qemu", "qemu-iso"}
-	kolaDistros       = []string{"fcos", "rhcos", "scos"}
+	kolaDistros       = []string{"fcos", "rhcos", "scos", "rhcos-base"}
 )
 
 func init() {
@@ -358,7 +358,7 @@ func syncOptionsImpl(useCosa bool) error {
 		kola.Options.Distribution = kolaDistros[0]
 	} else if kola.Options.Distribution == "scos" {
 		// Consider SCOS the same as RHCOS for now
-		kola.Options.Distribution = "rhcos"
+		kola.Options.Distribution = "rhcos-base"
 	} else if err := validateOption("distro", kola.Options.Distribution, kolaDistros); err != nil {
 		return err
 	}
@@ -442,6 +442,11 @@ func syncStreamOptions() error {
 			return errors.Wrapf(err, "failed to fetch stream")
 		}
 	case "rhcos":
+		artifacts, err = rhcos.FetchStreamArtifacts(kola.Options.Stream, kola.Options.CosaBuildArch)
+		if err != nil {
+			return errors.Wrapf(err, "failed to fetch stream")
+		}
+	case "rhcos-base":
 		artifacts, err = rhcos.FetchStreamArtifacts(kola.Options.Stream, kola.Options.CosaBuildArch)
 		if err != nil {
 			return errors.Wrapf(err, "failed to fetch stream")

--- a/mantle/util/distros.go
+++ b/mantle/util/distros.go
@@ -38,8 +38,10 @@ func TargetDistro(build *builds.Build) (string, error) {
 	switch build.Name {
 	case "rhcos":
 		return "rhcos", nil
+	case "rhcos-base":
+		return "rhcos-base", nil
 	case "scos":
-		return "rhcos", nil
+		return "rhcos-base", nil
 	case "fedora-coreos":
 		return "fcos", nil
 	default:


### PR DESCRIPTION
As we introduced pure rhel and rhcos variants in [1], we did not change the `name` key in meta.json

Kola uses this key to determine the distribution of the image to discriminate relevant tests.
Some tests are tied to OCP content, e.g. `crio.base` and `crio.network` [2] and inherently won't work
with the base because they rely on content that
is added as part of the node image layer.

Currently we skip the tests tagged with `openshift` in prow [3] and pipelie to work around this.

Going with the principle of least disruption
by adding `rhcos-base` rather than adding `rhcos-ocp` because all of the build already out there contains the old name and a I don't want to break compatibility if someone use a newer cosa to test those older
builds.

[1] https://github.com/openshift/os/pull/1445
[2] https://github.com/coreos/coreos-assembler/blob/main/mantle/kola/tests/crio/crio.go
[3] https://github.com/openshift/os/blob/48a18918794f5418352c03a3415fac3fde28e1b6/ci/prow-entrypoint.sh#L306

See https://github.com/openshift/os/issues/1790