### PR TITLE
cmd-import: add an ending newline to json files

### DIFF
--- a/src/cmd-import
+++ b/src/cmd-import
@@ -150,12 +150,14 @@ def generate_lockfile_and_commitmeta(tmpd, ostree_commit, build_meta):
 
     with open(tmp_commitmeta, 'w') as f:
         json.dump(commitmeta, f, indent=2)
+        f.write('\n')  # Add newline to the end of the file
 
     with open(tmp_lockfile, 'w') as f:
         json.dump(fp=f, obj={
             'packages': rpmdb,
             'metadata': {'generated': rfc3339_time(set_midnight=True)}
         })
+        f.write('\n')  # Add newline to the end of the file
 
     return tmp_lockfile, tmp_commitmeta
 


### PR DESCRIPTION
Our whitespace checker [1] will complain if there are newlines at the end of files and since we are now copying the generated lockfiles into the src/config repo in bump-lockfile [2] the whitespace checker is complaining about it.

json.dump() itself doesn't add a newline because it isn't required to [3]. Let's just explicitly do it here.

[1] https://github.com/coreos/repo-templates/blob/5386c91f3f4b8f81009997efecf28b24cc8597a0/find-whitespace/script.sh#L27-L40
[2] https://github.com/coreos/fedora-coreos-pipeline/commit/0029f128c3ecee87e69db945be8060cd296935f1
[3] https://stackoverflow.com/questions/54716132/why-is-json-dump-not-ending-the-line-with-n