### PR TITLE
mantle/platform/azure: Add support for Azure Shared Image Gallery (SIG) and other enhancements

### DIFF
--- a/mantle/cmd/kola/kola.go
+++ b/mantle/cmd/kola/kola.go
@@ -300,13 +300,14 @@ func writeProps() error {
 		InstanceType string `json:"type"`
 	}
 	type Azure struct {
-		DiskURI   string `json:"diskUri"`
-		Publisher string `json:"publisher"`
-		Offer     string `json:"offer"`
-		Sku       string `json:"sku"`
-		Version   string `json:"version"`
-		Location  string `json:"location"`
-		Size      string `json:"size"`
+		DiskURI          string `json:"diskUri"`
+		Publisher        string `json:"publisher"`
+		Offer            string `json:"offer"`
+		Sku              string `json:"sku"`
+		Version          string `json:"version"`
+		Location         string `json:"location"`
+		Size             string `json:"size"`
+		AvailabilityZone string `json:"availability_zone"`
 	}
 	type DO struct {
 		Region string `json:"region"`
@@ -355,13 +356,14 @@ func writeProps() error {
 			InstanceType: kola.AWSOptions.InstanceType,
 		},
 		Azure: Azure{
-			DiskURI:   kola.AzureOptions.DiskURI,
-			Publisher: kola.AzureOptions.Publisher,
-			Offer:     kola.AzureOptions.Offer,
-			Sku:       kola.AzureOptions.Sku,
-			Version:   kola.AzureOptions.Version,
-			Location:  kola.AzureOptions.Location,
-			Size:      kola.AzureOptions.Size,
+			DiskURI:          kola.AzureOptions.DiskURI,
+			Publisher:        kola.AzureOptions.Publisher,
+			Offer:            kola.AzureOptions.Offer,
+			Sku:              kola.AzureOptions.Sku,
+			Version:          kola.AzureOptions.Version,
+			Location:         kola.AzureOptions.Location,
+			Size:             kola.AzureOptions.Size,
+			AvailabilityZone: kola.AzureOptions.AvailabilityZone,
 		},
 		DO: DO{
 			Region: kola.DOOptions.Region,

--- a/mantle/cmd/kola/kola.go
+++ b/mantle/cmd/kola/kola.go
@@ -308,7 +308,6 @@ func writeProps() error {
 		Location         string `json:"location"`
 		Size             string `json:"size"`
 		AvailabilityZone string `json:"availability_zone"`
-		HyperVGeneration string `json:"hyper_v_generation"`
 	}
 	type DO struct {
 		Region string `json:"region"`
@@ -365,7 +364,6 @@ func writeProps() error {
 			Location:         kola.AzureOptions.Location,
 			Size:             kola.AzureOptions.Size,
 			AvailabilityZone: kola.AzureOptions.AvailabilityZone,
-			HyperVGeneration: kola.AzureOptions.HyperVGeneration,
 		},
 		DO: DO{
 			Region: kola.DOOptions.Region,

--- a/mantle/cmd/kola/kola.go
+++ b/mantle/cmd/kola/kola.go
@@ -308,6 +308,7 @@ func writeProps() error {
 		Location         string `json:"location"`
 		Size             string `json:"size"`
 		AvailabilityZone string `json:"availability_zone"`
+		HyperVGeneration string `json:"hyper_v_generation"`
 	}
 	type DO struct {
 		Region string `json:"region"`
@@ -364,6 +365,7 @@ func writeProps() error {
 			Location:         kola.AzureOptions.Location,
 			Size:             kola.AzureOptions.Size,
 			AvailabilityZone: kola.AzureOptions.AvailabilityZone,
+			HyperVGeneration: kola.AzureOptions.HyperVGeneration,
 		},
 		DO: DO{
 			Region: kola.DOOptions.Region,

--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -101,7 +101,6 @@ func init() {
 	sv(&kola.AzureOptions.Location, "azure-location", "westus", "Azure location (default \"westus\"")
 	sv(&kola.AzureOptions.Size, "azure-size", "Standard_D2_v2", "Azure machine size (default \"Standard_D2_v2\")")
 	sv(&kola.AzureOptions.AvailabilityZone, "azure-availability-zone", "1", "Azure Availability Zone (default \"1\")")
-	sv(&kola.AzureOptions.HyperVGeneration, "azure-hyper-v-generation", "V1", "Azure Hyper-V Generation (default \"V1\")")
 
 	// do-specific options
 	sv(&kola.DOOptions.ConfigPath, "do-config-file", "", "DigitalOcean config file (default \"~/"+auth.DOConfigPath+"\")")

--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -100,6 +100,7 @@ func init() {
 	sv(&kola.AzureOptions.Version, "azure-version", "", "Azure image version")
 	sv(&kola.AzureOptions.Location, "azure-location", "westus", "Azure location (default \"westus\"")
 	sv(&kola.AzureOptions.Size, "azure-size", "Standard_D2_v2", "Azure machine size (default \"Standard_D2_v2\")")
+	sv(&kola.AzureOptions.AvailabilityZone, "azure-availability-zone", "1", "Azure Availability Zone (default \"1\")")
 
 	// do-specific options
 	sv(&kola.DOOptions.ConfigPath, "do-config-file", "", "DigitalOcean config file (default \"~/"+auth.DOConfigPath+"\")")

--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -101,6 +101,7 @@ func init() {
 	sv(&kola.AzureOptions.Location, "azure-location", "westus", "Azure location (default \"westus\"")
 	sv(&kola.AzureOptions.Size, "azure-size", "Standard_D2_v2", "Azure machine size (default \"Standard_D2_v2\")")
 	sv(&kola.AzureOptions.AvailabilityZone, "azure-availability-zone", "1", "Azure Availability Zone (default \"1\")")
+	sv(&kola.AzureOptions.HyperVGeneration, "azure-hyper-v-generation", "V1", "Azure Hyper-V Generation (default \"V1\")")
 
 	// do-specific options
 	sv(&kola.DOOptions.ConfigPath, "do-config-file", "", "DigitalOcean config file (default \"~/"+auth.DOConfigPath+"\")")

--- a/mantle/cmd/ore/azure/azure.go
+++ b/mantle/cmd/ore/azure/azure.go
@@ -34,7 +34,6 @@ var (
 
 	azureCredentials string
 	azureLocation    string
-	azureHyperVGen   string
 	azurePublisher   string
 
 	api *azure.API
@@ -46,7 +45,6 @@ func init() {
 	sv := Azure.PersistentFlags().StringVar
 	sv(&azureCredentials, "azure-credentials", "", "Azure credentials file location (default \"~/"+auth.AzureCredentialsPath+"\")")
 	sv(&azureLocation, "azure-location", "westus", "Azure location (default \"westus\")")
-	sv(&azureHyperVGen, "azure-hyper-v-generation", "V1", "Azure Hypervisor Generation")
 	sv(&azurePublisher, "azure-publisher", "CoreOS", "Azure image publisher")
 }
 
@@ -56,7 +54,6 @@ func preauth(cmd *cobra.Command, args []string) error {
 	a, err := azure.New(&azure.Options{
 		AzureCredentials: azureCredentials,
 		Location:         azureLocation,
-		HyperVGeneration: azureHyperVGen,
 		Publisher:        azurePublisher,
 	})
 	if err != nil {

--- a/mantle/cmd/ore/azure/azure.go
+++ b/mantle/cmd/ore/azure/azure.go
@@ -35,6 +35,7 @@ var (
 	azureCredentials string
 	azureLocation    string
 	azureHyperVGen   string
+	azurePublisher   string
 
 	api *azure.API
 )
@@ -46,6 +47,7 @@ func init() {
 	sv(&azureCredentials, "azure-credentials", "", "Azure credentials file location (default \"~/"+auth.AzureCredentialsPath+"\")")
 	sv(&azureLocation, "azure-location", "westus", "Azure location (default \"westus\")")
 	sv(&azureHyperVGen, "azure-hyper-v-generation", "V1", "Azure Hypervisor Generation")
+	sv(&azurePublisher, "azure-publisher", "CoreOS", "Azure image publisher")
 }
 
 func preauth(cmd *cobra.Command, args []string) error {
@@ -55,6 +57,7 @@ func preauth(cmd *cobra.Command, args []string) error {
 		AzureCredentials: azureCredentials,
 		Location:         azureLocation,
 		HyperVGeneration: azureHyperVGen,
+		Publisher:        azurePublisher,
 	})
 	if err != nil {
 		plog.Fatalf("Failed to create Azure API: %v", err)

--- a/mantle/cmd/ore/azure/azure.go
+++ b/mantle/cmd/ore/azure/azure.go
@@ -34,6 +34,7 @@ var (
 
 	azureCredentials string
 	azureLocation    string
+	azureHyperVGen   string
 
 	api *azure.API
 )
@@ -44,6 +45,7 @@ func init() {
 	sv := Azure.PersistentFlags().StringVar
 	sv(&azureCredentials, "azure-credentials", "", "Azure credentials file location (default \"~/"+auth.AzureCredentialsPath+"\")")
 	sv(&azureLocation, "azure-location", "westus", "Azure location (default \"westus\")")
+	sv(&azureHyperVGen, "azure-hyper-v-generation", "V1", "Azure Hypervisor Generation")
 }
 
 func preauth(cmd *cobra.Command, args []string) error {
@@ -52,6 +54,7 @@ func preauth(cmd *cobra.Command, args []string) error {
 	a, err := azure.New(&azure.Options{
 		AzureCredentials: azureCredentials,
 		Location:         azureLocation,
+		HyperVGeneration: azureHyperVGen,
 	})
 	if err != nil {
 		plog.Fatalf("Failed to create Azure API: %v", err)

--- a/mantle/cmd/ore/azure/create-gallery-image.go
+++ b/mantle/cmd/ore/azure/create-gallery-image.go
@@ -1,0 +1,95 @@
+// Copyright 2025 Red Hat
+// Copyright 2018 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package azure
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	cmdCreateGalleryImage = &cobra.Command{
+		Use:     "create-gallery-image",
+		Short:   "Create Azure Gallery image",
+		Long:    "Create Azure Gallery image from a blob url",
+		RunE:    runCreateGalleryImage,
+		Aliases: []string{"create-gallery-image-arm"},
+
+		SilenceUsage: true,
+	}
+
+	galleryImageName string
+	galleryName      string
+)
+
+func init() {
+	sv := cmdCreateGalleryImage.Flags().StringVar
+
+	sv(&galleryImageName, "gallery-image-name", "", "gallery image name")
+	sv(&galleryName, "gallery-name", "kola", "gallery name")
+	sv(&blobUrl, "image-blob", "", "source blob url")
+	sv(&resourceGroup, "resource-group", "kola", "resource group name")
+
+	Azure.AddCommand(cmdCreateGalleryImage)
+}
+
+func runCreateGalleryImage(cmd *cobra.Command, args []string) error {
+	if blobUrl == "" {
+		fmt.Fprintf(os.Stderr, "must supply --image-blob\n")
+		os.Exit(1)
+	}
+
+	if err := api.SetupClients(); err != nil {
+		fmt.Fprintf(os.Stderr, "setting up clients: %v\n", err)
+		os.Exit(1)
+	}
+
+	img, err := api.CreateImage(galleryImageName, resourceGroup, blobUrl)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Couldn't create Azure image: %v\n", err)
+		os.Exit(1)
+	}
+	if img.ID == nil {
+		fmt.Fprintf(os.Stderr, "received nil image\n")
+		os.Exit(1)
+	}
+	sourceImageId := *img.ID
+
+	galleryImage, err := api.CreateGalleryImage(galleryImageName, galleryName, resourceGroup, sourceImageId)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Couldn't create Azure Shared Image Gallery image: %v\n", err)
+		os.Exit(1)
+	}
+	if galleryImage.ID == nil {
+		fmt.Fprintf(os.Stderr, "received nil gallery image\n")
+		os.Exit(1)
+	}
+	err = json.NewEncoder(os.Stdout).Encode(&struct {
+		ID       *string
+		Location *string
+	}{
+		ID:       galleryImage.ID,
+		Location: galleryImage.Location,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Couldn't encode result: %v\n", err)
+		os.Exit(1)
+	}
+	return nil
+}

--- a/mantle/cmd/ore/azure/delete-gallery-image.go
+++ b/mantle/cmd/ore/azure/delete-gallery-image.go
@@ -1,0 +1,77 @@
+// Copyright 2025 Red Hat
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package azure
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	cmdDeleteGalleryImage = &cobra.Command{
+		Use:     "delete-gallery-image",
+		Short:   "Delete Azure Gallery image",
+		Long:    "Remove a Shared Image Gallery image from Azure.",
+		RunE:    runDeleteGalleryImage,
+		Aliases: []string{"delete-gallery-image-arm"},
+
+		SilenceUsage: true,
+	}
+
+	deleteGallery bool
+)
+
+func init() {
+	sv := cmdDeleteGalleryImage.Flags().StringVar
+	bv := cmdDeleteGalleryImage.Flags().BoolVar
+
+	sv(&imageName, "gallery-image-name", "", "gallery image name")
+	sv(&resourceGroup, "resource-group", "kola", "resource group name")
+	sv(&galleryName, "gallery-name", "kola", "gallery name")
+	bv(&deleteGallery, "delete-entire-gallery", false, "delete entire gallery")
+
+	Azure.AddCommand(cmdDeleteGalleryImage)
+}
+
+func runDeleteGalleryImage(cmd *cobra.Command, args []string) error {
+	if err := api.SetupClients(); err != nil {
+		return fmt.Errorf("setting up clients: %v\n", err)
+	}
+
+	if deleteGallery {
+		err := api.DeleteGallery(galleryName, resourceGroup)
+		if err != nil {
+			return fmt.Errorf("Couldn't delete gallery: %v\n", err)
+		}
+		plog.Printf("Gallery %q in resource group %q removed", galleryName, resourceGroup)
+		return nil
+	}
+
+	err := api.DeleteGalleryImage(imageName, resourceGroup, galleryName)
+	if err != nil {
+		return fmt.Errorf("Couldn't delete gallery image: %v\n", err)
+	}
+
+	// Gallery image versions are backed by managed images with the same name,
+	// so we can easily identify and delete them together.
+	err = api.DeleteImage(imageName, resourceGroup)
+	if err != nil {
+		return fmt.Errorf("Couldn't delete image: %v\n", err)
+	}
+
+	plog.Printf("Image %q in gallery %q in resource group %q removed", imageName, galleryName, resourceGroup)
+	return nil
+}

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -1027,6 +1027,7 @@ type externalTestMeta struct {
 	Conflicts                 []string `json:"conflicts"                           yaml:"conflicts"`
 	AllowConfigWarnings       bool     `json:"allowConfigWarnings"                 yaml:"allowConfigWarnings"`
 	NoInstanceCreds           bool     `json:"noInstanceCreds"                     yaml:"noInstanceCreds"`
+	InstanceType              string   `json:"instanceType"                        yaml:"instanceType"`
 	Description               string   `json:"description"                         yaml:"description"`
 }
 
@@ -1236,6 +1237,7 @@ ExecStart=%s
 		AdditionalNics:            targetMeta.AdditionalNics,
 		AppendKernelArgs:          targetMeta.AppendKernelArgs,
 		AppendFirstbootKernelArgs: targetMeta.AppendFirstbootKernelArgs,
+		InstanceType:              targetMeta.InstanceType,
 		NonExclusive:              !targetMeta.Exclusive,
 		Conflicts:                 targetMeta.Conflicts,
 
@@ -1757,6 +1759,7 @@ func runTest(h *harness.H, t *register.Test, pltfrm string, flight platform.Flig
 			AppendKernelArgs:          t.AppendKernelArgs,
 			AppendFirstbootKernelArgs: t.AppendFirstbootKernelArgs,
 			SkipStartMachine:          true,
+			InstanceType:              t.InstanceType,
 		}
 
 		// Providers sometimes fail to bring up a machine within a

--- a/mantle/kola/register/register.go
+++ b/mantle/kola/register/register.go
@@ -117,6 +117,10 @@ type Test struct {
 	// Conflicts is non-empty iff nonexclusive is true
 	// Contains the tests that conflict with this particular test
 	Conflicts []string
+
+	// If provided, this test will be run on the target instance type.
+	// This overrides the instance type set with `kola run`
+	InstanceType string
 }
 
 // Registered tests that run as part of `kola run` live here. Mapping of names

--- a/mantle/platform/api/azure/api.go
+++ b/mantle/platform/api/azure/api.go
@@ -31,16 +31,21 @@ import (
 )
 
 type API struct {
-	azIdCred   *azidentity.DefaultAzureCredential
-	rgClient   *armresources.ResourceGroupsClient
-	imgClient  *armcompute.ImagesClient
-	compClient *armcompute.VirtualMachinesClient
-	netClient  *armnetwork.VirtualNetworksClient
-	subClient  *armnetwork.SubnetsClient
-	ipClient   *armnetwork.PublicIPAddressesClient
-	intClient  *armnetwork.InterfacesClient
-	accClient  *armstorage.AccountsClient
-	opts       *Options
+	azIdCred        *azidentity.DefaultAzureCredential
+	rgClient        *armresources.ResourceGroupsClient
+	imgClient       *armcompute.ImagesClient
+	compClient      *armcompute.VirtualMachinesClient
+	galClient       *armcompute.GalleriesClient
+	galImgClient    *armcompute.GalleryImagesClient
+	galImgVerClient *armcompute.GalleryImageVersionsClient
+	diskClient      *armcompute.DisksClient
+	netClient       *armnetwork.VirtualNetworksClient
+	subClient       *armnetwork.SubnetsClient
+	ipClient        *armnetwork.PublicIPAddressesClient
+	intClient       *armnetwork.InterfacesClient
+	nsgClient       *armnetwork.SecurityGroupsClient
+	accClient       *armstorage.AccountsClient
+	opts            *Options
 }
 
 // New creates a new Azure client. If no publish settings file is provided or
@@ -89,6 +94,26 @@ func (a *API) SetupClients() error {
 		return err
 	}
 
+	a.galClient, err = armcompute.NewGalleriesClient(a.opts.SubscriptionID, a.azIdCred, nil)
+	if err != nil {
+		return err
+	}
+
+	a.galImgClient, err = armcompute.NewGalleryImagesClient(a.opts.SubscriptionID, a.azIdCred, nil)
+	if err != nil {
+		return err
+	}
+
+	a.galImgVerClient, err = armcompute.NewGalleryImageVersionsClient(a.opts.SubscriptionID, a.azIdCred, nil)
+	if err != nil {
+		return err
+	}
+
+	a.diskClient, err = armcompute.NewDisksClient(a.opts.SubscriptionID, a.azIdCred, nil)
+	if err != nil {
+		return err
+	}
+
 	a.netClient, err = armnetwork.NewVirtualNetworksClient(a.opts.SubscriptionID, a.azIdCred, nil)
 	if err != nil {
 		return err
@@ -105,6 +130,11 @@ func (a *API) SetupClients() error {
 	}
 
 	a.intClient, err = armnetwork.NewInterfacesClient(a.opts.SubscriptionID, a.azIdCred, nil)
+	if err != nil {
+		return err
+	}
+
+	a.nsgClient, err = armnetwork.NewSecurityGroupsClient(a.opts.SubscriptionID, a.azIdCred, nil)
 	if err != nil {
 		return err
 	}

--- a/mantle/platform/api/azure/disk.go
+++ b/mantle/platform/api/azure/disk.go
@@ -1,0 +1,107 @@
+// Copyright 2025 Red Hat
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package azure
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute"
+
+	"github.com/coreos/coreos-assembler/mantle/util"
+)
+
+// CreateDisk provisions a new managed disk in the specified Azure resource group using
+// the given name, size (in GiB), and SKU (e.g., Premium_LRS). The disk is created in
+// the location and availability zone specified in the API options.
+func (a *API) CreateDisk(name, resourceGroup string, sizeGB int32, sku armcompute.DiskStorageAccountTypes) (string, error) {
+	ctx := context.Background()
+	poller, err := a.diskClient.BeginCreateOrUpdate(ctx, resourceGroup, name, armcompute.Disk{
+		Location: &a.opts.Location,
+		Zones:    []*string{&a.opts.AvailabilityZone},
+		Tags: map[string]*string{
+			"createdBy": to.Ptr("mantle"),
+		},
+		SKU: &armcompute.DiskSKU{
+			Name: to.Ptr(sku),
+		},
+		Properties: &armcompute.DiskProperties{
+			DiskSizeGB: to.Ptr(sizeGB),
+			CreationData: &armcompute.CreationData{
+				CreateOption: to.Ptr(armcompute.DiskCreateOptionEmpty),
+			},
+		},
+	}, nil)
+
+	if err != nil {
+		return "", fmt.Errorf("failed to create azure disk %v", err)
+	}
+
+	diskResponse, err := poller.PollUntilDone(context.Background(), nil)
+	if err != nil {
+		return "", err
+	}
+
+	if diskResponse.Disk.ID == nil {
+		return "", fmt.Errorf("failed to get azure disk id")
+	}
+
+	return *diskResponse.Disk.ID, nil
+}
+
+// DeleteDisk deletes a managed disk by name from the specified Azure resource group.
+func (a *API) DeleteDisk(name, resourceGroup string) error {
+	ctx := context.Background()
+	poller, err := a.diskClient.BeginDelete(ctx, resourceGroup, name, nil)
+	if err != nil {
+		return err
+	}
+	_, err = poller.PollUntilDone(ctx, nil)
+	return err
+}
+
+// ParseDisk parses a disk specification string from a kola test and returns the
+// disk size and the Azure disk SKU. The spec format is "<size>:sku=<type>",
+// e.g., ["10G:sku=UltraSSD_LRS"] for NVMe disks. If no SKU is specified, "Standard_LRS" is used.
+func (a *API) ParseDisk(spec string) (int64, armcompute.DiskStorageAccountTypes, error) {
+	sku := armcompute.DiskStorageAccountTypes(armcompute.DiskStorageAccountTypesStandardLRS)
+	size, diskmap, err := util.ParseDiskSpec(spec, false)
+	if err != nil {
+		return size, sku, fmt.Errorf("failed to parse disk spec %q: %w", spec, err)
+	}
+	for key, value := range diskmap {
+		switch key {
+		case "sku":
+			normalizedSku := strings.ToUpper(value)
+			foundSku := false
+			for _, validSku := range armcompute.PossibleDiskStorageAccountTypesValues() {
+				if strings.EqualFold(normalizedSku, string(validSku)) {
+					sku = validSku
+					foundSku = true
+					break
+				}
+			}
+			if !foundSku {
+				return size, sku, fmt.Errorf("unsupported disk sku: %s", value)
+			}
+		default:
+			return size, sku, fmt.Errorf("invalid key: %s", key)
+		}
+	}
+	return size, sku, nil
+}

--- a/mantle/platform/api/azure/gallery.go
+++ b/mantle/platform/api/azure/gallery.go
@@ -18,7 +18,6 @@ package azure
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
@@ -48,16 +47,11 @@ func (a *API) CreateGalleryImage(name, galleryName, resourceGroup, sourceImageID
 
 	// enable NVMe support for Gen2 images only. NVMe support is not available on Gen1 images.
 	// DiskControllerTypes is set to SCSI by default for Gen1 images.
-	var galleryImageFeatures []*armcompute.GalleryImageFeature
-	if strings.EqualFold(a.opts.HyperVGeneration, string(armcompute.HyperVGenerationV2)) {
-		galleryImageFeatures = []*armcompute.GalleryImageFeature{
-			{
-				Name:  to.Ptr("DiskControllerTypes"),
-				Value: to.Ptr("SCSI,NVMe"),
-			},
-		}
-	} else {
-		galleryImageFeatures = nil
+	galleryImageFeatures := []*armcompute.GalleryImageFeature{
+		{
+			Name:  to.Ptr("DiskControllerTypes"),
+			Value: to.Ptr("SCSI,NVMe"),
+		},
 	}
 
 	// Create a Gallery Image Definition with the specified Hyper-V generation (V1 or V2).
@@ -66,7 +60,7 @@ func (a *API) CreateGalleryImage(name, galleryName, resourceGroup, sourceImageID
 		Properties: &armcompute.GalleryImageProperties{
 			OSState:          to.Ptr(armcompute.OperatingSystemStateTypesGeneralized),
 			OSType:           to.Ptr(armcompute.OperatingSystemTypesLinux),
-			HyperVGeneration: to.Ptr(armcompute.HyperVGeneration(a.opts.HyperVGeneration)),
+			HyperVGeneration: to.Ptr(armcompute.HyperVGeneration(armcompute.HyperVGenerationV2)),
 			Identifier: &armcompute.GalleryImageIdentifier{
 				Publisher: &a.opts.Publisher,
 				Offer:     to.Ptr(name),

--- a/mantle/platform/api/azure/gallery.go
+++ b/mantle/platform/api/azure/gallery.go
@@ -1,0 +1,195 @@
+// Copyright 2025 Red Hat
+// Copyright 2016 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package azure
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute"
+
+	"github.com/coreos/coreos-assembler/mantle/util"
+)
+
+func (a *API) CreateGalleryImage(name, galleryName, resourceGroup, sourceImageID string) (armcompute.GalleryImageVersion, error) {
+	ctx := context.Background()
+
+	// Ensure the Azure Shared Image Gallery exists. BeginCreateOrUpdate will create the gallery
+	// in the specified resource group if it doesn't already exist, or update it if it does.
+	// Since no properties are being changed here, this acts as a no-op if the gallery does exist.
+	// Note: the gallery's location is immutable. If a gallery with the same name exists in a different
+	// location within the same resource group, the operation will fail.
+	galleryPoller, err := a.galClient.BeginCreateOrUpdate(ctx, resourceGroup, galleryName, armcompute.Gallery{
+		Location: &a.opts.Location,
+	}, nil)
+	if err != nil {
+		return armcompute.GalleryImageVersion{}, err
+	}
+	_, err = galleryPoller.PollUntilDone(context.Background(), nil)
+	if err != nil {
+		return armcompute.GalleryImageVersion{}, err
+	}
+
+	// enable NVMe support for Gen2 images only. NVMe support is not available on Gen1 images.
+	// DiskControllerTypes is set to SCSI by default for Gen1 images.
+	var galleryImageFeatures []*armcompute.GalleryImageFeature
+	if strings.EqualFold(a.opts.HyperVGeneration, string(armcompute.HyperVGenerationV2)) {
+		galleryImageFeatures = []*armcompute.GalleryImageFeature{
+			{
+				Name:  to.Ptr("DiskControllerTypes"),
+				Value: to.Ptr("SCSI,NVMe"),
+			},
+		}
+	} else {
+		galleryImageFeatures = nil
+	}
+
+	// Create a Gallery Image Definition with the specified Hyper-V generation (V1 or V2).
+	galleryImagePoller, err := a.galImgClient.BeginCreateOrUpdate(ctx, resourceGroup, galleryName, name, armcompute.GalleryImage{
+		Location: &a.opts.Location,
+		Properties: &armcompute.GalleryImageProperties{
+			OSState:          to.Ptr(armcompute.OperatingSystemStateTypesGeneralized),
+			OSType:           to.Ptr(armcompute.OperatingSystemTypesLinux),
+			HyperVGeneration: to.Ptr(armcompute.HyperVGeneration(a.opts.HyperVGeneration)),
+			Identifier: &armcompute.GalleryImageIdentifier{
+				Publisher: &a.opts.Publisher,
+				Offer:     to.Ptr(name),
+				SKU:       to.Ptr(util.RandomName("sku")),
+			},
+			Features: galleryImageFeatures,
+		},
+	}, nil)
+	if err != nil {
+		return armcompute.GalleryImageVersion{}, err
+	}
+	_, err = galleryImagePoller.PollUntilDone(context.Background(), nil)
+	if err != nil {
+		return armcompute.GalleryImageVersion{}, err
+	}
+
+	// Create a Gallery Image Version
+	versionName := "1.0.0"
+	imageVersionPoller, err := a.galImgVerClient.BeginCreateOrUpdate(ctx, resourceGroup, galleryName, name, versionName, armcompute.GalleryImageVersion{
+		Location: &a.opts.Location,
+		Properties: &armcompute.GalleryImageVersionProperties{
+			StorageProfile: &armcompute.GalleryImageVersionStorageProfile{
+				Source: &armcompute.GalleryArtifactVersionSource{
+					ID: to.Ptr(sourceImageID),
+				},
+			},
+		},
+	}, nil)
+	if err != nil {
+		return armcompute.GalleryImageVersion{}, err
+	}
+	imageVersionResponse, err := imageVersionPoller.PollUntilDone(context.Background(), nil)
+	if err != nil {
+		return armcompute.GalleryImageVersion{}, err
+	}
+
+	return imageVersionResponse.GalleryImageVersion, nil
+}
+
+func (a *API) DeleteGalleryImage(imageName, resourceGroup, galleryName string) error {
+	ctx := context.Background()
+
+	timeout := 5 * time.Minute
+	delay := 5 * time.Second
+	// There is sometimes a delay in the azure backend where deleted gallery images versions
+	// still show within the image definition causing a failure during image deletion. We'll
+	// retry the delete command again until a specified timeout to ensure the image is deleted.
+	err := util.RetryUntilTimeout(timeout, delay, func() error {
+		// Find all image versions in the image definition and delete them.
+		// Gallery images can only be deleted if they have no nested resources.
+		versionPager := a.galImgVerClient.NewListByGalleryImagePager(resourceGroup, galleryName, imageName, nil)
+		for versionPager.More() {
+			versionPage, err := versionPager.NextPage(ctx)
+			if err != nil {
+				return fmt.Errorf("failed to list image versions for %s: %v", imageName, err)
+			}
+			for _, version := range versionPage.Value {
+				poller, err := a.galImgVerClient.BeginDelete(ctx, resourceGroup, galleryName, imageName, *version.Name, nil)
+				if err != nil {
+					return err
+				}
+				_, err = poller.PollUntilDone(ctx, nil)
+				if err != nil {
+					return err
+				}
+			}
+		}
+
+		// delete the gallery image
+		poller, err := a.galImgClient.BeginDelete(ctx, resourceGroup, galleryName, imageName, nil)
+		if err != nil {
+			return err
+		}
+		_, err = poller.PollUntilDone(ctx, nil)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+
+	return err
+
+}
+
+func (a *API) DeleteGallery(galleryName, resourceGroup string) error {
+	ctx := context.Background()
+
+	timeout := 10 * time.Minute
+	delay := 5 * time.Second
+	// There is sometimes a delay in the azure backend where deleted gallery images still show
+	// within the gallery causing a failure during gallery deletion. We'll retry the delete
+	// command again until a specified timeout to ensure the gallery is deleted.
+	err := util.RetryUntilTimeout(timeout, delay, func() error {
+		// Find all images in the gallery and delete them.
+		// Galleries can only be deleted if they have no nested resources.
+		imagePager := a.galImgClient.NewListByGalleryPager(resourceGroup, galleryName, nil)
+		for imagePager.More() {
+			page, err := imagePager.NextPage(ctx)
+			if err != nil {
+				return fmt.Errorf("failed to get image definitions")
+			}
+			for _, image := range page.Value {
+				err := a.DeleteGalleryImage(*image.Name, resourceGroup, galleryName)
+				if err != nil {
+					return fmt.Errorf("Couldn't delete gallery image: %v\n", err)
+				}
+			}
+		}
+
+		// delete the gallery
+		poller, err := a.galClient.BeginDelete(ctx, resourceGroup, galleryName, nil)
+		if err != nil {
+			return err
+		}
+		_, err = poller.PollUntilDone(ctx, nil)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+
+	return err
+
+}

--- a/mantle/platform/api/azure/image.go
+++ b/mantle/platform/api/azure/image.go
@@ -28,7 +28,7 @@ func (a *API) CreateImage(name, resourceGroup, blobURI string) (armcompute.Image
 		Name:     &name,
 		Location: &a.opts.Location,
 		Properties: &armcompute.ImageProperties{
-			HyperVGeneration: to.Ptr(armcompute.HyperVGenerationTypesV1),
+			HyperVGeneration: to.Ptr(armcompute.HyperVGenerationTypes(a.opts.HyperVGeneration)),
 			StorageProfile: &armcompute.ImageStorageProfile{
 				OSDisk: &armcompute.ImageOSDisk{
 					OSType:  to.Ptr(armcompute.OperatingSystemTypesLinux),

--- a/mantle/platform/api/azure/image.go
+++ b/mantle/platform/api/azure/image.go
@@ -28,7 +28,7 @@ func (a *API) CreateImage(name, resourceGroup, blobURI string) (armcompute.Image
 		Name:     &name,
 		Location: &a.opts.Location,
 		Properties: &armcompute.ImageProperties{
-			HyperVGeneration: to.Ptr(armcompute.HyperVGenerationTypes(a.opts.HyperVGeneration)),
+			HyperVGeneration: to.Ptr(armcompute.HyperVGenerationTypes(armcompute.HyperVGenerationTypesV2)),
 			StorageProfile: &armcompute.ImageStorageProfile{
 				OSDisk: &armcompute.ImageOSDisk{
 					OSType:  to.Ptr(armcompute.OperatingSystemTypesLinux),

--- a/mantle/platform/api/azure/instance.go
+++ b/mantle/platform/api/azure/instance.go
@@ -24,7 +24,6 @@ import (
 	"math"
 	"math/big"
 	"regexp"
-	"strings"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
@@ -108,13 +107,8 @@ func (a *API) getVMParameters(name, userdata, sshkey, storageAccountURI, size st
 		}
 	}
 	// UltraSSDEnabled=true is required for NVMe support on Gen2 VMs
-	var additionalCapabilities *armcompute.AdditionalCapabilities
-	if strings.EqualFold(a.opts.HyperVGeneration, string(armcompute.HyperVGenerationV2)) {
-		additionalCapabilities = &armcompute.AdditionalCapabilities{
-			UltraSSDEnabled: to.Ptr(true),
-		}
-	} else {
-		additionalCapabilities = nil
+	additionalCapabilities := &armcompute.AdditionalCapabilities{
+		UltraSSDEnabled: to.Ptr(true),
 	}
 	return armcompute.VirtualMachine{
 		Name:     &name,

--- a/mantle/platform/api/azure/network.go
+++ b/mantle/platform/api/azure/network.go
@@ -18,10 +18,8 @@ package azure
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
-	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
 
 	"github.com/coreos/coreos-assembler/mantle/util"
@@ -91,25 +89,13 @@ func (a *API) createPublicIP(resourceGroup string) (armnetwork.PublicIPAddress, 
 	var ipZones []*string
 
 	// set SKU=Standard, Allocation Method=Static and Availability Zone on public IPs when creating Gen2 images
-	if strings.EqualFold(a.opts.HyperVGeneration, string(armcompute.HyperVGenerationV2)) {
-		ipSKU = &armnetwork.PublicIPAddressSKU{
-			Name: to.Ptr(armnetwork.PublicIPAddressSKUNameStandard),
-		}
-		ipProperties = &armnetwork.PublicIPAddressPropertiesFormat{
-			PublicIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodStatic),
-		}
-		ipZones = []*string{to.Ptr(a.opts.AvailabilityZone)}
-		// gen 1
-	} else {
-		ipSKU = &armnetwork.PublicIPAddressSKU{
-			Name: to.Ptr(armnetwork.PublicIPAddressSKUNameBasic),
-		}
-		ipProperties = &armnetwork.PublicIPAddressPropertiesFormat{
-			PublicIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodDynamic),
-		}
-		// No Zones for Gen1
-		ipZones = nil
+	ipSKU = &armnetwork.PublicIPAddressSKU{
+		Name: to.Ptr(armnetwork.PublicIPAddressSKUNameStandard),
 	}
+	ipProperties = &armnetwork.PublicIPAddressPropertiesFormat{
+		PublicIPAllocationMethod: to.Ptr(armnetwork.IPAllocationMethodStatic),
+	}
+	ipZones = []*string{to.Ptr(a.opts.AvailabilityZone)}
 
 	poller, err := a.ipClient.BeginCreateOrUpdate(ctx, resourceGroup, name, armnetwork.PublicIPAddress{
 		Location:   to.Ptr(a.opts.Location),

--- a/mantle/platform/api/azure/options.go
+++ b/mantle/platform/api/azure/options.go
@@ -33,6 +33,7 @@ type Options struct {
 	Size             string
 	Location         string
 	AvailabilityZone string
+	HyperVGeneration string
 
 	SubscriptionName string
 	SubscriptionID   string

--- a/mantle/platform/api/azure/options.go
+++ b/mantle/platform/api/azure/options.go
@@ -25,13 +25,14 @@ type Options struct {
 	AzureCredentials  string
 	AzureSubscription string
 
-	DiskURI   string
-	Publisher string
-	Offer     string
-	Sku       string
-	Version   string
-	Size      string
-	Location  string
+	DiskURI          string
+	Publisher        string
+	Offer            string
+	Sku              string
+	Version          string
+	Size             string
+	Location         string
+	AvailabilityZone string
 
 	SubscriptionName string
 	SubscriptionID   string

--- a/mantle/platform/api/azure/options.go
+++ b/mantle/platform/api/azure/options.go
@@ -33,7 +33,6 @@ type Options struct {
 	Size             string
 	Location         string
 	AvailabilityZone string
-	HyperVGeneration string
 
 	SubscriptionName string
 	SubscriptionID   string

--- a/mantle/platform/machine/aws/cluster.go
+++ b/mantle/platform/machine/aws/cluster.go
@@ -57,6 +57,10 @@ func (ac *cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 		return nil, errors.New("platform aws does not support appending firstboot kernel arguments")
 	}
 
+	if options.InstanceType != "" {
+		return nil, errors.New("platform aws does not support changing instance types")
+	}
+
 	conf, err := ac.RenderUserData(userdata, map[string]string{
 		"$public_ipv4":  "${COREOS_EC2_IPV4_PUBLIC}",
 		"$private_ipv4": "${COREOS_EC2_IPV4_LOCAL}",

--- a/mantle/platform/machine/azure/cluster.go
+++ b/mantle/platform/machine/azure/cluster.go
@@ -46,9 +46,6 @@ func (ac *cluster) NewMachine(userdata *conf.UserData) (platform.Machine, error)
 }
 
 func (ac *cluster) NewMachineWithOptions(userdata *conf.UserData, options platform.MachineOptions) (platform.Machine, error) {
-	if len(options.AdditionalDisks) > 0 {
-		return nil, errors.New("platform azure does not yet support additional disks")
-	}
 	if options.MultiPathDisk {
 		return nil, errors.New("platform azure does not support multipathed disks")
 	}
@@ -69,7 +66,7 @@ func (ac *cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 		return nil, err
 	}
 
-	instance, err := ac.flight.api.CreateInstance(ac.vmname(), conf.String(), ac.sshKey, ac.ResourceGroup, ac.StorageAccount)
+	instance, err := ac.flight.api.CreateInstance(ac.vmname(), conf.String(), ac.sshKey, ac.ResourceGroup, ac.StorageAccount, options)
 	if err != nil {
 		return nil, err
 	}

--- a/mantle/platform/machine/do/cluster.go
+++ b/mantle/platform/machine/do/cluster.go
@@ -52,6 +52,9 @@ func (dc *cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 	if options.AppendFirstbootKernelArgs != "" {
 		return nil, errors.New("platform do does not support appending firstboot kernel arguments")
 	}
+	if options.InstanceType != "" {
+		return nil, errors.New("platform do does not support changing instance types")
+	}
 
 	conf, err := dc.RenderUserData(userdata, map[string]string{
 		"$public_ipv4":  "${COREOS_DIGITALOCEAN_IPV4_PUBLIC_0}",

--- a/mantle/platform/machine/esx/cluster.go
+++ b/mantle/platform/machine/esx/cluster.go
@@ -58,6 +58,9 @@ func (ec *cluster) NewMachineWithOptions(userdata *platformConf.UserData, option
 	if options.AppendFirstbootKernelArgs != "" {
 		return nil, errors.New("platform esx does not support appending firstboot kernel arguments")
 	}
+	if options.InstanceType != "" {
+		return nil, errors.New("platform esx does not support changing instance types")
+	}
 
 	conf, err := ec.RenderUserData(userdata, map[string]string{
 		"$public_ipv4":  "${COREOS_ESX_IPV4_PUBLIC_0}",

--- a/mantle/platform/machine/gcloud/cluster.go
+++ b/mantle/platform/machine/gcloud/cluster.go
@@ -49,6 +49,9 @@ func (gc *cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 	if options.AppendFirstbootKernelArgs != "" {
 		return nil, errors.New("platform gcp does not support appending firstboot kernel arguments")
 	}
+	if options.InstanceType != "" {
+		return nil, errors.New("platform gcp does not support changing instance types")
+	}
 
 	conf, err := gc.RenderUserData(userdata, map[string]string{
 		"$public_ipv4":  "${COREOS_GCE_IP_EXTERNAL_0}",

--- a/mantle/platform/machine/openstack/cluster.go
+++ b/mantle/platform/machine/openstack/cluster.go
@@ -50,6 +50,9 @@ func (oc *cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 	if options.AppendFirstbootKernelArgs != "" {
 		return nil, errors.New("platform openstack does not support appending firstboot kernel arguments")
 	}
+	if options.InstanceType != "" {
+		return nil, errors.New("platform openstack does not support changing instance types")
+	}
 
 	conf, err := oc.RenderUserData(userdata, map[string]string{
 		"$public_ipv4":  "${COREOS_OPENSTACK_IPV4_PUBLIC}",

--- a/mantle/platform/machine/qemu/cluster.go
+++ b/mantle/platform/machine/qemu/cluster.go
@@ -49,6 +49,9 @@ func (qc *Cluster) NewMachine(userdata *conf.UserData) (platform.Machine, error)
 }
 
 func (qc *Cluster) NewMachineWithOptions(userdata *conf.UserData, options platform.MachineOptions) (platform.Machine, error) {
+	if options.InstanceType != "" {
+		return nil, errors.New("platform qemu does not support changing instance types")
+	}
 	return qc.NewMachineWithQemuOptions(userdata, platform.QemuMachineOptions{
 		MachineOptions: options,
 	})

--- a/mantle/platform/machine/qemuiso/cluster.go
+++ b/mantle/platform/machine/qemuiso/cluster.go
@@ -47,15 +47,18 @@ func (qc *Cluster) NewMachine(userdata *conf.UserData) (platform.Machine, error)
 }
 
 func (qc *Cluster) NewMachineWithOptions(userdata *conf.UserData, options platform.MachineOptions) (platform.Machine, error) {
+	if options.InstanceType != "" {
+		return nil, errors.New("platform qemu-iso does not support changing instance types")
+	}
+	if options.MultiPathDisk {
+		return nil, errors.New("platform qemu-iso does not support multipathed primary disks")
+	}
 	return qc.NewMachineWithQemuOptions(userdata, platform.QemuMachineOptions{
 		MachineOptions: options,
 	})
 }
 
 func (qc *Cluster) NewMachineWithQemuOptions(userdata *conf.UserData, options platform.QemuMachineOptions) (platform.Machine, error) {
-	if options.MultiPathDisk {
-		return nil, errors.New("platform qemu-iso does not support multipathed primary disks")
-	}
 	id := uuid.New()
 
 	dir := filepath.Join(qc.RuntimeConf().OutputDir, id)

--- a/mantle/platform/platform.go
+++ b/mantle/platform/platform.go
@@ -163,6 +163,7 @@ type MachineOptions struct {
 	AppendKernelArgs          string
 	AppendFirstbootKernelArgs string
 	SkipStartMachine          bool // Skip platform.StartMachine on machine bringup
+	InstanceType              string
 }
 
 // SystemdDropin is a userdata type agnostic struct representing a systemd dropin


### PR DESCRIPTION
This PR introduces support for building and running Azure Shared Image Gallery (SIG) images, also known as "gallery images", alongside traditional managed images. ~~Both image types can now be used with either Hyper-V Generation 1 or Generation 2.~~ Both images types now default to using Hyper-V Generation 2.

Additional enhancements include:
- Support for overriding the instance type per kola test via external test configuration (useful for tests requiring specific VM sizes).

- Ability to attach additional data disks to Azure instances, as specified in kola tests.

This enables testing the Azure disk udev rules that were added in https://github.com/coreos/fedora-coreos-config/pull/3378, as NVMe support is only available on Gen2 Gallery Images.

See: https://issues.redhat.com/browse/COS-3125


EDIT: a commit was added to remove the option to set the Hyper-V generation. All images will now default to Gen2.

---
```
commit 89c9f8b3c8de67d723f8a90bedf40813c085e70c
Author: Michael Armijo <marmijo@redhat.com>
Date:   Wed May 28 15:08:36 2025 -0600

    azure: only build and run Hyper-V Gen2 images
    
    Remove the option to specify the Hyper-V Generation during image
    creation and when running instances through kola. Instead, only
    build traditional and gallery images using Hyper-V Gen2.


commit 270e9e4c5cf175efe62381dc0bf57226c29a8586
Author: Michael Armijo <marmijo@redhat.com>
Date:   Fri May 16 17:11:02 2025 -0600

    mantle/kola: add InstanceType to PlatformOptions for external tests
    
    Add an `InstanceType` field  to `PlatformOptions` to allow external
    tests to override the instance type used in `kola run`. This is useful
    for cases where a specific test needs to run on a different (potentially
    more expensive) instance type. Support for this is currently limited
    to the Azure Platform.
    
    Also, fix the `MultiPathDisk` for the qemu-iso platform. The check is
    now correctly performed in the `NewMachineWithOptions` function, since
    `MultiPathDisk` is part of `platform.MachineOptions`.

commit 386e133a741e41a8969951b4f5a8ce5789ec72e6
Author: Michael Armijo <marmijo@redhat.com>
Date:   Wed May 14 17:58:40 2025 -0600

    ore/azure: add options to create and delete Shared Image Gallery Images
    
    Add a new `create-gallery-image` ore command to Support creating images
    within Azure Shared Image Galleries (Gallery Images). The command
    creates image definitions and versions in Azure Shared Image Galleries.
    Gallery images can be created from either a blob URL or an existing
    managed image. A `--azure-publisher` flag is added to assign a publisher
    to the gallery image.
    
    `delete-gallery-image` is also added to delete individual gallery images
    or an entire Shared Image Gallery.

commit 0be49d77209a89a8af65414d4ddec5cd099cb9e2
Author: Michael Armijo <marmijo@redhat.com>
Date:   Wed May 14 17:26:58 2025 -0600

    azure: add --azure-hyper-v-generation flag
    
    Add a new flag to allow specifying the Hyper-V generation (V1 or V2)
    when creating Azure images. This enables support for both Gen1 and Gen2
    image creation.


commit 54658f96aa716dc17f8da26a48d8cf08b3ef4f9c
Author: Michael Armijo <marmijo@redhat.com>
Date:   Wed May 14 16:49:34 2025 -0600

    platform/azure: support additional data disks
    
    Add support for attaching additional data disks to instances created in
    Azure. Disks are defined through the machines options as the Size in GB
    and the 'sku', or storage type, e.g. '["100G:sku=UltraSSD_LRS"]' for
    NVMe disks.

```