### PR TITLE
Update deprecated systemddbus

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/coreos/butane v0.25.1
 	github.com/coreos/go-semver v0.3.1
 	github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
-	github.com/coreos/go-systemd/v22 v22.6.0
+	github.com/coreos/go-systemd/v22 v22.7.0
 	github.com/coreos/ignition/v2 v2.25.0
 	github.com/coreos/pkg v0.0.0-20240122114842-bbd7aa9bf6fb
 	github.com/coreos/rpmostree-client-go v0.0.0-20240514234259-72a33e8554b6

--- a/go.sum
+++ b/go.sum
@@ -110,8 +110,8 @@ github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr
 github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e h1:Wf6HqHfScWJN9/ZjdUKyjop4mf3Qdd+1TvvltAvM3m8=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
-github.com/coreos/go-systemd/v22 v22.6.0 h1:aGVa/v8B7hpb0TKl0MWoAavPDmHvobFe5R5zn0bCJWo=
-github.com/coreos/go-systemd/v22 v22.6.0/go.mod h1:iG+pp635Fo7ZmV/j14KUcmEyWF+0X7Lua8rrTWzYgWU=
+github.com/coreos/go-systemd/v22 v22.7.0 h1:LAEzFkke61DFROc7zNLX/WA2i5J8gYqe0rSj9KI28KA=
+github.com/coreos/go-systemd/v22 v22.7.0/go.mod h1:xNUYtjHu2EDXbsxz1i41wouACIwT7Ybq9o0BQhMwD0w=
 github.com/coreos/ignition/v2 v2.25.0 h1:4TboIy9z2ofMZmIv5ypyXCFTeKjPNwE5mQNpgkJLdMM=
 github.com/coreos/ignition/v2 v2.25.0/go.mod h1:L8tzd8rDzGMKtEvJ22Rk41jW5chE50sDK5Rn/8C1JsE=
 github.com/coreos/pkg v0.0.0-20240122114842-bbd7aa9bf6fb h1:GIzvVQ9UkUlOhSDlqmrQAAAUd6R3E+caIisNEyWXvNE=

--- a/mantle/cmd/kolet/kolet.go
+++ b/mantle/cmd/kolet/kolet.go
@@ -403,7 +403,7 @@ func runExtUnit(cmd *cobra.Command, args []string) error {
 		return n != unitname
 	}
 	compareFunc := func(u1, u2 *systemddbus.UnitStatus) bool { return *u1 != *u2 }
-	unitevents, uniterrs := sdconn.SubscribeUnitsCustom(time.Second, 0, compareFunc, filterFunc)
+	unitevents, uniterrs := sdconn.SubscribeUnitsCustomContext(ctx, time.Second, 0, compareFunc, filterFunc)
 
 	for {
 		systemdjournal.Print(systemdjournal.PriInfo, "Awaiting events")

--- a/vendor/github.com/coreos/go-systemd/v22/dbus/dbus.go
+++ b/vendor/github.com/coreos/go-systemd/v22/dbus/dbus.go
@@ -95,7 +95,7 @@ type Conn struct {
 	sigobj  dbus.BusObject
 
 	jobListener struct {
-		jobs map[dbus.ObjectPath]chan<- string
+		jobs map[dbus.ObjectPath][]chan<- string
 		sync.Mutex
 	}
 	subStateSubscriber struct {
@@ -207,7 +207,7 @@ func NewConnection(dialBus func() (*dbus.Conn, error)) (*Conn, error) {
 	}
 
 	c.subStateSubscriber.ignore = make(map[dbus.ObjectPath]int64)
-	c.jobListener.jobs = make(map[dbus.ObjectPath]chan<- string)
+	c.jobListener.jobs = make(map[dbus.ObjectPath][]chan<- string)
 
 	// Setup the listeners on jobs so that we can get completions
 	c.sigconn.BusObject().Call("org.freedesktop.DBus.AddMatch", 0,

--- a/vendor/github.com/coreos/go-systemd/v22/dbus/set.go
+++ b/vendor/github.com/coreos/go-systemd/v22/dbus/set.go
@@ -14,28 +14,43 @@
 
 package dbus
 
+import (
+	"sync"
+)
+
 type set struct {
 	data map[string]bool
+	mu   sync.Mutex
 }
 
 func (s *set) Add(value string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.data[value] = true
 }
 
 func (s *set) Remove(value string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	delete(s.data, value)
 }
 
 func (s *set) Contains(value string) (exists bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	_, exists = s.data[value]
 	return
 }
 
 func (s *set) Length() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	return len(s.data)
 }
 
 func (s *set) Values() (values []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	for val := range s.data {
 		values = append(values, val)
 	}
@@ -43,5 +58,5 @@ func (s *set) Values() (values []string) {
 }
 
 func newSet() *set {
-	return &set{make(map[string]bool)}
+	return &set{data: make(map[string]bool)}
 }

--- a/vendor/github.com/coreos/go-systemd/v22/dbus/subscription_set.go
+++ b/vendor/github.com/coreos/go-systemd/v22/dbus/subscription_set.go
@@ -15,6 +15,7 @@
 package dbus
 
 import (
+	"context"
 	"time"
 )
 
@@ -29,14 +30,19 @@ func (s *SubscriptionSet) filter(unit string) bool {
 	return !s.Contains(unit)
 }
 
-// Subscribe starts listening for dbus events for all of the units in the set.
+// SubscribeContext starts listening for dbus events for all of the units in the set.
 // Returns channels identical to conn.SubscribeUnits.
-func (s *SubscriptionSet) Subscribe() (<-chan map[string]*UnitStatus, <-chan error) {
+func (s *SubscriptionSet) SubscribeContext(ctx context.Context) (<-chan map[string]*UnitStatus, <-chan error) {
 	// TODO: Make fully evented by using systemd 209 with properties changed values
-	return s.conn.SubscribeUnitsCustom(time.Second, 0,
+	return s.conn.SubscribeUnitsCustomContext(ctx, time.Second, 0,
 		mismatchUnitStatus,
 		func(unit string) bool { return s.filter(unit) },
 	)
+}
+
+// Deprecated: use SubscribeContext instead.
+func (s *SubscriptionSet) Subscribe() (<-chan map[string]*UnitStatus, <-chan error) {
+	return s.SubscribeContext(context.Background())
 }
 
 // NewSubscriptionSet returns a new subscription set.

--- a/vendor/github.com/coreos/go-systemd/v22/journal/journal_unix.go
+++ b/vendor/github.com/coreos/go-systemd/v22/journal/journal_unix.go
@@ -106,7 +106,7 @@ func fdIsJournalStream(fd int) (bool, error) {
 	var expectedStat syscall.Stat_t
 	_, err := fmt.Sscanf(journalStream, "%d:%d", &expectedStat.Dev, &expectedStat.Ino)
 	if err != nil {
-		return false, fmt.Errorf("failed to parse JOURNAL_STREAM=%q: %v", journalStream, err)
+		return false, fmt.Errorf("failed to parse JOURNAL_STREAM=%q: %w", journalStream, err)
 	}
 
 	var stat syscall.Stat_t

--- a/vendor/github.com/coreos/go-systemd/v22/unit/deserialize.go
+++ b/vendor/github.com/coreos/go-systemd/v22/unit/deserialize.go
@@ -54,8 +54,8 @@ func DeserializeSections(f io.Reader) ([]*UnitSection, error) {
 }
 
 // Deserialize parses a systemd unit file into a list of UnitOptions.
-// Note: this function is deprecated in favor of DeserializeOptions
-// and will be removed at a future date.
+//
+// Deprecated: use [DeserializeOptions] instead.
 func Deserialize(f io.Reader) (opts []*UnitOption, err error) {
 	return DeserializeOptions(f)
 }
@@ -94,8 +94,7 @@ func deserializeAll(f io.Reader) ([]*UnitSection, []*UnitOption, error) {
 
 				// sanity check. "should not happen" as sectionKind is first in code flow.
 				if len(sections) == 0 {
-					return nil, nil, fmt.Errorf(
-						"Unit file misparse: option before section")
+					return nil, nil, errors.New("unit file misparse: option before section")
 				}
 
 				// add to newest section entries.

--- a/vendor/github.com/coreos/go-systemd/v22/unit/escape.go
+++ b/vendor/github.com/coreos/go-systemd/v22/unit/escape.go
@@ -57,7 +57,7 @@ func escape(unescaped string, isPath bool) string {
 		if c == '/' {
 			e = append(e, '-')
 		} else if start && c == '.' || strings.IndexByte(allowed, c) == -1 {
-			e = append(e, []byte(fmt.Sprintf(`\x%x`, c))...)
+			e = fmt.Appendf(e, `\x%x`, c)
 		} else {
 			e = append(e, c)
 		}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -416,7 +416,7 @@ github.com/coreos/go-semver/semver
 ## explicit
 github.com/coreos/go-systemd/journal
 github.com/coreos/go-systemd/unit
-# github.com/coreos/go-systemd/v22 v22.6.0
+# github.com/coreos/go-systemd/v22 v22.7.0
 ## explicit; go 1.23
 github.com/coreos/go-systemd/v22/dbus
 github.com/coreos/go-systemd/v22/journal


### PR DESCRIPTION
Update `kola.go` to use `sdconn.SubscribeUnitsCustomContext` instead of `sdconn.SubscribeUnitsCustom` since its deprecated.

This should fix the following error in `golangci-lint`:

```
Error: SA1019: sdconn.SubscribeUnitsCustom is deprecated: use SubscribeUnitsCustomContext instead.  (staticcheck)
```

Closes #4436