### PR TITLE
cosalib: add Builds().get_build_image_json(); drop use of flatten_image_yaml()

### DIFF
--- a/src/cmd-compress
+++ b/src/cmd-compress
@@ -11,9 +11,7 @@ import argparse
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from cosalib.builds import Builds
-from cosalib.meta import GenericBuildMeta
 from cosalib.cmdlib import (
-    import_ostree_commit,
     ncpu,
     rm_allow_noent,
     runcmd,
@@ -42,7 +40,7 @@ parser.add_argument("--fast", action='store_true',
                     help="Override compression to `gzip -1`")
 args = parser.parse_args()
 
-builds = Builds()
+builds = Builds(workdir=os.getcwd())
 
 # default to latest build if not specified
 if args.build:
@@ -250,30 +248,11 @@ def uncompress_one_builddir(builddir):
     return at_least_one
 
 
-def get_image_json():
-    # All arches might not be local. Find one that has the info.
-    workdir = os.getcwd()
-    for arch in builds.get_build_arches(build):
-        builddir = builds.get_build_dir(build, arch)
-        if not os.path.exists(os.path.join(builddir, 'meta.json')):
-            continue
-        buildmeta = GenericBuildMeta(workdir=workdir, build=build, basearch=arch)
-        if not os.path.exists(os.path.join(builddir, buildmeta['images']['ostree']['path'])):
-            continue
-        import_ostree_commit(workdir, builddir, buildmeta)  # runs extract_image_json()
-        with open(os.path.join(workdir, 'tmp/image.json')) as f:
-            return json.load(f)
-    # If we get here we were unsuccessful
-    print("Could not find/extract image.json. Please pass --compressor\n" +
-          "or make sure local ociarchive exists in the build directory.")
-    raise Exception("Could not find/extract image.json")
-
-
 changed = []
 if args.mode == "compress":
     # Find what compressor we should use, either picking it up from
     # CLI args or from image.json
-    image_json = get_image_json()
+    image_json = builds.get_build_image_json(build)
     gzip_level = 9
     if args.fast:
         args.compressor = 'gzip'

--- a/src/cosalib/aws.py
+++ b/src/cosalib/aws.py
@@ -3,10 +3,8 @@ import os
 import subprocess
 import sys
 
-from cosalib.cmdlib import (
-    flatten_image_yaml,
-    runcmd
-)
+from cosalib.builds import Builds
+from cosalib.cmdlib import runcmd
 from tenacity import (
     retry,
     stop_after_attempt
@@ -124,17 +122,15 @@ def aws_run_ore(build, args):
     region = "us-east-1"
     if args.region is not None and len(args.region) > 0:
         region = args.region[0]
-    # Capture any input from image.yaml
-    image_yaml = flatten_image_yaml(
-        '/usr/lib/coreos-assembler/image-default.yaml',
-        flatten_image_yaml('src/config/image.yaml')
-    )
-    if 'aws-imdsv2-only' in image_yaml and image_yaml['aws-imdsv2-only']:
+
+    # Capture any settings from image json.
+    image_json = Builds(workdir=os.getcwd()).get_build_image_json(build.build_id)
+    if 'aws-imdsv2-only' in image_json and image_json['aws-imdsv2-only']:
         ore_args.extend(['--imdsv2-only'])
-    if 'aws-volume-type' in image_yaml:
-        ore_args.extend(['--volume-type', image_yaml['aws-volume-type']])
-    if 'aws-x86-boot-mode' in image_yaml:
-        ore_args.extend(['--x86-boot-mode', image_yaml['aws-x86-boot-mode']])
+    if 'aws-volume-type' in image_json:
+        ore_args.extend(['--volume-type', image_json['aws-volume-type']])
+    if 'aws-x86-boot-mode' in image_json:
+        ore_args.extend(['--x86-boot-mode', image_json['aws-x86-boot-mode']])
 
     ore_args.extend([
         '--region', f"{region}",


### PR DESCRIPTION
As part of c61da89 we started to allow templating in the image.yaml file. This means we now need to pass the dict of things to template into flatten-image-yaml and that is now causing us issues if there are things to template but not template dict passed in.

One case we were doing this was in our AWS upload where we pick up some values from image.yaml. Except, we shouldn't have been picking them up from image.yaml in the src/config as this stage but rather the image.json that had been baked into the build.

Let's switch over cosalib/aws to pick the info up from image.json instead. As part of this add a helper the the cosalib Builds library to make this easier for us in various places to do it. This addition was conveniently stolen from cmd-compress that already had code to do this.