### PR TITLE
cmd-fetch: Derive kofnlus lockfiles from rpm-ostree

### DIFF
--- a/src/cmd-fetch
+++ b/src/cmd-fetch
@@ -32,6 +32,8 @@ Usage: coreos-assembler fetch --help
   --write-lockfile-to=FILE Write updated base lockfile to separate file
   --with-cosa-overrides    Don't ignore cosa overrides in `overrides/rpm`
   --autolock=VERSION       If no base lockfile used, create one from any arch build of `VERSION`
+  --konflux                Generate hermeto lockfile for Konflux. Will only do something when called
+                           alongside --update-lockfile
 
 EOF
 }
@@ -43,8 +45,9 @@ IGNORE_COSA_OVERRIDES_ARG=--ignore-cosa-overrides
 DRY_RUN=
 FORCE_ARG=
 STRICT=
+KONFLUX=
 rc=0
-options=$(getopt --options h --longoptions help,update-lockfile,dry-run,with-cosa-overrides,write-lockfile-to:,strict,force,autolock: -- "$@") || rc=$?
+options=$(getopt --options h --longoptions help,update-lockfile,dry-run,with-cosa-overrides,write-lockfile-to:,strict,force,autolock:,konflux -- "$@") || rc=$?
 [ $rc -eq 0 ] || {
     print_help
     exit 1
@@ -79,6 +82,9 @@ while true; do
         --autolock)
             shift;
             AUTOLOCK_VERSION=$1
+            ;;
+        --konflux)
+            KONFLUX=1
             ;;
         --)
             shift
@@ -175,4 +181,16 @@ if [ -n "${UPDATE_LOCKFILE}" ]; then
     # cd back to workdir in case OUTPUT_LOCKFILE is relative
     (cd "${workdir}" && mv -f "${tmprepo}/tmp/manifest-lock.json" "${outfile}")
     echo "Wrote out lockfile ${outfile}"
+
+   if [ -n "${KONFLUX}" ]; then
+       echo "Generating hermeto input file..."
+       /usr/lib/coreos-assembler/konflux-rpm-lockfile generate "${manifest}" --context "${configdir}" --output "${tmprepo}/tmp/rpm.in.${arch}.yaml"
+       rpm-lockfile-prototype "${tmprepo}/tmp/rpm.in.${arch}.yaml" --outfile "${tmprepo}/tmp/rpms.lock.${arch}.yaml"
+       # Sanity check the generated hermeto lockfile
+       echo "Sanity check consistency between konflux and rpm-ostree lockfiles..."
+       /usr/lib/coreos-assembler/konflux-rpm-lockfile compare "${configdir}/manifest-lock.${arch}.json" "${tmprepo}/tmp/rpms.lock.${arch}.yaml"
+       (cd "${workdir}" && mv -f "${tmprepo}/tmp/rpms.lock.${arch}.yaml" "konflux-rpms-lock.${arch}.yaml")
+       echo "Wrote out hermeto lockfile: /tmp/rpms.lock.${arch}.yaml
+
+   fi
 fi

--- a/src/cosalib/cmdlib.py
+++ b/src/cosalib/cmdlib.py
@@ -575,3 +575,52 @@ def ensure_glob(pathname, **kwargs):
 def ncpu():
     '''Return the number of usable CPUs we have for parallelism.'''
     return int(subprocess.check_output(['kola', 'ncpu']))
+
+
+def get_treefile(manifest_path, deriving=False):
+    """
+    Parses an rpm-ostree manifest using 'rpm-ostree compose tree'.
+    If deriving is True, it ensures that the treefile represents only the
+    CoreOS bits and doesn't recurse into fedora-bootc.
+    """
+    with tempfile.NamedTemporaryFile(suffix='.json', mode='w') as tmp_manifest:
+        json.dump({
+            "variables": {
+                "deriving": deriving
+            },
+            "include": manifest_path
+        }, tmp_manifest)
+        tmp_manifest.flush()
+        data = subprocess.check_output(['rpm-ostree', 'compose', 'tree',
+                                        '--print-only', tmp_manifest.name])
+    return json.loads(data)
+
+
+def get_locked_nevras(srcdir):
+    """
+    Gathers all locked packages from the manifest-lock files.
+    The return format can be a dictionary of {pkgname: evr} or a list
+    of strings in the format 'pkgname-evr'.
+    For example:
+    - as_strings=False: {'rpm-ostree': '2024.4-1.fc40'}
+    - as_strings=True: ['rpm-ostree-2024.4-1.fc40']
+    """
+    arch = get_basearch()
+    lockfile_path = os.path.join(srcdir, f"manifest-lock.{arch}.json")
+    overrides_path = os.path.join(srcdir, "manifest-lock.overrides.yaml")
+    overrides_arch_path = os.path.join(srcdir, f"manifest-lock.overrides.{arch}.json")
+
+    locks = {}
+    for path in [lockfile_path, overrides_path, overrides_arch_path]:
+        if os.path.exists(path):
+            with open(path) as f:
+                if path.endswith('.yaml'):
+                    data = yaml.safe_load(f)
+                else:
+                    data = json.load(f)
+                # this essentially re-implements the merge semantics of rpm-ostree
+                locks.update({pkgname: v.get('evra') or v.get('evr')
+                              for (pkgname, v) in data['packages'].items()})
+
+    return locks
+ 

--- a/src/konflux-rpm-lockfile
+++ b/src/konflux-rpm-lockfile
@@ -1,0 +1,198 @@
+#!/usr/bin/python
+
+import argparse
+import json
+import os
+import re
+import sys
+import yaml
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from cosalib.cmdlib import get_treefile, get_locked_nevras, get_basearch
+
+
+ARCH = get_basearch()
+
+
+def locks_mismatch(rpm_ostree_lock, hermeto_lock):
+    """
+    Compares a JSON manifest lock with a YAML RPM lock for x86_64.
+
+    Args:
+        rpm_ostree_lock (str): Path to the rpm-ostree JSON manifest lock file.
+        hermeto_lock (str): Path to the hermeto YAML lock file.
+
+    Returns:
+        bool: True if there are differences, False otherwise.
+    """
+    with open(rpm_ostree_lock, 'r') as f:
+        manifest_data = {name: details['evra'] for name, details in json.load(f).get('packages', {}).items()}
+
+    with open(hermeto_lock, 'r') as f:
+        yaml_data = {pkg['name']: str(pkg['evr']) for arch in yaml.safe_load(f).get('arches', []) if arch.get('arch') == 'x86_64' for pkg in arch.get('packages', [])}
+
+    rpm_ostree_lock_set = set(manifest_data.keys())
+    hermeto_lock_set = set(yaml_data.keys())
+
+    differences_found = False
+
+    if only_in_manifest := sorted(list(rpm_ostree_lock_set - hermeto_lock_set)):
+        differences_found = True
+        print("Packages only in rpm-ostree lockfile:")
+        for pkg in only_in_manifest:
+            print(f"- {pkg} ({manifest_data[pkg]})")
+
+    if only_in_yaml := sorted(list(hermeto_lock_set - rpm_ostree_lock_set)):
+        differences_found = True
+        print("\nPackages only in hermeto lockfile:")
+        for pkg in only_in_yaml:
+            print(f"- {pkg} ({yaml_data[pkg]})")
+
+    mismatches = []
+    for pkg in sorted(list(rpm_ostree_lock_set.intersection(hermeto_lock_set))):
+        manifest_evr = manifest_data[pkg].rsplit('.', 1)[0]
+        if manifest_evr != yaml_data[pkg]:
+            mismatches.append(f"- {pkg}:\n  - rpm-ostree: {manifest_data[pkg]}\n  - hermeto: {yaml_data[pkg]}")
+
+    if mismatches:
+        differences_found = True
+        print("\nVersion mismatches:")
+        for mismatch in mismatches:
+            print(mismatch)
+    else:
+        print(f"\u2705 No mismatches founds between {rpm_ostree_lock} and {hermeto_lock}")
+
+    return differences_found
+
+
+def filter_repofile(repos, locked_nevras, repo_path, output_dir):
+    if not os.path.exists(repo_path):
+        print(f"Error: {repo_path} not found. Cannot inject includepkg filter.")
+        return
+
+    include_str = ','.join(locked_nevras)
+
+    with open(repo_path, 'r') as f:
+        repofile = f.read()
+
+    # We use a regex that looks for [reo_name] on a line by itself,
+    # possibly with whitespace.
+    sections = re.split(r'^\s*(\[.+\])\s*', repofile, flags=re.MULTILINE)
+
+    new_content = sections[0]  # part before any section
+    keep = False
+
+    # sections will be [before, section1_name, section1_content, section2_name, section2_content, ...]
+    for i in range(1, len(sections), 2):
+        name = sections[i]
+        # ignore repos that don't match the repos we want to use
+        if name.strip("[]") in repos:
+            repodef = sections[i+1]
+            if 'includepkgs=' not in repodef:
+                # We only keep the repo definition that we edited
+                # to avoid accidentaly taking in other packages
+                # from a repofile already having an includepkgs
+                # directive.
+                keep = True
+                new_content += name + '\n'
+                repodef += f"includepkgs={include_str}\n"
+                new_content += repodef
+
+    filename = None
+    if keep:
+        filename = os.path.basename(repo_path.removesuffix(".repo"))
+        filename = os.path.join(output_dir, f"{filename}-hermeto.repo")
+        with open(filename, 'w') as f:
+            f.write(new_content)
+        print(f"Wrote filtered repo to: {filename}")
+
+    return keep, filename
+
+
+def build_rpm_lockfile_config(packages, repo_files):
+    """
+    Augments package names in rpm_in_data with version numbers from locks.
+    Populates contentOrigin and repofiles.
+    """
+    # Initialize the structure for rpm_lockfile_input, similar to write_rpms_input_file
+    # This ensures consistency whether it comes from a manifest or directly
+    rpm_lockfile_config = {
+        'contentOrigin': {
+            'repofiles': repo_files
+        },
+        'installWeakDeps': False,
+        'context': {
+            'bare': True,
+        },
+        'packages': packages
+    }
+
+    return rpm_lockfile_config
+
+def generate_lockfile(contextdir, manifest, output_path):
+    """
+    Generates the rpm-lockfile-prototype input file.
+    """
+    manifest_data = get_treefile(manifest, deriving=False)
+    repos = manifest_data.get('repos', [])
+    repos += manifest_data.get('lockfile-repos', [])
+    packages = manifest_data.get('packages', [])
+    locks = get_locked_nevras(contextdir)
+    repofiles = [file for file in os.listdir(contextdir) if file.endswith('.repo')]
+    relevant_repofiles = []
+    output_dir = os.path.dirname(output_path)
+
+    if locks:
+        locked_nevras = [f'{k}-{v}' for (k, v) in locks.items()]
+        for repofile in repofiles:
+            keep, newrepo = filter_repofile(repos, locked_nevras, os.path.join(contextdir, repofile), output_dir)
+            if keep:
+                relevant_repofiles.append(newrepo)
+
+    augmented_rpm_in = build_rpm_lockfile_config(packages, relevant_repofiles)
+
+    try:
+        with open(output_path, 'w') as f:
+            yaml.safe_dump(augmented_rpm_in, f, default_flow_style=False)
+        print(f"rpm-lockfile-prototype input config wrote to: {output_path}")
+    except IOError as e:
+        print(f"\u274c Error: Could not write to final output file '{output_path}'. Reason: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Generate and compare rpm-lockfile-prototype input files."
+    )
+    subparsers = parser.add_subparsers(dest='command', required=True)
+
+    parser_generate = subparsers.add_parser('generate', help='Generate rpm-lockfile-prototype input file.')
+    parser_generate.add_argument(
+        'manifest',
+        help='Path to the rpm-ostree manifest (e.g., fedora-coreos-config/manifest.yaml)'
+    )
+
+    parser_generate.add_argument(
+        '--context',
+        default='.',
+        help="Path to the directory containing repofiles and lockfiles. (default: '.')"
+    )
+
+    parser_generate.add_argument(
+        '--output',
+        default='./rpms.in.yaml',
+        help="Path for the final rpm-lockfile-protoype config file. (default: './rpms.in.yaml')"
+    )
+
+    parser_compare = subparsers.add_parser('compare', help='Compare rpm-ostree JSON lockfile with hermeto RPM lock.')
+    parser_compare.add_argument('rpmostree_lockfile', help='Path to the rpm-ostree manifest lock file (JSON).')
+    parser_compare.add_argument('hermeto_lockfile', help='Path to the hermeto RPM lock file (YAML).')
+
+    args = parser.parse_args()
+
+    if args.command == 'generate':
+        manifest_abs_path = os.path.abspath(args.manifest)
+        generate_lockfile(args.context, manifest_abs_path, args.output)
+    elif args.command == 'compare':
+        if locks_mismatch(args.rpmostree_lockfile, args.hermeto_lockfile):
+            sys.exit(1)


### PR DESCRIPTION
Let's use our lockfiles to get hermeto download a set of matching RPMs. This is done through injecting `includepkg` filters to the repofiles then feeding that to `rpm-lockfile-prototype`.

The overview is:
we parse the manifest for a package list and enabled repos. For each package, we take the expected EVRA in the rpm-ostree lockfile and inject it in the `includepkg` filter in the repos files. Finally we feed that package list and the custom repo definition to rpm-ostree-prototype.
The result is a hermeto/cachi2 lockfile we will commit to the repo.

This `--konflux` flag would then be added to the Jenkins bump-lockfiles job to update both lockfiles in the same commit.

This will allow hermetic builds in Konflux.

I also added a sanity check at the end that iterate over both lockfiles and compare all versions string to make sure we have exact matches all around.

See also https://github.com/coreos/fedora-coreos-config/pull/3644 for the inital implementation.