### PR TITLE
cmd-build-with-buildah: add --parent-build and --force for compatibility

### DIFF
--- a/src/cmd-build-with-buildah
+++ b/src/cmd-build-with-buildah
@@ -123,6 +123,7 @@ build_with_buildah() {
     lockfile="manifest-lock.${arch}.json"
     if [ ! -f "src/config/${lockfile}" ] && { [ -n "${VERSION}" ] || [ -n "${AUTOLOCK_VERSION}" ]; }; then
         autolockfile=$(tmprepo=tmp/repo; workdir=.;
+                       ostree init --repo="${tmprepo}" --mode=archive;
                        generate_autolock "${AUTOLOCK_VERSION:-${VERSION}}")
         if [ -n "${autolockfile}" ]; then
             echo "Injecting autolock-generated ${lockfile}..."


### PR DESCRIPTION
cmd-build-with-buildah: add --parent-build for compatibility

The `--parent-build` concept doesn't translate well to the
container-native path. Two main things it was used for was for
maintaining valid OSTree branch history (which is no longer a
concept in the OCI world) and generating good layer chunking
to optimize deltas, which I think the successor to that now is
https://github.com/coreos/rpm-ostree/issues/5460.

For easier ratcheting, allow the switch but make it do nothing.

---

cmd-build-with-buildah: add --force for compatibility

There is no good change detection right now on the container-native
side. Hermetic Konflux builds should help there, but I'd also like to
make our builds reproducible which is the ultimate solution to this
though less efficient (we'd still do the build, but since we'd get
the same digest, it'd be a no-op -- this is why it's still useful even
with reproducible builds to have good "path change" triggers like what
Konflux offers).

