### PR TITLE
vmdeps: add bootupd and bootc

### DIFF
--- a/src/vmdeps-aarch64.txt
+++ b/src/vmdeps-aarch64.txt
@@ -1,6 +1,5 @@
 # For grub install when creating images and pxe install
 grub2 grub2-tools-extra
-bootupd
 
 # For creating bootable UEFI media on aarch64
 shim-aa64 grub2-efi-aa64

--- a/src/vmdeps-x86_64.txt
+++ b/src/vmdeps-x86_64.txt
@@ -1,6 +1,5 @@
 # For grub install when creating images without anaconda
 grub2
-bootupd
 
 # For generating ISO images
 syslinux-nonlinux

--- a/src/vmdeps.txt
+++ b/src/vmdeps.txt
@@ -11,6 +11,9 @@ genisoimage squashfs-tools erofs-utils
 # for composes
 rpm-ostree distribution-gpg-keys jq
 
+# to create disk images with bootc install to-filesystem
+bootc bootupd
+
 # for clean reboot
 systemd
 


### PR DESCRIPTION
In the ppc64le case, the supermin VM is missing the `bootupct` binary, which is used by bootc to determine what bootloader to use. This issue does not appear on other arches, where it is brought into supermin through dependencies probably.

But since we now rely on bootc to create the disk images on all arches let's explicitely bring bootc and bootupd.