### PR TITLE
ci/prow-rhcos: update for rhcos repo split

### DIFF
--- a/ci/prow-rhcos.sh
+++ b/ci/prow-rhcos.sh
@@ -7,9 +7,8 @@ set -xeuo pipefail
 # rehearsal jobs: https://github.com/coreos/coreos-assembler/pull/2598
 BRANCH=${OPENSHIFT_BUILD_REFERENCE:-${PULL_BASE_REF:-main}}
 case ${BRANCH} in
-    # For now; OpenShift hasn't done the master->main transition
-    main|master) RHCOS_BRANCH=master;;
-    rhcos-*) RHCOS_BRANCH=release-${BRANCH#rhcos-};;
+    main) REPO=https://github.com/coreos/rhel-coreos-config; RHCOS_BRANCH=main;;
+    rhcos-*) REPO=https://github.com/openshift/os; RHCOS_BRANCH=release-${BRANCH#rhcos-};;
     *) echo "Unhandled base ref: ${BRANCH}" 1>&2 && exit 1;;
 esac
 
@@ -17,6 +16,6 @@ esac
 export COSA_SKIP_OVERLAY=1
 # Create a temporary cosa workdir
 cd "$(mktemp -d)"
-cosa init --transient -b "${RHCOS_BRANCH}" https://github.com/openshift/os
+cosa init --transient -b "${RHCOS_BRANCH}" "${REPO}"
 # Use a COSA specifc test entry point to focus on tests relevant for COSA
 exec src/config/ci/prow-entrypoint.sh rhcos-cosa-prow-pr-ci


### PR DESCRIPTION
The repo was split such that going forward coreos/rhel-coreos-config will be used so let's update it so that we test again that repo for latest main branch of COSA.