### PR TITLE
deps: add `copr-cli` to support for copr build in coreos-ci

### DIFF
--- a/src/deps.txt
+++ b/src/deps.txt
@@ -101,3 +101,6 @@ python-anytree
 
 # For mkfs.erofs
 erofs-utils
+
+# Support for copr build in coreos-ci
+copr-cli


### PR DESCRIPTION
See https://github.com/coreos/coreos-ci/pull/86#discussion_r2056199428