### PR TITLE
Make `cosa build` support building "ostree" artifact using podman/buildah

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -195,7 +195,7 @@ patch_osbuild() {
    ## in the places delivered by the RPM.
    mv /usr/lib/osbuild/tools/osbuild-mpp /usr/bin/osbuild-mpp
    mv /usr/lib/osbuild/osbuild /usr/lib/python3.13/site-packages/osbuild
-   mkdir /usr/lib/osbuild/osbuild
+   mkdir -p /usr/lib/osbuild/osbuild
 }
 
 if [ $# -ne 0 ]; then

--- a/src/cmd-build
+++ b/src/cmd-build
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+if [ -n "${COSA_BUILD_WITH_BUILDAH:-}" ]; then
+    exec /usr/lib/coreos-assembler/cmd-build-with-buildah "$@"
+fi
+
 dn=$(dirname "$0")
 # shellcheck source=src/cmdlib.sh
 . "${dn}"/cmdlib.sh

--- a/src/cmd-build-with-buildah
+++ b/src/cmd-build-with-buildah
@@ -14,16 +14,15 @@ Usage: coreos-assembler build-with-buildah
   `cosa build` will pivot to this script when the environment variable `COREOS_ASSEMBLER_BUILD_WITH_BUILDAH` is set.
 
   The following options are supported:
-  --versionary          Use the versionary script from the source config to drive version.
-  --direct              Run buildah directly rather than within supermin.
+  --version           Use the versionary script from the source config to drive version.
+  --direct            Run buildah directly rather than within supermin.
 EOF
 }
 
-VERSIONARY=
 VERSION=
 DIRECT=
 rc=0
-options=$(getopt --options h,v,d --longoptions help,versionary,direct -- "$@") || rc=$?
+options=$(getopt --options h,v,d --longoptions help,version:,direct -- "$@") || rc=$?
 [ $rc -eq 0 ] || {
     print_help
     exit 1
@@ -35,8 +34,9 @@ while true; do
             print_help
             exit 0
             ;;
-        -v | --versionary)
-            VERSIONARY=1
+        -v | --version)
+            shift
+            VERSION=$1
             ;;
         -d | --direct)
             DIRECT=1
@@ -55,15 +55,13 @@ while true; do
     shift
 done
 
-if [ -n "${VERSIONARY}" ]; then
+if [ -z "${VERSION}" ]; then
     # let error out if file does not exist
     VERSION=$(src/config/versionary)
-    echo "New version will be ${VERSION}"
 fi
 
 build_with_buildah() {
-    VERSION=$1
-    echo "Building with container runtime (buildah)..."
+    echo "Building with container runtime (buildah) with VERSION=${VERSION}..."
 
     tempdir=$(mktemp -d --tmpdir=tmp "build-with-buildah.XXXXXXXX")
 
@@ -77,13 +75,15 @@ build_with_buildah() {
         argsfile=build-args-${variant}.conf
     fi
 
+    if [ "$(check_build_exists "${VERSION}")" == "True" ]; then
+        echo "Build ${VERSION} already exists"
+        exit 0
+    fi
+
     set -- build --security-opt=label=disable --cap-add=all --device /dev/fuse \
             --build-arg-file "$argsfile" -v "$(realpath "${tempdir}/src")":/run/src \
+            --build-arg VERSION="${VERSION}" \
             -t oci-archive:"${tmp_oci_archive_path}"
-
-    if [ -n "${VERSION}" ]; then
-        set -- "$@" --build-arg VERSION="${VERSION}"
-    fi
 
     if [ -n "$DIRECT" ]; then
         # turn on layer caching in the direct case; it wouldn't hurt in the
@@ -99,4 +99,4 @@ build_with_buildah() {
     rm -rf "${tempdir}"
 }
 
-build_with_buildah "$VERSION"
+build_with_buildah

--- a/src/cmd-build-with-buildah
+++ b/src/cmd-build-with-buildah
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+dn=$(dirname "$0")
+# shellcheck source=src/cmdlib.sh
+. "${dn}"/cmdlib.sh
+
+print_help() {
+    cat 1>&2 <<'EOF'
+Usage: coreos-assembler build-with-buildah
+       coreos-assembler build-with-buildah [OPTIONS]...
+
+  Build bootable container (ostree) and image base artifacts using the container runtime (buildah).
+  `cosa build` will pivot to this script when the environment variable `COREOS_ASSEMBLER_BUILD_WITH_BUILDAH` is set.
+
+  The following options are supported:
+  --versionary          Use the versionary script from the source config to drive version.
+EOF
+}
+
+VERSIONARY=
+VERSION=
+rc=0
+options=$(getopt --options h,v --longoptions help,versionary -- "$@") || rc=$?
+[ $rc -eq 0 ] || {
+    print_help
+    exit 1
+}
+eval set -- "$options"
+while true; do
+    case "$1" in
+        -h | --help)
+            print_help
+            exit 0
+            ;;
+        -v | --versionary)
+            VERSIONARY=1
+            ;;
+        --)
+            shift
+            break
+            ;;
+        -*)
+            fatal "$0: unrecognized option: $1"
+            ;;
+        *)
+            break
+            ;;
+    esac
+    shift
+done
+
+if [ -n "${VERSIONARY}" ]; then
+    # let error out if file does not exist
+    VERSION=$(src/config/versionary)
+    echo "New version will be ${VERSION}"
+fi
+
+build_with_buildah() {
+    VERSION=$1
+    echo "Building with container runtime (buildah)..."
+
+    tempdir=$(mktemp -d --tmpdir=tmp "build-with-buildah.XXXXXXXX")
+
+    # the config dir virtiofs mount is mounted ro; copy it to the tempdir
+    cp -r src/config/ "${tempdir}/src"
+
+    tmp_oci_archive_path=$(realpath "${tempdir}/out.ociarchive")
+
+    argsfile=build-args.conf
+    if [ -n "${variant:-}" ]; then
+        argsfile=build-args-${variant}.conf
+    fi
+
+    set -- build --security-opt=label=disable --cap-add=all --device /dev/fuse \
+            --build-arg-file "$argsfile" -v "$(realpath "${tempdir}/src")":/run/src \
+            -t oci-archive:"${tmp_oci_archive_path}"
+
+    if [ -n "${VERSION}" ]; then
+        set -- "$@" --build-arg VERSION="${VERSION}"
+    fi
+
+    /usr/lib/coreos-assembler/cmd-supermin-run --cache \
+        env -C "${tempdir}/src" TMPDIR="$(realpath cache)" buildah "$@" .
+
+    /usr/lib/coreos-assembler/cmd-import "oci-archive:${tmp_oci_archive_path}"
+
+    rm -rf "${tempdir}"
+}
+
+build_with_buildah "$VERSION"

--- a/src/cmd-build-with-buildah
+++ b/src/cmd-build-with-buildah
@@ -15,13 +15,15 @@ Usage: coreos-assembler build-with-buildah
 
   The following options are supported:
   --versionary          Use the versionary script from the source config to drive version.
+  --direct              Run buildah directly rather than within supermin.
 EOF
 }
 
 VERSIONARY=
 VERSION=
+DIRECT=
 rc=0
-options=$(getopt --options h,v --longoptions help,versionary -- "$@") || rc=$?
+options=$(getopt --options h,v,d --longoptions help,versionary,direct -- "$@") || rc=$?
 [ $rc -eq 0 ] || {
     print_help
     exit 1
@@ -35,6 +37,9 @@ while true; do
             ;;
         -v | --versionary)
             VERSIONARY=1
+            ;;
+        -d | --direct)
+            DIRECT=1
             ;;
         --)
             shift
@@ -80,8 +85,14 @@ build_with_buildah() {
         set -- "$@" --build-arg VERSION="${VERSION}"
     fi
 
-    /usr/lib/coreos-assembler/cmd-supermin-run --cache \
-        env -C "${tempdir}/src" TMPDIR="$(realpath cache)" buildah "$@" .
+    if [ -n "$DIRECT" ]; then
+        # turn on layer caching in the direct case; it wouldn't hurt in the
+        # supermin path, but it'd be a waste of space on the rootfs
+        env -C "${tempdir}/src" buildah "$@" --layers=true .
+    else
+        /usr/lib/coreos-assembler/cmd-supermin-run --cache \
+            env -C "${tempdir}/src" TMPDIR="$(realpath cache)" buildah "$@" .
+    fi
 
     /usr/lib/coreos-assembler/cmd-import "oci-archive:${tmp_oci_archive_path}"
 

--- a/src/cmd-import
+++ b/src/cmd-import
@@ -65,7 +65,12 @@ def parse_args():
 
 def generate_oci_archive(args, tmpd):
     tmpf = os.path.join(tmpd, 'out.ociarchive')
-    subprocess.check_call(['skopeo', 'copy', '--preserve-digests', args.srcimg,
+
+    if args.srcimg.startswith('oci-archive:'):
+        print(f"Copying {args.srcimg.partition(':')[2]} to {tmpf}")
+        shutil.copy(args.srcimg.partition(':')[2], tmpf)
+    else:
+        subprocess.check_call(['skopeo', 'copy', '--preserve-digests', args.srcimg,
                            f"oci-archive:{tmpf}"])
     return tmpf
 

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -1105,6 +1105,17 @@ cmdlib.import_ostree_commit(workdir, builddir, buildmeta, extract_json=('${extra
 ")
 }
 
+check_build_exists() {
+    local buildid=$1; shift
+    (python3 -c "
+import sys
+sys.path.insert(0, '${DIR}')
+from cosalib.builds import Builds
+builds = Builds('${workdir:-$(pwd)}')
+print(builds.has('${buildid}'))
+")
+}
+
 # Extract the value of NAME from os-release
 extract_osrelease_name() {
     local buildid=$1; shift


### PR DESCRIPTION
1. If `COREOS_ASSEMBLER_BUILD_WITH_BUILDAH=1`, build ostree artifacts using buildah. Else, got the traditional way.
2. Copy source ociarchive in `cosa import` rather than importing layer by layer.
3. Force create `buildid` ref on importing ociarchive