### PR TITLE
cmd/podman-remote-build: always pull images

### DIFF
--- a/src/cmd-remote-build-container
+++ b/src/cmd-remote-build-container
@@ -41,6 +41,9 @@ def build_container_image(labels, buildDir, containerfile, fromimage, cacheTTL,
         cmd.extend(["-v", "/etc/pki/ca-trust:/etc/pki/ca-trust:ro"])
     if security_opt:
         cmd.extend(["--security-opt", security_opt])
+    # Always checking if there is a newer base image to build on make sense here.
+    # If it's already present in the local container storage it may be stale.
+    cmd.extend(['--pull=always'])
     # Long running command. Send output to stdout for logging
     runcmd(cmd)
 


### PR DESCRIPTION
We hit several caching issues in the nodeimage layered build where the arch builders were building on top of stale base images. Hard coding `--pull=always` make sense here : if we already have the image locally it's just a check, but we need to be sure.