### PR TITLE
kola: fix SIGSEGV in luks.cex test

### DIFF
--- a/mantle/kola/tests/ignition/luks.go
+++ b/mantle/kola/tests/ignition/luks.go
@@ -242,6 +242,9 @@ func runCexTest(c cluster.TestCluster) {
 	switch pc := c.Cluster.(type) {
 	case *qemu.Cluster:
 		m, err = pc.NewMachineWithQemuOptions(ignition, opts)
+		if err != nil {
+			c.Fatalf("Unable to create test machine: %v", err)
+		}
 	default:
 		panic("Unsupported cluster type")
 	}
@@ -251,12 +254,7 @@ func runCexTest(c cluster.TestCluster) {
 		c.Fatal(err)
 	}
 	coretest.LocalTests(c)
-
-	if err != nil {
-		c.Fatalf("Unable to create test machine: %v", err)
-	}
 	rootPart := "/dev/disk/by-partlabel/root"
-
 	ut.LUKSSanityCEXTest(c, m, rootPart)
 }
 


### PR DESCRIPTION
This fixes null pointer derefernce when VM starup fails:
```
--- FAIL: luks.cex (5.83s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x75d18a]
```