### PR TITLE
[rhcos-4.18] cmd-push-container-manifest: backport --write-digest-to-file option

### DIFF
--- a/src/cmd-push-container-manifest
+++ b/src/cmd-push-container-manifest
@@ -28,7 +28,7 @@ def main():
     if args.images:
         # User provided images directly
         create_and_push_container_manifest(
-            args.repo, args.tags, args.images, args.v2s2)
+            args.repo, args.tags, args.images, args.write_digest_to_file, args.v2s2)
     else:
         # Picking up images from artifacts in meta.json
         builds = Builds()
@@ -104,7 +104,7 @@ def main():
 
         # Create/Upload the manifest list to the container registry
         manifest_info = create_and_push_container_manifest(
-            args.repo, args.tags, images, args.v2s2)
+            args.repo, args.tags, images, args.write_digest_to_file, args.v2s2)
         # if we pushed in v2s2 mode, we need to reload from the repo the actual
         # final digests: https://github.com/containers/podman/issues/16603
         if args.v2s2:
@@ -159,6 +159,8 @@ Examples:
     parser.add_argument('--v2s2', action='store_true',
                         help='Use old image manifest version 2 schema 2 format')
     parser.add_argument("--force", help="Force manifest overwriting", action='store_true')
+    parser.add_argument('--write-digest-to-file', required=False,
+                        help='Write digest of pushed manifest to named file')
 
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument("--image", dest='images', action='append', default=[],

--- a/src/cosalib/container_manifest.py
+++ b/src/cosalib/container_manifest.py
@@ -48,7 +48,7 @@ def delete_local_container_manifest(repo, tag):
     runcmd(cmd)
 
 
-def push_container_manifest(repo, tags, v2s2=False):
+def push_container_manifest(repo, tags, write_digest_to_file, v2s2=False):
     '''
     Push manifest to registry
     @param repo str registry repository
@@ -61,12 +61,14 @@ def push_container_manifest(repo, tags, v2s2=False):
         # to create a manifest with 2 different mediaType. It seems to be
         # a Quay issue.
         base_cmd.extend(["--remove-signatures", "-f", "v2s2"])
+    if write_digest_to_file:
+        base_cmd.extend(["--digestfile", write_digest_to_file])
     runcmd(base_cmd + [f"{repo}:{tags[0]}"])
     for tag in tags[1:]:
         runcmd(base_cmd + [f"{repo}:{tag}"])
 
 
-def create_and_push_container_manifest(repo, tags, images, v2s2) -> dict:
+def create_and_push_container_manifest(repo, tags, images, write_digest_to_file, v2s2) -> dict:
     '''
     Do it all! Create, push, cleanup, and return the final manifest JSON.
     @param repo str registry repository
@@ -78,6 +80,6 @@ def create_and_push_container_manifest(repo, tags, images, v2s2) -> dict:
         # perhaps left over from a previous failed run -> delete
         delete_local_container_manifest(repo, tags[0])
     manifest_info = create_local_container_manifest(repo, tags[0], images)
-    push_container_manifest(repo, tags, v2s2)
+    push_container_manifest(repo, tags, write_digest_to_file, v2s2)
     delete_local_container_manifest(repo, tags[0])
     return manifest_info


### PR DESCRIPTION
Adding the container signature in the pipeline [1] added an extra argument to the container push call. 

Cherry-pick https://github.com/coreos/coreos-assembler/commit/677fe262a8c5edfb2437f53acda9179a7bdac6eb to add the option to unbreak the pipeline for RHCOS.

[1] https://github.com/coreos/fedora-coreos-pipeline/commit/b4df2de138386e66fda886f5c7fd5a57f0fc1beb