### PR TITLE
konflux: disable renovate activity

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,3 @@
+{
+  "enabled": false
+}


### PR DESCRIPTION
Updates will still be detected by Renovate, but we're pausing automatic PR submission.