### PR TITLE
build.sh: use NO_NETWORK:-0 to prevent errors when NO_NETWORK is unbound

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -31,7 +31,7 @@ srcdir=$(pwd)
 
 configure_yum_repos() {
     [ "${arch}" == "riscv64" ] && return # No continuous repo for riscv64 yet
-    [ "${NO_NETWORK}" == "1" ] && return
+    [ "${NO_NETWORK:-0}" == "1" ] && return
     local version_id
     version_id=$(. /etc/os-release && echo ${VERSION_ID})
     # Add continuous tag for latest build tools and mark as required so we
@@ -47,7 +47,7 @@ install_rpms() {
     # First, a general update; this is best practice.  We also hit an issue recently
     # where qemu implicitly depended on an updated libusbx but didn't have a versioned
     # requires https://bugzilla.redhat.com/show_bug.cgi?id=1625641
-    [ "${NO_NETWORK}" == "0" ] && yum -y distro-sync
+    [ "${NO_NETWORK:-0}" == "0" ] && yum -y distro-sync
 
     # xargs is part of findutils, which may not be installed
     yum -y install /usr/bin/xargs
@@ -105,7 +105,7 @@ install_rpms() {
 # to CoreOS.
 install_ocp_tools() {
     [ "${arch}" == "riscv64" ] && return # No ocp tools for riscv64
-    if [ "${NO_NETWORK}" == "0" ]; then
+    if [ "${NO_NETWORK:-0}" == "0" ]; then
         # If $OCP_VERSION is defined we'll grab that specific version.
         # Otherwise we'll get the latest.
         local url="https://mirror.openshift.com/pub/openshift-v4/${arch}/clients/ocp/latest${OCP_VERSION:+-$OCP_VERSION}/openshift-client-linux.tar.gz"


### PR DESCRIPTION
I build COSA normally inside my toolbox container, and hit this on a recent re-build.