### PR TITLE
release: stop putting ostree commits into release metadata

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/coreos/ignition/v2 v2.22.0
 	github.com/coreos/pkg v0.0.0-20240122114842-bbd7aa9bf6fb
 	github.com/coreos/rpmostree-client-go v0.0.0-20240514234259-72a33e8554b6
-	github.com/coreos/stream-metadata-go v0.4.9
+	github.com/coreos/stream-metadata-go v0.4.10
 	github.com/coreos/vcontext v0.0.0-20231102161604-685dc7299dc5
 	github.com/digitalocean/go-qemu v0.0.0-20250212194115-ee9b0668d242
 	github.com/digitalocean/godo v1.163.0

--- a/go.sum
+++ b/go.sum
@@ -77,8 +77,8 @@ github.com/coreos/pkg v0.0.0-20240122114842-bbd7aa9bf6fb h1:GIzvVQ9UkUlOhSDlqmrQ
 github.com/coreos/pkg v0.0.0-20240122114842-bbd7aa9bf6fb/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/rpmostree-client-go v0.0.0-20240514234259-72a33e8554b6 h1:0pX2AoeeKHmH5QOQ4PiWxVgBXFp05abmu4hJfLwm0FE=
 github.com/coreos/rpmostree-client-go v0.0.0-20240514234259-72a33e8554b6/go.mod h1:S6BkMZ83zhB/htKQApNv23A1OMERqD9e7ihxHw5ILb0=
-github.com/coreos/stream-metadata-go v0.4.9 h1:7EHsEYr0/oEJZumWc4b7+2KxD5PXy43esipOII2+JVk=
-github.com/coreos/stream-metadata-go v0.4.9/go.mod h1:fMObQqQm8Ku91G04btKzEH3AsdP1mrAb986z9aaK0tE=
+github.com/coreos/stream-metadata-go v0.4.10 h1:PlZjbJF94cCeCAHwkeBOrLhdT36qq1O8RdJ/auFa7DI=
+github.com/coreos/stream-metadata-go v0.4.10/go.mod h1:dTE8UEFgyUcrbdUg7vGT3uIP7S8a1IwUlmWLKlOp8G8=
 github.com/coreos/vcontext v0.0.0-20231102161604-685dc7299dc5 h1:sMZSC2BW5LKCdvNbfN12SbKrNvtLBUNjfHZmMvI2ItY=
 github.com/coreos/vcontext v0.0.0-20231102161604-685dc7299dc5/go.mod h1:Salmysdw7DAVuobBW/LwsKKgpyCPHUhjyJoMJD+ZJiI=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=

--- a/mantle/cmd/plume/release.go
+++ b/mantle/cmd/plume/release.go
@@ -299,10 +299,12 @@ func modifyReleaseMetadataIndex(api *aws.API, rel release.Release) {
 	var commits []release.IndexReleaseCommit
 	var pullspecs []release.IndexReleaseOciImage
 	for arch, vals := range rel.Architectures {
-		commits = append(commits, release.IndexReleaseCommit{
-			Architecture: arch,
-			Checksum:     vals.Commit,
-		})
+		if vals.Commit != "" {
+			commits = append(commits, release.IndexReleaseCommit{
+				Architecture: arch,
+				Checksum:     vals.Commit,
+			})
+		}
 		pullspecs = append(pullspecs, release.IndexReleaseOciImage{
 			Architecture:   arch,
 			ContainerImage: *vals.OciImage,

--- a/src/cmd-build
+++ b/src/cmd-build
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [ -n "${COSA_BUILD_WITH_BUILDAH:-}" ]; then
-    exec /usr/lib/coreos-assembler/cmd-build-with-buildah "$@"
-fi
-
 dn=$(dirname "$0")
 # shellcheck source=src/cmdlib.sh
 . "${dn}"/cmdlib.sh
+
+if should_build_with_buildah; then
+    info 'redirecting to build-with-buildah'
+    exec /usr/lib/coreos-assembler/cmd-build-with-buildah "$@"
+fi
 
 print_help() {
     cat 1>&2 <<'EOF'

--- a/src/cmd-build-with-buildah
+++ b/src/cmd-build-with-buildah
@@ -170,7 +170,7 @@ build_with_buildah() {
                 (cd overrides/rpm && createrepo_c .)
             fi
         fi
-        set -- "$@" -v "$(realpath overrides)":/run/src/overrides
+        set -- "$@" -v "$(realpath overrides)":/src/overrides
     fi
 
     if [ -n "$DIRECT" ]; then

--- a/src/cmd-fetch
+++ b/src/cmd-fetch
@@ -5,6 +5,13 @@ dn=$(dirname "$0")
 # shellcheck source=src/cmdlib.sh
 . "${dn}"/cmdlib.sh
 
+if should_build_with_buildah; then
+    # shellcheck disable=SC2016
+    info 'fetch is not useful when building with buildah'
+    info 'skipping fetch'
+    exit 0
+fi
+
 FILE=cache/pkgcache-repo
 if [ -d "${FILE}" ]
 then
@@ -94,13 +101,6 @@ done
 if [ $# -ne 0 ]; then
     print_help
     fatal "ERROR: Too many arguments"
-fi
-
-if [ -n "${COSA_BUILD_WITH_BUILDAH:-}" ]; then
-    # shellcheck disable=SC2016
-    info 'fetch is not useful when using $COSA_BUILD_WITH_BUILDAH'
-    info 'Skipping fetch'
-    exit 0
 fi
 
 prepare_build

--- a/src/cmd-generate-release-meta
+++ b/src/cmd-generate-release-meta
@@ -146,7 +146,8 @@ def append_build(out, input_):
     print(f"  {arch} images:")
     # build the architectures dict
     arch_dict = {"media": {}}
-    ensure_dup(input_, arch_dict, "ostree-commit", "commit")
+    if not input_.get('coreos-assembler.oci-imported'):
+        ensure_dup(input_, arch_dict, "ostree-commit", "commit")
 
     # within the CoreOS pipelines, we always expect base-oscontainer to be set,
     # but this script is also currently used by OKD but they only care about

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -148,6 +148,17 @@ yaml2json() {
     python3 -c 'import sys, json, yaml; json.dump(yaml.safe_load(sys.stdin), sys.stdout, sort_keys=True)' < "$1" > "$2"
 }
 
+should_build_with_buildah() {
+    if [ -n "${COSA_BUILD_WITH_BUILDAH:-}" ]; then
+        if [ "${COSA_BUILD_WITH_BUILDAH:-}" = 1 ]; then
+            return 0
+        else
+            return 1
+        fi
+    fi
+    return 1
+}
+
 prepare_build() {
     preflight
     preflight_kvm

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -149,12 +149,23 @@ yaml2json() {
 }
 
 should_build_with_buildah() {
+    local variant manifest
     if [ -n "${COSA_BUILD_WITH_BUILDAH:-}" ]; then
         if [ "${COSA_BUILD_WITH_BUILDAH:-}" = 1 ]; then
             return 0
         else
             return 1
         fi
+    fi
+    # this slightly duplicates some logic in `prepare_build`, but meh...
+    if [[ -f "src/config.json" ]]; then
+        variant="$(jq --raw-output '."coreos-assembler.config-variant"' src/config.json)"
+        manifest="src/config/manifest-${variant}.yaml"
+    else
+        manifest="src/config/manifest.yaml"
+    fi
+    if [ "$(yq .metadata.build_with_buildah "${manifest}")" = true ]; then
+        return 0
     fi
     return 1
 }

--- a/vendor/github.com/coreos/stream-metadata-go/fedoracoreos/fcos.go
+++ b/vendor/github.com/coreos/stream-metadata-go/fedoracoreos/fcos.go
@@ -36,7 +36,10 @@ func getStream(u url.URL) (*stream.Stream, error) {
 		return nil, err
 	}
 	body, err := io.ReadAll(resp.Body)
-	resp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+	err = resp.Body.Close()
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/coreos/stream-metadata-go/release/release.go
+++ b/vendor/github.com/coreos/stream-metadata-go/release/release.go
@@ -19,7 +19,7 @@ type Index struct {
 
 // IndexRelease is a "release pointer" from a release index
 type IndexRelease struct {
-	Commits     []IndexReleaseCommit   `json:"commits"`
+	Commits     []IndexReleaseCommit   `json:"commits,omitempty"`
 	OciImages   []IndexReleaseOciImage `json:"oci-images,omitempty"`
 	Version     string                 `json:"version"`
 	MetadataURL string                 `json:"metadata"`
@@ -52,7 +52,7 @@ type Metadata struct {
 
 // Arch release details
 type Arch struct {
-	Commit               string               `json:"commit"`
+	Commit               string               `json:"commit,omitempty"`
 	OciImage             *ContainerImage      `json:"oci-image,omitempty"`
 	Media                Media                `json:"media"`
 	RHELCoreOSExtensions *relrhcos.Extensions `json:"rhel-coreos-extensions,omitempty"`

--- a/vendor/github.com/coreos/stream-metadata-go/stream/artifact_utils.go
+++ b/vendor/github.com/coreos/stream-metadata-go/stream/artifact_utils.go
@@ -2,6 +2,7 @@ package stream
 
 import (
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -19,7 +20,9 @@ func (a *Artifact) Fetch(w io.Writer) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		err = errors.Join(resp.Body.Close())
+	}()
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("%s returned status: %s", a.Location, resp.Status)

--- a/vendor/github.com/coreos/stream-metadata-go/stream/rhcos/rhcos.go
+++ b/vendor/github.com/coreos/stream-metadata-go/stream/rhcos/rhcos.go
@@ -1,9 +1,12 @@
 package rhcos
 
+import "fmt"
+
 // Extensions is data specific to Red Hat Enterprise Linux CoreOS
 type Extensions struct {
-	AwsWinLi  *AwsWinLi  `json:"aws-winli,omitempty"`
-	AzureDisk *AzureDisk `json:"azure-disk,omitempty"`
+	AwsWinLi    *AwsWinLi    `json:"aws-winli,omitempty"`
+	AzureDisk   *AzureDisk   `json:"azure-disk,omitempty"`
+	Marketplace *Marketplace `json:"marketplace,omitempty"`
 }
 
 // AzureDisk represents an Azure disk image that can be imported
@@ -35,4 +38,55 @@ type ReplicatedImage struct {
 type SingleImage struct {
 	Release string `json:"release"`
 	Image   string `json:"image"`
+}
+
+// Marketplace contains marketplace images for all clouds.
+type Marketplace struct {
+	Azure *AzureMarketplace `json:"azure,omitempty"`
+}
+
+// AzureMarketplaceImages contains both the HyperV- Gen1 & Gen2
+// images for a purchase plan.
+type AzureMarketplaceImages struct {
+	Gen1 *AzureMarketplaceImage `json:"hyperVGen1,omitempty"`
+	Gen2 *AzureMarketplaceImage `json:"hyperVGen2,omitempty"`
+}
+
+// AzureMarketplace lists images, both paid and
+// unpaid, available in the Azure marketplace.
+type AzureMarketplace struct {
+	// NoPurchasePlan is the standard, unpaid RHCOS image.
+	NoPurchasePlan *AzureMarketplaceImages `json:"no-purchase-plan,omitempty"`
+
+	// OCP is the paid marketplace image for OpenShift Container Platform.
+	OCP *AzureMarketplaceImages `json:"ocp,omitempty"`
+
+	// OPP is the paid marketplace image for OpenShift Platform Plus.
+	OPP *AzureMarketplaceImages `json:"opp,omitempty"`
+
+	// OKE is the paid marketplace image for OpenShift Kubernetes Engine.
+	OKE *AzureMarketplaceImages `json:"oke,omitempty"`
+
+	// OCPEMEA is the paid marketplace image for OpenShift Container Platform in EMEA regions.
+	OCPEMEA *AzureMarketplaceImages `json:"ocp-emea,omitempty"`
+
+	// OPPEMEA is the paid marketplace image for OpenShift Platform Plus in EMEA regions.
+	OPPEMEA *AzureMarketplaceImages `json:"opp-emea,omitempty"`
+
+	// OKEEMEA is the paid marketplace image for OpenShift Kubernetes Engine in EMEA regions.
+	OKEEMEA *AzureMarketplaceImages `json:"oke-emea,omitempty"`
+}
+
+// AzureMarketplaceImage defines the attributes for an Azure
+// marketplace image.
+type AzureMarketplaceImage struct {
+	Publisher string `json:"publisher"`
+	Offer     string `json:"offer"`
+	SKU       string `json:"sku"`
+	Version   string `json:"version"`
+}
+
+// URN returns the image URN for the marketplace image.
+func (i *AzureMarketplaceImage) URN() string {
+	return fmt.Sprintf("%s:%s:%s:%s", i.Publisher, i.Offer, i.SKU, i.Version)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -367,7 +367,7 @@ github.com/coreos/pkg/multierror
 ## explicit; go 1.17
 github.com/coreos/rpmostree-client-go/pkg/client
 github.com/coreos/rpmostree-client-go/pkg/imgref
-# github.com/coreos/stream-metadata-go v0.4.9
+# github.com/coreos/stream-metadata-go v0.4.10
 ## explicit; go 1.18
 github.com/coreos/stream-metadata-go/arch
 github.com/coreos/stream-metadata-go/fedoracoreos


### PR DESCRIPTION
We've fully cut over to OCI now for updates so we can stop having ostree commit info in there. It'll make even less sense with the buildah path where the commit hash is synthetic.

In `cosa generate-release-metadata`, stop propagating the commit. In plume, stop propagating the commit to the release index.