### PR TITLE
move diff calculations into `cosa import`

### DIFF
--- a/src/cmd-build-with-buildah
+++ b/src/cmd-build-with-buildah
@@ -35,6 +35,7 @@ DIRECT=
 AUTOLOCK_VERSION=
 SKIP_PRUNE=
 STRICT=
+PARENT_BUILD=
 rc=0
 options=$(getopt --options h,d --longoptions help,version:,versionary,direct,autolock:,skip-prune,parent-build:,force,strict -- "$@") || rc=$?
 [ $rc -eq 0 ] || {
@@ -231,21 +232,9 @@ build_with_buildah() {
     fi
 
     if [ -z "${skip_import:-}" ]; then
-        /usr/lib/coreos-assembler/cmd-import "${final_ref}" ${SKIP_PRUNE:+--skip-prune}
+        /usr/lib/coreos-assembler/cmd-import "${final_ref}" \
+            ${PARENT_BUILD:+--parent-build=${PARENT_BUILD}} ${SKIP_PRUNE:+--skip-prune}
     fi
-
-    # For the logs, print the RPM diff
-    /usr/lib/coreos-assembler/cmd-diff \
-        --rpms ${PARENT_BUILD:+--from=$PARENT_BUILD}
-
-    # For meta.json let's record the RPM diff and advisory diff information
-    /usr/lib/coreos-assembler/cmd-diff \
-        --rpms-json ${PARENT_BUILD:+--from=$PARENT_BUILD} |
-        jq '{"pkgdiff": .pkgdiff, "advisories-diff": .advisories}' > "${tempdir}/diff.json"
-    /usr/lib/coreos-assembler/cmd-meta --build="${VERSION}" \
-        --skip-validation --artifact-json "${tempdir}/diff.json"
-    # Run a 'dump' now to perform schema validation since we skipped it above.
-    /usr/lib/coreos-assembler/cmd-meta --dump --build="${VERSION}" > /dev/null
 
     rm -rf "${tempdir}"
 }

--- a/src/cmd-import
+++ b/src/cmd-import
@@ -24,6 +24,7 @@ from cosalib.cmdlib import (
     get_basearch,
     sha256sum_file,
     import_oci_archive)
+from cosalib.meta import GenericBuildMeta
 
 
 def main():
@@ -63,6 +64,14 @@ def main():
         # move into official location
         finalize_build(builds, build_meta, tmp_oci_archive, tmp_oci_manifest, tmp_lockfile, tmp_commitmeta)
 
+    # Now that the build has been created (i.e. files put into the
+    # right places) let's use `cosa diff` to insert package and
+    # advisory diffs into the meta.json and log the RPM diff, but
+    # only if we have something to diff against.
+    if args.parent_build or len(builds.get_builds()) > 1:
+        starting_buildid = args.parent_build if args.parent_build else builds.get_previous()
+        calculate_and_log_diffs(builds, buildid, arch, starting_buildid)
+
     if not args.skip_prune:
         subprocess.check_call(['/usr/lib/coreos-assembler/cmd-prune'])
 
@@ -73,6 +82,8 @@ def parse_args():
                         help="image to import (containers-transports(5) format)")
     parser.add_argument("--skip-prune", action='store_true',
                         help="Skip prunning previous builds")
+    parser.add_argument("--parent-build",
+                        help="The parent build to diff against")
     return parser.parse_args()
 
 
@@ -226,6 +237,28 @@ def finalize_build(builds, build_meta, tmp_oci_archive, tmp_oci_manifest, tmp_lo
     os.symlink(f'{buildid}', 'builds/latest', target_is_directory=True)
 
     print(f'Imported OCI image as build {buildid}')
+
+
+def calculate_and_log_diffs(builds, buildid, arch, starting_buildid):
+    # Get the RPM/Advisory diff info
+    diff_cmd_json = ['/usr/lib/coreos-assembler/cmd-diff', '--rpms-json',
+                     '--from', starting_buildid, '--to', buildid]
+    diff_json_str = subprocess.check_output(diff_cmd_json)
+    diff_data = json.loads(diff_json_str)
+
+    # Update the meta.json file with the RPM/Advisory diff info. Yes we
+    # just created this file, but let's use the library now for access.
+    meta = GenericBuildMeta(workdir=os.getcwd(), build=buildid, basearch=arch)
+    meta.update({
+        'pkgdiff': diff_data.get('pkgdiff'),
+        'advisories-diff': diff_data.get('advisories')
+    })
+    meta.write()
+
+    # For the logs let's output the RPM diff
+    diff_cmd_log = ['/usr/lib/coreos-assembler/cmd-diff', '--rpms',
+                    '--from', starting_buildid, '--to', buildid]
+    subprocess.check_call(diff_cmd_log)
 
 
 def skopeo_inspect(image):


### PR DESCRIPTION
This moves the RPM/Advisory diffing into `cosa import`, which means we'll get that info even when importing from another source.

It also changes the code such that we'll only attempt to add that info if there was something to diff against. i.e. for a first build in a stream (like when doing a local dev build for the first time) now we won't error out.

Fixes https://github.com/coreos/coreos-assembler/issues/4336