### PR TITLE
cmd-build-with-buildah: fix use of uninitialized var

### DIFF
--- a/src/cmd-build-with-buildah
+++ b/src/cmd-build-with-buildah
@@ -223,7 +223,7 @@ build_with_buildah() {
         set -euxo pipefail
         if [ -n "${REGISTRY_AUTH_FILE:-}" ]; then
             # Since we are changing dirs below let's make it an absolute path
-            export REGISTRY_AUTH_FILE=\$(readlink -f "${REGISTRY_AUTH_FILE}")
+            export REGISTRY_AUTH_FILE=\$(readlink -f "${REGISTRY_AUTH_FILE:-}")
         fi
         env -C ${tempdir}/src TMPDIR=$(realpath cache) buildah $@
         skopeo copy --quiet "${final_ref}" "${tmp_oci_archive}"


### PR DESCRIPTION
I had thought since this was under an if conditional that validates the value was non-zero then it would be OK to not provide a default value for it here too, but in this case the var gets evaluated when written to the file (via the heredoc/EOF) so it does matter.

Fixes 8a4f404