### PR TITLE
github/dependabot: merge two configs together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,17 +3,7 @@ updates:
 - package-ecosystem: gomod
   directory: "/"
   schedule:
-    interval: daily
-  allow:
-    # For now, only enable the deps we know we want to keep fresh
-    - dependency-name: "github.com/coreos/butane"
-    - dependency-name: "github.com/coreos/ignition/v2"
-    - dependency-name: "github.com/coreos/stream-metadata-go"
-
-- package-ecosystem: gomod
-  directory: "/"
-  schedule:
-    interval: monthly
+    interval: weekly
   # Group all updates together in a single PR. We can remove some
   # updates from a combined update PR via comments to dependabot:
   # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/managing-pull-requests-for-dependency-updates#managing-dependabot-pull-requests-for-grouped-updates-with-comment-commands


### PR DESCRIPTION
Apparently you can't have two config entries for `gomod` so we'll have to merge these two together. I'll just compromise and go from daily in one and monthly in the other and settle on weekly for both.

Unfortunately there isn't really a way to validate your dependabot config before merging the PR and going to the dependabot tab so we'll YOLO until it works.