### PR TITLE
mantle/azure: Add ability to set managed identity on Azure instances

### DIFF
--- a/mantle/cmd/kola/kola.go
+++ b/mantle/cmd/kola/kola.go
@@ -300,14 +300,15 @@ func writeProps() error {
 		InstanceType string `json:"type"`
 	}
 	type Azure struct {
-		DiskURI          string `json:"diskUri"`
-		Publisher        string `json:"publisher"`
-		Offer            string `json:"offer"`
-		Sku              string `json:"sku"`
-		Version          string `json:"version"`
-		Location         string `json:"location"`
-		Size             string `json:"size"`
-		AvailabilityZone string `json:"availability_zone"`
+		DiskURI           string `json:"diskUri"`
+		Publisher         string `json:"publisher"`
+		Offer             string `json:"offer"`
+		Sku               string `json:"sku"`
+		Version           string `json:"version"`
+		Location          string `json:"location"`
+		Size              string `json:"size"`
+		AvailabilityZone  string `json:"availability_zone"`
+		ManagedIdentityID string `json:"managed_identity_id"`
 	}
 	type DO struct {
 		Region string `json:"region"`
@@ -356,14 +357,15 @@ func writeProps() error {
 			InstanceType: kola.AWSOptions.InstanceType,
 		},
 		Azure: Azure{
-			DiskURI:          kola.AzureOptions.DiskURI,
-			Publisher:        kola.AzureOptions.Publisher,
-			Offer:            kola.AzureOptions.Offer,
-			Sku:              kola.AzureOptions.Sku,
-			Version:          kola.AzureOptions.Version,
-			Location:         kola.AzureOptions.Location,
-			Size:             kola.AzureOptions.Size,
-			AvailabilityZone: kola.AzureOptions.AvailabilityZone,
+			DiskURI:           kola.AzureOptions.DiskURI,
+			Publisher:         kola.AzureOptions.Publisher,
+			Offer:             kola.AzureOptions.Offer,
+			Sku:               kola.AzureOptions.Sku,
+			Version:           kola.AzureOptions.Version,
+			Location:          kola.AzureOptions.Location,
+			Size:              kola.AzureOptions.Size,
+			AvailabilityZone:  kola.AzureOptions.AvailabilityZone,
+			ManagedIdentityID: kola.AzureOptions.ManagedIdentityID,
 		},
 		DO: DO{
 			Region: kola.DOOptions.Region,

--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -102,6 +102,7 @@ func init() {
 	sv(&kola.AzureOptions.Location, "azure-location", "westus", "Azure location (default \"westus\"")
 	sv(&kola.AzureOptions.Size, "azure-size", "", "Azure machine size")
 	sv(&kola.AzureOptions.AvailabilityZone, "azure-availability-zone", "1", "Azure Availability Zone (default \"1\")")
+	sv(&kola.AzureOptions.ManagedIdentityID, "azure-managed-identity", "", "Azure Managed Identity resource ID to assign to VM")
 
 	// do-specific options
 	sv(&kola.DOOptions.ConfigPath, "do-config-file", "", "DigitalOcean config file (default \"~/"+auth.DOConfigPath+"\")")

--- a/mantle/platform/api/azure/instance.go
+++ b/mantle/platform/api/azure/instance.go
@@ -106,6 +106,15 @@ func (a *API) getVMParameters(name, userdata, sshkey, storageAccountURI, size st
 			Version:   &a.opts.Version,
 		}
 	}
+	var managedIdentity *armcompute.VirtualMachineIdentity
+	if a.opts.ManagedIdentityID != "" {
+		managedIdentity = &armcompute.VirtualMachineIdentity{
+			Type: to.Ptr(armcompute.ResourceIdentityTypeUserAssigned),
+			UserAssignedIdentities: map[string]*armcompute.UserAssignedIdentitiesValue{
+				a.opts.ManagedIdentityID: {},
+			},
+		}
+	}
 	// UltraSSDEnabled=true is required for NVMe support on Gen2 VMs
 	additionalCapabilities := &armcompute.AdditionalCapabilities{
 		UltraSSDEnabled: to.Ptr(true),
@@ -117,6 +126,7 @@ func (a *API) getVMParameters(name, userdata, sshkey, storageAccountURI, size st
 		Tags: map[string]*string{
 			"createdBy": to.Ptr("mantle"),
 		},
+		Identity: managedIdentity,
 		Properties: &armcompute.VirtualMachineProperties{
 			HardwareProfile: &armcompute.HardwareProfile{
 				VMSize: to.Ptr(armcompute.VirtualMachineSizeTypes(size)),

--- a/mantle/platform/api/azure/options.go
+++ b/mantle/platform/api/azure/options.go
@@ -25,14 +25,15 @@ type Options struct {
 	AzureCredentials  string
 	AzureSubscription string
 
-	DiskURI          string
-	Publisher        string
-	Offer            string
-	Sku              string
-	Version          string
-	Size             string
-	Location         string
-	AvailabilityZone string
+	DiskURI           string
+	Publisher         string
+	Offer             string
+	Sku               string
+	Version           string
+	Size              string
+	Location          string
+	AvailabilityZone  string
+	ManagedIdentityID string
 
 	SubscriptionName string
 	SubscriptionID   string


### PR DESCRIPTION
Add support for configuring user-assigned managed identities`[1]` on Azure VM instances to be able to access secure resources within Azure. Add an option to kola to set the managed identity ID and carry it through to VM instance creation.

`[1]`: https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/overview

see: https://github.com/coreos/fedora-coreos-tracker/issues/1871

Co-authored-by: Steven Presti <spresti@redhat.com>