### PR TITLE
cmd-build-with-buildah: retain overrides/ API functionality

### DIFF
--- a/src/cmd-build-with-buildah
+++ b/src/cmd-build-with-buildah
@@ -133,6 +133,13 @@ build_with_buildah() {
                     -v /etc/pki/ca-trust:/etc/pki/ca-trust:ro
     fi
 
+    if [ -d overrides ]; then
+        if [[ -n $(ls overrides/rpm/*.rpm 2> /dev/null) ]]; then
+            (cd overrides/rpm && rm -rf .repodata && createrepo_c .)
+        fi
+        set -- "$@" -v "$(realpath overrides)":/run/src/overrides
+    fi
+
     if [ -n "$DIRECT" ]; then
         # turn on layer caching in the direct case; it wouldn't hurt in the
         # supermin path, but it'd be a waste of space on the rootfs

--- a/src/cmd-build-with-buildah
+++ b/src/cmd-build-with-buildah
@@ -116,8 +116,7 @@ build_with_buildah() {
 
     set -- build --security-opt=label=disable --cap-add=all --device /dev/fuse \
             --build-arg-file "$argsfile" -v "$(realpath "${tempdir}/src")":/run/src \
-            --build-arg VERSION="${VERSION}" \
-            -t oci-archive:"${tmp_oci_archive_path}"
+            --build-arg VERSION="${VERSION}"
 
     # XXX: Temporary hack until we have https://github.com/coreos/rpm-ostree/pull/5454
     # which would allow us to fold this back into the build process.
@@ -143,13 +142,28 @@ build_with_buildah() {
     if [ -n "$DIRECT" ]; then
         # turn on layer caching in the direct case; it wouldn't hurt in the
         # supermin path, but it'd be a waste of space on the rootfs
-        env -C "${tempdir}/src" buildah "$@" --layers=true .
+        set -- "$@" --layers=true
+        # output to a tag since it's more convenient for development;
+        # buildah doesn't support doing both at once
+        # shellcheck disable=SC1090
+        osname=$(source "src/config/${argsfile}"; echo "${NAME}")
+        final_ref="containers-storage:localhost/${osname}:${VERSION}"
     else
-        /usr/lib/coreos-assembler/cmd-supermin-run --cache \
-            env -C "${tempdir}/src" TMPDIR="$(realpath cache)" buildah "$@" .
+        final_ref="oci-archive:${tmp_oci_archive_path}"
     fi
 
-    /usr/lib/coreos-assembler/cmd-import "oci-archive:${tmp_oci_archive_path}"
+    # and finally, add the tag and context dir
+    set -- "$@" -t "${final_ref}" .
+
+    echo "Running:" buildah "$@"
+    if [ -n "$DIRECT" ]; then
+        env -C "${tempdir}/src" buildah "$@"
+    else
+        /usr/lib/coreos-assembler/cmd-supermin-run --cache \
+            env -C "${tempdir}/src" TMPDIR="$(realpath cache)" buildah "$@"
+    fi
+
+    /usr/lib/coreos-assembler/cmd-import "${final_ref}"
 
     rm -rf "${tempdir}"
 }

--- a/src/cmd-build-with-buildah
+++ b/src/cmd-build-with-buildah
@@ -20,6 +20,7 @@ Usage: coreos-assembler build-with-buildah
   --autolock=VERSION  If no base lockfile used, create one from any arch build of `VERSION`.
                       Note this is automatically enabled when adding to an existing multi-arch
                       non-strict build.
+  --skip-prune        Skip prunning previous builds
 EOF
 }
 
@@ -27,8 +28,9 @@ VERSION=
 VERSIONARY=
 DIRECT=
 AUTOLOCK_VERSION=
+SKIP_PRUNE=
 rc=0
-options=$(getopt --options h,d --longoptions help,version:,versionary,direct,autolock: -- "$@") || rc=$?
+options=$(getopt --options h,d --longoptions help,version:,versionary,direct,autolock:,skip-prune -- "$@") || rc=$?
 [ $rc -eq 0 ] || {
     print_help
     exit 1
@@ -53,6 +55,9 @@ while true; do
         --autolock)
             shift;
             AUTOLOCK_VERSION=$1
+            ;;
+        --skip-prune)
+            SKIP_PRUNE=1
             ;;
         --)
             shift
@@ -163,7 +168,7 @@ build_with_buildah() {
             env -C "${tempdir}/src" TMPDIR="$(realpath cache)" buildah "$@"
     fi
 
-    /usr/lib/coreos-assembler/cmd-import "${final_ref}"
+    /usr/lib/coreos-assembler/cmd-import "${final_ref}" ${SKIP_PRUNE:+--skip-prune}
 
     rm -rf "${tempdir}"
 }

--- a/src/cmd-import
+++ b/src/cmd-import
@@ -79,7 +79,7 @@ def generate_oci_archive(args, tmpd):
         shutil.copy(args.srcimg.partition(':')[2], tmpf)
     else:
         subprocess.check_call(['skopeo', 'copy', '--preserve-digests', args.srcimg,
-                           f"oci-archive:{tmpf}"])
+                               f"oci-archive:{tmpf}"])
     return tmpf
 
 

--- a/src/cmd-import
+++ b/src/cmd-import
@@ -58,13 +58,16 @@ def main():
         # move into official location
         finalize_build(builds, build_meta, tmp_oci_archive, tmp_oci_manifest, tmp_lockfile)
 
-    subprocess.check_call(['/usr/lib/coreos-assembler/cmd-prune'])
+    if not args.skip_prune:
+        subprocess.check_call(['/usr/lib/coreos-assembler/cmd-prune'])
 
 
 def parse_args():
     parser = argparse.ArgumentParser(prog='cosa import')
     parser.add_argument("srcimg", metavar='IMAGE',
                         help="image to import (containers-transports(5) format)")
+    parser.add_argument("--skip-prune", action='store_true',
+                        help="Skip prunning previous builds")
     return parser.parse_args()
 
 

--- a/src/cmd-sign
+++ b/src/cmd-sign
@@ -111,6 +111,14 @@ def cmd_robosignatory(args):
 def robosign_ostree(args, s3, build, gpgkey):
     builds = Builds()
     builddir = builds.get_build_dir(args.build, args.arch)
+
+    if build['coreos-assembler.oci-imported']:
+        # this is a known gap currently; we just no-op for
+        # now until we cut over to Konflux and stop using this code; see
+        # https://github.com/coreos/fedora-coreos-tracker/issues/1986
+        print("OSTree commit signing is not supported on imported OCI builds; ignoring...")
+        return
+
     checksum = build['ostree-commit']
 
     # Copy commit object to a temporary location. A preferred approach here is


### PR DESCRIPTION
`build-rootfs` in f-c-c learned a new `overrides/` API that matches how it works in cosa. Use that API to proxy through the cosa workdir `overrides/` dir.