### PR TITLE
cmd-build-with-buildah: add fedora-coreos.stream as annotation too

### DIFF
--- a/src/cmd-build-with-buildah
+++ b/src/cmd-build-with-buildah
@@ -128,7 +128,8 @@ build_with_buildah() {
     # shellcheck source=/dev/null
     stream=$(yaml2json "$manifest" /dev/stdout | jq -r '.variables.stream')
     if [ "${stream}" != null ]; then
-        set -- "$@" --label fedora-coreos.stream="$stream"
+        set -- "$@" --label fedora-coreos.stream="$stream" \
+                    --annotation fedora-coreos.stream="$stream"
     fi
 
     if [ -d "src/yumrepos" ] && [ -e "src/yumrepos/${variant:-}.repo" ]; then


### PR DESCRIPTION
In the legacy path, `fedora-coreos.stream` is both an OCI annotation (which lives in the image manifest) and a label (which lives in the image config).

Zincati only checks the annotation, not the label. I think checking the label would've been more appropriate, but anyway for now at least, let's match the existing semantic in the new container-native path.

Partially fixes https://github.com/coreos/fedora-coreos-tracker/issues/1996