### PR TITLE
src/cmd-import: indent lockfiles properly

### DIFF
--- a/src/cmd-import
+++ b/src/cmd-import
@@ -152,7 +152,7 @@ def generate_lockfile_and_commitmeta(tmpd, ostree_commit, build_meta):
         json.dump(commitmeta, f, indent=2)
 
     with open(tmp_lockfile, 'w') as f:
-        json.dump(fp=f, obj={
+        json.dump(fp=f, indent=2, obj={
             'packages': rpmdb,
             'metadata': {'generated': rfc3339_time(set_midnight=True)}
         })


### PR DESCRIPTION
We want to use the lockfiles generated by the cmd-import command into our bump-lockfile Jenkins job. 
If the job is successful then we commit those files into the config repo. 
So we need them to be properly formatted/indented.