### PR TITLE
cmd-coreos-prune: correct barrier release info

### DIFF
--- a/src/cmd-coreos-prune
+++ b/src/cmd-coreos-prune
@@ -118,7 +118,9 @@ def main():
     if stream in ['stable', 'testing', 'next']:
         update_graph = get_update_graph(stream)['releases']
         # Keep only the barrier releases
-        barrier_releases = set([release["version"] for release in update_graph if "barrier" in release])
+        barrier_releases = set([release["version"] for release in update_graph if "barrier" in release["metadata"]])
+        # Verify we got some data. Otherwise there was an issue
+        assert len(barrier_releases) > 0
 
     # Iterate through builds from oldest to newest
     for build in reversed(builds):


### PR DESCRIPTION
The `barrier` key is under the `metadata` dict. Let's update it here and also add an assert to make sure we always get some barrier release info before continuing.