### PR TITLE
Docs: Add `osbuild` to documentation 

### DIFF
--- a/docs/building-fcos.md
+++ b/docs/building-fcos.md
@@ -185,24 +185,23 @@ repository.
 
 ## Performing a build
 
-First, we fetch all the metadata and packages:
-
-```
-$ cosa fetch
-```
-
-And now we can build from these inputs:
+We will now build the bootable container (ostree) and image base artifacts, which
+can later be used to produce images for specific target platforms. Each build generates
+a new directory in `$PWD/builds/`.
 
 ```
 $ cosa build
 ```
 
-Each build will create a new directory in `$PWD/builds/`, containing the
-generated OSTree commit (as a tarball) and the qemu VM image.
-
 Next, rerun `cosa build` and notice the system correctly
-deduces that nothing changed.  You can run `cosa fetch`
-again to check for updated RPMs.
+deduces that nothing changed.
+
+At this point we can generate a platform-specific image, we will generate a 
+qemu image by running:
+
+```
+$ cosa osbuild qemu
+```
 
 ## Running
 

--- a/docs/cosa.md
+++ b/docs/cosa.md
@@ -13,29 +13,30 @@ supported arguments.
 
 | Name | Description |
 | ---- | ----------- |
-| [build](https://github.com/coreos/coreos-assembler/blob/main/src/cmd-build) | Build OSTree and image base artifacts from previously fetched packages
+| [build](https://github.com/coreos/coreos-assembler/blob/main/src/cmd-build) | Build an OCI bootable container
 | [clean](https://github.com/coreos/coreos-assembler/blob/main/src/cmd-clean) | Delete all build artifacts
 | [fetch](https://github.com/coreos/coreos-assembler/blob/main/src/cmd-fetch) | Fetch and import the latest packages
 | [init](https://github.com/coreos/coreos-assembler/blob/main/src/cmd-init) | Setup the current working directory for CoreOS Assembler and clone the given project URL as Git config
 | [kola](https://github.com/coreos/coreos-assembler/blob/main/src/cmd-kola) | Run tests with [kola](kola.md)
 | [list](https://github.com/coreos/coreos-assembler/blob/main/src/cmd-list) | List builds available locally
+| [osbuild](https://github.com/coreos/coreos-assembler/blob/main/src/cmd-osbuild) | Derive the OCI container to a bootable disk image for a given platform
 | [run](https://github.com/coreos/coreos-assembler/blob/main/src/cmd-run) | Run a CoreOS instance in QEMU with access to a root shell
 | [shell](https://github.com/coreos/coreos-assembler/blob/main/src/cmd-shell) | Get an interactive shell or run a command in a CoreOS Assembler container
 | [virt-install](https://github.com/coreos/coreos-assembler/blob/main/src/cmd-virt-install) | "Install" a CoreOS system with libvirt
 
-## buildextend commands
+# osbuild commands
 
-By default, the `build` command will build an OSTree and a QEMU image as base
-artifacts. Those commands extend those artifacts to make them functional on
-other platforms or cloud providers:
+By default, the `build` command will build an OS Bootable Container. The
+`osbuild` command will take the bootable container and create artifacts/images for
+various platforms, such as cloud providers.
 
 | Name | Description |
 | ---- | ----------- |
-| [buildextend-live](https://github.com/coreos/coreos-assembler/blob/main/src/cmd-buildextend-live) | Generate the Live ISO
-| [buildextend-{dasd,metal,metal4k,qemu,secex}](https://github.com/coreos/coreos-assembler/blob/main/src/cmd-buildextend-metal) | Generate artifacts for the given platforms
-| [buildextend-{aliyun,aws,azure,digitalocean,exoscale,gcp,vultr}](https://github.com/coreos/coreos-assembler/blob/main/src/cmd-ore-wrapper) | Generate artifacts for the given platforms
-| [buildextend-{azurestack,ibmcloud,openstack,vmware}](https://github.com/coreos/coreos-assembler/blob/main/src/cmd-artifact-disk) | Generate artifacts for the given platforms
-| [{aliyun,aws}-replicate](https://github.com/coreos/coreos-assembler/blob/main/src/cmd-ore-wrapper) | Replicate images on the platforms (AMIs for AWS)
+| `osbuild qemu` | Create a qemu image
+| `osbuild live` | Create a live iso 
+| `osbuild <platform>` | Create an image for the specified platform
+| `osbuild --supported-platforms` | List of all supported platforms
+
 
 ## Misc commands
 


### PR DESCRIPTION
- Add `osbuild` to the [list of main commands](https://coreos.github.io/coreos-assembler/cosa/), and remove `buildextend` commands.
- Add `cosa osbuild qemu` as a step in the [build docs](https://coreos.github.io/coreos-assembler/building-fcos/).

Closes: #4304 