### PR TITLE
cmd-import: proxy org.opencontainers.image.title to summary in meta.json

### DIFF
--- a/src/cmd-import
+++ b/src/cmd-import
@@ -155,6 +155,10 @@ def generate_build_meta(tmp_oci_archive, tmp_oci_manifest, metadata, ostree_comm
             'commit': commit,
         }
 
+    summary = metadata.get('Labels', {}).get('org.opencontainers.image.title')
+    if summary:
+        meta['summary'] = summary
+
     # add a reference to ourselves as well
     try:
         with open('/cosa/coreos-assembler-git.json') as f:

--- a/src/cmd-list
+++ b/src/cmd-list
@@ -38,7 +38,7 @@ def main():
             config = git['commit']
             if 'branch' in git:
                 config = f"{git['branch']} ({config[:12]})"
-            if git['dirty'] != "false":
+            if git.get('dirty', 'false') != "false":
                 config += " (dirty)"
             print(f"      Config: {config}")
         if build['id'] in tags:


### PR DESCRIPTION
This is used by some code in this codebase. Notably some cloud uploads and e.g. our OVAs.

Closes: https://github.com/coreos/fedora-coreos-tracker/issues/2017