### PR TITLE
cosalib/aws.py: fix replicate logic for amis already replicated

### DIFF
--- a/src/cosalib/aws.py
+++ b/src/cosalib/aws.py
@@ -1,7 +1,6 @@
 import json
 import os
 import subprocess
-import sys
 
 from cosalib.builds import Builds
 from cosalib.cmdlib import runcmd
@@ -69,8 +68,7 @@ def aws_run_ore_replicate(build, args):
         region_list = list(set(args.region) - set(duplicates))
         if len(region_list) == 0:
             print("no new regions detected")
-            sys.exit(0)
-
+            continue
         source_image = None
         for a in buildmeta[key]:
             if a['name'] == args.source_region:


### PR DESCRIPTION
This should have been part of https://github.com/coreos/coreos-assembler/commit/a0921c916cedd8dcc3714b23b56601bf17e0906d. 
Don't exit when the ami has already been replicated and there are no more regions to replicate to. Now that this is in a for loop, we should continue here so we can also process aws-winli images.