### PR TITLE
build.sh: fix logic failure

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -225,8 +225,9 @@ fixup_file_permissions() {
     chmod -R g+w /usr/
     # And also one exception for /etc/grub.d (on arches that support
     # grub) since ostree upstream tries to put a symlink in this directory.
-    [ -d /etc/grub.d ] && chmod g+rwx /etc/grub.d
-
+    if [ -d /etc/grub.d ]; then
+        chmod g+rwx /etc/grub.d
+    fi
 }
 
 if [ $# -ne 0 ]; then


### PR DESCRIPTION
I was a bit confused why f7ef7d3 started causing a failure on s390x again so I asked AI and it reminded me:

```
The failure is caused by an interaction between `set -e` (error exit) and the fact that the conditional check is now the **last command** in the function.

Here is the technical breakdown:

1.  **The Command Fails**:
    On platforms without grub, `/etc/grub.d` is missing. The test `[ -d /etc/grub.d ]` returns exit code `1` (false).
    Because of the `&&` operator, the execution short-circuits (stops), and the exit status of that entire line is `1`.

2.  **Why It Worked Before**:
    In the previous version (inside `install_rpms`), this line was **not** the last command.
    ```bash
    [ -d /etc/grub.d ] && chmod g+rwx /etc/grub.d
    yum clean all  <-- Last command, returns 0
    ```
    Although the check returned `1`, `set -e` does not exit if the failing command is on the left side of an `&&` list. The script continued to `yum clean all`, which succeeded (returned `0`), so the function `install_rpms` returned `0`.

3.  **Why It Fails Now**:
    In the new commit, this logic was moved to `fixup_file_permissions` and is now the **last command**:
    ```bash
    fixup_file_permissions() {
        chmod -R g+w /usr/
        [ -d /etc/grub.d ] && chmod g+rwx /etc/grub.d
    } <-- Exits with code 1
    ```
    Since it is the final command, the function `fixup_file_permissions` returns failure (`1`).
    Calling a function that returns failure triggers `set -e` in the main script, causing the build to abort.
```

Let's fix it by wrapping the logic in an if statement.

Assisted-By: <google/gemini-3-pro-preview>