### PR TITLE
deps: add kustomize

### DIFF
--- a/src/deps.txt
+++ b/src/deps.txt
@@ -107,3 +107,6 @@ copr-cli
 
 # To mount metal disk images in cmd-diff
 python3-libguestfs
+
+# For generating kubernetes YAML files (e.g Konflux resources)
+kustomize


### PR DESCRIPTION
As a follow-up of [1], we need kustomize to generate the tekton pipelines properly. 
It can also be used for other usecases.

[1] https://github.com/coreos/fedora-coreos-config/pull/3613