### PR TITLE
cmd-import: handle manifest lists

### DIFF
--- a/src/cmd-import
+++ b/src/cmd-import
@@ -22,6 +22,7 @@ from cosalib.builds import Builds
 from cosalib.cmdlib import (
     rfc3339_time,
     get_basearch,
+    goarch_to_rpmarch,
     sha256sum_file,
     import_oci_archive)
 
@@ -88,11 +89,40 @@ def generate_oci_archive(args, tmpd):
 
 
 def generate_oci_manifest(args, tmpd):
+    raw_inspect = skopeo_inspect_raw_resolve_manifest_list(args.srcimg)
     tmpf = os.path.join(tmpd, 'oci-manifest.json')
-    with open(tmpf, 'wb') as f:
-        f.write(subprocess.check_output(["skopeo", "inspect", "--raw", args.srcimg]))
+    with open(tmpf, 'w', encoding='utf-8') as f:
+        f.write(raw_inspect)
         os.fchmod(f.fileno(), S_IREAD | S_IRGRP | S_IROTH)
     return tmpf
+
+
+def skopeo_inspect_raw_resolve_manifest_list(image: str):
+    raw_inspect = subprocess.check_output(["skopeo", "inspect", "--raw", image], encoding='utf-8')
+    inspect = json.loads(raw_inspect)
+
+    # check if it's a manifest list; this implicitly handles both docker v2s2 and oci formats
+    if 'manifests' not in inspect:
+        return raw_inspect  # we're done!
+
+    arch = get_basearch()
+    for manifest in inspect['manifests']:
+        if goarch_to_rpmarch(manifest['platform']['architecture']) == arch:
+            arch_digest = manifest['digest']
+            break
+    else:
+        raise Exception(f"no manifest found for architecture {arch}")
+
+    base, repo = image.rsplit('/', 1)
+    adjusted_image = base + '/'
+    if ':' in repo:  # e.g. quay.io/org/image:tag
+        adjusted_image += repo[:repo.index(':')] + '@' + arch_digest
+    elif '@' in repo:  # e.g. quay.io/org/image@sha256:...
+        adjusted_image += repo[:repo.index('@')] + '@' + arch_digest
+    else:  # e.g. quay.io/org/image
+        adjusted_image += '@' + arch_digest
+
+    return subprocess.check_output(["skopeo", "inspect", "--raw", adjusted_image], encoding='utf-8')
 
 
 def generate_lockfile_and_commitmeta(tmpd, ostree_commit, build_meta):

--- a/src/cmd-push-container-manifest
+++ b/src/cmd-push-container-manifest
@@ -10,6 +10,7 @@ import sys
 from cosalib.container_manifest import create_and_push_container_manifest
 from cosalib.builds import Builds
 from cosalib.meta import GenericBuildMeta
+from cosalib.cmdlib import goarch_to_rpmarch
 from cosalib.cmdlib import runcmd
 from cosalib.cmdlib import sha256sum_file
 
@@ -18,9 +19,6 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 def main():
     args = parse_args()
-    map_arch = {}
-    map_arch['arm64'] = 'aarch64'
-    map_arch['amd64'] = 'x86_64'
     allow_missing_arches = False
 
     if args.authfile:
@@ -57,9 +55,7 @@ def main():
         if inspect.returncode == 0:
             manifests = json.loads(inspect.stdout)
             for manifest in manifests['manifests']:
-                arch = manifest['platform']['architecture']
-                if arch in map_arch:
-                    arch = map_arch[arch]
+                arch = goarch_to_rpmarch(manifest['platform']['architecture'])
                 registry_digests[arch] = manifest['digest']
 
         for arch in args.arches:
@@ -119,9 +115,7 @@ def main():
         # digest. See: https://github.com/coreos/coreos-assembler/issues/3122.
         assert len(manifest_info['manifests']) == len(buildmetas)
         for manifest in manifest_info['manifests']:
-            arch = manifest['platform']['architecture']
-            if arch in map_arch:
-                arch = map_arch[arch]
+            arch = goarch_to_rpmarch(manifest['platform']['architecture'])
             image = {
                 'image': args.repo,
                 'digest': manifest['digest'],

--- a/src/cosalib/cmdlib.py
+++ b/src/cosalib/cmdlib.py
@@ -413,6 +413,13 @@ def get_basearch():
         return get_basearch.saved
 
 
+def goarch_to_rpmarch(goarch):
+    map_arch = {'arm64': 'aarch64', 'amd64': 'x86_64'}
+    if goarch in map_arch:
+        return map_arch[goarch]
+    return goarch
+
+
 def parse_fcos_version_to_timestamp(version):
     '''
     Parses an FCOS build ID and verifies the versioning is accurate. Then


### PR DESCRIPTION
When saving the image manifest, we need to make sure to handle manifest lists correctly; i.e. we want the actual underlying archful manifest, not the manifest list itself.

Unfortunately, there isn't really good tooling for this in skopeo so we're kind of on our own. See also: https://github.com/containers/skopeo/issues/1554.

Fixes: #4310