### PR TITLE
mantle/kola: check console log for error even in timeout

### DIFF
--- a/mantle/kola/tests/ignition/qemufailure.go
+++ b/mantle/kola/tests/ignition/qemufailure.go
@@ -106,7 +106,7 @@ func verifyError(builder *platform.QemuBuilder, searchPattern string) error {
 		return err
 	}
 	defer inst.Destroy()
-	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 
 	defer cancel()
 


### PR DESCRIPTION
There is a race condition that occurs for
/dev/virtio-ports/com.coreos.ignition.journal and it's hard to
track down. In this case we are just detecting a failure anyway.

If we can find the original search failure term after the timeout
happens let's consider that success too.

See https://github.com/coreos/fedora-coreos-tracker/issues/2019
for more context.
