### PR TITLE
konflux: update pipeline

### DIFF
--- a/.tekton/coreos-assembler-pull-request.yaml
+++ b/.tekton/coreos-assembler-pull-request.yaml
@@ -49,7 +49,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/jcapitao/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta@sha256:a3993688715cba973af5e7fba95bc91f92673e8491f2524853736161974334fb
+      value: quay.io/jcapitao/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta@sha256:52a4ef40ecdabd82822e583f67f010d5771b92d959df55087456ed6aa3c7606e
     - name: name
       value: docker-build-multi-platform-oci-ta
     - name: kind

--- a/.tekton/coreos-assembler-push.yaml
+++ b/.tekton/coreos-assembler-push.yaml
@@ -46,7 +46,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/jcapitao/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta@sha256:a3993688715cba973af5e7fba95bc91f92673e8491f2524853736161974334fb
+      value: quay.io/jcapitao/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta@sha256:52a4ef40ecdabd82822e583f67f010d5771b92d959df55087456ed6aa3c7606e
     - name: name
       value: docker-build-multi-platform-oci-ta
     - name: kind

--- a/.tekton/coreos-assembler-renovate-push.yaml
+++ b/.tekton/coreos-assembler-renovate-push.yaml
@@ -49,7 +49,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/jcapitao/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta@sha256:a3993688715cba973af5e7fba95bc91f92673e8491f2524853736161974334fb
+      value: quay.io/jcapitao/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta@sha256:52a4ef40ecdabd82822e583f67f010d5771b92d959df55087456ed6aa3c7606e
     - name: name
       value: docker-build-multi-platform-oci-ta
     - name: kind

--- a/.tekton/kola-nfs-pull-request.yaml
+++ b/.tekton/kola-nfs-pull-request.yaml
@@ -51,7 +51,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/jcapitao/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta@sha256:a3993688715cba973af5e7fba95bc91f92673e8491f2524853736161974334fb
+      value: quay.io/jcapitao/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta@sha256:52a4ef40ecdabd82822e583f67f010d5771b92d959df55087456ed6aa3c7606e
     - name: name
       value: docker-build-multi-platform-oci-ta
     - name: kind

--- a/.tekton/kola-nfs-push.yaml
+++ b/.tekton/kola-nfs-push.yaml
@@ -47,7 +47,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/jcapitao/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta@sha256:a3993688715cba973af5e7fba95bc91f92673e8491f2524853736161974334fb
+      value: quay.io/jcapitao/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta@sha256:52a4ef40ecdabd82822e583f67f010d5771b92d959df55087456ed6aa3c7606e
     - name: name
       value: docker-build-multi-platform-oci-ta
     - name: kind

--- a/.tekton/kola-nfs-renovate-push.yaml
+++ b/.tekton/kola-nfs-renovate-push.yaml
@@ -51,7 +51,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/jcapitao/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta@sha256:a3993688715cba973af5e7fba95bc91f92673e8491f2524853736161974334fb
+      value: quay.io/jcapitao/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta@sha256:52a4ef40ecdabd82822e583f67f010d5771b92d959df55087456ed6aa3c7606e
     - name: name
       value: docker-build-multi-platform-oci-ta
     - name: kind

--- a/.tekton/kola-tang-pull-request.yaml
+++ b/.tekton/kola-tang-pull-request.yaml
@@ -51,7 +51,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/jcapitao/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta@sha256:a3993688715cba973af5e7fba95bc91f92673e8491f2524853736161974334fb
+      value: quay.io/jcapitao/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta@sha256:52a4ef40ecdabd82822e583f67f010d5771b92d959df55087456ed6aa3c7606e
     - name: name
       value: docker-build-multi-platform-oci-ta
     - name: kind

--- a/.tekton/kola-tang-push.yaml
+++ b/.tekton/kola-tang-push.yaml
@@ -47,7 +47,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/jcapitao/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta@sha256:a3993688715cba973af5e7fba95bc91f92673e8491f2524853736161974334fb
+      value: quay.io/jcapitao/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta@sha256:52a4ef40ecdabd82822e583f67f010d5771b92d959df55087456ed6aa3c7606e
     - name: name
       value: docker-build-multi-platform-oci-ta
     - name: kind

--- a/.tekton/kola-tang-renovate-push.yaml
+++ b/.tekton/kola-tang-renovate-push.yaml
@@ -51,7 +51,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/jcapitao/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta@sha256:a3993688715cba973af5e7fba95bc91f92673e8491f2524853736161974334fb
+      value: quay.io/jcapitao/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta@sha256:52a4ef40ecdabd82822e583f67f010d5771b92d959df55087456ed6aa3c7606e
     - name: name
       value: docker-build-multi-platform-oci-ta
     - name: kind

--- a/.tekton/kola-targetcli-pull-request.yaml
+++ b/.tekton/kola-targetcli-pull-request.yaml
@@ -51,7 +51,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/jcapitao/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta@sha256:a3993688715cba973af5e7fba95bc91f92673e8491f2524853736161974334fb
+      value: quay.io/jcapitao/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta@sha256:52a4ef40ecdabd82822e583f67f010d5771b92d959df55087456ed6aa3c7606e
     - name: name
       value: docker-build-multi-platform-oci-ta
     - name: kind

--- a/.tekton/kola-targetcli-push.yaml
+++ b/.tekton/kola-targetcli-push.yaml
@@ -47,7 +47,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/jcapitao/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta@sha256:a3993688715cba973af5e7fba95bc91f92673e8491f2524853736161974334fb
+      value: quay.io/jcapitao/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta@sha256:52a4ef40ecdabd82822e583f67f010d5771b92d959df55087456ed6aa3c7606e
     - name: name
       value: docker-build-multi-platform-oci-ta
     - name: kind

--- a/.tekton/kola-targetcli-renovate-push.yaml
+++ b/.tekton/kola-targetcli-renovate-push.yaml
@@ -51,7 +51,7 @@ spec:
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/jcapitao/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta@sha256:a3993688715cba973af5e7fba95bc91f92673e8491f2524853736161974334fb
+      value: quay.io/jcapitao/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta@sha256:52a4ef40ecdabd82822e583f67f010d5771b92d959df55087456ed6aa3c7606e
     - name: name
       value: docker-build-multi-platform-oci-ta
     - name: kind


### PR DESCRIPTION
The hermeto project drop the dev-package-managers flag from the RPM backend [1]. Once the prefetch-dependencies konflux task updated to pull the new hermeto [2], we'll be able to switch back to official Konflux pipeline. But for now we have to update our own temporary pipeline (more context in [3]).

[1] https://github.com/hermetoproject/hermeto/issues/986
[2] https://github.com/konflux-ci/build-definitions/blob/116f1d3c86b8ab188e5a5aaee80f01b79398bca7/task/prefetch-dependencies-oci-ta/0.2/prefetch-dependencies-oci-ta.yaml#L165
[3] https://github.com/konflux-ci/build-definitions/pull/2421