### PR TITLE
live: fix wrong paths in s390x ISO

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -168,25 +168,25 @@ write_archive_info() {
 }
 
 patch_osbuild() {
-   return # we have no patches right now
+   # return # we have no patches right now
    ## Add a few patches that either haven't made it into a release or
    ## that will be obsoleted with other work that will be done soon.
 
    ## To make it easier to apply patches we'll move around the osbuild
    ## code on the system first:
-   #rmdir /usr/lib/osbuild/osbuild
-   #mv /usr/lib/python3.13/site-packages/osbuild /usr/lib/osbuild/
-   #mkdir /usr/lib/osbuild/tools
-   #mv /usr/bin/osbuild-mpp /usr/lib/osbuild/tools/
+   rmdir /usr/lib/osbuild/osbuild
+   mv /usr/lib/python3.13/site-packages/osbuild /usr/lib/osbuild/
+   mkdir /usr/lib/osbuild/tools
+   mv /usr/bin/osbuild-mpp /usr/lib/osbuild/tools/
 
    ## Now all the software is under the /usr/lib/osbuild dir and we can patch
-   #cat foo.patch | patch -d /usr/lib/osbuild -p1
+   patch -d /usr/lib/osbuild -p1 < src/0001-stages-coreos.live-artifacts-fix-kernel-and-initrd-p.patch
    #
    ## And then move the files back; supermin appliance creation will need it back
    ## in the places delivered by the RPM.
-   #mv /usr/lib/osbuild/tools/osbuild-mpp /usr/bin/osbuild-mpp
-   #mv /usr/lib/osbuild/osbuild /usr/lib/python3.13/site-packages/osbuild
-   #mkdir /usr/lib/osbuild/osbuild
+   mv /usr/lib/osbuild/tools/osbuild-mpp /usr/bin/osbuild-mpp
+   mv /usr/lib/osbuild/osbuild /usr/lib/python3.13/site-packages/osbuild
+   mkdir /usr/lib/osbuild/osbuild
 }
 
 if [ $# -ne 0 ]; then

--- a/src/0001-stages-coreos.live-artifacts-fix-kernel-and-initrd-p.patch
+++ b/src/0001-stages-coreos.live-artifacts-fix-kernel-and-initrd-p.patch
@@ -1,0 +1,42 @@
+From 41f6d206cc58f3af01c7630effab4acd2cc1b31a Mon Sep 17 00:00:00 2001
+From: Nikita Dubrovskii <nikita@linux.ibm.com>
+Date: Thu, 17 Apr 2025 14:25:09 +0200
+Subject: [PATCH] stages/coreos.live-artifacts: fix kernel and initrd paths in
+ s390x ISO
+
+The `generic.ins` template uses:
+  images/kernel.img
+  images/initrd.img
+
+However, kernel and initrd are currently stored as:
+  images/pxeboot/vmlinuz
+  images/pxeboot/initrd.img
+
+This change ensures correct paths are used.
+---
+ stages/org.osbuild.coreos.live-artifacts.mono | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/stages/org.osbuild.coreos.live-artifacts.mono b/stages/org.osbuild.coreos.live-artifacts.mono
+index 5cad484a..1384a343 100755
+--- a/stages/org.osbuild.coreos.live-artifacts.mono
++++ b/stages/org.osbuild.coreos.live-artifacts.mono
+@@ -247,7 +247,14 @@ def genisoargs_s390x(paths, test_fixture, volid, name_version):
+     with open(os.path.join(lorax_templates, 'generic.ins'), 'r', encoding='utf8') as fp1:
+         with open(os.path.join(paths["iso"], 'generic.ins'), 'w', encoding='utf8') as fp2:
+             for line in fp1:
+-                fp2.write(line.replace('@INITRD_LOAD_ADDRESS@', INITRD_ADDRESS))
++                # The paths to the kernel and initrd on our ISO differ slightly from those in generic.ins.
++                # https://github.com/coreos/coreos-assembler/commit/6f533ef55ee5cf2b10ad97df51eb2d190b6b2c2b
++                # Let's update the paths in the template to the correct locations.
++                line = line.replace('images/kernel.img', "images/pxeboot/vmlinuz")
++                line = line.replace('images/initrd.img', "images/pxeboot/initrd.img")
++                # Also replace the initrd address in the template with actual value.
++                line = line.replace('@INITRD_LOAD_ADDRESS@', INITRD_ADDRESS)
++                fp2.write(line)
+     for prmfile in [paths["iso/images/cdboot.prm"],
+                     paths["iso/images/generic.prm"],
+                     paths["iso/images/genericdvd.prm"]]:
+-- 
+2.49.0
+

--- a/src/cmd-buildextend-live
+++ b/src/cmd-buildextend-live
@@ -483,7 +483,13 @@ def generate_iso():
         shutil.copy(os.path.join(lorax_templates, 'redhat.exec'), tmpisoimages)
         with open(os.path.join(lorax_templates, 'generic.ins'), 'r') as fp1:
             with open(os.path.join(tmpisoroot, 'generic.ins'), 'w') as fp2:
-                [fp2.write(line.replace('@INITRD_LOAD_ADDRESS@', INITRD_ADDRESS)) for line in fp1]
+                for line in fp1:
+                    line = line.replace('images/kernel.img', "images/pxeboot/kernel.img")
+                    line = line.replace(
+                        'images/initrd.img @INITRD_LOAD_ADDRESS@',
+                        f"images/pxeboot/initrd.img {INITRD_ADDRESS}")
+                    fp2.write(line)
+
         for prmfile in ['cdboot.prm', 'genericdvd.prm', 'generic.prm']:
             with open(os.path.join(tmpisoimages, prmfile), 'w') as fp1:
                 with open(os.path.join(tmpisoroot, 'zipl.prm'), 'r') as fp2:


### PR DESCRIPTION
This PR fixes the paths stored in s390x ISO `generic.ins`:
```
$ cat generic.ins 
* minimal lpar ins file
images/kernel.img 0x00000000
images/initrd.img 0x02000000
```
with actual layout:
```
$ find images/pxeboot/
images/pxeboot/initrd.img
images/pxeboot/vmlinuz

```
```
$ cat generic.ins 
* minimal lpar ins file
images/pxeboot/vmlinuz 0x00000000
images/pxeboot/initrd.img 0x02000000
```

Issue: https://github.com/coreos/coreos-assembler/issues/4077
