### PR TITLE
cmd-podman-build: stop passing the git yum repos

### DIFF
--- a/src/cmd-podman-build
+++ b/src/cmd-podman-build
@@ -40,10 +40,9 @@ case "${target}" in
 esac
 shift
 
-repos_file="tmp/all.repo"
-cat src/config/*.repo > "$repos_file"
+echo > tmp/all.repo
 if [ -d src/yumrepos ]; then
-  cat src/yumrepos/*.repo >> "$repos_file"
+  cat src/yumrepos/*.repo >> tmp/all.repo
 fi
 
 if [ "${PRINT_ARGS_AND_EXIT:-}" == "1" ]; then
@@ -56,6 +55,6 @@ fi
 $cmd --from "$from" \
   -t "${tag}" \
   -f "${containerfile}" \
-  --secret id=yumrepos,src="$repos_file" \
+  --secret id=yumrepos,src=tmp/all.repo \
   -v /etc/pki/ca-trust:/etc/pki/ca-trust:ro \
   --security-opt label=disable src/config "$@"


### PR DESCRIPTION
This goes together with Jonathan's commit in
https://github.com/openshift/os/pull/1498 titled "build-node-image.sh: include yum repos from git as part of build".

There's no point in adding the repo files already in the git repo into the secret; the node and extension builds already have access to those. So we'd just be duplicating them.

Another way to think of this is that the secret injection we do here should be considered equivalent to `get-ocp-repo.sh` in OpenShift CI in terms of what repos get injected.