### PR TITLE
ore/azure: support building aarch64 images

### DIFF
--- a/mantle/cmd/ore/azure/create-gallery-image.go
+++ b/mantle/cmd/ore/azure/create-gallery-image.go
@@ -36,6 +36,7 @@ var (
 
 	galleryImageName string
 	galleryName      string
+	architecture     string
 )
 
 func init() {
@@ -45,6 +46,7 @@ func init() {
 	sv(&galleryName, "gallery-name", "kola", "gallery name")
 	sv(&blobUrl, "image-blob", "", "source blob url")
 	sv(&resourceGroup, "resource-group", "kola", "resource group name")
+	sv(&architecture, "arch", "", "The target architecture for the image")
 
 	Azure.AddCommand(cmdCreateGalleryImage)
 }
@@ -71,7 +73,7 @@ func runCreateGalleryImage(cmd *cobra.Command, args []string) error {
 	}
 	sourceImageId := *img.ID
 
-	galleryImage, err := api.CreateGalleryImage(galleryImageName, galleryName, resourceGroup, sourceImageId)
+	galleryImage, err := api.CreateGalleryImage(galleryImageName, galleryName, resourceGroup, sourceImageId, architecture)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Couldn't create Azure Shared Image Gallery image: %v\n", err)
 		os.Exit(1)


### PR DESCRIPTION
Add a flag to `create-gallery-image` to allow setting the architecture to aarch64 (Arm64). The Azure SDK for Go only supports setting the arch when creating gallery images.