### PR TITLE
cmd-remote-build-container: add --add-openshift-build-labels

### DIFF
--- a/src/cmd-remote-build-container
+++ b/src/cmd-remote-build-container
@@ -166,6 +166,9 @@ def main():
         # Add some information about the commit to labels for the container
         args.labels.append(f"org.opencontainers.image.revision={commit}")
         args.labels.append(f"org.opencontainers.image.source={args.git_url}")
+        if args.add_openshift_build_labels:
+            args.labels.append(f"io.openshift.build.commit.id={commit}")
+            args.labels.append(f"io.openshift.build.source-location={args.git_url}")
         # If a tag wasn't passed then use the arch + shortcommit
         if not args.tag:
             args.tag = f"{args.arch}-{shortcommit}"
@@ -257,6 +260,9 @@ Examples:
     parser.add_argument(
         '--label', dest="labels", default=[], action='append',
         required=False, help='Add image label(s)')
+    parser.add_argument(
+        '--add-openshift-build-labels', required=False, action='store_true',
+        help='Add io.openshift.build.* labels with git information')
     parser.add_argument(
         '--mount-host-ca-certs', required=False, action='store_true',
         help='Mount the CA certificate from the remote host')


### PR DESCRIPTION
Currently, `oc` looks for non-standard labels for git information, which it then places in e.g. `image-references` in the release payload.

Ideally `oc` would also check for the standard
`org.opencontainers.image.{revision,source}` labels too for this purpose but this assumption is wired in a bunch of places so let's just conform for now to it.

Add a new option to inject these labels. This can then be used when building the node image extensions image. In turn, this makes the release controller page for a release have working links for our images to the openshift/os commit they were built from, just like the other images.