### PR TITLE
tests/podman: podman rmi output check

### DIFF
--- a/mantle/kola/tests/podman/podman.go
+++ b/mantle/kola/tests/podman/podman.go
@@ -216,10 +216,9 @@ func podmanWorkflow(c cluster.TestCluster) {
 	// Test: Delete container
 	c.Run("delete", func(c cluster.TestCluster) {
 		cmd := fmt.Sprintf("sudo podman rmi %s", image)
-		out := c.MustSSH(m, cmd)
-		imageID := string(out)
+		c.MustSSH(m, cmd)
 
-		cmd = fmt.Sprintf("sudo podman images | grep %s", imageID)
+		cmd = fmt.Sprintf("sudo podman image exists %s", image)
 		out, err := c.SSH(m, cmd)
 		if err == nil {
 			c.Fatalf("Image should be deleted but found %s", string(out))


### PR DESCRIPTION
podman rmi only produces two lines of output without a -q option that might produce a "docker-ish" output displaying only the abbreviated image ID.

To simplify rmi success checking, indirect testing using the expected ID output was replaced with a direct reference to the image name. Bash piping with grep was also removed in favor of a single command.