### PR TITLE
osbuild-manifests: enable kubevirt image for s390x

### DIFF
--- a/src/osbuild-manifests/coreos.osbuild.s390x.mpp.yaml
+++ b/src/osbuild-manifests/coreos.osbuild.s390x.mpp.yaml
@@ -648,3 +648,5 @@ pipelines:
       path: platform.qemu-secex.ipp.yaml
   - mpp-import-pipelines:
       path: platform.live.ipp.yaml
+  - mpp-import-pipelines:
+      path: platform.kubevirt.ipp.yaml

--- a/src/osbuild-manifests/platform.kubevirt.ipp.yaml
+++ b/src/osbuild-manifests/platform.kubevirt.ipp.yaml
@@ -52,6 +52,43 @@ pipelines:
              partition:
                mpp-format-int: '{image.layout[''boot''].partnum}'
              target: /boot
+      # If on s390x then run zipl, which must run after the kernel
+      # arguments get finalized in the coreos.platform stage above
+      - mpp-if: arch == 's390x'
+        then:
+          type: org.osbuild.zipl.inst
+          options:
+            kernel: "1"
+            kernel_opts_append:
+              - ignition.firstboot
+            location:
+              mpp-format-int: '{image.layout[''boot''].start}'
+          devices:
+            disk:
+              type: org.osbuild.loopback
+              options:
+                filename: disk.img
+                partscan: true
+          mounts:
+            - name: root
+              type: org.osbuild.xfs
+              source: disk
+              partition:
+                mpp-format-int: '{image.layout[''root''].partnum}'
+              target: /
+            - name: boot
+              type: org.osbuild.ext4
+              source: disk
+              partition:
+                mpp-format-int: '{image.layout[''boot''].partnum}'
+              target: /boot
+        inputs:
+            disk_image:
+              type: org.osbuild.files
+              origin: org.osbuild.pipeline
+              references:
+                name:raw-kubevirt-image:
+                  file: disk.img
   - name: qemu-kubevirt-image
     build:
       mpp-format-string: '{host_as_buildroot}'


### PR DESCRIPTION
Hi,
Based on the jira ticket https://issues.redhat.com/browse/COS-3221 . 
https://issues.redhat.com/browse/OCPBUGS-54751

Have done the testing using coreos-assember image with changes in osbuild-manifests. Able to generate kubevirt archive for FCOS as well as RHCOS.

RHCOS

```
 rhcos419-kubevirt]# cosa list
COREOS_ASSEMBLER_CONTAINER=quay.io/coreos/coreos-assember-kubevirt:latest
COREOS_ASSEMBLER_ADD_CERTS=y
+ podman run --rm -ti --security-opt=label=disable --privileged --userns=keep-id:uid=1000,gid=1000 -v=/root/rhcos419-kubevirt:/srv/ --device=/dev/kvm --device=/dev/fuse --tmpfs=/tmp -v=/var/tmp:/var/tmp --name=cosa -v=/etc/pki/ca-trust:/etc/pki/ca-trust:ro quay.io/coreos/coreos-assember-kubevirt:latest list
419.96.202505071254-0
   Timestamp: 2025-05-07T12:59:19Z (0:33:04 ago)
   Artifacts: ostree oci-manifest qemu kubevirt
      Config: release-4.19 (44326c819510)

+ rc=0
+ set +x
```

FCOS

```
fcos419-kubevirt]# cosa list
+ podman run --rm -ti --security-opt=label=disable --privileged --userns=keep-id:uid=1000,gid=1000 -v=/root/fcos419-kubevirt:/srv/ --device=/dev/kvm --device=/dev/fuse --tmpfs=/tmp -v=/var/tmp:/var/tmp --name=cosa quay.io/coreos/coreos-assember-kubevirt:latest list
42.20250507.dev.0
   Timestamp: 2025-05-07T09:15:27Z (0:08:59 ago)
   Artifacts: ostree oci-manifest qemu kubevirt
      Config: testing-devel (5046a4e48d80)

+ rc=0
+ set +x
```