### PR TITLE
tests/ostree.sync: tag with "reprovision"

### DIFF
--- a/mantle/kola/tests/ignition/kdump.go
+++ b/mantle/kola/tests/ignition/kdump.go
@@ -28,12 +28,15 @@ func init() {
 		Tags:        []string{"kdump", kola.SkipBaseChecksTag, kola.NeedsInternetTag},
 		Platforms:   []string{"qemu"},
 	})
+	// Add tag "reprovision" to run serially to avoid NFS port conflicts.
+	// This is hack until a better solution exists.
+	// See https://github.com/coreos/coreos-assembler/issues/4117#issuecomment-3495048106
 	register.RegisterTest(&register.Test{
 		Run:         kdumpNFSTest,
 		ClusterSize: 0,
 		Name:        `kdump.crash.nfs`,
 		Description: "Verifies kdump logs are exported to NFS destination",
-		Tags:        []string{"kdump", kola.SkipBaseChecksTag, kola.NeedsInternetTag},
+		Tags:        []string{"kdump", kola.SkipBaseChecksTag, kola.NeedsInternetTag, "reprovision"},
 		Platforms:   []string{"qemu"},
 	})
 }

--- a/mantle/kola/tests/ostree/sync.go
+++ b/mantle/kola/tests/ostree/sync.go
@@ -71,14 +71,17 @@ systemd:
       enabled: true`)
 
 func init() {
+	// See https://github.com/ostreedev/ostree/pull/2968
+	// Add tag "reprovision" to run serially to avoid NFS port conflicts.
+	// This is hack until a better solution exists.
+	// See https://github.com/coreos/coreos-assembler/issues/4117#issuecomment-3495048106
 	register.RegisterTest(&register.Test{
-		// See https://github.com/ostreedev/ostree/pull/2968
 		Run:         ostreeSyncTest,
 		ClusterSize: 0,
 		Name:        "ostree.sync",
 		Description: "Verify ostree can sync the filesystem with disconnected the NFS volume.",
 		Distros:     []string{"rhcos"},
-		Tags:        []string{"ostree", kola.SkipBaseChecksTag, kola.NeedsInternetTag},
+		Tags:        []string{"ostree", kola.SkipBaseChecksTag, kola.NeedsInternetTag, "reprovision"},
 	})
 }
 


### PR DESCRIPTION
There is a race condition for `ostree.sync` and `kdump.crash.nfs` to bind port 2049, according to https://github.com/coreos/coreos-assembler/issues/4117#issuecomment-3495048106, add tag `reprovision` to force it to run serially now.