### PR TITLE
konflux: switch back to official pipeline ref

### DIFF
--- a/.tekton/coreos-assembler-pull-request.yaml
+++ b/.tekton/coreos-assembler-pull-request.yaml
@@ -40,16 +40,12 @@ spec:
     value: false
   #- name: prefetch-input
   #  value: '[{"type": "rpm", "path": "ci/hermetic"}, {"path": "ci/hermetic", "type": "generic"}]'
-  # Note: to be removed once rpm fully supported
-  # https://github.com/hermetoproject/hermeto?tab=readme-ov-file#package-managers
-  #- name: dev-package-managers
-  #  value: true
   #- name: build-args
   #  value: ["NO_NETWORK=1"]
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/jcapitao/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta@sha256:52a4ef40ecdabd82822e583f67f010d5771b92d959df55087456ed6aa3c7606e
+      value: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta@sha256:39a1abd4657035029db5e1e215333aba0cf094c3984df58e12cb157f4cb62207
     - name: name
       value: docker-build-multi-platform-oci-ta
     - name: kind

--- a/.tekton/coreos-assembler-push.yaml
+++ b/.tekton/coreos-assembler-push.yaml
@@ -37,16 +37,12 @@ spec:
     value: false
   #- name: prefetch-input
   #  value: '[{"type": "rpm", "path": "ci/hermetic"}, {"path": "ci/hermetic", "type": "generic"}]'
-  # Note: to be removed once rpm fully supported
-  # https://github.com/hermetoproject/hermeto?tab=readme-ov-file#package-managers
-  #- name: dev-package-managers
-  #  value: true
   #- name: build-args
   #  value: ["NO_NETWORK=1"]
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/jcapitao/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta@sha256:52a4ef40ecdabd82822e583f67f010d5771b92d959df55087456ed6aa3c7606e
+      value: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta@sha256:39a1abd4657035029db5e1e215333aba0cf094c3984df58e12cb157f4cb62207
     - name: name
       value: docker-build-multi-platform-oci-ta
     - name: kind

--- a/.tekton/coreos-assembler-renovate-push.yaml
+++ b/.tekton/coreos-assembler-renovate-push.yaml
@@ -40,16 +40,12 @@ spec:
     value: false
   #- name: prefetch-input
   #  value: '[{"type": "rpm", "path": "ci/hermetic"}, {"path": "ci/hermetic", "type": "generic"}]'
-  # Note: to be removed once rpm fully supported
-  # https://github.com/hermetoproject/hermeto?tab=readme-ov-file#package-managers
-  #- name: dev-package-managers
-  #  value: true
   #- name: build-args
   #  value: ["NO_NETWORK=1"]
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/jcapitao/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta@sha256:52a4ef40ecdabd82822e583f67f010d5771b92d959df55087456ed6aa3c7606e
+      value: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta@sha256:39a1abd4657035029db5e1e215333aba0cf094c3984df58e12cb157f4cb62207
     - name: name
       value: docker-build-multi-platform-oci-ta
     - name: kind

--- a/.tekton/kola-nfs-pull-request.yaml
+++ b/.tekton/kola-nfs-pull-request.yaml
@@ -44,14 +44,10 @@ spec:
     value: false
   #- name: prefetch-input
   #  value: '[{"type": "rpm", "path": "ci/hermetic"}]'
-  # Note: to be removed once rpm fully supported
-  # https://github.com/hermetoproject/hermeto?tab=readme-ov-file#package-managers
-  - name: dev-package-managers
-    value: true
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/jcapitao/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta@sha256:52a4ef40ecdabd82822e583f67f010d5771b92d959df55087456ed6aa3c7606e
+      value: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta@sha256:39a1abd4657035029db5e1e215333aba0cf094c3984df58e12cb157f4cb62207
     - name: name
       value: docker-build-multi-platform-oci-ta
     - name: kind

--- a/.tekton/kola-nfs-push.yaml
+++ b/.tekton/kola-nfs-push.yaml
@@ -40,14 +40,10 @@ spec:
     value: false
   #- name: prefetch-input
   #  value: '[{"type": "rpm", "path": "ci/hermetic"}]'
-  # Note: to be removed once rpm fully supported
-  # https://github.com/hermetoproject/hermeto?tab=readme-ov-file#package-managers
-  - name: dev-package-managers
-    value: true
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/jcapitao/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta@sha256:52a4ef40ecdabd82822e583f67f010d5771b92d959df55087456ed6aa3c7606e
+      value: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta@sha256:39a1abd4657035029db5e1e215333aba0cf094c3984df58e12cb157f4cb62207
     - name: name
       value: docker-build-multi-platform-oci-ta
     - name: kind

--- a/.tekton/kola-nfs-renovate-push.yaml
+++ b/.tekton/kola-nfs-renovate-push.yaml
@@ -44,14 +44,10 @@ spec:
     value: false
   #- name: prefetch-input
   #  value: '[{"type": "rpm", "path": "ci/hermetic"}]'
-  # Note: to be removed once rpm fully supported
-  # https://github.com/hermetoproject/hermeto?tab=readme-ov-file#package-managers
-  - name: dev-package-managers
-    value: true
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/jcapitao/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta@sha256:52a4ef40ecdabd82822e583f67f010d5771b92d959df55087456ed6aa3c7606e
+      value: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta@sha256:39a1abd4657035029db5e1e215333aba0cf094c3984df58e12cb157f4cb62207
     - name: name
       value: docker-build-multi-platform-oci-ta
     - name: kind

--- a/.tekton/kola-tang-pull-request.yaml
+++ b/.tekton/kola-tang-pull-request.yaml
@@ -44,14 +44,10 @@ spec:
     value: false
   #- name: prefetch-input
   #  value: '[{"type": "rpm", "path": "ci/hermetic"}]'
-  # Note: to be removed once rpm fully supported
-  # https://github.com/hermetoproject/hermeto?tab=readme-ov-file#package-managers
-  - name: dev-package-managers
-    value: true
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/jcapitao/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta@sha256:52a4ef40ecdabd82822e583f67f010d5771b92d959df55087456ed6aa3c7606e
+      value: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta@sha256:39a1abd4657035029db5e1e215333aba0cf094c3984df58e12cb157f4cb62207
     - name: name
       value: docker-build-multi-platform-oci-ta
     - name: kind

--- a/.tekton/kola-tang-push.yaml
+++ b/.tekton/kola-tang-push.yaml
@@ -40,14 +40,10 @@ spec:
     value: false
   #- name: prefetch-input
   #  value: '[{"type": "rpm", "path": "ci/hermetic"}]'
-  # Note: to be removed once rpm fully supported
-  # https://github.com/hermetoproject/hermeto?tab=readme-ov-file#package-managers
-  - name: dev-package-managers
-    value: true
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/jcapitao/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta@sha256:52a4ef40ecdabd82822e583f67f010d5771b92d959df55087456ed6aa3c7606e
+      value: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta@sha256:39a1abd4657035029db5e1e215333aba0cf094c3984df58e12cb157f4cb62207
     - name: name
       value: docker-build-multi-platform-oci-ta
     - name: kind

--- a/.tekton/kola-tang-renovate-push.yaml
+++ b/.tekton/kola-tang-renovate-push.yaml
@@ -44,14 +44,10 @@ spec:
     value: false
   #- name: prefetch-input
   #  value: '[{"type": "rpm", "path": "ci/hermetic"}]'
-  # Note: to be removed once rpm fully supported
-  # https://github.com/hermetoproject/hermeto?tab=readme-ov-file#package-managers
-  - name: dev-package-managers
-    value: true
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/jcapitao/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta@sha256:52a4ef40ecdabd82822e583f67f010d5771b92d959df55087456ed6aa3c7606e
+      value: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta@sha256:39a1abd4657035029db5e1e215333aba0cf094c3984df58e12cb157f4cb62207
     - name: name
       value: docker-build-multi-platform-oci-ta
     - name: kind

--- a/.tekton/kola-targetcli-pull-request.yaml
+++ b/.tekton/kola-targetcli-pull-request.yaml
@@ -44,14 +44,10 @@ spec:
     value: false
   #- name: prefetch-input
   #  value: '[{"type": "rpm", "path": "ci/hermetic"}]'
-  # Note: to be removed once rpm fully supported
-  # https://github.com/hermetoproject/hermeto?tab=readme-ov-file#package-managers
-  - name: dev-package-managers
-    value: true
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/jcapitao/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta@sha256:52a4ef40ecdabd82822e583f67f010d5771b92d959df55087456ed6aa3c7606e
+      value: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta@sha256:39a1abd4657035029db5e1e215333aba0cf094c3984df58e12cb157f4cb62207
     - name: name
       value: docker-build-multi-platform-oci-ta
     - name: kind

--- a/.tekton/kola-targetcli-push.yaml
+++ b/.tekton/kola-targetcli-push.yaml
@@ -40,14 +40,10 @@ spec:
     value: false
   #- name: prefetch-input
   #  value: '[{"type": "rpm", "path": "ci/hermetic"}]'
-  # Note: to be removed once rpm fully supported
-  # https://github.com/hermetoproject/hermeto?tab=readme-ov-file#package-managers
-  - name: dev-package-managers
-    value: true
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/jcapitao/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta@sha256:52a4ef40ecdabd82822e583f67f010d5771b92d959df55087456ed6aa3c7606e
+      value: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta@sha256:39a1abd4657035029db5e1e215333aba0cf094c3984df58e12cb157f4cb62207
     - name: name
       value: docker-build-multi-platform-oci-ta
     - name: kind

--- a/.tekton/kola-targetcli-renovate-push.yaml
+++ b/.tekton/kola-targetcli-renovate-push.yaml
@@ -44,14 +44,10 @@ spec:
     value: false
   #- name: prefetch-input
   #  value: '[{"type": "rpm", "path": "ci/hermetic"}]'
-  # Note: to be removed once rpm fully supported
-  # https://github.com/hermetoproject/hermeto?tab=readme-ov-file#package-managers
-  - name: dev-package-managers
-    value: true
   pipelineRef:
     params:
     - name: bundle
-      value: quay.io/jcapitao/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta@sha256:52a4ef40ecdabd82822e583f67f010d5771b92d959df55087456ed6aa3c7606e
+      value: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta@sha256:39a1abd4657035029db5e1e215333aba0cf094c3984df58e12cb157f4cb62207
     - name: name
       value: docker-build-multi-platform-oci-ta
     - name: kind


### PR DESCRIPTION
As a follow-up of [1][2], we can switch back to the official pipeline reference since [3]. 
See more details about this at the end of the thread [4].

[1] c2c1b415a804c245881d71764c51b10d52020d41
[2] b1ca0bcee92a73049a0bf84e73b14d83fd5cbbc4
[3] https://github.com/hermetoproject/hermeto/issues/986
[4] https://github.com/konflux-ci/build-definitions/pull/2421