### PR TITLE
Use DPS UUIDs for root and boot partitions

### DIFF
--- a/src/osbuild-manifests/coreos.osbuild.aarch64.mpp.yaml
+++ b/src/osbuild-manifests/coreos.osbuild.aarch64.mpp.yaml
@@ -66,11 +66,11 @@ mpp-define-images:
           size:
             mpp-format-int: "{efi_system_size_mb * 1024 * 1024 / sector_size}"
         - name: boot
-          type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
+          type: BC13C2FF-59E6-4262-A352-B275FD6F7172
           size:
             mpp-format-int: "{boot_size_mb * 1024 * 1024 / sector_size}"
         - name: root
-          type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
+          type: B921B045-1DF0-41C3-AF44-4C6F280D3FAE
   - id: image4k
     sector_size:
         mpp-format-int: "{four_k_sector_size}"
@@ -89,11 +89,11 @@ mpp-define-images:
           size:
             mpp-format-int: "{efi_system_size_mb * 1024 * 1024 / four_k_sector_size}"
         - name: boot
-          type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
+          type: BC13C2FF-59E6-4262-A352-B275FD6F7172
           size:
             mpp-format-int: "{boot_size_mb * 1024 * 1024 / four_k_sector_size}"
         - name: root
-          type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
+          type: B921B045-1DF0-41C3-AF44-4C6F280D3FAE
 pipelines:
   # If installing from container then let's pull the container file into a pipeline
   - name: oci-archive

--- a/src/osbuild-manifests/coreos.osbuild.ppc64le.mpp.yaml
+++ b/src/osbuild-manifests/coreos.osbuild.ppc64le.mpp.yaml
@@ -67,11 +67,11 @@ mpp-define-images:
           size:
             mpp-format-int: "{reserved_part_size_mb * 1024 * 1024 / sector_size}"
         - name: boot
-          type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
+          type: BC13C2FF-59E6-4262-A352-B275FD6F7172
           size:
             mpp-format-int: "{boot_size_mb * 1024 * 1024 / sector_size}"
         - name: root
-          type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
+          type: C31C45E6-3F39-412E-80FB-4809C4980599
   - id: image4k
     sector_size:
         mpp-format-int: "{four_k_sector_size}"
@@ -91,11 +91,11 @@ mpp-define-images:
           size:
             mpp-format-int: "{reserved_part_size_mb * 1024 * 1024 / four_k_sector_size}"
         - name: boot
-          type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
+          type: BC13C2FF-59E6-4262-A352-B275FD6F7172
           size:
             mpp-format-int: "{boot_size_mb * 1024 * 1024 / four_k_sector_size}"
         - name: root
-          type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
+          type: C31C45E6-3F39-412E-80FB-4809C4980599
 pipelines:
   # If installing from container then let's pull the container file into a pipeline
   - name: oci-archive

--- a/src/osbuild-manifests/coreos.osbuild.riscv64.mpp.yaml
+++ b/src/osbuild-manifests/coreos.osbuild.riscv64.mpp.yaml
@@ -66,11 +66,11 @@ mpp-define-images:
           size:
             mpp-format-int: "{efi_system_size_mb * 1024 * 1024 / sector_size}"
         - name: boot
-          type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
+          type: BC13C2FF-59E6-4262-A352-B275FD6F7172
           size:
             mpp-format-int: "{boot_size_mb * 1024 * 1024 / sector_size}"
         - name: root
-          type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
+          type: 72EC70A6-CF74-40E6-BD49-4BDA08E8F224
   - id: image4k
     sector_size:
         mpp-format-int: "{four_k_sector_size}"
@@ -89,11 +89,11 @@ mpp-define-images:
           size:
             mpp-format-int: "{efi_system_size_mb * 1024 * 1024 / four_k_sector_size}"
         - name: boot
-          type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
+          type: BC13C2FF-59E6-4262-A352-B275FD6F7172
           size:
             mpp-format-int: "{boot_size_mb * 1024 * 1024 / four_k_sector_size}"
         - name: root
-          type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
+          type: 72EC70A6-CF74-40E6-BD49-4BDA08E8F224
 pipelines:
   # If installing from container then let's pull the container file into a pipeline
   - name: oci-archive

--- a/src/osbuild-manifests/coreos.osbuild.s390x.mpp.yaml
+++ b/src/osbuild-manifests/coreos.osbuild.s390x.mpp.yaml
@@ -62,12 +62,12 @@ mpp-define-images:
       label: gpt
       partitions:
         - name: boot
-          type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
+          type: BC13C2FF-59E6-4262-A352-B275FD6F7172
           size:
             mpp-format-int: "{boot_size_mb * 1024 * 1024 / sector_size}"
           partnum: 3
         - name: root
-          type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
+          type: 5EEAD9A9-FE09-4A1E-A1D7-520D00531306
           partnum: 4
   - id: image4k
     sector_size:
@@ -79,12 +79,12 @@ mpp-define-images:
       label: gpt
       partitions:
         - name: boot
-          type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
+          type: BC13C2FF-59E6-4262-A352-B275FD6F7172
           size:
             mpp-format-int: "{boot_size_mb * 1024 * 1024 / four_k_sector_size}"
           partnum: 3
         - name: root
-          type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
+          type: 5EEAD9A9-FE09-4A1E-A1D7-520D00531306
           partnum: 4
 pipelines:
   # If installing from container then let's pull the container file into a pipeline

--- a/src/osbuild-manifests/coreos.osbuild.x86_64.mpp.yaml
+++ b/src/osbuild-manifests/coreos.osbuild.x86_64.mpp.yaml
@@ -67,11 +67,11 @@ mpp-define-images:
           size:
             mpp-format-int: "{efi_system_size_mb * 1024 * 1024 / sector_size}"
         - name: boot
-          type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
+          type: BC13C2FF-59E6-4262-A352-B275FD6F7172
           size:
             mpp-format-int: "{boot_size_mb * 1024 * 1024 / sector_size}"
         - name: root
-          type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
+          type: 4F68BCE3-E8CD-4DB1-96E7-FBCAF984B709
   - id: image4k
     sector_size:
         mpp-format-int: "{four_k_sector_size}"
@@ -91,11 +91,11 @@ mpp-define-images:
           size:
             mpp-format-int: "{efi_system_size_mb * 1024 * 1024 / four_k_sector_size}"
         - name: boot
-          type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
+          type: BC13C2FF-59E6-4262-A352-B275FD6F7172
           size:
             mpp-format-int: "{boot_size_mb * 1024 * 1024 / four_k_sector_size}"
         - name: root
-          type: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
+          type: 4F68BCE3-E8CD-4DB1-96E7-FBCAF984B709
 pipelines:
   # If installing from container then let's pull the container file into a pipeline
   - name: oci-archive


### PR DESCRIPTION
Use the Discoverable Partition Specification UUID for root and boot
partitions

We were already using DPS UUID for both partitions, but they were UUIDs
for generic Linux Data Parition

This lets us use `systemd-systemd-gpt-auto-generator` which is a good
choice for LUKS decryption without UKI addons for composefs backend

Use architecture specific DPS UUID for root partition, and use XBOOTLDR
UUID for boot partition

Related: https://github.com/coreos/fedora-coreos-tracker/issues/2060

Closes: https://github.com/coreos/fedora-coreos-tracker/issues/1038