### PR TITLE
konflux: fix renovate json file

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -63,7 +63,7 @@
       "depNameTemplate": "openshift-client",
       "versioningTemplate": "semver",
       "matchStrings": [
-        "- download_url:.*openshift-client-linux-(?<currentValue>.*)\.tar\.gz",
+        "- download_url:.*openshift-client-linux-(?<currentValue>.*)\\.tar\\.gz",
         "- download_url:.*ocp/(?<currentValue>.*)/openshift-client-linux.*"
       ]
     }


### PR DESCRIPTION
According to the Mintmaker team, this format error is preventing Renovate to automerge the RPM lockfile update commit, so let's fix it.