### PR TITLE
cmd-generate-release-meta: fix typo in platforms list

### DIFF
--- a/src/cmd-generate-release-meta
+++ b/src/cmd-generate-release-meta
@@ -152,7 +152,7 @@ def append_build(out, input_):
     platforms = ["aliyun", "applehv", "aws", "azure", "azurestack",
                  "digitalocean", "exoscale", "gcp", "hetzner", "hyperv",
                  "ibmcloud", "kubevirt", "metal", "nutanix", "openstack",
-                 "proxmoxve" "powervs", "qemu", "virtualbox", "vmware",
+                 "proxmoxve", "powervs", "qemu", "virtualbox", "vmware",
                  "vultr", "qemu-secex"]
     for platform in platforms:
         if input_.get("images", {}).get(platform, None) is not None:


### PR DESCRIPTION
Fixes 8db6aff.