### PR TITLE
[rhcos-4.18] build.sh: set frozendeps to some value

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -40,7 +40,7 @@ configure_yum_repos() {
 
 install_rpms() {
     local builddeps
-    local frozendeps
+    local frozendeps=""
 
     # freeze grub2 for https://github.com/coreos/fedora-coreos-tracker/issues/1886
     case "${arch}" in


### PR DESCRIPTION
Otherwise we get a use of unitialized variable in the s390x case.

(cherry picked from commit 5a320f7a1c6e177bdf09b6a294ba9ac766a69666)