### PR TITLE
qemu: Ensure virtio journal streaming is killed on shutdown

### DIFF
--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -1649,7 +1649,12 @@ func (builder *QemuBuilder) VirtioJournal(config *conf.Conf, queryArguments stri
 	# won't be added to this unit, which would cause it to get
 	# taken down when isolating to emergency.target
 	DefaultDependencies=no
-	After=systemd.journal.service
+	After=systemd-journald.socket
+	# Do however ensure we get killed before /var is going to be
+	# unmounted, otherwise we keep it open.
+	After=local-fs.target
+	# Do get killed on shutdown
+	Conflicts=shutdown.target
 	# After systemd-journal-flush because otherwise the journalctl -f
 	# below will stop when the journal is flushed. Not sure if this is
 	# a bug or intended behavior.


### PR DESCRIPTION
In https://github.com/ostreedev/ostree/issues/3513 i'm trying to ensure that all the ostree mounts are cleaned up. It turned out that it was *this* unit keeping `/var` open because the `journalctl` binary doesn't know to stop tracking the `/var/log/journal` files when the daemon has flushed.

(We could obviously fix systemd to handle this)

But anyways the main reason this exists is to forward logs from startup and especially entering emergency.target. While it's useful to get logs from shutdown, there are other ways to do that.

This makes `var.mount` reliably unmounted for me.