### PR TITLE
kola: Add soft-reboot support for external tests

### DIFF
--- a/docs/kola/external-tests.md
+++ b/docs/kola/external-tests.md
@@ -110,6 +110,37 @@ it out.
 (Previously the API for this was to send `SIGTERM` to the current process; that
 method is deprecated and will be removed at some point)
 
+## Support for soft-rebooting
+
+Kola also supports soft-rebooting using systemd's `systemctl soft-reboot` command.
+Soft-reboot restarts the userspace while keeping the kernel and hardware state intact.
+This is useful for testing userspace updates without a full system reboot.
+
+The soft-reboot API is similar to the regular reboot API:
+
+```
+#!/bin/bash
+# Example of soft-reboot test
+set -xeuo pipefail
+case "${AUTOPKGTEST_REBOOT_MARK:-}" in
+  "") echo "test beginning"; /tmp/autopkgtest-soft-reboot mark1 ;;
+  mark1) echo "test in mark1"; /tmp/autopkgtest-soft-reboot mark2 ;;
+  mark2) echo "test in mark2" ;;
+  *) echo "unexpected mark: ${AUTOPKGTEST_REBOOT_MARK}"; exit 1;;
+esac
+echo "ok autopkgtest soft-rebooting"
+```
+
+Key differences with soft-reboot:
+- The kernel boot ID (`/proc/sys/kernel/random/boot_id`) remains the same
+- Hardware state and kernel memory are preserved
+- `/run` is not cycled.
+- Only userspace is restarted
+- Uses `systemctl soft-reboot` instead of `reboot`
+
+Both `/tmp/autopkgtest-soft-reboot` and `/tmp/autopkgtest-soft-reboot-prepare` scripts are available,
+analogous to their regular reboot counterparts.
+
 ## HTTP Server
 
 The `kolet` binary is copied into the `/usr/local/bin/` directory on the CoreOS

--- a/mantle/cmd/kola/devshell.go
+++ b/mantle/cmd/kola/devshell.go
@@ -239,6 +239,8 @@ func runDevShellSSH(ctx context.Context, builder *platform.QemuBuilder, conf *co
 					_ = inst.Kill()
 				case guestStateInReboot:
 					statusMsg = "QEMU guest initiated reboot"
+				case guestStateInSoftReboot:
+					statusMsg = "QEMU guest initiated soft-reboot"
 				case guestStateOpenSshStopped:
 					statusMsg = "QEMU openssh is not listening"
 				case guestStateSshDisconnected:
@@ -285,6 +287,8 @@ const (
 	guestStateInShutdown
 	// guestStateInReboot indicates that the guest has started a reboot
 	guestStateInReboot
+	// guestStateInSoftReboot indicates that the guest has started a soft-reboot
+	guestStateInSoftReboot
 	// guestStateHalted indicates that the guest has halted or shutdown
 	guestStateHalted
 	// guestStateBooting indicates that the instance is in early boot
@@ -324,6 +328,9 @@ func checkWriteState(msg string, c chan<- guestState) {
 	}
 	if strings.Contains(msg, "Starting Reboot...") {
 		c <- guestStateInReboot
+	}
+	if strings.Contains(msg, "Reached target soft-reboot") {
+		c <- guestStateInSoftReboot
 	}
 }
 
@@ -427,6 +434,11 @@ func watchJournal(builder *platform.QemuBuilder, conf *conf.Conf, stateChan chan
 			unit:       "systemd-poweroff.service",
 			messageID:  "7d4958e842da4a758f6c1cdc7b36dcc5",
 			guestState: guestStateInShutdown,
+		},
+		{
+			unit:       "systemd-soft-reboot.service",
+			messageID:  "7d4958e842da4a758f6c1cdc7b36dcc5",
+			guestState: guestStateInSoftReboot,
 		},
 	}
 

--- a/mantle/platform/machine/aws/machine.go
+++ b/mantle/platform/machine/aws/machine.go
@@ -80,6 +80,10 @@ func (am *machine) WaitForReboot(timeout time.Duration, oldBootId string) error 
 	return platform.WaitForMachineReboot(am, am.journal, timeout, oldBootId)
 }
 
+func (am *machine) WaitForSoftReboot(timeout time.Duration, oldSoftRebootsCount string) error {
+	return platform.WaitForMachineSoftReboot(am, am.journal, timeout, oldSoftRebootsCount)
+}
+
 func (am *machine) Destroy() {
 	origConsole, err := am.cluster.flight.api.GetConsoleOutput(am.ID())
 	if err != nil {

--- a/mantle/platform/machine/azure/machine.go
+++ b/mantle/platform/machine/azure/machine.go
@@ -108,6 +108,15 @@ func (am *machine) WaitForReboot(timeout time.Duration, oldBootId string) error 
 	return am.refetchIPs()
 }
 
+func (am *machine) WaitForSoftReboot(timeout time.Duration, oldSoftRebootsCount string) error {
+	err := platform.WaitForMachineSoftReboot(am, am.journal, timeout, oldSoftRebootsCount)
+	if err != nil {
+		return err
+	}
+	// For soft-reboot, IP addresses should not change, but let's refetch to be safe
+	return am.refetchIPs()
+}
+
 func (am *machine) Destroy() {
 	if err := am.saveConsole(); err != nil {
 		// log error, but do not fail to terminate instance

--- a/mantle/platform/machine/do/machine.go
+++ b/mantle/platform/machine/do/machine.go
@@ -77,6 +77,10 @@ func (dm *machine) WaitForReboot(timeout time.Duration, oldBootId string) error 
 	return platform.WaitForMachineReboot(dm, dm.journal, timeout, oldBootId)
 }
 
+func (dm *machine) WaitForSoftReboot(timeout time.Duration, oldSoftRebootsCount string) error {
+	return platform.WaitForMachineSoftReboot(dm, dm.journal, timeout, oldSoftRebootsCount)
+}
+
 func (dm *machine) Destroy() {
 	if err := dm.cluster.flight.api.DeleteDroplet(context.TODO(), dm.droplet.ID); err != nil {
 		plog.Errorf("Error deleting droplet %v: %v", dm.droplet.ID, err)

--- a/mantle/platform/machine/esx/machine.go
+++ b/mantle/platform/machine/esx/machine.go
@@ -78,6 +78,10 @@ func (em *machine) WaitForReboot(timeout time.Duration, oldBootId string) error 
 	return platform.WaitForMachineReboot(em, em.journal, timeout, oldBootId)
 }
 
+func (em *machine) WaitForSoftReboot(timeout time.Duration, oldSoftRebootsCount string) error {
+	return platform.WaitForMachineSoftReboot(em, em.journal, timeout, oldSoftRebootsCount)
+}
+
 func (em *machine) Destroy() {
 	if err := em.cluster.flight.api.TerminateDevice(em.ID()); err != nil {
 		plog.Errorf("Error terminating device %v: %v", em.ID(), err)

--- a/mantle/platform/machine/gcloud/machine.go
+++ b/mantle/platform/machine/gcloud/machine.go
@@ -78,6 +78,10 @@ func (gm *machine) WaitForReboot(timeout time.Duration, oldBootId string) error 
 	return platform.WaitForMachineReboot(gm, gm.journal, timeout, oldBootId)
 }
 
+func (gm *machine) WaitForSoftReboot(timeout time.Duration, oldSoftRebootsCount string) error {
+	return platform.WaitForMachineSoftReboot(gm, gm.journal, timeout, oldSoftRebootsCount)
+}
+
 func (gm *machine) Destroy() {
 	if err := gm.saveConsole(); err != nil {
 		plog.Errorf("Error saving console for instance %v: %v", gm.ID(), err)

--- a/mantle/platform/machine/openstack/machine.go
+++ b/mantle/platform/machine/openstack/machine.go
@@ -99,6 +99,10 @@ func (om *machine) WaitForReboot(timeout time.Duration, oldBootId string) error 
 	return platform.WaitForMachineReboot(om, om.journal, timeout, oldBootId)
 }
 
+func (om *machine) WaitForSoftReboot(timeout time.Duration, oldSoftRebootsCount string) error {
+	return platform.WaitForMachineSoftReboot(om, om.journal, timeout, oldSoftRebootsCount)
+}
+
 func (om *machine) Destroy() {
 	if err := om.saveConsole(); err != nil {
 		plog.Errorf("Error saving console for instance %v: %v", om.ID(), err)

--- a/mantle/platform/machine/qemu/machine.go
+++ b/mantle/platform/machine/qemu/machine.go
@@ -87,6 +87,10 @@ func (m *machine) WaitForReboot(timeout time.Duration, oldBootId string) error {
 	return platform.WaitForMachineReboot(m, m.journal, timeout, oldBootId)
 }
 
+func (m *machine) WaitForSoftReboot(timeout time.Duration, oldSoftRebootsCount string) error {
+	return platform.WaitForMachineSoftReboot(m, m.journal, timeout, oldSoftRebootsCount)
+}
+
 func (m *machine) Destroy() {
 	m.inst.Destroy()
 

--- a/mantle/platform/machine/qemuiso/machine.go
+++ b/mantle/platform/machine/qemuiso/machine.go
@@ -87,6 +87,10 @@ func (m *machine) WaitForReboot(timeout time.Duration, oldBootId string) error {
 	return platform.WaitForMachineReboot(m, m.journal, timeout, oldBootId)
 }
 
+func (m *machine) WaitForSoftReboot(timeout time.Duration, oldSoftRebootsCount string) error {
+	return platform.WaitForMachineSoftReboot(m, m.journal, timeout, oldSoftRebootsCount)
+}
+
 func (m *machine) Destroy() {
 	m.inst.Destroy()
 

--- a/mantle/platform/platform.go
+++ b/mantle/platform/platform.go
@@ -78,6 +78,9 @@ type Machine interface {
 	// WaitForReboot waits for the machine to restart and waits for it to come back.
 	WaitForReboot(time.Duration, string) error
 
+	// WaitForSoftReboot waits for the machine to soft-reboot and waits for it to come back.
+	WaitForSoftReboot(time.Duration, string) error
+
 	// Destroy terminates the machine and frees associated resources. It should log
 	// any failures; since they are not actionable, it does not return an error.
 	Destroy()

--- a/tests/kola-ci-self/tests/kola/autopkgtest-soft-reboot
+++ b/tests/kola-ci-self/tests/kola/autopkgtest-soft-reboot
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Test for soft-reboot functionality similar to autopkgtest-reboot but using systemctl soft-reboot
+# This test validates that the Kola soft-reboot API works correctly
+set -xeuo pipefail
+
+# Caches the initial kernel boot ID
+BOOT_ID_FILE="/var/cache/kola-boot-id"
+
+log() {
+  set +x
+  echo "$@"
+}
+
+case "${AUTOPKGTEST_REBOOT_MARK:-}" in
+  "")
+    log "test beginning"
+
+    if test -f "$BOOT_ID_FILE"; then
+      log "error: found $BOOT_ID_FILE" 1>&2
+      exit 1
+    fi
+    # Check that boot_id stays the same across soft-reboot
+    INITIAL_BOOT_ID=$(cat /proc/sys/kernel/random/boot_id)
+    log "Initial boot ID: $INITIAL_BOOT_ID"
+    
+    # Save boot ID to persistent file for comparison across reboots
+    echo "$INITIAL_BOOT_ID" > "$BOOT_ID_FILE"
+    
+    /tmp/autopkgtest-soft-reboot mark1
+    ;;
+  mark1)
+    log "test in mark1"
+    # Verify boot_id is the same (soft-reboot should not change it)
+    CURRENT_BOOT_ID=$(cat /proc/sys/kernel/random/boot_id)
+    INITIAL_BOOT_ID=$(cat "$BOOT_ID_FILE")
+    log "Initial boot ID: $INITIAL_BOOT_ID"
+    log "Current boot ID after soft-reboot: $CURRENT_BOOT_ID"
+    
+    if [ "$CURRENT_BOOT_ID" != "$INITIAL_BOOT_ID" ]; then
+        log "ERROR: Boot ID changed after soft-reboot! Expected: $INITIAL_BOOT_ID, Got: $CURRENT_BOOT_ID"
+        exit 1
+    fi
+    log "SUCCESS: Boot ID preserved across soft-reboot"
+
+    # Test the prepare API with forced soft-reboot
+    /tmp/autopkgtest-soft-reboot-prepare mark2
+    systemctl soft-reboot
+    sleep infinity
+    ;;
+  mark2)
+    log "test in mark2"
+    FINAL_BOOT_ID=$(cat /proc/sys/kernel/random/boot_id)
+    INITIAL_BOOT_ID=$(cat "$BOOT_ID_FILE")
+    log "Initial boot ID: $INITIAL_BOOT_ID"
+    log "Final boot ID after forced soft-reboot: $FINAL_BOOT_ID"
+
+    # Verify all boot IDs are the same for soft-reboot
+    if [ "$FINAL_BOOT_ID" != "$INITIAL_BOOT_ID" ]; then
+        log "ERROR: Boot ID changed after forced soft-reboot! Expected: $INITIAL_BOOT_ID, Got: $FINAL_BOOT_ID"
+        exit 1
+    fi
+    log "SUCCESS: Boot ID preserved across forced soft-reboot"
+    
+    # Clean up
+    rm -f "$BOOT_ID_FILE"
+    log "Soft-reboot test completed successfully"
+    ;;
+  *)
+    log "unexpected mark: ${AUTOPKGTEST_REBOOT_MARK}"
+    exit 1
+    ;;
+esac
+log "ok autopkgtest soft-rebooting"


### PR DESCRIPTION
Implements soft-reboot capabilities for Kola,
it enables tests to use systemd's soft-reboot functionality.

The implementation follows the same pattern as regular reboots but for `systemctl soft-reboot`, tracks systemd boot
timestamps rather than kernel boot IDs for state detection.