### PR TITLE
Add bootupd option `bios.device`

### DIFF
--- a/src/osbuild-manifests/coreos.osbuild.x86_64.mpp.yaml
+++ b/src/osbuild-manifests/coreos.osbuild.x86_64.mpp.yaml
@@ -694,6 +694,8 @@ pipelines:
             target: /boot/efi
       - type: org.osbuild.bootupd
         options:
+          bios:
+            device: disk
           static-configs: true
           deployment:
             default: true


### PR DESCRIPTION
Because of the change https://github.com/coreos/bootupd/commit/f6ef3d1077a7eccf89a751cc5c805613e62857e9 in new bootupd-0.2.28, we use `sfdisk` to find esp part, so we need to pass the target device.

Fix live build error when running:
```
$ cosa osbuild metal metal4k live
...
org.osbuild.bootupd: ed39b5197b7c952249a72fff63355163dae556a95eb000b3bb1d2ae72cb5b3f1 {
  "static-configs": true,
  "deployment": {
    "default": true
  }
}

Skip installing component BIOS without target device
error: boot data installation failed: installing component EFI:
Listing partitions of : Subprocess failed: ExitStatus(unix_wait_status(256))
sfdisk: cannot open : No such file or directory
...
subprocess.CalledProcessError: Command '['chroot', '/run/osbuild
/mounts/ostree/deploy/fedora-coreos/deploy/xx',
'/usr/bin/bootupctl', 'backend', 'install', '--with-static-configs',
'/run/osbuild/mounts']' returned non-zero exit status 1.
```