### PR TITLE
osbuild: fix fake-genprotimgvm generation

### DIFF
--- a/src/cmd-osbuild
+++ b/src/cmd-osbuild
@@ -114,7 +114,8 @@ postprocess_qemu_secex() {
             chmod +w "${genprotimgvm}"
             genvm_args=("-drive" "if=none,id=hda,format=qcow2,file=${genprotimgvm},auto-read-only=off,cache=unsafe" \
                         "-device" "virtio-blk,drive=hda,bootindex=1")
-            kola qemuexec -i "${ignition_cfg}" -- "${genvm_args[@]}"
+            # Set `workdir=none` to prevent kola from using local artifacts and attaching the default image.
+            kola qemuexec --workdir none -i "${ignition_cfg}" -- "${genvm_args[@]}"
         fi
     fi
 


### PR DESCRIPTION
By default, `kola qemuexec` attaches `builds/latest/coreos.qcow2`
with `snapshot=on,bootindex=1`(ro). When building `secex2` locally,
`coreos.qcow2` is converted into a persistent `tmp/fake-secure-vm.qcow2`,
which is then used to create `sdboot` on the `se`-labeled partition.

When `fake-secure-vm.qcow2` is passed via QEMU options(rw), kola still
attaches its default image, resulting in two qcow2 images with the same
`bootindex=1` and causing the run to fail.

Set `workdir=none` to prevent kola from using local artifacts and
attaching the default image.