### PR TITLE
Add support for riscv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,10 @@ ifeq ($(GOARCH),x86_64)
 else ifeq ($(GOARCH),aarch64)
 	GOARCH="arm64"
 endif
+ifeq ($(GOARCH),riscv64)
+	# https://github.com/golang/go/issues/72840
+	export CGO_ENABLED := 0
+endif
 
 bin/coreos-assembler:
 	cd cmd && go build -mod vendor -o ../$@

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@ PYIGNORE ?= E128,E241,E402,E501,E722,W503,W504
 .PHONY: all check shellcheck flake8 pycheck unittest clean mantle mantle-check install
 
 MANTLE_BINARIES := ore kola plume
-KOLET_ARCHES := aarch64 ppc64le s390x x86_64
+# Typically just build kolet for the architecture we are on.
+export KOLET_ARCHES:=$(shell uname -m)
 
 all: bin/coreos-assembler mantle
 
@@ -26,9 +27,14 @@ cwd_checked:=$(patsubst ./%,.%.shellchecked,${cwd})
 GOARCH:=$(shell uname -m)
 export COSA_META_SCHEMA:=$(shell pwd)/src/v1.json
 ifeq ($(GOARCH),x86_64)
-        GOARCH="amd64"
+	GOARCH="amd64"
+	# On x86_64 only we'll build kolet for all the other architectures.
+	# This is mainly so we can initiate tests against a remote that is
+	# a different architecture. i.e. x86_64 kola testing against an
+	# aarch64 EC2 instance.
+	export KOLET_ARCHES := aarch64 ppc64le s390x x86_64
 else ifeq ($(GOARCH),aarch64)
-        GOARCH="arm64"
+	GOARCH="arm64"
 endif
 
 bin/coreos-assembler:

--- a/build.sh
+++ b/build.sh
@@ -30,6 +30,7 @@ set -x
 srcdir=$(pwd)
 
 configure_yum_repos() {
+    [ "${arch}" == "riscv64" ] && return # No continuous repo for riscv64 yet
     local version_id
     version_id=$(. /etc/os-release && echo ${VERSION_ID})
     # Add continuous tag for latest build tools and mark as required so we
@@ -102,6 +103,7 @@ install_rpms() {
 # and it is very useful to have in the same place/flow as where we do builds/tests related
 # to CoreOS.
 install_ocp_tools() {
+    [ "${arch}" == "riscv64" ] && return # No ocp tools for riscv64
     # If $OCP_VERSION is defined we'll grab that specific version.
     # Otherwise we'll get the latest.
     local url="https://mirror.openshift.com/pub/openshift-v4/${arch}/clients/ocp/latest${OCP_VERSION:+-$OCP_VERSION}/openshift-client-linux.tar.gz"

--- a/mantle/build
+++ b/mantle/build
@@ -11,7 +11,8 @@ if [[ $# -eq 0 ]]; then
 fi
 
 declare -A BASEARCH_TO_GOARCH=([s390x]=s390x [x86_64]=amd64 [aarch64]=arm64 [ppc64le]=ppc64le)
-KOLET_ARCHES="${KOLET_ARCHES:-s390x x86_64 aarch64 ppc64le}"
+ARCH=$(arch)
+KOLET_ARCHES="${KOLET_ARCHES:-${ARCH}}"
 
 race=
 if [ -n "${ENABLE_GO_RACE_DETECTOR:-}" ] && [[ ! "$(uname -m)" =~ "s390" ]]; then

--- a/mantle/build
+++ b/mantle/build
@@ -10,7 +10,7 @@ if [[ $# -eq 0 ]]; then
     set -- cmd/* schema
 fi
 
-declare -A BASEARCH_TO_GOARCH=([s390x]=s390x [x86_64]=amd64 [aarch64]=arm64 [ppc64le]=ppc64le)
+declare -A BASEARCH_TO_GOARCH=([x86_64]=amd64 [aarch64]=arm64 [ppc64le]=ppc64le [riscv64]=riscv64 [s390x]=s390x)
 ARCH=$(arch)
 KOLET_ARCHES="${KOLET_ARCHES:-${ARCH}}"
 

--- a/src/cmd-osbuild
+++ b/src/cmd-osbuild
@@ -337,7 +337,7 @@ main() {
     fi
 
     case "$basearch" in
-        "x86_64"|"aarch64"|"s390x"|"ppc64le") ;;
+        "x86_64"|"aarch64"|"s390x"|"ppc64le"|"riscv64") ;;
         *) fatal "$basearch is not supported for this command" ;;
     esac
 

--- a/src/osbuild-manifests/coreos.osbuild.riscv64.mpp.yaml
+++ b/src/osbuild-manifests/coreos.osbuild.riscv64.mpp.yaml
@@ -1,0 +1,778 @@
+version: '2'
+mpp-vars:
+  artifact_name_prefix: $artifact_name_prefix
+  ostree_repo: $ostree_repo
+  ostree_ref: $ostree_ref
+  ociarchive: $ociarchive
+  osname: $osname
+  container_imgref: $container_imgref
+  container_repo: $container_repo
+  container_tag: $container_tag
+  extra_kargs: $extra_kargs
+  metal_image_size_mb: $metal_image_size_mb
+  cloud_image_size_mb: $cloud_image_size_mb
+  bios_boot_size_mb: 1
+  ppc_prep_size_mb: 4
+  reserved_part_size_mb: 1
+  efi_system_size_mb: 127
+  boot_size_mb: 384
+  sector_size: 512
+  four_k_sector_size: 4096
+  # Filesystem UUID and label definitions. These UUIDs
+  # are looked for on boot and if found replaced with
+  # a new random UUID to make each install unique.
+  boot_fs_uuid: 96d15588-3596-4b3c-adca-a2ff7279ea63
+  boot_fs_label: boot
+  root_fs_uuid: 910678ff-f77e-4a7d-8d53-86f2ac47a823
+  root_fs_label: root
+  # For some stages (i.e. the qemu stages) we'll use the host as
+  # the buildroot (i.e. COSA in most cases but sometimes just
+  # the actual HOST filesystem like in coreos/custom-coreos-disk-images).
+  # This is useful/necessary because we definitely don't include
+  # qemu-img or tools like zip in the actual CoreOS OS. "" here
+  # means to use the host as buildroot. It is worth noting that
+  # the host buildroot is the default if nothing is specified.
+  # We're still defining it here in an attempt to be explicit.
+  host_as_buildroot: ""
+  # Set the buildroot string to use for most operations here. We create
+  # the buildroot from the target OSTree contents so we have version
+  # matches. Unfortunately for FCOS there is no python so we can't
+  # really use FCOS as the buildroot so we'll use the host as the
+  # buildroot there.
+  buildroot:
+    mpp-if: osname in ['rhcos', 'scos']
+    then: "name:deployed-tree"
+    else:
+      mpp-format-string: '{host_as_buildroot}'
+mpp-define-images:
+  - id: image
+    sector_size:
+        mpp-format-int: "{sector_size}"
+    size:
+      mpp-format-string: "{metal_image_size_mb * 1024 * 1024}"
+    table:
+      uuid: 00000000-0000-4000-a000-000000000001
+      label: gpt
+      partitions:
+        - name: reserved
+          type: 8DA63339-0007-60C0-C436-083AC8230908
+          size:
+            mpp-format-int: "{reserved_part_size_mb * 1024 * 1024 / sector_size}"
+        - name: EFI-SYSTEM
+          type: C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+          size:
+            mpp-format-int: "{efi_system_size_mb * 1024 * 1024 / sector_size}"
+        - name: boot
+          type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
+          size:
+            mpp-format-int: "{boot_size_mb * 1024 * 1024 / sector_size}"
+        - name: root
+          type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
+  - id: image4k
+    sector_size:
+        mpp-format-int: "{four_k_sector_size}"
+    size:
+      mpp-format-string: "{metal_image_size_mb * 1024 * 1024}"
+    table:
+      uuid: 00000000-0000-4000-a000-000000000001
+      label: gpt
+      partitions:
+        - name: reserved
+          type: 8DA63339-0007-60C0-C436-083AC8230908
+          size:
+            mpp-format-int: "{reserved_part_size_mb * 1024 * 1024 / four_k_sector_size}"
+        - name: EFI-SYSTEM
+          type: C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+          size:
+            mpp-format-int: "{efi_system_size_mb * 1024 * 1024 / four_k_sector_size}"
+        - name: boot
+          type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
+          size:
+            mpp-format-int: "{boot_size_mb * 1024 * 1024 / four_k_sector_size}"
+        - name: root
+          type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
+pipelines:
+  # If installing from container then let's pull the container file into a pipeline
+  - name: oci-archive
+    stages:
+      - mpp-if: ociarchive != ''
+        then:
+          type: org.osbuild.copy
+          inputs:
+            inlinefile:
+              type: org.osbuild.files
+              origin: org.osbuild.source
+              mpp-embed:
+                id: coreos.ociarchive
+                url:
+                  mpp-format-string: 'file://{ociarchive}'
+          options:
+            paths:
+              - from:
+                  mpp-format-string: input://inlinefile/{embedded['coreos.ociarchive']}
+                to: tree:///coreos.ociarchive
+        else:
+          type: org.osbuild.noop
+  # Construct a tree here that is a representation of the filesystem
+  # that you would see on a running OSTree system. i.e. instead of just
+  # /ostree and /sysroot at the toplevel we see /usr/ /var/ /etc/ ... that
+  # you would see inside an OSTree deployment. Having the plain files accessible
+  # allows for this pipeline to be used as a buildroot for some stages
+  # or as inputs for others (i.e. file_context input to the org.osbuild.selinux
+  # stages). This pipeline isn't actually used for built artifacts but
+  # to help during build.
+  #
+  # NOTE: this is only used as a buildroot on RHCOS (FCOS doesn't ship python).
+  - name: deployed-tree
+    stages:
+      - mpp-if: ociarchive != ''
+        then:
+          type: org.osbuild.container-deploy
+          inputs:
+            images:
+              type: org.osbuild.containers
+              origin: org.osbuild.pipeline
+              references:
+                name:oci-archive:
+                  name: coreos.ociarchive
+        else:
+          type: org.osbuild.container-deploy
+          inputs:
+            images:
+              type: org.osbuild.containers
+              origin: org.osbuild.source
+              mpp-resolve-images:
+                images:
+                  - source: $container_repo
+                    tag: $container_tag
+  - name: tree
+    build:
+      mpp-format-string: '{buildroot}'
+    source-epoch: 1659397331
+    stages:
+      # Set the context of the root of the tree so that we avoid unlabeled_t files.
+      # https://github.com/coreos/fedora-coreos-tracker/issues/1772
+      - type: org.osbuild.selinux
+        options:
+          file_contexts: input://tree/etc/selinux/targeted/contexts/files/file_contexts
+          target: tree:///
+        inputs:
+          tree:
+            type: org.osbuild.tree
+            origin: org.osbuild.pipeline
+            references:
+              - name:deployed-tree
+      - type: org.osbuild.ostree.init-fs
+      - type: org.osbuild.ostree.os-init
+        options:
+          osname:
+            mpp-format-string: '{osname}'
+      - type: org.osbuild.ostree.config
+        options:
+          repo: /ostree/repo
+          config:
+            sysroot:
+              readonly: true
+              bootloader: none
+              # https://github.com/coreos/fedora-coreos-tracker/issues/1333
+              bls-append-except-default: grub_users=""
+              # Opt-in to https://github.com/ostreedev/ostree/pull/2705 which will
+              # add /boot as the prefix on top of BLS config entries. This is OK
+              # because there is a symlink that is created in the root of the boot
+              # filesystem by OSTree (boot -> .) that makes it so that /boot paths
+              # will always work.
+              bootprefix: true
+      - type: org.osbuild.mkdir
+        options:
+          paths:
+            - path: /boot/efi
+              mode: 493
+      - type: org.osbuild.ignition
+      # Deploy via OSTree repo if specified, otherwise ociarchive or container.
+      - mpp-if: ostree_repo != ''
+        then:
+          type: org.osbuild.ostree.deploy
+          options:
+            osname:
+              mpp-format-string: '{osname}'
+            remote: fedora
+            mounts:
+              - /boot
+              - /boot/efi
+            kernel_opts:
+              - rw
+              - '$ignition_firstboot'
+              - mpp-format-string: '{extra_kargs}'
+          inputs:
+            commits:
+              type: org.osbuild.ostree
+              origin: org.osbuild.source
+              mpp-resolve-ostree-commits:
+                commits:
+                  - ref: $ostree_ref
+                    remote:
+                      url: $ostree_repo
+        else:
+          mpp-if: ociarchive != ''
+          then:
+            type: org.osbuild.ostree.deploy.container
+            options:
+              osname:
+                mpp-format-string: '{osname}'
+              target_imgref:
+                mpp-format-string: '{container_imgref}'
+              mounts:
+                - /boot
+                - /boot/efi
+              kernel_opts:
+                - rw
+                - '$ignition_firstboot'
+                - mpp-format-string: '{extra_kargs}'
+            inputs:
+              images:
+                type: org.osbuild.containers
+                origin: org.osbuild.pipeline
+                references:
+                  name:oci-archive:
+                    name: coreos.ociarchive
+          else:
+            type: org.osbuild.ostree.deploy.container
+            options:
+              osname:
+                mpp-format-string: '{osname}'
+              target_imgref:
+                mpp-format-string: '{container_imgref}'
+              mounts:
+                - /boot
+                - /boot/efi
+              kernel_opts:
+                - rw
+                - '$ignition_firstboot'
+                - mpp-format-string: '{extra_kargs}'
+            inputs:
+              images:
+                type: org.osbuild.containers
+                origin: org.osbuild.source
+                mpp-resolve-images:
+                  images:
+                    - source: $container_repo
+                      tag: $container_tag
+      - type: org.osbuild.ostree.aleph
+        options:
+          coreos_compat: true
+          deployment:
+            default: true
+      - type: org.osbuild.ostree.selinux
+        options:
+          deployment:
+            default: true
+  - name: raw-image
+    build:
+      mpp-format-string: '{buildroot}'
+    stages:
+      - type: org.osbuild.truncate
+        options:
+          filename: disk.img
+          size:
+            mpp-format-string: '{image.size}'
+      - type: org.osbuild.sfdisk
+        devices:
+          device:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+        options:
+          mpp-format-json: '{image.layout}'
+      - type: org.osbuild.mkfs.fat
+        devices:
+          device:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              start:
+                mpp-format-int: '{image.layout[''EFI-SYSTEM''].start}'
+              size:
+                mpp-format-int: '{image.layout[''EFI-SYSTEM''].size}'
+              lock: true
+        options:
+          label: EFI-SYSTEM
+          volid: 7B7795E7
+      - type: org.osbuild.mkfs.ext4
+        devices:
+          device:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              start:
+                mpp-format-int: '{image.layout[''boot''].start}'
+              size:
+                mpp-format-int: '{image.layout[''boot''].size}'
+              lock: true
+        options:
+          uuid:
+            mpp-format-string: '{boot_fs_uuid}'
+          label:
+            mpp-format-string: '{boot_fs_label}'
+          # Set manually the metadata_csum_seed ext4 option otherwise changing the
+          # filesystem UUID while it's mounted doesn't work. Can remove this when
+          # metadata_csum_seed is default in RHEL, which can be checked by looking
+          # in /etc/mke2fs.conf.
+          metadata_csum_seed: true
+      - type: org.osbuild.mkfs.xfs
+        devices:
+          device:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              start:
+                mpp-format-int: '{image.layout[''root''].start}'
+              size:
+                mpp-format-int: '{image.layout[''root''].size}'
+              lock: true
+        options:
+          uuid:
+            mpp-format-string: '{root_fs_uuid}'
+          label:
+            mpp-format-string: '{root_fs_label}'
+      # We've created the filesystems. Now let's create the mountpoints (directories)
+      # on the filesystems and label them with appropriate SELinux labels. This also
+      # covers things like filesystem autogenerated files like 'lost+found'. The labeling
+      # will happen once with just the root filesystem mounted and once with the boot
+      # filesystem mounted too (to make sure we get all potentially hidden mountpoints).
+      # https://github.com/coreos/fedora-coreos-tracker/issues/1771
+      - type: org.osbuild.mkdir
+        options:
+          paths:
+            - path: mount://root/boot
+              mode: 493
+            - path: mount://boot/efi
+              mode: 493
+        devices:
+          disk:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              partscan: true
+        mounts:
+          - name: root
+            type: org.osbuild.xfs
+            source: disk
+            partition:
+              mpp-format-int: '{image.layout[''root''].partnum}'
+            target: /root-mount-point
+          - name: boot
+            type: org.osbuild.ext4
+            source: disk
+            partition:
+              mpp-format-int: '{image.layout[''boot''].partnum}'
+            target: /boot-mount-point
+      - type: org.osbuild.selinux
+        options:
+          file_contexts: input://tree/etc/selinux/targeted/contexts/files/file_contexts
+          target: mount://root/
+        inputs:
+          tree:
+            type: org.osbuild.tree
+            origin: org.osbuild.pipeline
+            references:
+              - name:deployed-tree
+        devices:
+          disk:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              partscan: true
+        mounts:
+          - name: root
+            type: org.osbuild.xfs
+            source: disk
+            partition:
+              mpp-format-int: '{image.layout[''root''].partnum}'
+            target: /
+      - type: org.osbuild.selinux
+        options:
+          file_contexts: input://tree/etc/selinux/targeted/contexts/files/file_contexts
+          target: mount://root/boot/
+        inputs:
+          tree:
+            type: org.osbuild.tree
+            origin: org.osbuild.pipeline
+            references:
+              - name:deployed-tree
+        devices:
+          disk:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              partscan: true
+        mounts:
+          - name: root
+            type: org.osbuild.xfs
+            source: disk
+            partition:
+              mpp-format-int: '{image.layout[''root''].partnum}'
+            target: /
+          - name: boot
+            type: org.osbuild.ext4
+            source: disk
+            partition:
+              mpp-format-int: '{image.layout[''boot''].partnum}'
+            target: /boot
+      - type: org.osbuild.copy
+        inputs:
+          tree:
+            type: org.osbuild.tree
+            origin: org.osbuild.pipeline
+            references:
+              - name:tree
+        options:
+          paths:
+            - from: input://tree/
+              to: mount://root/
+        devices:
+          disk:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              partscan: true
+        mounts:
+          - name: root
+            type: org.osbuild.xfs
+            source: disk
+            partition:
+              mpp-format-int: '{image.layout[''root''].partnum}'
+            target: /
+          - name: boot
+            type: org.osbuild.ext4
+            source: disk
+            partition:
+              mpp-format-int: '{image.layout[''boot''].partnum}'
+            target: /boot
+          - name: efi
+            type: org.osbuild.fat
+            source: disk
+            partition:
+              mpp-format-int: '{image.layout[''EFI-SYSTEM''].partnum}'
+            target: /boot/efi
+      - type: org.osbuild.bootupd
+        options:
+          static-configs: true
+          deployment:
+            default: true
+        devices:
+          disk:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              partscan: true
+        mounts:
+          - name: root
+            type: org.osbuild.xfs
+            source: disk
+            partition:
+              mpp-format-int: '{image.layout[''root''].partnum}'
+            target: /
+          - name: boot
+            type: org.osbuild.ext4
+            source: disk
+            partition:
+              mpp-format-int: '{image.layout[''boot''].partnum}'
+            target: /boot
+          - name: efi
+            type: org.osbuild.fat
+            source: disk
+            partition:
+              mpp-format-int: '{image.layout[''EFI-SYSTEM''].partnum}'
+            target: /boot/efi
+      - type: org.osbuild.chattr
+        options:
+          items:
+            mount://root/:
+              immutable: true
+        devices:
+          disk:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              partscan: true
+        mounts:
+          - name: root
+            type: org.osbuild.xfs
+            source: disk
+            partition:
+              mpp-format-int: '{image.layout[''root''].partnum}'
+            target: /
+          - name: ostree.deployment
+            type: org.osbuild.ostree.deployment
+            options:
+              source: mount
+              deployment:
+                default: true
+  - name: raw-4k-image
+    build:
+      mpp-format-string: '{buildroot}'
+    stages:
+      - type: org.osbuild.truncate
+        options:
+          filename: disk.img
+          size:
+            mpp-format-string: '{image4k.size}'
+      - type: org.osbuild.sfdisk
+        devices:
+          device:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              sector-size:
+                  mpp-format-int: "{four_k_sector_size}"
+        options:
+          mpp-format-json: '{image4k.layout}'
+      - type: org.osbuild.mkfs.fat
+        devices:
+          device:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              start:
+                mpp-format-int: '{image4k.layout[''EFI-SYSTEM''].start}'
+              size:
+                mpp-format-int: '{image4k.layout[''EFI-SYSTEM''].size}'
+              lock: true
+              sector-size:
+                  mpp-format-int: "{four_k_sector_size}"
+        options:
+          label: EFI-SYSTEM
+          volid: 7B7795E7
+      - type: org.osbuild.mkfs.ext4
+        devices:
+          device:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              start:
+                mpp-format-int: '{image4k.layout[''boot''].start}'
+              size:
+                mpp-format-int: '{image4k.layout[''boot''].size}'
+              lock: true
+              sector-size:
+                  mpp-format-int: "{four_k_sector_size}"
+        options:
+          uuid:
+            mpp-format-string: '{boot_fs_uuid}'
+          label:
+            mpp-format-string: '{boot_fs_label}'
+          # Set manually the metadata_csum_seed ext4 option otherwise changing the
+          # filesystem UUID while it's mounted doesn't work. Can remove this when
+          # metadata_csum_seed is default in RHEL, which can be checked by looking
+          # in /etc/mke2fs.conf.
+          metadata_csum_seed: true
+      - type: org.osbuild.mkfs.xfs
+        devices:
+          device:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              start:
+                mpp-format-int: '{image4k.layout[''root''].start}'
+              size:
+                mpp-format-int: '{image4k.layout[''root''].size}'
+              lock: true
+              sector-size:
+                  mpp-format-int: "{four_k_sector_size}"
+        options:
+          uuid:
+            mpp-format-string: '{root_fs_uuid}'
+          label:
+            mpp-format-string: '{root_fs_label}'
+      # We've created the filesystems. Now let's create the mountpoints (directories)
+      # on the filesystems and label them with appropriate SELinux labels. This also
+      # covers things like filesystem autogenerated files like 'lost+found'. The labeling
+      # will happen once with just the root filesystem mounted and once with the boot
+      # filesystem mounted too (to make sure we get all potentially hidden mountpoints).
+      # https://github.com/coreos/fedora-coreos-tracker/issues/1771
+      - type: org.osbuild.mkdir
+        options:
+          paths:
+            - path: mount://root/boot
+              mode: 493
+            - path: mount://boot/efi
+              mode: 493
+        devices:
+          disk:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              partscan: true
+              sector-size:
+                  mpp-format-int: "{four_k_sector_size}"
+        mounts:
+          - name: root
+            type: org.osbuild.xfs
+            source: disk
+            partition:
+              mpp-format-int: '{image4k.layout[''root''].partnum}'
+            target: /root-mount-point
+          - name: boot
+            type: org.osbuild.ext4
+            source: disk
+            partition:
+              mpp-format-int: '{image4k.layout[''boot''].partnum}'
+            target: /boot-mount-point
+      - type: org.osbuild.selinux
+        options:
+          file_contexts: input://tree/etc/selinux/targeted/contexts/files/file_contexts
+          target: mount://root/
+        inputs:
+          tree:
+            type: org.osbuild.tree
+            origin: org.osbuild.pipeline
+            references:
+              - name:deployed-tree
+        devices:
+          disk:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              partscan: true
+              sector-size:
+                  mpp-format-int: "{four_k_sector_size}"
+        mounts:
+          - name: root
+            type: org.osbuild.xfs
+            source: disk
+            partition:
+              mpp-format-int: '{image4k.layout[''root''].partnum}'
+            target: /
+      - type: org.osbuild.selinux
+        options:
+          file_contexts: input://tree/etc/selinux/targeted/contexts/files/file_contexts
+          target: mount://root/boot/
+        inputs:
+          tree:
+            type: org.osbuild.tree
+            origin: org.osbuild.pipeline
+            references:
+              - name:deployed-tree
+        devices:
+          disk:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              partscan: true
+              sector-size:
+                  mpp-format-int: "{four_k_sector_size}"
+        mounts:
+          - name: root
+            type: org.osbuild.xfs
+            source: disk
+            partition:
+              mpp-format-int: '{image4k.layout[''root''].partnum}'
+            target: /
+          - name: boot
+            type: org.osbuild.ext4
+            source: disk
+            partition:
+              mpp-format-int: '{image4k.layout[''boot''].partnum}'
+            target: /boot
+      - type: org.osbuild.copy
+        inputs:
+          tree:
+            type: org.osbuild.tree
+            origin: org.osbuild.pipeline
+            references:
+              - name:tree
+        options:
+          paths:
+            - from: input://tree/
+              to: mount://root/
+        devices:
+          disk:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              partscan: true
+              sector-size:
+                  mpp-format-int: "{four_k_sector_size}"
+        mounts:
+          - name: root
+            type: org.osbuild.xfs
+            source: disk
+            partition:
+              mpp-format-int: '{image4k.layout[''root''].partnum}'
+            target: /
+          - name: boot
+            type: org.osbuild.ext4
+            source: disk
+            partition:
+              mpp-format-int: '{image4k.layout[''boot''].partnum}'
+            target: /boot
+          - name: efi
+            type: org.osbuild.fat
+            source: disk
+            partition:
+              mpp-format-int: '{image4k.layout[''EFI-SYSTEM''].partnum}'
+            target: /boot/efi
+      - type: org.osbuild.bootupd
+        options:
+          static-configs: true
+          deployment:
+            default: true
+        devices:
+          disk:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              partscan: true
+              sector-size:
+                  mpp-format-int: "{four_k_sector_size}"
+        mounts:
+          - name: root
+            type: org.osbuild.xfs
+            source: disk
+            partition:
+              mpp-format-int: '{image4k.layout[''root''].partnum}'
+            target: /
+          - name: boot
+            type: org.osbuild.ext4
+            source: disk
+            partition:
+              mpp-format-int: '{image4k.layout[''boot''].partnum}'
+            target: /boot
+          - name: efi
+            type: org.osbuild.fat
+            source: disk
+            partition:
+              mpp-format-int: '{image4k.layout[''EFI-SYSTEM''].partnum}'
+            target: /boot/efi
+      - type: org.osbuild.chattr
+        options:
+          items:
+            mount://root/:
+              immutable: true
+        devices:
+          disk:
+            type: org.osbuild.loopback
+            options:
+              filename: disk.img
+              partscan: true
+              sector-size:
+                  mpp-format-int: "{four_k_sector_size}"
+        mounts:
+          - name: root
+            type: org.osbuild.xfs
+            source: disk
+            partition:
+              mpp-format-int: '{image4k.layout[''root''].partnum}'
+            target: /
+          - name: ostree.deployment
+            type: org.osbuild.ostree.deployment
+            options:
+              source: mount
+              deployment:
+                default: true
+  - mpp-import-pipelines:
+      path: platform.metal.ipp.yaml
+  - mpp-import-pipelines:
+      path: platform.qemu.ipp.yaml
+  - mpp-import-pipelines:
+      path: platform.live.ipp.yaml


### PR DESCRIPTION
This is initial support for being able to build against a riscv64
architecture target.

xref: https://github.com/coreos/fedora-coreos-tracker/issues/1931

There is also a commit in here for limiting the number of architectures we
build `kolet` for by default. See the commit message for more details.