### PR TITLE
kola: add support for tests with Secure Boot enabled

### DIFF
--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -100,6 +100,9 @@ const snoozeFormat = "2006-01-02"
 // This overlaps with SkipBaseChecksTag above, but is really a special flag for kola-denylist.yaml.
 const SkipConsoleWarningsTag = "skip-console-warnings"
 
+// NeedsSecureBoot will setup the machines with uefi with secure boot enabled on supported platforms
+const secureBoot = "secure-boot"
+
 var (
 	plog = capnslog.NewPackageLogger("github.com/coreos/coreos-assembler/mantle", "kola")
 
@@ -336,6 +339,10 @@ func testSkipBaseChecks(test *register.Test) bool {
 
 func testRequiresInternet(test *register.Test) bool {
 	return HasString(NeedsInternetTag, test.Tags)
+}
+
+func testSecureBoot(test *register.Test) bool {
+	return HasString(secureBoot, test.Tags)
 }
 
 func markTestForRerunSuccess(test *register.Test, msg string) {
@@ -1760,6 +1767,10 @@ func runTest(h *harness.H, t *register.Test, pltfrm string, flight platform.Flig
 			AppendFirstbootKernelArgs: t.AppendFirstbootKernelArgs,
 			SkipStartMachine:          true,
 			InstanceType:              t.InstanceType,
+		}
+
+		if testSecureBoot(t) {
+			options.Firmware = "uefi-secure"
 		}
 
 		// Providers sometimes fail to bring up a machine within a

--- a/mantle/platform/machine/qemu/cluster.go
+++ b/mantle/platform/machine/qemu/cluster.go
@@ -54,6 +54,7 @@ func (qc *Cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 	}
 	return qc.NewMachineWithQemuOptions(userdata, platform.QemuMachineOptions{
 		MachineOptions: options,
+		Firmware:       options.Firmware,
 	})
 }
 

--- a/mantle/platform/platform.go
+++ b/mantle/platform/platform.go
@@ -164,6 +164,7 @@ type MachineOptions struct {
 	AppendFirstbootKernelArgs string
 	SkipStartMachine          bool // Skip platform.StartMachine on machine bringup
 	InstanceType              string
+	Firmware                  string
 }
 
 // SystemdDropin is a userdata type agnostic struct representing a systemd dropin


### PR DESCRIPTION
Add a new kola tag to configure qemu with Secure Boot enabled

Fixes: https://github.com/coreos/coreos-assembler/issues/4112
Needed for: https://github.com/coreos/fedora-coreos-config/pull/3326