### PR TITLE
cmd-podman-build: support --args for just printing arguments

### DIFF
--- a/src/cmd-podman-build
+++ b/src/cmd-podman-build
@@ -35,7 +35,7 @@ cat src/config/*.repo > tmp/all.repo
 if [ -d src/yumrepos ]; then
   cat src/yumrepos/*.repo >> tmp/all.repo
 fi
-repos=$(realpath tmp/all.repo)
+repos="tmp/all.repo"
 
 set -x
 podman build --from "$from" \

--- a/src/cmd-podman-build
+++ b/src/cmd-podman-build
@@ -31,16 +31,16 @@ case "${target}" in
 esac
 shift
 
-cat src/config/*.repo > tmp/all.repo
+repos_file="tmp/all.repo"
+cat src/config/*.repo > "$repos_file"
 if [ -d src/yumrepos ]; then
-  cat src/yumrepos/*.repo >> tmp/all.repo
+  cat src/yumrepos/*.repo >> "$repos_file"
 fi
-repos="tmp/all.repo"
 
 set -x
 podman build --from "$from" \
   -t "${tag}" \
   -f "${containerfile}" \
-  --secret id=yumrepos,src="$repos" \
+  --secret id=yumrepos,src="$repos_file" \
   -v /etc/pki/ca-trust:/etc/pki/ca-trust:ro \
   --security-opt label=disable src/config "$@"

--- a/src/cmd-podman-build
+++ b/src/cmd-podman-build
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -xeuo pipefail
+set -euo pipefail
 
 meta=builds/latest/$(arch)/meta.json
 name=$(jq -r .name "${meta}")
@@ -14,6 +14,15 @@ print(y["metadata"]["ocp_version"])')
 
 node_tag=localhost/${name}-${ocp_version}-${version}-node
 extensions_tag=localhost/${name}-${ocp_version}-${version}-extensions
+
+# If a user provides args then they just want us to print
+# out what args to run `podman build` with and exit so they
+# can run podman build themselves (most likely outside the
+# COSA container).
+if [ "${1:-}" == "--args" ]; then
+    PRINT_ARGS_AND_EXIT=1
+    shift
+fi
 
 target=${1:-}
 case "${target}" in
@@ -37,8 +46,14 @@ if [ -d src/yumrepos ]; then
   cat src/yumrepos/*.repo >> "$repos_file"
 fi
 
-set -x
-podman build --from "$from" \
+if [ "${PRINT_ARGS_AND_EXIT:-}" == "1" ]; then
+    cmd='echo'
+else
+    cmd='podman build'
+    set -x
+fi
+
+$cmd --from "$from" \
   -t "${tag}" \
   -f "${containerfile}" \
   --secret id=yumrepos,src="$repos_file" \


### PR DESCRIPTION
In the case where you are running COSA via the alias/func [1] and not
in a custom toolbox container then `cosa podman-build node` today
won't work because running `podman` inside a rootless container
doesn't really work.

Add a new `--args` argument here to just tell `cosa podman-build`
to set up for the build (i.e. generate tmp files and necessary
arguments) and then print what would have been passed to `podman build`.

This can then be used on the host to run `podman build` with something
like:

```
node-build() {
    local args=$(cosa podman-build --args node)
    # Translate src/config to the location of the repo on disk. Also
    # tr to remove the trailing `\r` from the output.
    args=$(echo "$args" | tr -d '\r' | sed s,src/config,$COREOS_ASSEMBLER_CONFIG_GIT,g)
    set -x
    podman build $args
    set +x
}
```

So you'd run `node-build` and it would do what you need for you.

[1] https://github.com/coreos/coreos-assembler/blob/main/docs/building-fcos.md#define-a-bash-alias-to-run-cosa
