### PR TITLE
kola/tests: move OCP tests to `RequiredTag`

### DIFF
--- a/mantle/kola/tests/crio/crio.go
+++ b/mantle/kola/tests/crio/crio.go
@@ -195,7 +195,8 @@ func init() {
 		Distros:     []string{"rhcos"},
 		UserData:    enableCrioIgn,
 		// crio pods require fetching a kubernetes pause image
-		Tags: []string{"crio", kola.NeedsInternetTag, "openshift"},
+		Tags:        []string{"crio", kola.NeedsInternetTag},
+		RequiredTag: "openshift",
 	})
 	register.RegisterTest(&register.Test{
 		Run:         crioNetwork,
@@ -205,7 +206,8 @@ func init() {
 		Distros:     []string{"rhcos"},
 		UserData:    enableCrioIgn,
 		// this test requires net connections outside the host
-		Tags: []string{"crio", kola.NeedsInternetTag, "openshift"},
+		Tags:        []string{"crio", kola.NeedsInternetTag},
+		RequiredTag: "openshift",
 		// qemu machines cannot communicate between each other
 		ExcludePlatforms: []string{"qemu"},
 	})

--- a/mantle/kola/tests/misc/network.go
+++ b/mantle/kola/tests/misc/network.go
@@ -69,7 +69,7 @@ func init() {
 		Timeout:        40 * time.Minute,
 		Distros:        []string{"rhcos"},
 		Platforms:      []string{"qemu"},
-		Tags:           []string{"openshift"},
+		RequiredTag:    "openshift",
 		AdditionalNics: 2,
 		UserData:       userdata,
 	})


### PR DESCRIPTION
Now that the layered CoreOS work has landed, the variants built by cosa no longer have OCP components. So let's default to not running OpenShift tests at the kola level by changing them to use `RequiredTag`.

This will allow us to drop the `--tag !openshift` in various places. Running OpenShift tests will require passing `--tag openshift`.