### PR TITLE
qemu: set 'devno' property to order additional NICs on s390x

### DIFF
--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -705,6 +705,13 @@ func (builder *QemuBuilder) setupAdditionalNetworking() error {
 
 		netdev := fmt.Sprintf("user,id=eth%s,dhcpstart=10.0.2.%s", idSuffix, netSuffix)
 		device := virtio(builder.architecture, "net", fmt.Sprintf("netdev=eth%s,mac=52:55:00:d1:56:%s", idSuffix, macSuffix))
+		// On s390x, devices use the CCW bus instead of PCI, which may cause them to appear in a different order.
+		// By default, the CSSID is 0xFE and the SSID is 0x0. For additional NICs, set the SSID to 0x1
+		// to avoid interference with other CCW devices
+		if builder.architecture == "s390x" {
+			device += fmt.Sprintf(",devno=fe.1.%04x", i)
+		}
+
 		builder.Append("-netdev", netdev, "-device", device)
 		macCounter++
 	}


### PR DESCRIPTION
On s390x, network interfaces use the CCW bus instead of PCI, which can lead to wrong NIC ordering. This causes the team-dhcp-via-ignition test to fail:
```
07:19:05  Jul 29 07:19:00 qemu0 kola-runext-test.sh[2336]: Error: get team0 ip = 10.0.2.32, expected is 10.0.2.31
```

This happens, because eth1 and eth2 are wrong ordered (altnames):
```
$ ip -o link
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000\    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP mode DEFAULT group default qlen 1000\    link/ether 52:54:00:12:34:56 brd ff:ff:ff:ff:ff:ff\    altname enc2\    altname enx525400123456
3: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel master team0 state UP mode DEFAULT group default qlen 1000\    link/ether 52:55:00:d1:56:01 brd ff:ff:ff:ff:ff:ff\    altname enc4\    altname enx525500d15601
4: eth2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel master team0 state UP mode DEFAULT group default qlen 1000\    link/ether 52:55:00:d1:56:01 brd ff:ff:ff:ff:ff:ff permaddr 52:55:00:d1:56:00\    altname enc3\    altname enx525500d15600
5: team0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT group default qlen 1000\    link/ether 52:55:00:d1:56:01 brd ff:ff:ff:ff:ff:ff
```

Issue: https://github.com/coreos/fedora-coreos-tracker/issues/1992