### PR TITLE
Revert "cmdlib: add excludepkgs for repos from fast-tracks.yaml"

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -551,7 +551,6 @@ for (repo, spec) in fast_tracks.items():
                         break
                 if passthrough:
                     f.write(line + '\n')
-        f.write('excludepkgs=*\n')
         f.write('includepkgs=' + ','.join(spec['packages']) + '\n')
 "
         rm "${tmp_overridesdir}/all.repo"


### PR DESCRIPTION
This reverts commit 8ffe5a3652c626214f70cb2f21c67fdadff14140.

It turns out the docs say that `includepkgs`:

> works in conjunction with excludepkgs and doesn’t override it

so if you definte `excludepkgs=*` first then I think you get undefined behavior. It initially worked for me because I was trying to get fancy with my `includepkgs` glob, but now I'm just seeing weird behavior. Let's revert.