### PR TITLE
cmd-prune: skip removing "unowned" blobs if 'layers' field doesn't exist

### DIFF
--- a/src/cmd-prune
+++ b/src/cmd-prune
@@ -198,8 +198,11 @@ if os.path.exists('tmp/repo'):
         if os.path.exists(oci_manifest):
             with open(oci_manifest) as f:
                 oci_manifest = json.load(f)
+                layers = oci_manifest.get('layers', [])
+                if len(layers) == 0:
+                    continue
                 referenced_blobs.update([prefix + layer['digest'].replace(':', '_3A_')
-                                         for layer in oci_manifest['layers']])
+                                         for layer in layers])
     blobs = set(subprocess.check_output(['ostree', 'refs', '--repo=tmp/repo',
                                          '--list', 'ostree/container/blob'],
                                         encoding='utf-8').splitlines())


### PR DESCRIPTION
Older images doesn't have 'layers' field in the oci manifest.

Fixes: https://github.com/coreos/coreos-assembler/issues/4310