### PR TITLE
vmdeps: add python3-dateutil

### DIFF
--- a/src/vmdeps.txt
+++ b/src/vmdeps.txt
@@ -45,3 +45,6 @@ osbuild osbuild-ostree osbuild-selinux osbuild-tools python3-pyrsistent zip
 # For resetting the terminal inside supermin shell
 /usr/bin/reset
 /usr/bin/clear
+
+# for cmdlib.py
+python3-dateutil


### PR DESCRIPTION
We moved some functions to cmdlib.py in ff3a1bb and it means that anything that uses cmdlib.py now needs to have the deps installed. Add python3-dateutil here so they make it into the supermin VM.