### PR TITLE
konflux: follow the Mintmaker schema

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,17 +7,10 @@
     "vendor/**"
   ],
   "branchConcurrentLimit": 0,
+  "gomod": {
+    "enabled": false
+  },
   "packageRules": [
-    {
-      "matchDatasources": ["go"],
-      "enabled": false,
-      "description": "Disable updates for Go modules"
-    },
-    {
-      "matchDatasources": ["golang-version"],
-      "enabled": false,
-      "description": "Disable updates for Go modules"
-    },
     {
       "matchDatasources": ["docker"],
       "matchDepNames": ["quay.io/fedora/fedora"],


### PR DESCRIPTION
We should use the MintMaker schema [1] and not the Renovate default one in order to apply properly the desired configuration.

[1] https://github.com/konflux-ci/mintmaker/blob/main/config/renovate/renovate.json