### PR TITLE
kola/testiso: make volume ID test arch-independent

### DIFF
--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -272,10 +272,13 @@ var verifyIsoVolumeId = `[Unit]
 Description=Verify ISO Volume ID
 OnFailure=emergency.target
 OnFailureJobMode=isolate
+# only if we're actually mounting the ISO
+ConditionPathIsMountPoint=/run/media/iso
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=bash -c "[[ $(lsblk -no LABEL /dev/sr0) == %s-* ]]"
+# the backing device name is arch-dependent, but we know it's mounted on /run/media/iso
+ExecStart=bash -c "[[ $(findmnt -no LABEL /run/media/iso) == %s-* ]]"
 [Install]
 RequiredBy=coreos-installer.target`
 


### PR DESCRIPTION
The actual backing device used for the live ISO is arch-dependent. For example on aarch64, it actually just looks like another virtio disk (e.g. `/dev/vdb`).

But we know that it must be mounted at `/run/media/iso`, so key off of that instead to find the backing device.

Fixes 06da4920a ("kola/testiso: test volume ID has OS name prefix").