### PR TITLE
test/targetcli: switch to Fedora OS as base layer

### DIFF
--- a/tests/containers/targetcli/Containerfile
+++ b/tests/containers/targetcli/Containerfile
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos:stream9
+FROM quay.io/fedora/fedora-minimal:42
 
 RUN dnf install -y targetcli kmod && dnf clean all
 RUN systemctl enable target


### PR DESCRIPTION
For consistency and simplicity, let's move to Fedora as base layer. This will simplify the onboarding to Konflux.