### PR TITLE
feat(kola): add --denylist-stream flag to allow running without manifest.yaml

### DIFF
--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -60,7 +60,7 @@ func init() {
 	sv(&kola.Options.BaseName, "basename", "kola", "Cluster name prefix")
 	ss("debug-systemd-unit", []string{}, "full-unit-name.service to enable SYSTEMD_LOG_LEVEL=debug on. Can be specified multiple times.")
 	ssv(&kola.DenylistedTests, "denylist-test", []string{}, "Test pattern to add to denylist. Can be specified multiple times.")
-	sv(&kola.DenylistStream, "denylist-stream", "", "Stream name used to match entries in the kola denylist")
+sv(&kola.DenylistStream, "denylist-stream", "", "Stream name for denylist filtering. If set, manifest.yaml is not read and 'osversion' will be empty for denylist evaluation.")
 	bv(&kola.NoNet, "no-net", false, "Don't run tests that require an Internet connection")
 	bv(&kola.ForceRunPlatformIndependent, "run-platform-independent", false, "Run tests that claim platform independence")
 	ssv(&kola.Tags, "tag", []string{}, "Test tag to run. Can be specified multiple times.")

--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -60,6 +60,7 @@ func init() {
 	sv(&kola.Options.BaseName, "basename", "kola", "Cluster name prefix")
 	ss("debug-systemd-unit", []string{}, "full-unit-name.service to enable SYSTEMD_LOG_LEVEL=debug on. Can be specified multiple times.")
 	ssv(&kola.DenylistedTests, "denylist-test", []string{}, "Test pattern to add to denylist. Can be specified multiple times.")
+	sv(&kola.DenylistStream, "denylist-stream", "", "Stream name used to match entries in the kola denylist")
 	bv(&kola.NoNet, "no-net", false, "Don't run tests that require an Internet connection")
 	bv(&kola.ForceRunPlatformIndependent, "run-platform-independent", false, "Run tests that claim platform independence")
 	ssv(&kola.Tags, "tag", []string{}, "Test tag to run. Can be specified multiple times.")

--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -60,7 +60,7 @@ func init() {
 	sv(&kola.Options.BaseName, "basename", "kola", "Cluster name prefix")
 	ss("debug-systemd-unit", []string{}, "full-unit-name.service to enable SYSTEMD_LOG_LEVEL=debug on. Can be specified multiple times.")
 	ssv(&kola.DenylistedTests, "denylist-test", []string{}, "Test pattern to add to denylist. Can be specified multiple times.")
-sv(&kola.DenylistStream, "denylist-stream", "", "Stream name for denylist filtering. If set, manifest.yaml is not read and 'osversion' will be empty for denylist evaluation.")
+	sv(&kola.DenylistStream, "denylist-stream", "", "Stream name for denylist filtering. If set, manifest.yaml is not read and 'osversion' will be empty for denylist evaluation.")
 	bv(&kola.NoNet, "no-net", false, "Don't run tests that require an Internet connection")
 	bv(&kola.ForceRunPlatformIndependent, "run-platform-independent", false, "Run tests that claim platform independence")
 	ssv(&kola.Tags, "tag", []string{}, "Test tag to run. Can be specified multiple times.")

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -127,6 +127,7 @@ var (
 	// SkipConsoleWarnings is set via SkipConsoleWarningsTag in kola-denylist.yaml
 	SkipConsoleWarnings bool
 	DenylistedTests     []string // tests which are on the denylist
+	DenylistStream      string   //denylist-stream
 	WarnOnErrorTests    []string // denylisted tests we are going to run and warn in case of error
 	Tags                []string // tags to be ran
 
@@ -395,38 +396,45 @@ func ParseDenyListYaml(pltfrm string) error {
 
 	plog.Debug("Parsed kola-denylist.yaml")
 
-	// Look for the right manifest, taking into account the variant
-	var manifest ManifestData
-	var pathToManifest string
-	pathToInitConfig := filepath.Join(Options.CosaWorkdir, "src/config.json")
-	initConfigFile, err := os.ReadFile(pathToInitConfig)
-	if os.IsNotExist(err) {
-		// No variant config found. Let's read the default manifest
-		pathToManifest = filepath.Join(Options.CosaWorkdir, "src/config/manifest.yaml")
-	} else if err != nil {
-		// Unexpected error
-		return err
-	} else {
-		// Figure out the variant and read the corresponding manifests
-		var initConfig InitConfigData
-		err = json.Unmarshal(initConfigFile, &initConfig)
+	var stream string
+	var osversion string
+
+	// Get the stream and osversion variables from the manifest since DenylistStream is not specified
+	if len(DenylistStream) == 0 {
+		// Look for the right manifest, taking into account the variant
+		var manifest ManifestData
+		var pathToManifest string
+		pathToInitConfig := filepath.Join(Options.CosaWorkdir, "src/config.json")
+		initConfigFile, err := os.ReadFile(pathToInitConfig)
+		if os.IsNotExist(err) {
+			// No variant config found. Let's read the default manifest
+			pathToManifest = filepath.Join(Options.CosaWorkdir, "src/config/manifest.yaml")
+		} else if err != nil {
+			// Unexpected error
+			return err
+		} else {
+			// Figure out the variant and read the corresponding manifests
+			var initConfig InitConfigData
+			err = json.Unmarshal(initConfigFile, &initConfig)
+			if err != nil {
+				return err
+			}
+			pathToManifest = filepath.Join(Options.CosaWorkdir, fmt.Sprintf("src/config/manifest-%s.yaml", initConfig.ConfigVariant))
+		}
+		manifestFile, err := os.ReadFile(pathToManifest)
 		if err != nil {
 			return err
 		}
-		pathToManifest = filepath.Join(Options.CosaWorkdir, fmt.Sprintf("src/config/manifest-%s.yaml", initConfig.ConfigVariant))
-	}
-	manifestFile, err := os.ReadFile(pathToManifest)
-	if err != nil {
-		return err
-	}
-	err = yaml.Unmarshal(manifestFile, &manifest)
-	if err != nil {
-		return err
-	}
+		err = yaml.Unmarshal(manifestFile, &manifest)
+		if err != nil {
+			return err
+		}
 
-	// Get the stream and osversion variables from the manifest
-	stream := manifest.Variables.Stream
-	osversion := manifest.Variables.OsVersion
+		stream = manifest.Variables.Stream
+		osversion = manifest.Variables.OsVersion
+	} else {
+		stream = DenylistStream
+	}
 
 	// Get the current arch & current time
 	arch := Options.CosaBuildArch


### PR DESCRIPTION
Kola normally requires a manifest.yaml to determine the stream for denylist filtering. This change adds support for passing the stream explicitly via the --denylist-stream flag, allowing kola to run without a manifest file.

See https://github.com/openshift/os/pull/1836#discussion_r2185930571