### PR TITLE
build.sh: move permissions changes to end

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN ./build.sh write_archive_info
 RUN ./build.sh make_and_makeinstall
 RUN ./build.sh configure_user
 RUN ./build.sh patch_osbuild
+RUN ./build.sh fixup_file_permissions
 
 # clean up scripts (it will get cached in layers, but oh well)
 WORKDIR /srv/


### PR DESCRIPTION
What I found is that doing this before kola (and friends) are built and installed means the `make install` from those set the /usr/bin permissions back. Let's just do this as a final step.

Fixup for 17b3f5204, d34ab4a47