### PR TITLE
cmd-build-with-buildah: ensure ociarchive is compressed

### DIFF
--- a/src/cmd-build-with-buildah
+++ b/src/cmd-build-with-buildah
@@ -159,6 +159,8 @@ build_with_buildah() {
         osname=$(source "src/config/${argsfile}"; echo "${NAME}")
         final_ref="containers-storage:localhost/${osname}:${VERSION}"
     else
+        # In the supermin path ensure the ociarchive gets compressed
+        set -- "$@" --disable-compression=false
         final_ref="oci-archive:${tmp_oci_archive_path}"
     fi
 


### PR DESCRIPTION
Without this option my builds were about twice as large:

```
$ ls -lhd builds/*/x86_64/*ociarchive
-rw-r--r--. 1 dustymabe dustymabe 1.7G Aug 21 16:44 builds/42.20250821.dev.0/x86_64/fedora-coreos-42.20250821.dev.0-ostree.x86_64.ociarchive
-rw-r--r--. 1 dustymabe dustymabe 931M Aug 21 16:58 builds/42.20250821.dev.1/x86_64/fedora-coreos-42.20250821.dev.1-ostree.x86_64.ociarchive
```