### PR TITLE
build.sh: Link the CentOS 10 gpg key in `/etc/pki/rmp-gpg`

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -87,6 +87,7 @@ install_rpms() {
     # CentOS-based artifacts.
     if [ ! -e "/etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial" ]; then
         ln -s /usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
+        ln -s /usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official-SHA256 /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial-SHA256
         ln -s {/usr/share/distribution-gpg-keys/centos,/etc/pki/rpm-gpg}/RPM-GPG-KEY-CentOS-SIG-Cloud
         ln -s {/usr/share/distribution-gpg-keys/centos,/etc/pki/rpm-gpg}/RPM-GPG-KEY-CentOS-SIG-Extras-SHA512
         ln -s {/usr/share/distribution-gpg-keys/centos,/etc/pki/rpm-gpg}/RPM-GPG-KEY-CentOS-SIG-NFV


### PR DESCRIPTION
The `centos-gpg-keys` is changed the location of the rpm gpg signing key in Centos 10. [1]
While also moving to a SHA256 key as SHA-1 is being dropped, at least in RHEL 10.

[1] https://gitlab.com/redhat/centos-stream/rpms/centos-stream-release/-/commit/e4bbded6ccfe46343d14d8f9c10c278be757921c