### PR TITLE
cmd-build-with-buildah: make build existence check arch-aware

### DIFF
--- a/src/cmd-build-with-buildah
+++ b/src/cmd-build-with-buildah
@@ -113,8 +113,8 @@ build_with_buildah() {
         argsfile=build-args.conf
     fi
 
-    if [ -e "builds/$VERSION" ]; then
-        echo "Build ${VERSION} already exists"
+    if [ -e "builds/$VERSION/${arch}" ]; then
+        echo "Build ${VERSION} ($arch) already exists"
         exit 0
     fi
 


### PR DESCRIPTION
When checking if a build with the given version already exists, we should check for a build for that specific arch too. We may be adding another arch to an existing build.