### PR TITLE
osbuild: drop support for building disk images from OSTree commit

### DIFF
--- a/src/osbuild-manifests/coreos.osbuild.aarch64.mpp.yaml
+++ b/src/osbuild-manifests/coreos.osbuild.aarch64.mpp.yaml
@@ -188,14 +188,15 @@ pipelines:
             - path: /boot/efi
               mode: 493
       - type: org.osbuild.ignition
-      # Deploy via OSTree repo if specified, otherwise ociarchive or container.
-      - mpp-if: ostree_repo != ''
+      # Deploy via ociarchive or container
+      - mpp-if: ociarchive != ''
         then:
-          type: org.osbuild.ostree.deploy
+          type: org.osbuild.ostree.deploy.container
           options:
             osname:
               mpp-format-string: '{osname}'
-            remote: fedora
+            target_imgref:
+              mpp-format-string: '{container_imgref}'
             mounts:
               - /boot
               - /boot/efi
@@ -204,59 +205,34 @@ pipelines:
               - '$ignition_firstboot'
               - mpp-format-string: '{extra_kargs}'
           inputs:
-            commits:
-              type: org.osbuild.ostree
-              origin: org.osbuild.source
-              mpp-resolve-ostree-commits:
-                commits:
-                  - ref: $ostree_ref
-                    remote:
-                      url: $ostree_repo
+            images:
+              type: org.osbuild.containers
+              origin: org.osbuild.pipeline
+              references:
+                name:oci-archive:
+                  name: coreos.ociarchive
         else:
-          mpp-if: ociarchive != ''
-          then:
-            type: org.osbuild.ostree.deploy.container
-            options:
-              osname:
-                mpp-format-string: '{osname}'
-              target_imgref:
-                mpp-format-string: '{container_imgref}'
-              mounts:
-                - /boot
-                - /boot/efi
-              kernel_opts:
-                - rw
-                - '$ignition_firstboot'
-                - mpp-format-string: '{extra_kargs}'
-            inputs:
-              images:
-                type: org.osbuild.containers
-                origin: org.osbuild.pipeline
-                references:
-                  name:oci-archive:
-                    name: coreos.ociarchive
-          else:
-            type: org.osbuild.ostree.deploy.container
-            options:
-              osname:
-                mpp-format-string: '{osname}'
-              target_imgref:
-                mpp-format-string: '{container_imgref}'
-              mounts:
-                - /boot
-                - /boot/efi
-              kernel_opts:
-                - rw
-                - '$ignition_firstboot'
-                - mpp-format-string: '{extra_kargs}'
-            inputs:
-              images:
-                type: org.osbuild.containers
-                origin: org.osbuild.source
-                mpp-resolve-images:
-                  images:
-                    - source: $container_repo
-                      tag: $container_tag
+          type: org.osbuild.ostree.deploy.container
+          options:
+            osname:
+              mpp-format-string: '{osname}'
+            target_imgref:
+              mpp-format-string: '{container_imgref}'
+            mounts:
+              - /boot
+              - /boot/efi
+            kernel_opts:
+              - rw
+              - '$ignition_firstboot'
+              - mpp-format-string: '{extra_kargs}'
+          inputs:
+            images:
+              type: org.osbuild.containers
+              origin: org.osbuild.source
+              mpp-resolve-images:
+                images:
+                  - source: $container_repo
+                    tag: $container_tag
       - type: org.osbuild.ostree.aleph
         options:
           coreos_compat: true

--- a/src/osbuild-manifests/coreos.osbuild.ppc64le.mpp.yaml
+++ b/src/osbuild-manifests/coreos.osbuild.ppc64le.mpp.yaml
@@ -185,14 +185,15 @@ pipelines:
               # will always work.
               bootprefix: true
       - type: org.osbuild.ignition
-      # Deploy via OSTree repo if specified, otherwise ociarchive or container.
-      - mpp-if: ostree_repo != ''
+      # Deploy via ociarchive or container
+      - mpp-if: ociarchive != ''
         then:
-          type: org.osbuild.ostree.deploy
+          type: org.osbuild.ostree.deploy.container
           options:
             osname:
               mpp-format-string: '{osname}'
-            remote: fedora
+            target_imgref:
+              mpp-format-string: '{container_imgref}'
             mounts:
               - /boot
             kernel_opts:
@@ -200,57 +201,33 @@ pipelines:
               - '$ignition_firstboot'
               - mpp-format-string: '{extra_kargs}'
           inputs:
-            commits:
-              type: org.osbuild.ostree
-              origin: org.osbuild.source
-              mpp-resolve-ostree-commits:
-                commits:
-                  - ref: $ostree_ref
-                    remote:
-                      url: $ostree_repo
+            images:
+              type: org.osbuild.containers
+              origin: org.osbuild.pipeline
+              references:
+                name:oci-archive:
+                  name: coreos.ociarchive
         else:
-          mpp-if: ociarchive != ''
-          then:
-            type: org.osbuild.ostree.deploy.container
-            options:
-              osname:
-                mpp-format-string: '{osname}'
-              target_imgref:
-                mpp-format-string: '{container_imgref}'
-              mounts:
-                - /boot
-              kernel_opts:
-                - rw
-                - '$ignition_firstboot'
-                - mpp-format-string: '{extra_kargs}'
-            inputs:
-              images:
-                type: org.osbuild.containers
-                origin: org.osbuild.pipeline
-                references:
-                  name:oci-archive:
-                    name: coreos.ociarchive
-          else:
-            type: org.osbuild.ostree.deploy.container
-            options:
-              osname:
-                mpp-format-string: '{osname}'
-              target_imgref:
-                mpp-format-string: '{container_imgref}'
-              mounts:
-                - /boot
-              kernel_opts:
-                - rw
-                - '$ignition_firstboot'
-                - mpp-format-string: '{extra_kargs}'
-            inputs:
-              images:
-                type: org.osbuild.containers
-                origin: org.osbuild.source
-                mpp-resolve-images:
-                  images:
-                    - source: $container_repo
-                      tag: $container_tag
+          type: org.osbuild.ostree.deploy.container
+          options:
+            osname:
+              mpp-format-string: '{osname}'
+            target_imgref:
+              mpp-format-string: '{container_imgref}'
+            mounts:
+              - /boot
+            kernel_opts:
+              - rw
+              - '$ignition_firstboot'
+              - mpp-format-string: '{extra_kargs}'
+          inputs:
+            images:
+              type: org.osbuild.containers
+              origin: org.osbuild.source
+              mpp-resolve-images:
+                images:
+                  - source: $container_repo
+                    tag: $container_tag
       # Drop the immutable bit here (we add it back later) because it
       # causes failures when cleaning up tmp dirs.
       - type: org.osbuild.chattr

--- a/src/osbuild-manifests/coreos.osbuild.riscv64.mpp.yaml
+++ b/src/osbuild-manifests/coreos.osbuild.riscv64.mpp.yaml
@@ -188,14 +188,15 @@ pipelines:
             - path: /boot/efi
               mode: 493
       - type: org.osbuild.ignition
-      # Deploy via OSTree repo if specified, otherwise ociarchive or container.
-      - mpp-if: ostree_repo != ''
+      # Deploy via ociarchive or container
+      - mpp-if: ociarchive != ''
         then:
-          type: org.osbuild.ostree.deploy
+          type: org.osbuild.ostree.deploy.container
           options:
             osname:
               mpp-format-string: '{osname}'
-            remote: fedora
+            target_imgref:
+              mpp-format-string: '{container_imgref}'
             mounts:
               - /boot
               - /boot/efi
@@ -204,59 +205,34 @@ pipelines:
               - '$ignition_firstboot'
               - mpp-format-string: '{extra_kargs}'
           inputs:
-            commits:
-              type: org.osbuild.ostree
-              origin: org.osbuild.source
-              mpp-resolve-ostree-commits:
-                commits:
-                  - ref: $ostree_ref
-                    remote:
-                      url: $ostree_repo
+            images:
+              type: org.osbuild.containers
+              origin: org.osbuild.pipeline
+              references:
+                name:oci-archive:
+                  name: coreos.ociarchive
         else:
-          mpp-if: ociarchive != ''
-          then:
-            type: org.osbuild.ostree.deploy.container
-            options:
-              osname:
-                mpp-format-string: '{osname}'
-              target_imgref:
-                mpp-format-string: '{container_imgref}'
-              mounts:
-                - /boot
-                - /boot/efi
-              kernel_opts:
-                - rw
-                - '$ignition_firstboot'
-                - mpp-format-string: '{extra_kargs}'
-            inputs:
-              images:
-                type: org.osbuild.containers
-                origin: org.osbuild.pipeline
-                references:
-                  name:oci-archive:
-                    name: coreos.ociarchive
-          else:
-            type: org.osbuild.ostree.deploy.container
-            options:
-              osname:
-                mpp-format-string: '{osname}'
-              target_imgref:
-                mpp-format-string: '{container_imgref}'
-              mounts:
-                - /boot
-                - /boot/efi
-              kernel_opts:
-                - rw
-                - '$ignition_firstboot'
-                - mpp-format-string: '{extra_kargs}'
-            inputs:
-              images:
-                type: org.osbuild.containers
-                origin: org.osbuild.source
-                mpp-resolve-images:
-                  images:
-                    - source: $container_repo
-                      tag: $container_tag
+          type: org.osbuild.ostree.deploy.container
+          options:
+            osname:
+              mpp-format-string: '{osname}'
+            target_imgref:
+              mpp-format-string: '{container_imgref}'
+            mounts:
+              - /boot
+              - /boot/efi
+            kernel_opts:
+              - rw
+              - '$ignition_firstboot'
+              - mpp-format-string: '{extra_kargs}'
+          inputs:
+            images:
+              type: org.osbuild.containers
+              origin: org.osbuild.source
+              mpp-resolve-images:
+                images:
+                  - source: $container_repo
+                    tag: $container_tag
       - type: org.osbuild.ostree.aleph
         options:
           coreos_compat: true

--- a/src/osbuild-manifests/coreos.osbuild.s390x.mpp.yaml
+++ b/src/osbuild-manifests/coreos.osbuild.s390x.mpp.yaml
@@ -176,14 +176,15 @@ pipelines:
               # will always work.
               bootprefix: true
       - type: org.osbuild.ignition
-      # Deploy via OSTree repo if specified, otherwise ociarchive or container.
-      - mpp-if: ostree_repo != ''
+      # Deploy via ociarchive or container
+      - mpp-if: ociarchive != ''
         then:
-          type: org.osbuild.ostree.deploy
+          type: org.osbuild.ostree.deploy.container
           options:
             osname:
               mpp-format-string: '{osname}'
-            remote: fedora
+            target_imgref:
+              mpp-format-string: '{container_imgref}'
             mounts:
               - /boot
             kernel_opts:
@@ -192,59 +193,34 @@ pipelines:
              #- '$ignition_firstboot'
               - mpp-format-string: '{extra_kargs}'
           inputs:
-            commits:
-              type: org.osbuild.ostree
-              origin: org.osbuild.source
-              mpp-resolve-ostree-commits:
-                commits:
-                  - ref: $ostree_ref
-                    remote:
-                      url: $ostree_repo
+            images:
+              type: org.osbuild.containers
+              origin: org.osbuild.pipeline
+              references:
+                name:oci-archive:
+                  name: coreos.ociarchive
         else:
-          mpp-if: ociarchive != ''
-          then:
-            type: org.osbuild.ostree.deploy.container
-            options:
-              osname:
-                mpp-format-string: '{osname}'
-              target_imgref:
-                mpp-format-string: '{container_imgref}'
-              mounts:
-                - /boot
-              kernel_opts:
-                - rw
-               ## '$ignition_firstboot' only works with GRUB, not available on s390x
-               #- '$ignition_firstboot'
-                - mpp-format-string: '{extra_kargs}'
-            inputs:
-              images:
-                type: org.osbuild.containers
-                origin: org.osbuild.pipeline
-                references:
-                  name:oci-archive:
-                    name: coreos.ociarchive
-          else:
-            type: org.osbuild.ostree.deploy.container
-            options:
-              osname:
-                mpp-format-string: '{osname}'
-              target_imgref:
-                mpp-format-string: '{container_imgref}'
-              mounts:
-                - /boot
-              kernel_opts:
-                - rw
-               ## '$ignition_firstboot' only works with GRUB, not available on s390x
-               #- '$ignition_firstboot'
-                - mpp-format-string: '{extra_kargs}'
-            inputs:
-              images:
-                type: org.osbuild.containers
-                origin: org.osbuild.source
-                mpp-resolve-images:
-                  images:
-                    - source: $container_repo
-                      tag: $container_tag
+          type: org.osbuild.ostree.deploy.container
+          options:
+            osname:
+              mpp-format-string: '{osname}'
+            target_imgref:
+              mpp-format-string: '{container_imgref}'
+            mounts:
+              - /boot
+            kernel_opts:
+              - rw
+             ## '$ignition_firstboot' only works with GRUB, not available on s390x
+             #- '$ignition_firstboot'
+              - mpp-format-string: '{extra_kargs}'
+          inputs:
+            images:
+              type: org.osbuild.containers
+              origin: org.osbuild.source
+              mpp-resolve-images:
+                images:
+                  - source: $container_repo
+                    tag: $container_tag
       # Drop the immutable bit here (we add it back later) because it
       # causes failures when cleaning up tmp dirs.
       - type: org.osbuild.chattr

--- a/src/osbuild-manifests/coreos.osbuild.x86_64.mpp.yaml
+++ b/src/osbuild-manifests/coreos.osbuild.x86_64.mpp.yaml
@@ -190,14 +190,15 @@ pipelines:
             - path: /boot/efi
               mode: 493
       - type: org.osbuild.ignition
-      # Deploy via OSTree repo if specified, otherwise ociarchive or container.
-      - mpp-if: ostree_repo != ''
+      # Deploy via ociarchive or container
+      - mpp-if: ociarchive != ''
         then:
-          type: org.osbuild.ostree.deploy
+          type: org.osbuild.ostree.deploy.container
           options:
             osname:
               mpp-format-string: '{osname}'
-            remote: fedora
+            target_imgref:
+              mpp-format-string: '{container_imgref}'
             mounts:
               - /boot
               - /boot/efi
@@ -206,59 +207,34 @@ pipelines:
               - '$ignition_firstboot'
               - mpp-format-string: '{extra_kargs}'
           inputs:
-            commits:
-              type: org.osbuild.ostree
-              origin: org.osbuild.source
-              mpp-resolve-ostree-commits:
-                commits:
-                  - ref: $ostree_ref
-                    remote:
-                      url: $ostree_repo
+            images:
+              type: org.osbuild.containers
+              origin: org.osbuild.pipeline
+              references:
+                name:oci-archive:
+                  name: coreos.ociarchive
         else:
-          mpp-if: ociarchive != ''
-          then:
-            type: org.osbuild.ostree.deploy.container
-            options:
-              osname:
-                mpp-format-string: '{osname}'
-              target_imgref:
-                mpp-format-string: '{container_imgref}'
-              mounts:
-                - /boot
-                - /boot/efi
-              kernel_opts:
-                - rw
-                - '$ignition_firstboot'
-                - mpp-format-string: '{extra_kargs}'
-            inputs:
-              images:
-                type: org.osbuild.containers
-                origin: org.osbuild.pipeline
-                references:
-                  name:oci-archive:
-                    name: coreos.ociarchive
-          else:
-            type: org.osbuild.ostree.deploy.container
-            options:
-              osname:
-                mpp-format-string: '{osname}'
-              target_imgref:
-                mpp-format-string: '{container_imgref}'
-              mounts:
-                - /boot
-                - /boot/efi
-              kernel_opts:
-                - rw
-                - '$ignition_firstboot'
-                - mpp-format-string: '{extra_kargs}'
-            inputs:
-              images:
-                type: org.osbuild.containers
-                origin: org.osbuild.source
-                mpp-resolve-images:
-                  images:
-                    - source: $container_repo
-                      tag: $container_tag
+          type: org.osbuild.ostree.deploy.container
+          options:
+            osname:
+              mpp-format-string: '{osname}'
+            target_imgref:
+              mpp-format-string: '{container_imgref}'
+            mounts:
+              - /boot
+              - /boot/efi
+            kernel_opts:
+              - rw
+              - '$ignition_firstboot'
+              - mpp-format-string: '{extra_kargs}'
+          inputs:
+            images:
+              type: org.osbuild.containers
+              origin: org.osbuild.source
+              mpp-resolve-images:
+                images:
+                  - source: $container_repo
+                    tag: $container_tag
       - type: org.osbuild.ostree.aleph
         options:
           coreos_compat: true


### PR DESCRIPTION
Now that we are building only F42+ images we are never passing in an OSTree commit. The FCOS pipeline was the only consumer of this so we can safely drop that conditional logic.