### PR TITLE
Revert "Fix CI E1101 error"

### DIFF
--- a/src/cosalib/fedora_messaging_request.py
+++ b/src/cosalib/fedora_messaging_request.py
@@ -195,6 +195,6 @@ def watch_finished_messages(cond, registered,
     }
 
     consumers = twisted_consume(callback, bindings=bindings, queues=queues)
-    consumers.addCallback(registered_cb)
+    consumers.addCallback(registered_cb)  # pylint: disable=E1101
     consumers.addErrback(error_cb)  # pylint: disable=E1101
     reactor.run(installSignalHandlers=False)  # pylint: disable=E1101


### PR DESCRIPTION
This reverts commit 4484b11c2a6460253bd342bb845c032fb957e7c0.

This is causing an infinite loop (and thus a memory leak), which means our pods get OOM killed when making signing requests.