### PR TITLE
cmd-import: make pre-existing build ID check arch-aware

### DIFF
--- a/src/cmd-import
+++ b/src/cmd-import
@@ -37,8 +37,9 @@ def main():
     buildid = metadata['Labels']['org.opencontainers.image.version']
 
     builds = Builds()
-    if builds.has(buildid):
-        print(f"ERROR: Build ID {buildid} already exists!")
+    arch = get_basearch()
+    if builds.has(buildid) and arch in builds.get_build_arches(buildid):
+        print(f"ERROR: Build ID {buildid} ({arch}) already exists!")
         sys.exit(1)
 
     with tempfile.TemporaryDirectory(prefix='cosa-import-', dir='tmp') as tmpd:


### PR DESCRIPTION
This is basically the same as 2de6b0dc5 ("cmd-build-with-buildah: make build existence check arch-aware") but for the import command.