### PR TITLE
cmdlib: bump default cache size to 45G

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -613,7 +613,7 @@ runcompose_tree() {
 
 # Run with cache disk.
 runvm_with_cache() {
-    local cache_size=${RUNVM_CACHE_SIZE:-40G}
+    local cache_size=${RUNVM_CACHE_SIZE:-45G}
     # "cache2" has an explicit label so we can find it in qemu easily
     if [ ! -f "${workdir}"/cache/cache2.qcow2 ]; then
         qemu-img create -f qcow2 cache2.qcow2.tmp "$cache_size"


### PR DESCRIPTION
We've added hetzner, proxmoxve, and oraclecloud, so we're running out of space now in x86_64 pipeline runs.