### PR TITLE
[invalid] ci/prow-rhcos: handle rhel-* branches too

### DIFF
--- a/ci/prow-rhcos.sh
+++ b/ci/prow-rhcos.sh
@@ -8,6 +8,7 @@ set -xeuo pipefail
 BRANCH=${OPENSHIFT_BUILD_REFERENCE:-${PULL_BASE_REF:-main}}
 case ${BRANCH} in
     main) REPO=https://github.com/coreos/rhel-coreos-config; RHCOS_BRANCH=main;;
+    rhel-*) REPO=https://github.com/coreos/rhel-coreos-config; RHCOS_BRANCH=${BRANCH};;
     rhcos-*) REPO=https://github.com/openshift/os; RHCOS_BRANCH=release-${BRANCH#rhcos-};;
     *) echo "Unhandled base ref: ${BRANCH}" 1>&2 && exit 1;;
 esac


### PR DESCRIPTION
We've now performed a branching event for our `rhel-*` style branches. Handle that case here too when determining what REPO/BRANCH to use.

(cherry picked from commit 81ddb30804c75b4b70a8af265a3f281a43e732b5)