### PR TITLE
cmd-build-with-buildah: remove temporary stream label hack

### DIFF
--- a/src/cmd-build-with-buildah
+++ b/src/cmd-build-with-buildah
@@ -167,15 +167,6 @@ build_with_buildah() {
             --label org.opencontainers.image.source="${source}" \
             --label org.opencontainers.image.revision="${commit}"
 
-    # XXX: Temporary hack until we have https://github.com/coreos/rpm-ostree/pull/5454
-    # which would allow us to fold this back into the build process.
-    # shellcheck source=/dev/null
-    stream=$(yaml2json "$manifest" /dev/stdout | jq -r '.variables.stream')
-    if [ "${stream}" != null ]; then
-        set -- "$@" --label fedora-coreos.stream="$stream" \
-                    --annotation fedora-coreos.stream="$stream"
-    fi
-
     if [ -d "src/yumrepos" ] && [ -e "src/yumrepos/${variant:-}.repo" ]; then
         set -- "$@" --secret id=yumrepos,src="$(realpath "src/yumrepos/$variant.repo")" \
                     --secret id=contentsets,src="$(realpath src/yumrepos/content_sets.yaml)" \


### PR DESCRIPTION
Remove the temporary workaround that manually set the `fedora-coreos.stream` label during image builds. This label is now applied directly by rpm-ostree through the build process, making the extra logic unnecessary and simplifying `cmd-build-with-buildah`.

See: https://github.com/coreos/coreos-assembler/issues/4337

Should be able to merge when we get https://github.com/coreos/fedora-coreos-config/pull/3867 merged