### PR TITLE
build.sh: freeze rpm-ostree on 2025.10-2.fc42

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -56,6 +56,10 @@ install_rpms() {
     local builddeps
     local frozendeps=""
 
+    # Freeze rpm-ostree on v2025.10 until we have new enough libselinux. See
+    # https://github.com/coreos/fedora-coreos-tracker/issues/2030.
+    frozendeps=$(echo rpm-ostree-{,libs-}2025.10-2.fc42)
+
     # First, a general update; this is best practice.  We also hit an issue recently
     # where qemu implicitly depended on an updated libusbx but didn't have a versioned
     # requires https://bugzilla.redhat.com/show_bug.cgi?id=1625641


### PR DESCRIPTION
Otherwise, we'll get the new substitution rules in stable/testing, which will cause mislabeling of `/usr/etc/systemd/system` due to a bug in libselinux v3.8.

This is basically the equivalent of
https://github.com/coreos/fedora-coreos-config/commit/fb167ed826c80e2d89cf1623c3ba48aa4ab77c76 for the legacy path.

See also https://github.com/coreos/fedora-coreos-tracker/issues/2030.