### PR TITLE
tests/network: use ethX naming to preserve NIC order by CCW devno on s390x

### DIFF
--- a/mantle/kola/tests/misc/network.go
+++ b/mantle/kola/tests/misc/network.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net"
 	"regexp"
+	"runtime"
 	"strings"
 	"time"
 
@@ -502,6 +503,10 @@ func setupMultipleNetworkTest(c cluster.TestCluster, primaryMac, secondaryMac st
 		MachineOptions: platform.MachineOptions{
 			AdditionalNics: 2,
 		},
+	}
+	// On s390x, multiple NICs are ordered by the CCW device number. Use classic ethX names to ensure consistent and ordered naming.
+	if runtime.GOARCH == "s390x" {
+		options.AppendKernelArgs = "net.ifnames=0"
 	}
 
 	var userdata = conf.Ignition(fmt.Sprintf(`{


### PR DESCRIPTION
The `rhcos.network.multiple-nics` test became broken on `s390x` after CCW NICs started being ordered by `devno`:
```
enc1.0001: 10.0.2.31 fec0::6910:99dc:96e0:3a3c  
enc1.0002: 10.0.2.32 fec0::201a:58e1:5f12:47c7  
enc3:       10.0.2.15 fec0::d840:1062:8c56:e755
```
Use classic `ethX` naming (`s390x` only), so devices are ordered by names as well:
```
eth0: 10.0.2.15 fe80::e5f8:95f0:8e1d:4bf3  
eth1: 10.0.2.31 fec0::aa38:f654:11a5:a0d1  
eth2: 10.0.2.32 fec0::b5a7:ca83:f49:323e
```