### PR TITLE
[rhcos-4.17] build: freeze grub2 due to ppc64le PXE test failures

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -42,7 +42,13 @@ install_rpms() {
     local builddeps
     local frozendeps
 
-    frozendeps=""
+    # freeze grub2 for https://github.com/coreos/fedora-coreos-tracker/issues/1886
+    case "${arch}" in
+        x86_64) frozendeps=$(echo grub2-{common,tools,tools-extra,tools-minimal,efi-x64,pc,pc-modules}-2.06-123.fc40);;
+        aarch64) frozendeps=$(echo grub2-{common,tools,tools-extra,tools-minimal,efi-aa64}-2.06-123.fc40);;
+        ppc64le) frozendeps=$(echo grub2-{common,tools,tools-extra,tools-minimal,ppc64le,ppc64le-modules}-2.06-123.fc40);;
+        *) ;;
+    esac
 
     # First, a general update; this is best practice.  We also hit an issue recently
     # where qemu implicitly depended on an updated libusbx but didn't have a versioned

--- a/build.sh
+++ b/build.sh
@@ -40,7 +40,7 @@ configure_yum_repos() {
 
 install_rpms() {
     local builddeps
-    local frozendeps
+    local frozendeps=""
 
     # freeze grub2 for https://github.com/coreos/fedora-coreos-tracker/issues/1886
     case "${arch}" in


### PR DESCRIPTION
A new version of GRUB was released right at the end of F40 before EOL
and it brought in the problems described in [1] making ppc64le tests
fail. We'll just pin on the older version.

See: https://github.com/coreos/fedora-coreos-tracker/issues/1886
(cherry picked from commit 8f0ddfffec64d334ddf5c386c25dae190030e2fe)
