### PR TITLE
cmd-coreos-prune: handle expired or deleted tags in skopeo inspect

### DIFF
--- a/src/cmd-coreos-prune
+++ b/src/cmd-coreos-prune
@@ -520,6 +520,12 @@ def skopeo_inspect(repo, tag, auth):
         if exit_code == 2:
             print(f"\t\t\tSkipping deletion for {repo}:{tag} since the tag does not exist.")
             return False
+        # Quay could return an "unknown" error code when a tag has expired or been GC’d.
+        # Check for this error message specifically and avoid raising an exception in that
+        # case, since the image is already gone.
+        elif "Tag" in error_message and "was deleted or has expired" in error_message:
+            print(f"\t\t\tSkipping deletion for {repo}:{tag} since the tag was deleted or has expired.")
+            return False
         else:
             # Handle other types of errors
             raise Exception(f"Inspection failed for {repo}:{tag} with exit code {exit_code}: {error_message}")


### PR DESCRIPTION
When a tag is expired or been garbage collected in Quay, skopeo inspect returns a "unknown" error with a message like:
```
Tag <tag> was deleted or has expired. To pull, revive via time machine
```
Check for this condition and skip raising the exception, instead just return since the tag has already been GC'd.

Aims to fix: https://github.com/coreos/coreos-assembler/issues/4087