### PR TITLE
kola: Update SELinux file context

### DIFF
--- a/mantle/kola/tests/misc/selinux.go
+++ b/mantle/kola/tests/misc/selinux.go
@@ -180,9 +180,9 @@ func SelinuxBooleanPersist(c cluster.TestCluster) {
 // have it persist across reboots
 func SelinuxManage(c cluster.TestCluster) {
 	cmdList := []cmdCheckOutput{
-		{"sudo semanage fcontext -l | grep vasd", true, ".*system_u:object_r:var_auth_t:s0"},
-		{"sudo semanage fcontext -m -t httpd_log_t \"/var/opt/quest/vas/vasd(/.*)?\"", false, ""},
-		{"sudo semanage fcontext -l | grep vasd", true, ".*system_u:object_r:httpd_log_t:s0"},
+		{"sudo semanage fcontext -l | grep pam_shield", true, ".*system_u:object_r:var_auth_t:s0"},
+		{"sudo semanage fcontext -m -t httpd_log_t \"/var/lib/pam_shield(/.*)?\"", false, ""},
+		{"sudo semanage fcontext -l | grep pam_shield", true, ".*system_u:object_r:httpd_log_t:s0"},
 	}
 
 	m := c.Machines()[0]
@@ -190,5 +190,5 @@ func SelinuxManage(c cluster.TestCluster) {
 	testSelinuxCmds(c, m, cmdList)
 
 	// the change should be persisted after a reboot
-	c.AssertCmdOutputMatches(m, "sudo semanage fcontext -l | grep vasd", regexp.MustCompile(".*system_u:object_r:httpd_log_t:s0"))
+	c.AssertCmdOutputMatches(m, "sudo semanage fcontext -l | grep pam_shield", regexp.MustCompile(".*system_u:object_r:httpd_log_t:s0"))
 }


### PR DESCRIPTION
vasd policy was removed from SELinux policy [1][2], so we update our test against another component, preferably a more stable one. I think "pam_shield" is a good candidate.

Closes https://github.com/coreos/rhel-coreos-config/issues/92

[1] https://github.com/fedora-selinux/selinux-policy/pull/2923
[2] https://issues.redhat.com/browse/RHEL-116512