### PR TITLE
build.sh: make /usr permission changes smarter

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -217,16 +217,16 @@ patch_osbuild() {
 }
 
 fixup_file_permissions() {
-    # Allow group write permissions on /usr/ because in upstream project's
-    # CI we want to overwrite software for testing. The directories
+    # Allow group write perms on directories under /usr/ because in upstream
+    # project's CI we want to overwrite software for testing. The directories
     # are typically owned by root:root and CI runs in openshift as a user
     # that is a member of the `root` (GID: 0) group.
     # See https://github.com/coreos/coreos-installer/pull/1716
-    chmod -R g+w /usr/
+    find /usr -type d -print0 | xargs -0 chmod -c g+w
     # And also one exception for /etc/grub.d (on arches that support
     # grub) since ostree upstream tries to put a symlink in this directory.
     if [ -d /etc/grub.d ]; then
-        chmod g+rwx /etc/grub.d
+        chmod -c g+rwx /etc/grub.d
     fi
 }
 


### PR DESCRIPTION
If we only change the permissions on the directories then we won't balloon the size of the container so much. As an example after the changes in 17b3f5204, f7ef7d325 we ended up almost doubling the size of the container:

```
builder@coreos-ppc64le-builder:~$ podman images
REPOSITORY                                 TAG              IMAGE ID      CREATED         SIZE
quay.io/coreos-assembler/staging           ppc64le-f7ef7d3  5ca4b8d1eae4  38 hours ago    9.18 GB
quay.io/coreos-assembler/staging           ppc64le-d34ab4a  659d6f7bbf7a  45 hours ago    5.11 GB
quay.io/coreos-assembler/staging           ppc64le-17b3f52  d2e55354e43f  2 days ago      5.11 GB
```

This should make it so the duplicated files in layers are only directories so they take up much less space.