### PR TITLE
kola: separate SCOS and RHCOS distros

### DIFF
--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -370,9 +370,6 @@ func syncOptionsImpl(useCosa bool) error {
 
 	if kola.Options.Distribution == "" {
 		kola.Options.Distribution = kolaDistros[0]
-	} else if kola.Options.Distribution == "scos" {
-		// Consider SCOS the same as RHCOS for now
-		kola.Options.Distribution = "rhcos"
 	} else if err := validateOption("distro", kola.Options.Distribution, kolaDistros); err != nil {
 		return err
 	}

--- a/mantle/kola/tests/coretest/core.go
+++ b/mantle/kola/tests/coretest/core.go
@@ -109,7 +109,7 @@ func init() {
 		NativeFuncs: map[string]register.NativeFuncWrap{
 			"ServicesDisabled": register.CreateNativeFuncWrap(TestServicesDisabledRHCOS),
 		},
-		Distros: []string{"rhcos"},
+		Distros: []string{"rhcos", "scos"},
 	})
 }
 

--- a/mantle/kola/tests/crio/crio.go
+++ b/mantle/kola/tests/crio/crio.go
@@ -192,7 +192,7 @@ func init() {
 		ClusterSize: 1,
 		Name:        `crio.base`,
 		Description: "Verify cri-o basic funcions work, include storage driver is overlay, storage root is /varlib/containers/storage, cgroup driver is systemd, and cri-o containers have reliable networking",
-		Distros:     []string{"rhcos"},
+		Distros:     []string{"rhcos", "scos"},
 		UserData:    enableCrioIgn,
 		// crio pods require fetching a kubernetes pause image
 		Tags:        []string{"crio", kola.NeedsInternetTag},
@@ -203,7 +203,7 @@ func init() {
 		ClusterSize: 2,
 		Name:        "crio.network",
 		Description: "Verify crio containers can make network connections outside of the host.",
-		Distros:     []string{"rhcos"},
+		Distros:     []string{"rhcos", "scos"},
 		UserData:    enableCrioIgn,
 		// this test requires net connections outside the host
 		Tags:        []string{"crio", kola.NeedsInternetTag},

--- a/mantle/kola/tests/etcd/rhcos.go
+++ b/mantle/kola/tests/etcd/rhcos.go
@@ -54,7 +54,7 @@ func init() {
   }
 }`),
 		Tags:    []string{kola.NeedsInternetTag}, // fetching etcd requires networking
-		Distros: []string{"rhcos"},
+		Distros: []string{"rhcos", "scos"},
 		// qemu machines cannot communicate between each other
 		ExcludePlatforms: []string{"qemu"},
 	})
@@ -89,7 +89,7 @@ func init() {
   }
 }`),
 		Tags:    []string{kola.NeedsInternetTag}, // fetching etcd requires networking
-		Distros: []string{"rhcos"},
+		Distros: []string{"rhcos", "scos"},
 		// qemu machines cannot communicate between each other
 		ExcludePlatforms: []string{"qemu"},
 	})

--- a/mantle/kola/tests/fips/failure.go
+++ b/mantle/kola/tests/fips/failure.go
@@ -90,7 +90,7 @@ func init() {
 		ClusterSize: 0,
 		Platforms:   []string{"qemu"},
 		Tags:        []string{"ignition"},
-		Distros:     []string{"rhcos"},
+		Distros:     []string{"rhcos", "scos"},
 	})
 }
 

--- a/mantle/kola/tests/fips/fips.go
+++ b/mantle/kola/tests/fips/fips.go
@@ -14,7 +14,7 @@ func init() {
 		Name:        `fips.enable`,
 		Description: "Verify that fips enabled works.",
 		Flags:       []register.Flag{},
-		Distros:     []string{"rhcos"},
+		Distros:     []string{"rhcos", "scos"},
 		UserData: conf.Ignition(`{
 			"ignition": {
 				"config": {
@@ -62,7 +62,7 @@ func init() {
 		Name:        `fips.enable.partitions`,
 		Description: "Verify that fips enabled works if custom partitions are present.",
 		Flags:       []register.Flag{},
-		Distros:     []string{"rhcos"},
+		Distros:     []string{"rhcos", "scos"},
 		Platforms:   []string{"qemu"},
 		UserData: conf.Ignition(`{
 			"ignition": {

--- a/mantle/kola/tests/ignition/luks.go
+++ b/mantle/kola/tests/ignition/luks.go
@@ -58,6 +58,7 @@ func init() {
 		Name:          `luks.cex`,
 		Description:   "Verify that CEX-based rootfs encryption works.",
 		Flags:         []register.Flag{},
+		Distros:       []string{"rhcos"},
 		Platforms:     []string{"qemu"},
 		Architectures: []string{"s390x"},
 		Tags:          []string{"luks", "cex", "reprovision"},

--- a/mantle/kola/tests/ignition/luks.go
+++ b/mantle/kola/tests/ignition/luks.go
@@ -27,7 +27,7 @@ func init() {
 		Name:        `luks.tang`,
 		Description: "Verify that the rootfs is encrypted with Tang.",
 		Flags:       []register.Flag{},
-		Distros:     []string{"rhcos"},
+		Distros:     []string{"rhcos", "scos"},
 		Tags:        []string{"luks", "tang", kola.NeedsInternetTag, "reprovision"},
 	})
 	register.RegisterTest(&register.Test{
@@ -36,7 +36,7 @@ func init() {
 		Name:                 `luks.sss.t1`,
 		Description:          "Verify that the rootfs is encrypted with SSS with t=1.",
 		Flags:                []register.Flag{},
-		Distros:              []string{"rhcos"},
+		Distros:              []string{"rhcos", "scos"},
 		Platforms:            []string{"qemu"},
 		ExcludeArchitectures: []string{"s390x"}, // no TPM backend support for s390x
 		Tags:                 []string{"luks", "tpm", "tang", "sss", kola.NeedsInternetTag, "reprovision"},
@@ -47,7 +47,7 @@ func init() {
 		Name:                 `luks.sss.t2`,
 		Description:          "Verify that the rootfs is encrypted with SSS with t=2.",
 		Flags:                []register.Flag{},
-		Distros:              []string{"rhcos"},
+		Distros:              []string{"rhcos", "scos"},
 		Platforms:            []string{"qemu"},
 		ExcludeArchitectures: []string{"s390x"}, // no TPM backend support for s390x
 		Tags:                 []string{"luks", "tpm", "tang", "sss", kola.NeedsInternetTag, "reprovision"},

--- a/mantle/kola/tests/ignition/units.go
+++ b/mantle/kola/tests/ignition/units.go
@@ -56,7 +56,7 @@ func init() {
 		// in a given system if the version of systemd is older than
 		// 240. RHCOS deosn't support this feature currently because
 		// its running an older version (v239) of systemd.
-		ExcludeDistros: []string{"rhcos"},
+		ExcludeDistros: []string{"rhcos", "scos"},
 	})
 }
 

--- a/mantle/kola/tests/misc/aws.go
+++ b/mantle/kola/tests/misc/aws.go
@@ -26,7 +26,7 @@ func init() {
 		Platforms:   []string{"aws"},
 		Run:         awsVerifyDiskFriendlyName,
 		ClusterSize: 1,
-		Distros:     []string{"rhcos"},
+		Distros:     []string{"rhcos", "scos"},
 	})
 }
 

--- a/mantle/kola/tests/misc/network.go
+++ b/mantle/kola/tests/misc/network.go
@@ -56,7 +56,7 @@ func init() {
 		Name:        "rhcos.network.multiple-nics",
 		Description: "Verify configuring networking with multiple NICs work.",
 		Timeout:     20 * time.Minute,
-		Distros:     []string{"rhcos"},
+		Distros:     []string{"rhcos", "scos"},
 		Platforms:   []string{"qemu"},
 	})
 	// This test follows the same network configuration used on https://github.com/RHsyseng/rhcos-slb
@@ -68,7 +68,7 @@ func init() {
 		Name:           "rhcos.network.init-interfaces-test",
 		Description:    "Verify init-interfaces script works in both fresh setup and reboot.",
 		Timeout:        40 * time.Minute,
-		Distros:        []string{"rhcos"},
+		Distros:        []string{"rhcos", "scos"},
 		Platforms:      []string{"qemu"},
 		RequiredTag:    "openshift",
 		AdditionalNics: 2,

--- a/mantle/kola/tests/misc/nfs-client.go
+++ b/mantle/kola/tests/misc/nfs-client.go
@@ -100,7 +100,7 @@ func init() {
 		Platforms:   []string{"qemu"},
 
 		// RHCOS has a separate test for NFS v4 server and client
-		ExcludeDistros: []string{"rhcos"},
+		ExcludeDistros: []string{"rhcos", "scos"},
 	})
 }
 

--- a/mantle/kola/tests/misc/selinux.go
+++ b/mantle/kola/tests/misc/selinux.go
@@ -41,7 +41,7 @@ func init() {
 		Run:         SelinuxManage,
 		ClusterSize: 1,
 		Name:        "rhcos.selinux.manage",
-		Distros:     []string{"rhcos"},
+		Distros:     []string{"rhcos", "scos"},
 		Description: "Verify modifying an selinux file context persists through reboots.",
 	})
 }

--- a/mantle/kola/tests/ostree/sync.go
+++ b/mantle/kola/tests/ostree/sync.go
@@ -77,7 +77,7 @@ func init() {
 		ClusterSize: 0,
 		Name:        "ostree.sync",
 		Description: "Verify ostree can sync the filesystem with disconnected the NFS volume.",
-		Distros:     []string{"rhcos"},
+		Distros:     []string{"rhcos", "scos"},
 		Tags:        []string{"ostree", kola.SkipBaseChecksTag, kola.NeedsInternetTag},
 	})
 }

--- a/mantle/kola/tests/rhcos/sssd.go
+++ b/mantle/kola/tests/rhcos/sssd.go
@@ -28,7 +28,7 @@ func init() {
 		Name:        `rhcos.sssd`,
 		Description: "Verify nss-altfiles and pam configs are expected.",
 		Flags:       []register.Flag{},
-		Distros:     []string{"rhcos"},
+		Distros:     []string{"rhcos", "scos"},
 		Platforms:   []string{"qemu"},
 		UserData: conf.Ignition(`{
 			"ignition": {

--- a/mantle/kola/tests/rhcos/upgrade.go
+++ b/mantle/kola/tests/rhcos/upgrade.go
@@ -48,7 +48,7 @@ func init() {
 		Description:          "Verify that rhcos supports upgrading with LUKS.",
 		FailFast:             true,
 		Tags:                 []string{"upgrade"},
-		Distros:              []string{"rhcos"},
+		Distros:              []string{"rhcos", "scos"},
 		ExcludeArchitectures: []string{"s390x", "aarch64"}, // no TPM backend support for s390x and upgrade test not valid for aarch64
 		UserData: conf.Ignition(`{
 			"ignition": {
@@ -76,7 +76,7 @@ func init() {
 		Description:          "Verify that rhcos supports upgrading.",
 		FailFast:             true,
 		Tags:                 []string{"upgrade"},
-		Distros:              []string{"rhcos"},
+		Distros:              []string{"rhcos", "scos"},
 		ExcludeArchitectures: []string{"aarch64"}, //upgrade test not valid for aarch64
 		UserData: conf.Ignition(`{
                         "ignition": {
@@ -92,7 +92,7 @@ func init() {
 		Description:          "Verify upgrading from the latest RHCOS released for OCP works.",
 		FailFast:             true,
 		Tags:                 []string{"upgrade", kola.NeedsInternetTag},
-		Distros:              []string{"rhcos"},
+		Distros:              []string{"rhcos", "scos"},
 		Platforms:            []string{"qemu"},
 		ExcludeArchitectures: []string{"s390x", "ppc64le", "aarch64"},
 		UserData: conf.Ignition(`{

--- a/mantle/util/distros.go
+++ b/mantle/util/distros.go
@@ -16,22 +16,9 @@ package util
 
 import (
 	"fmt"
-	"path/filepath"
-	"strings"
 
 	"github.com/coreos/coreos-assembler/pkg/builds"
 )
-
-// TargetDistroFromName returns the distribution given
-// the path to an artifact (usually a disk image).
-func TargetDistroFromName(artifact string) string {
-	basename := filepath.Base(artifact)
-	if strings.HasPrefix(basename, "rhcos-") || strings.HasPrefix(basename, "scos-") {
-		return "rhcos"
-	}
-	// For now, just assume fcos
-	return "fcos"
-}
 
 // TargetDistro returns the distribution of a cosa build
 func TargetDistro(build *builds.Build) (string, error) {

--- a/mantle/util/distros.go
+++ b/mantle/util/distros.go
@@ -23,10 +23,8 @@ import (
 // TargetDistro returns the distribution of a cosa build
 func TargetDistro(build *builds.Build) (string, error) {
 	switch build.Name {
-	case "rhcos":
-		return "rhcos", nil
-	case "scos":
-		return "rhcos", nil
+	case "rhcos", "scos":
+		return build.Name, nil
 	case "fedora-coreos":
 		return "fcos", nil
 	default:


### PR DESCRIPTION
Despite SCOS and RHCOS being largely similar, certain features (such as s390x Secure Execution and LUKS-CEX) are only supported on RHCOS. 

It does not make sense to run RHCOS-only tests on SCOS, as they  may fail, specially on s390x, where some [magic]( https://github.com/coreos/fedora-coreos-pipeline/blob/main/multi-arch-builders/coreos-s390x-rhcos-builder.bu#L107) is required.