### PR TITLE
src/cmd-fetch: remove --konflux option

### DIFF
--- a/src/cmd-fetch
+++ b/src/cmd-fetch
@@ -39,8 +39,6 @@ Usage: coreos-assembler fetch --help
   --write-lockfile-to=FILE Write updated base lockfile to separate file
   --with-cosa-overrides    Don't ignore cosa overrides in `overrides/rpm`
   --autolock=VERSION       If no base lockfile used, create one from any arch build of `VERSION`
-  --konflux                Generate hermeto lockfile for Konflux derived from the rpm-ostree lockfiles.
-                           Auto enabled if `rpms.lock.yaml` is found in the config directory.
 EOF
 }
 
@@ -51,9 +49,8 @@ IGNORE_COSA_OVERRIDES_ARG=--ignore-cosa-overrides
 DRY_RUN=
 FORCE_ARG=
 STRICT=
-KONFLUX=
 rc=0
-options=$(getopt --options h --longoptions help,update-lockfile,dry-run,with-cosa-overrides,write-lockfile-to:,strict,force,autolock:,konflux -- "$@") || rc=$?
+options=$(getopt --options h --longoptions help,update-lockfile,dry-run,with-cosa-overrides,write-lockfile-to:,strict,force,autolock: -- "$@") || rc=$?
 [ $rc -eq 0 ] || {
     print_help
     exit 1
@@ -88,9 +85,6 @@ while true; do
         --autolock)
             shift;
             AUTOLOCK_VERSION=$1
-            ;;
-        --konflux)
-            KONFLUX=1
             ;;
         --)
             shift
@@ -181,12 +175,4 @@ if [ -n "${UPDATE_LOCKFILE}" ]; then
     # cd back to workdir in case OUTPUT_LOCKFILE is relative
     (cd "${workdir}" && mv -f "${tmprepo}/tmp/manifest-lock.json" "${outfile}")
     echo "Wrote out lockfile ${outfile}"
-fi
-
-KONFLUX_LOCKFILE=rpms.lock.yaml
-if [ -n "${KONFLUX}" ] || [ -f "${configdir}/${KONFLUX_LOCKFILE}" ]; then
-   echo "Generating hermeto lockfile..."
-   /usr/lib/coreos-assembler/konflux-rpm-lockfile generate "${flattened_manifest}" --context "${configdir}" --output "${tmprepo}/tmp/${arch}.${KONFLUX_LOCKFILE}"
-   mv -f "${tmprepo}/tmp/${arch}.${KONFLUX_LOCKFILE}" "${configdir}/${arch}.${KONFLUX_LOCKFILE}"
-   echo "Wrote out hermeto (konflux) lockfile: ${configdir}/${arch}.${KONFLUX_LOCKFILE}"
 fi


### PR DESCRIPTION
Since we remove the bootc submodule from f-c-c, we cannot generate the Konflux lockfile during the cosa fetch in bump-lockfile Jenkins job. See [1] for more details.

[1] https://github.com/coreos/fedora-coreos-pipeline/pull/1282