### PR TITLE
cmdlib: umount containers storage prior to remount,ro

### DIFF
--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -778,6 +778,15 @@ else
 fi
 echo \$rc > ${rc_file}
 if [ -n "\${cachedev}" ]; then
+    # Sometimes if failures occur the containers storage stack will leave
+    # around some overlayfs mounts so let's recursively unmount here.
+    # I wasn't able to reproduce this outside of our supermin VM setup so
+    # didn't report this issue upstream.
+    if mountpoint -q ${workdir}/cache/cache-containers-storage/storage/overlay; then
+        umount -R ${workdir}/cache/cache-containers-storage/storage/overlay
+    fi
+
+    # Recover any unused space and attempt to safely umount the cache
     /sbin/fstrim -v ${workdir}/cache
     mount -o remount,ro ${workdir}/cache
     fsfreeze -f ${workdir}/cache


### PR DESCRIPTION
We've seen failures with `cosa build-with-buildah` where a failing step in the containr build will cause the supermin VM teardown to fail:

```
+ /sbin/fstrim -v /srv/cache
/srv/cache: 50 GiB (53686960128 bytes) trimmed
+ mount -o remount,ro /srv/cache
mount: /srv/cache: mount point is busy.
```

This in turn causes the supermin VM to panic and not return properly, hanging the `cosa build` and causing it to not return until CTRL-C is entered.

It turns out this is because there were overlayfs mounts that were hanging around:

```
/dev/vdb1 /srv/cache/cache-containers-storage/storage/overlay xfs rw,seclabel,relatime,inode64,logbufs=8,logbsize=32k,noquota 0 0
overlay /srv/cache/cache-containers-storage/storage/overlay/9dfb507d30cdc259627c62d260c1d08cc39ee46c7690a9133802fb54e8d87a14/merged overlay .....
```

After a `umount -R /srv/cache/cache-containers-storage/storage/overlay` the remount,ro works fine.

This appears to be a bug in podman/buildah but I can't reproduce outside of this supermin VM setup so I chose not to report the issue upstream.