### PR TITLE
support running osbuild as root

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -178,6 +178,10 @@ configure_user(){
     echo -e "builder:1:999\nbuilder:1001:64535" > /etc/subuid
     echo -e "builder:1:999\nbuilder:1001:64535" > /etc/subgid
 
+    # Allow a few directories to be accessed by unprivileged users.
+    # Remove when https://github.com/containers/common/pull/2507 has merged
+    chmod 755 /usr/lib/containers/storage/overlay-images
+    chmod 755 /usr/lib/containers/storage/overlay-layers
 }
 
 write_archive_info() {

--- a/build.sh
+++ b/build.sh
@@ -30,14 +30,26 @@ set -x
 srcdir=$(pwd)
 
 configure_yum_repos() {
-    [ "${arch}" == "riscv64" ] && return # No continuous repo for riscv64 yet
     [ "${NO_NETWORK:-0}" == "1" ] && return
     local version_id
     version_id=$(. /etc/os-release && echo ${VERSION_ID})
-    # Add continuous tag for latest build tools and mark as required so we
-    # can depend on those latest tools being available in all container
-    # builds.
-    echo -e "[f${version_id}-coreos-continuous]\nenabled=1\nmetadata_expire=1m\nbaseurl=https://kojipkgs.fedoraproject.org/repos-dist/f${version_id}-coreos-continuous/latest/\$basearch/\ngpgcheck=0\nskip_if_unavailable=False\n" > /etc/yum.repos.d/coreos.repo
+    if [ "${arch}" == "riscv64" ]; then
+        # No continuous repo for riscv64 yet, but let's enable the
+        # fedora-riscv-koji repo to get the latest packages.
+        sed -i 's/enabled=0/enabled=1/g' /etc/yum.repos.d/fedora-riscv-koji.repo
+    else
+        # Add continuous tag for latest build tools and mark as required so we
+        # can depend on those latest tools being available in all container
+        # builds.
+        cat <<EOF > /etc/yum.repos.d/coreos.repo
+[f${version_id}-coreos-continuous]
+enabled=1
+metadata_expire=1m
+baseurl=https://kojipkgs.fedoraproject.org/repos-dist/f${version_id}-coreos-continuous/latest/\$basearch/
+gpgcheck=0
+skip_if_unavailable=False
+EOF
+    fi
 }
 
 install_rpms() {

--- a/src/cmd-osbuild
+++ b/src/cmd-osbuild
@@ -397,7 +397,12 @@ main() {
     fi
 
     outdir=$(mktemp -p "${tmp_builddir}" -d)
-    runvm_with_cache -- /usr/lib/coreos-assembler/runvm-osbuild                                         \
+    if has_privileges && [ "${COSA_NO_KVM:-}" == "1" ]; then
+        cmd="env" # run outside of supermin if we are root already
+    else
+        cmd="runvm_with_cache"
+    fi
+    $cmd -- /usr/lib/coreos-assembler/runvm-osbuild                                                     \
                 --config "${runvm_osbuild_config_json}"                                                 \
                 --mpp "/usr/lib/coreos-assembler/osbuild-manifests/coreos.osbuild.${basearch}.mpp.yaml" \
                 --outdir "${outdir}"                                                                    \

--- a/src/runvm-osbuild
+++ b/src/runvm-osbuild
@@ -91,12 +91,6 @@ outdir=cache/osbuild/out
 
 processed_json=$(mktemp -t osbuild-XXXX.json)
 
-# Run `podman images` here to initialize a few directories inside the
-# supermin VM. Otherwise the org.osbuild.container-deploy stage will
-# fail to copy things into containers-storage. This also happens to
-# clean up a skopeo error relating to /etc/containers/networks not existing.
-podman images > /dev/null
-
 # Run through the preprocessor
 # Note: don't quote the size arguements since they are numbers, not strings
 set -x; osbuild-mpp                                       \

--- a/src/runvm-osbuild
+++ b/src/runvm-osbuild
@@ -37,8 +37,9 @@ log_disk_usage(){
     # 10 seconds.
     yellow="\033[33m"; default="\033[39m"
     (while true; do
-        echo -e "$yellow"; df -kh ./cache; echo -e "$default";
         sleep 10;
+        test -e ./cache || continue
+        echo -e "$yellow"; df -kh ./cache; echo -e "$default";
         pgrep --exact osbuild >/dev/null || break;
     done) &
 }


### PR DESCRIPTION


    In some limited cases we don't have access to /dev/kvm. For example,
    riscv just added support for KVM virtualization, but there is very
    little to no hardware that actually supports it. In order to build
    disk images for riscv using osbuild we'll need to support running
    outside the supermin VM. This code change allows for that.

    This is mostly a hack and shouldn't be used unless absolutely required.

    Here is the cosa alias I used to get this to work:

    ```
    cosa() {
        env | grep COREOS_ASSEMBLER >&2
        rm -f "${COREOS_ASSEMBLER_CONTAINER_NAME}-variant-config.json"
        if [ "$COREOS_ASSEMBLER_CONFIG_VARIANT" != "" ]; then
            cat <<EOF > "${COREOS_ASSEMBLER_CONTAINER_NAME}-variant-config.json"
    {
      "coreos-assembler.config-variant": "${COREOS_ASSEMBLER_CONFIG_VARIANT}"
    }
    EOF
        fi
        set -x # so we can see what command gets run
        sudo podman run --rm -ti --security-opt label=disable --privileged                                 \
                   --user root --userns host -v /dev/:/dev/ -e COSA_NO_KVM=1                               \
                   -v ${PWD}:/srv/                                                                         \
                   --tmpfs /tmp -v /var/tmp:/var/tmp --name ${COREOS_ASSEMBLER_CONTAINER_NAME:-cosa}       \
                   ${COREOS_ASSEMBLER_CONFIG_VARIANT:+-v ./"${COREOS_ASSEMBLER_CONTAINER_NAME}-variant-config.json":/srv/src/config.json:ro} \
                   ${COREOS_ASSEMBLER_CONFIG_GIT:+-v $COREOS_ASSEMBLER_CONFIG_GIT:/srv/src/config/:ro}     \
                   ${COREOS_ASSEMBLER_RHCOS_REPOS:+-v $COREOS_ASSEMBLER_RHCOS_REPOS:/srv/src/yumrepos/:ro} \
                   ${COREOS_ASSEMBLER_FCOS_SUBMODULE:+-v $COREOS_ASSEMBLER_FCOS_SUBMODULE:/srv/src/config/fedora-coreos-config:ro} \
                   ${COREOS_ASSEMBLER_GIT:+-v $COREOS_ASSEMBLER_GIT/src/:/usr/lib/coreos-assembler/:ro}    \
                   ${COREOS_ASSEMBLER_ADD_CERTS:+-v /etc/pki/ca-trust:/etc/pki/ca-trust:ro}                \
                   ${COREOS_ASSEMBLER_CONTAINER_RUNTIME_ARGS}                                              \
                   ${COREOS_ASSEMBLER_CONTAINER:-quay.io/coreos-assembler/coreos-assembler:latest} "$@"
       rc=$?; set +x; return $rc
    }
    ```

    Of note is the `--user root --userns host -v /dev/:/dev/ -e COSA_NO_KVM=1` line and the fact that
    we are using `sudo` to become root.