### PR TITLE
cmd-push-container-manifest: add --write-digest-to-file

### DIFF
--- a/src/cmd-push-container-manifest
+++ b/src/cmd-push-container-manifest
@@ -28,7 +28,7 @@ def main():
     if args.images:
         # User provided images directly
         create_and_push_container_manifest(
-            args.repo, args.tags, args.images, args.v2s2)
+            args.repo, args.tags, args.images, args.write_digest_to_file, args.v2s2)
     else:
         # Picking up images from artifacts in meta.json
         builds = Builds()
@@ -104,7 +104,7 @@ def main():
 
         # Create/Upload the manifest list to the container registry
         manifest_info = create_and_push_container_manifest(
-            args.repo, args.tags, images, args.v2s2)
+            args.repo, args.tags, images, args.write_digest_to_file, args.v2s2)
         # if we pushed in v2s2 mode, we need to reload from the repo the actual
         # final digests: https://github.com/containers/podman/issues/16603
         if args.v2s2:
@@ -165,6 +165,8 @@ Examples:
     parser.add_argument('--v2s2', action='store_true',
                         help='Use old image manifest version 2 schema 2 format')
     parser.add_argument("--force", help="Force manifest overwriting", action='store_true')
+    parser.add_argument('--write-digest-to-file', required=False,
+                        help='Write digest of pushed manifest to named file')
 
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument("--image", dest='images', action='append', default=[],

--- a/src/cosalib/container_manifest.py
+++ b/src/cosalib/container_manifest.py
@@ -53,7 +53,7 @@ def delete_local_container_imgref(repo, tag):
     runcmd(cmd)
 
 
-def push_container_manifest(repo, tags, v2s2=False):
+def push_container_manifest(repo, tags, write_digest_to_file, v2s2=False):
     '''
     Push manifest to registry
     @param repo str registry repository
@@ -66,12 +66,14 @@ def push_container_manifest(repo, tags, v2s2=False):
         # to create a manifest with 2 different mediaType. It seems to be
         # a Quay issue.
         base_cmd.extend(["--remove-signatures", "-f", "v2s2"])
+    if write_digest_to_file:
+        base_cmd.extend(["--digestfile", write_digest_to_file])
     runcmd(base_cmd + [f"{repo}:{tags[0]}"])
     for tag in tags[1:]:
         runcmd(base_cmd + [f"{repo}:{tag}"])
 
 
-def create_and_push_container_manifest(repo, tags, images, v2s2) -> dict:
+def create_and_push_container_manifest(repo, tags, images, write_digest_to_file, v2s2) -> dict:
     '''
     Do it all! Create, push, cleanup, and return the final manifest JSON.
     @param repo str registry repository
@@ -83,6 +85,6 @@ def create_and_push_container_manifest(repo, tags, images, v2s2) -> dict:
         # perhaps left over from a previous failed run -> delete
         delete_local_container_imgref(repo, tags[0])
     manifest_info = create_local_container_manifest(repo, tags[0], images)
-    push_container_manifest(repo, tags, v2s2)
+    push_container_manifest(repo, tags, write_digest_to_file, v2s2)
     delete_local_container_imgref(repo, tags[0])
     return manifest_info


### PR DESCRIPTION
- This maps to Podman's --digestfile option, allowing the manifest digest to be saved for future reference or use.