### PR TITLE
Revert "build.sh: freeze rpm-ostree on 2025.10-2.fc42"

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -56,10 +56,6 @@ install_rpms() {
     local builddeps
     local frozendeps=""
 
-    # Freeze rpm-ostree on v2025.10 until we have new enough libselinux. See
-    # https://github.com/coreos/fedora-coreos-tracker/issues/2030.
-    frozendeps=$(echo rpm-ostree-{,libs-}2025.10-2.fc42)
-
     # First, a general update; this is best practice.  We also hit an issue recently
     # where qemu implicitly depended on an updated libusbx but didn't have a versioned
     # requires https://bugzilla.redhat.com/show_bug.cgi?id=1625641


### PR DESCRIPTION
This reverts commit 712634cef0e303cf5a170c0f612771354b92c897.

We can have v2025.11 in cosa now that we have new libselinux.

We don't strictly need something from it but there's no point in keeping a pin either.