### PR TITLE
cmd-build-with-buildah: drop reading from manifest

### DIFF
--- a/src/cmd-build-with-buildah
+++ b/src/cmd-build-with-buildah
@@ -122,10 +122,8 @@ build_with_buildah() {
     initconfig="src/config.json"
     if [ -f "${initconfig}" ]; then
         variant="$(jq --raw-output '."coreos-assembler.config-variant"' "${initconfig}")"
-        manifest="src/config/manifest-${variant}.yaml"
         argsfile=build-args-${variant}.conf
     else
-        manifest="src/config/manifest.yaml"
         argsfile=build-args.conf
     fi
 
@@ -174,9 +172,9 @@ build_with_buildah() {
 
     # XXX: Temporary hack until we have https://github.com/coreos/rpm-ostree/pull/5454
     # which would allow us to fold this back into the build process.
-    # shellcheck source=/dev/null
-    stream=$(yaml2json "$manifest" /dev/stdout | jq -r '.variables.stream')
-    if [ "${stream}" != null ]; then
+    # shellcheck source=/dev/null disable=SC2153
+    stream=$(eval "$(grep 'STREAM=' "src/config/${argsfile}")"; echo "${STREAM}")
+    if [ -n "${stream}" ]; then
         set -- "$@" --label fedora-coreos.stream="$stream" \
                     --annotation fedora-coreos.stream="$stream"
     fi


### PR DESCRIPTION
We can pickup the stream from the build-args now so let's do that because we are moving more and more stuff out of the manifests themselves.