### PR TITLE
cmd-osbuild: add comment for relevance of rootful codepath

### DIFF
--- a/src/cmd-osbuild
+++ b/src/cmd-osbuild
@@ -398,7 +398,10 @@ main() {
 
     outdir=$(mktemp -p "${tmp_builddir}" -d)
     if has_privileges && [ "${COSA_NO_KVM:-}" == "1" ]; then
-        cmd="env" # run outside of supermin if we are root already
+        # Run outside of supermin if we are root already. This is useful
+        # mostly on riscv where /dev/kvm isn't really supported by any
+        # hardware right now (2025/08).
+        cmd="env"
     else
         cmd="runvm_with_cache"
     fi


### PR DESCRIPTION
This came up in the prior code review [1] and we agreed to add the comment as a followon PR.

[1] https://github.com/coreos/coreos-assembler/pull/4251#discussion_r2273583462