### PR TITLE
[rhcos-4.18] kola: remove IBM CEX device test for the s390x build

### DIFF
--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -168,8 +168,6 @@ func init() {
 	bv(&kola.QEMUOptions.SecureExecution, "qemu-secex", false, "Run IBM Secure Execution Image")
 	sv(&kola.QEMUOptions.SecureExecutionIgnitionPubKey, "qemu-secex-ignition-pubkey", "", "Path to Ignition GPG Public Key")
 	sv(&kola.QEMUOptions.SecureExecutionHostKey, "qemu-secex-hostkey", "", "Path to Secure Execution HKD certificate")
-	// s390x CEX-specific options
-	bv(&kola.QEMUOptions.Cex, "qemu-cex", false, "Attach CEX device to guest")
 }
 
 // Sync up the command line options if there is dependency

--- a/mantle/cmd/kola/qemuexec.go
+++ b/mantle/cmd/kola/qemuexec.go
@@ -391,14 +391,6 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// IBM Cex based luks encryption.
-	if kola.QEMUOptions.Cex {
-		err := builder.AddCexDevice()
-		if err != nil {
-			return err
-		}
-	}
-
 	if devshell && !devshellConsole {
 		return runDevShellSSH(ctx, builder, config, sshCommand)
 	}

--- a/mantle/kola/tests/util/luks.go
+++ b/mantle/kola/tests/util/luks.go
@@ -79,21 +79,3 @@ func LUKSSanityTest(c cluster.TestCluster, tangd TangServer, m platform.Machine,
 	luksDump = c.MustSSH(m, "sudo cryptsetup luksDump "+rootPart)
 	mustMatch(c, "Cipher: *aes", luksDump)
 }
-
-// LUKSSanityCEXTest verifies that the rootfs is encrypted with Cex based LUKS
-func LUKSSanityCEXTest(c cluster.TestCluster, m platform.Machine, rootPart string) {
-	var err error
-	luksDump := c.MustSSH(m, "sudo cryptsetup luksDump "+rootPart)
-	mustMatch(c, "cipher: paes-*", luksDump)
-	mustNotMatch(c, "Cipher: *cipher_null-ecb", luksDump)
-	mustMatch(c, "0: paes-verification-pattern", luksDump)
-	mustNotMatch(c, "9: *coreos", luksDump)
-
-	err = m.Reboot()
-
-	if err != nil {
-		c.Fatalf("Failed to reboot the machine: %v", err)
-	}
-	luksDump = c.MustSSH(m, "sudo cryptsetup luksDump "+rootPart)
-	mustMatch(c, "cipher: paes-*", luksDump)
-}

--- a/mantle/platform/machine/qemu/cluster.go
+++ b/mantle/platform/machine/qemu/cluster.go
@@ -150,12 +150,6 @@ func (qc *Cluster) NewMachineWithQemuOptions(userdata *conf.UserData, options pl
 		primaryDisk = *diskp
 	}
 
-	if qc.flight.opts.Cex || options.Cex {
-		if err := builder.AddCexDevice(); err != nil {
-			return nil, err
-		}
-	}
-
 	if qc.flight.opts.Nvme || options.Nvme {
 		primaryDisk.Channel = "nvme"
 	}

--- a/mantle/platform/machine/qemu/flight.go
+++ b/mantle/platform/machine/qemu/flight.go
@@ -55,9 +55,6 @@ type Options struct {
 	SecureExecutionIgnitionPubKey string
 	SecureExecutionHostKey        string
 
-	// Option to create IBM cex based luks encryption
-	Cex bool
-
 	*platform.Options
 }
 

--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -74,7 +74,6 @@ type QemuMachineOptions struct {
 	OverrideBackingFile string
 	Firmware            string
 	Nvme                bool
-	Cex                 bool
 }
 
 // QEMUMachine represents a qemu instance.
@@ -2058,14 +2057,4 @@ func (builder *QemuBuilder) Close() {
 	if builder.tempdir != "" {
 		os.RemoveAll(builder.tempdir)
 	}
-}
-
-// supports IBM Cex based LUKS encryption if it is s390x host (zKVM/LPAR)
-func (builder *QemuBuilder) AddCexDevice() error {
-	cex_uuid := os.Getenv("KOLA_CEX_UUID")
-	if cex_uuid == "" {
-		return errors.New("cannot add CEX device: KOLA_CEX_UUID env var undefined")
-	}
-	builder.Append("-device", fmt.Sprintf("vfio-ap,sysfsdev=/sys/devices/vfio_ap/matrix/%s", cex_uuid))
-	return nil
 }


### PR DESCRIPTION
This test was added to coreos-assembler before 4.19 branched, so it ended up in 4.18 but was intended for 4.19+. It recently started failing in 4.18 due to the addition of CEX configuration in RHCOS. Remove the test from 4.18 to unblock the pipeline.

This reverts commit 41e5c4a3a554706fbff86dd71906411d934cc568.