### PR TITLE
build.sh/patch_osbuild: point to python3.14 site-packages

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -198,7 +198,7 @@ patch_osbuild() {
     # To make it easier to apply patches we'll move around the osbuild
     # code on the system first:
     rmdir /usr/lib/osbuild/osbuild
-    mv /usr/lib/python3.13/site-packages/osbuild /usr/lib/osbuild/
+    mv /usr/lib/python3.14/site-packages/osbuild /usr/lib/osbuild/
     mkdir -p /usr/lib/osbuild/tools
     mv /usr/bin/osbuild-mpp /usr/lib/osbuild/tools/
 
@@ -214,7 +214,7 @@ patch_osbuild() {
     # And then move the files back; supermin appliance creation will need it back
     # in the places delivered by the RPM.
     mv /usr/lib/osbuild/tools/osbuild-mpp /usr/bin/osbuild-mpp
-    mv /usr/lib/osbuild/osbuild /usr/lib/python3.13/site-packages/osbuild
+    mv /usr/lib/osbuild/osbuild /usr/lib/python3.14/site-packages/osbuild
     mkdir -p /usr/lib/osbuild/osbuild
 }
 


### PR DESCRIPTION
Fedora 43 now includes Python 3.14, so python3-osbuild installs into /usr/lib/python3.14/site-packages.

https://fedoraproject.org/wiki/Changes/Python3.14