### PR TITLE
osbuild: apply python-layer from COSA for FCOS builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,6 @@ COPY ./build.sh /root/containerbuild/
 RUN ./build.sh configure_yum_repos
 RUN ./build.sh install_rpms
 RUN ./build.sh install_ocp_tools
-RUN ./build.sh trust_redhat_gpg_keys
 
 COPY ./ /root/containerbuild/
 RUN ./build.sh write_archive_info

--- a/build.sh
+++ b/build.sh
@@ -102,17 +102,6 @@ install_rpms() {
     chmod 755 /usr/lib/containers/storage/overlay-images
     chmod 755 /usr/lib/containers/storage/overlay-layers
 
-    # Symlink the CentOS Stream GPG keys to /etc to make it easier to build
-    # CentOS-based artifacts.
-    if [ ! -e "/etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial" ]; then
-        ln -s /usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
-        ln -s /usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official-SHA256 /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial-SHA256
-        ln -s {/usr/share/distribution-gpg-keys/centos,/etc/pki/rpm-gpg}/RPM-GPG-KEY-CentOS-SIG-Cloud
-        ln -s {/usr/share/distribution-gpg-keys/centos,/etc/pki/rpm-gpg}/RPM-GPG-KEY-CentOS-SIG-Extras-SHA512
-        ln -s {/usr/share/distribution-gpg-keys/centos,/etc/pki/rpm-gpg}/RPM-GPG-KEY-CentOS-SIG-NFV
-        ln -s {/usr/share/distribution-gpg-keys/centos,/etc/pki/rpm-gpg}/RPM-GPG-KEY-CentOS-SIG-Virtualization
-    fi
-
     # Further cleanup
     yum clean all
 }
@@ -242,7 +231,6 @@ else
     write_archive_info
     make_and_makeinstall
     install_ocp_tools
-    trust_redhat_gpg_keys
     configure_user
     patch_osbuild
     fixup_file_permissions

--- a/src/deps.txt
+++ b/src/deps.txt
@@ -12,12 +12,14 @@ sudo
 # libvirt forking qemu and assuming the process gets reaped on shutdown.
 dumb-init
 
-# For composes
-rpm-ostree createrepo_c openssh-clients python3-createrepo_c composefs
-dnf-utils
+# For connectivity
+openssh-clients
 
 # Standard build tools
-make git rpm-build
+make git rpm-build dnf-utils
+
+# For cmd-build
+createrepo_c
 
 # virt dependencies
 libguestfs-tools libguestfs-tools-c virtiofsd /usr/bin/qemu-img qemu-kvm swtpm

--- a/src/osbuild-manifests/build.common.ipp.yaml
+++ b/src/osbuild-manifests/build.common.ipp.yaml
@@ -29,9 +29,7 @@ pipelines:
   # allows for this pipeline to be used as a buildroot for some stages
   # or as inputs for others (i.e. file_context input to the org.osbuild.selinux
   # stages). This pipeline isn't actually used for built artifacts but
-  # to help during build.
-  #
-  # NOTE: this is only used as a buildroot on RHCOS (FCOS doesn't ship python).
+  # to help during build as a buildroot or as inputs for some stages.
   - name: deployed-tree
     stages:
       - mpp-if: ociarchive != ''
@@ -54,6 +52,19 @@ pipelines:
                 images:
                   - source: $container_repo
                     tag: $container_tag
+      - mpp-if: python_layer_tarball != ''
+        then:
+          type: org.osbuild.untar
+          inputs:
+            file:
+              type: org.osbuild.files
+              origin: org.osbuild.source
+              mpp-embed:
+                id: coreos.python_layer_tarball
+                url:
+                  mpp-format-string: 'file://{python_layer_tarball}'
+          options:
+            prefix: /
   # Build up the filesystem tree used to construct disk images later.
   # This is only needed for the non-bootc path; when using bootc install
   # the tree construction is handled by bootc install-to-filesystem.

--- a/src/osbuild-manifests/coreos.osbuild.aarch64.mpp.yaml
+++ b/src/osbuild-manifests/coreos.osbuild.aarch64.mpp.yaml
@@ -40,14 +40,8 @@ mpp-vars:
   host_as_buildroot: ""
   # Set the buildroot string to use for most operations here. We create
   # the buildroot from the target OSTree contents so we have version
-  # matches. Unfortunately for FCOS there is no python so we can't
-  # really use FCOS as the buildroot so we'll use the host as the
-  # buildroot there.
-  buildroot:
-    mpp-if: osname in ['rhcos', 'scos']
-    then: "name:deployed-tree"
-    else:
-      mpp-format-string: '{host_as_buildroot}'
+  # matches.
+  buildroot: "name:deployed-tree"
   # Set the names of the files to use to import raw and raw4k pipelines
   raw_image_pipeline_file:
     mpp-if: use_bootc_install == 'true'

--- a/src/osbuild-manifests/coreos.osbuild.ppc64le.mpp.yaml
+++ b/src/osbuild-manifests/coreos.osbuild.ppc64le.mpp.yaml
@@ -40,14 +40,8 @@ mpp-vars:
   host_as_buildroot: ""
   # Set the buildroot string to use for most operations here. We create
   # the buildroot from the target OSTree contents so we have version
-  # matches. Unfortunately for FCOS there is no python so we can't
-  # really use FCOS as the buildroot so we'll use the host as the
-  # buildroot there.
-  buildroot:
-    mpp-if: osname in ['rhcos', 'scos']
-    then: "name:deployed-tree"
-    else:
-      mpp-format-string: '{host_as_buildroot}'
+  # matches.
+  buildroot: "name:deployed-tree"
   # Set the names of the files to use to import raw and raw4k pipelines
   raw_image_pipeline_file:
     mpp-if: use_bootc_install == 'true'

--- a/src/osbuild-manifests/coreos.osbuild.riscv64.mpp.yaml
+++ b/src/osbuild-manifests/coreos.osbuild.riscv64.mpp.yaml
@@ -40,14 +40,8 @@ mpp-vars:
   host_as_buildroot: ""
   # Set the buildroot string to use for most operations here. We create
   # the buildroot from the target OSTree contents so we have version
-  # matches. Unfortunately for FCOS there is no python so we can't
-  # really use FCOS as the buildroot so we'll use the host as the
-  # buildroot there.
-  buildroot:
-    mpp-if: osname in ['rhcos', 'scos']
-    then: "name:deployed-tree"
-    else:
-      mpp-format-string: '{host_as_buildroot}'
+  # matches.
+  buildroot: "name:deployed-tree"
   # Set the names of the files to use to import raw and raw4k pipelines
   raw_image_pipeline_file:
     mpp-if: use_bootc_install == 'true'

--- a/src/osbuild-manifests/coreos.osbuild.s390x.mpp.yaml
+++ b/src/osbuild-manifests/coreos.osbuild.s390x.mpp.yaml
@@ -44,14 +44,8 @@ mpp-vars:
   host_as_buildroot: ""
   # Set the buildroot string to use for most operations here. We create
   # the buildroot from the target OSTree contents so we have version
-  # matches. Unfortunately for FCOS there is no python so we can't
-  # really use FCOS as the buildroot so we'll use the host as the
-  # buildroot there.
-  buildroot:
-    mpp-if: osname in ['rhcos', 'scos']
-    then: "name:deployed-tree"
-    else:
-      mpp-format-string: '{host_as_buildroot}'
+  # matches.
+  buildroot: "name:deployed-tree"
   # Set the names of the files to use to import raw and raw4k pipelines
   raw_image_pipeline_file:
     mpp-if: use_bootc_install == 'true'

--- a/src/osbuild-manifests/coreos.osbuild.x86_64.mpp.yaml
+++ b/src/osbuild-manifests/coreos.osbuild.x86_64.mpp.yaml
@@ -40,14 +40,8 @@ mpp-vars:
   host_as_buildroot: ""
   # Set the buildroot string to use for most operations here. We create
   # the buildroot from the target OSTree contents so we have version
-  # matches. Unfortunately for FCOS there is no python so we can't
-  # really use FCOS as the buildroot so we'll use the host as the
-  # buildroot there.
-  buildroot:
-    mpp-if: osname in ['rhcos', 'scos']
-    then: "name:deployed-tree"
-    else:
-      mpp-format-string: '{host_as_buildroot}'
+  # matches.
+  buildroot: "name:deployed-tree"
   # Set the names of the files to use to import raw and raw4k pipelines
   raw_image_pipeline_file:
     mpp-if: use_bootc_install == 'true'

--- a/src/runvm-osbuild
+++ b/src/runvm-osbuild
@@ -73,6 +73,33 @@ container_tag=$(getconfig_def "container-tag" "")
 extra_kargs=$(getconfig "extra-kargs-string" "")
 use_bootc_install=$(getconfig_def "use-bootc-install" "false")
 
+# If we're on fedora-coreos there is no python in the OS itself so in
+# order to use the OS as the buildroot (which is good for tightly
+# coupling versions of userspace tools used to create the disk images,
+# like mkfs.xfs, to the versions actually in the disk images) we need
+# to generate a thin python layer tarball to layer on top of the OS
+# for the buildroot. This solves a long standing problem we have where
+# using COSA as the buildroot has caused issues over time.
+python_layer_tarball=""
+if [ "${osname}" == 'fedora-coreos' ]; then
+    echo "Adding python layer for ${osname} to support OSBuild"
+    # Store the python layer in the cache and name it based on
+    # the build_version. If the file already exists we use that
+    # instead of generating a new one because creating reproducible
+    # tarballs is hard and we want the deployed-tree in OSBuild to be
+    # cached across successive runs against the same build. Use an
+    # absolute path here. OSBuild can't handle a relative path.
+    python_layer_tarball="$(readlink -f ./cache)/python-layer-${build_version}.tar.gz"
+    if [ ! -f "${python_layer_tarball}" ]; then
+        # Cleanup any old ones.
+        rm -f cache/python-layer*tar.gz
+        # Create the tarball; ignore missing files because supermin wouldn't
+        # have included things like docs into the filesystem here.
+        tar -cz --ignore-failed-read --warning=no-failed-read \
+            --files-from=<(rpm -ql python3 python3-libs) --file="${python_layer_tarball}"
+    fi
+fi
+
 # Since the underlying osbuild manifests will prefer the ociarchive
 # if it exists then let's check here to see if the container exists
 # in local container storage. If it does then we'll just pass that
@@ -118,6 +145,7 @@ set -x; osbuild-mpp                                       \
     -D container_tag=\""${container_tag}"\"               \
     -D extra_kargs=\""${extra_kargs}"\"                   \
     -D use_bootc_install=\""${use_bootc_install}"\"       \
+    -D python_layer_tarball=\""${python_layer_tarball}"\" \
     -D metal_image_size_mb="${metal_image_size_mb}"       \
     -D cloud_image_size_mb="${cloud_image_size_mb}"       \
     -D rootfs_size_mb="${rootfs_size_mb}"                 \

--- a/src/supermin-init-prelude.sh
+++ b/src/supermin-init-prelude.sh
@@ -8,6 +8,10 @@ mount -t sysfs /sys /sys
 mount -t cgroup2 cgroup2 -o rw,nosuid,nodev,noexec,relatime,seclabel,nsdelegate,memory_recursiveprot /sys/fs/cgroup
 mount -t devtmpfs devtmpfs /dev
 
+# /dev/fd is needed for things like process substitution
+# https://www.gnu.org/software/bash/manual/bash.html#Process-Substitution
+ln -s /proc/self/fd /dev/fd
+
 # this is also normally set up by systemd in early boot
 ln -s /proc/self/fd/0 /dev/stdin
 ln -s /proc/self/fd/1 /dev/stdout
@@ -19,7 +23,6 @@ mount -t tmpfs tmpfs /dev/shm
 
 # load selinux policy
 LANG=C /sbin/load_policy  -i
-
 
 # need fuse module for rofiles-fuse/bwrap during post scripts run
 /sbin/modprobe fuse

--- a/src/supermin-init-prelude.sh
+++ b/src/supermin-init-prelude.sh
@@ -90,34 +90,3 @@ touch /etc/cosa-supermin
 # the missing link.
 update-alternatives --install /etc/alternatives/iptables iptables /usr/sbin/iptables-nft 1
 update-alternatives --install /etc/alternatives/ip6tables ip6tables /usr/sbin/ip6tables-nft 1
-
-# To build the disk image using osbuild and bootc install to-filesystem we need to
-# have a prepare-root config in the build environnement for bootc to read.
-# This workaround can be removed when https://github.com/bootc-dev/bootc/issues/1410
-# is fixed or we have python in all streams which allows us to use the OCI image as the buildroot.
-# Note that RHCOS and SCOS use the OCI as buildroot so they should not be affected by this.
-cat > /usr/lib/ostree/prepare-root.conf <<EOF
-[composefs]
-enabled = true
-EOF
-
-# Tell bootc to enforce that `/etc/containers/policy.json` include a default
-# policy that verify our images signature.
-# When moving to image-builder, this config can be moved into the container itself
-# but as long as we are using osbuild manually we have to carry this in the buildroot.
-# TODO: uncomment this when https://github.com/bootc-dev/bootc/pull/2116
-# is merged and released
-# cat > usr/lib/bootc/install/10-sigpolicy.toml <<EOF
-# [install]
-# enforce-container-sigpolicy = true
-# EOF
-
-# TODO move this to an overlay in fedora-coreos-config
-# so it get baked into the container at build time. We
-# want the container to be the source of truth as much as possible.
-# Same as the entries above, we need to have this in cosa until
-# we move to image builder
-cat <<EOF > /usr/lib/bootc/install/10-grub-users.toml
-[install.ostree]
-bls-append-except-default = 'grub_users=""'
-EOF

--- a/src/vmdeps-s390x.txt
+++ b/src/vmdeps-s390x.txt
@@ -1,7 +1,4 @@
 s390utils-base
 
-# for building iso image
-lorax
-
 # for Secure Execution
 veritysetup

--- a/src/vmdeps.txt
+++ b/src/vmdeps.txt
@@ -1,18 +1,12 @@
 # These packages will be included in the VM image created by
 # supermin that we use via `runvm`, which currently is mostly
-# rpm-ostree runs (when run unprivileged) and create-disk.sh.
+# podman/buildah runs (to build container) and osbuild.
 
 # bare essentials
-bash vim-minimal coreutils util-linux procps-ng kmod kernel-modules
+bash jq vim-minimal coreutils util-linux procps-ng kmod kernel-modules gzip tar
 
-# For generating ISO images
-genisoimage squashfs-tools erofs-utils
-
-# for composes
-rpm-ostree distribution-gpg-keys jq
-
-# to create disk images with bootc install to-filesystem
-bootc bootupd
+# For generating ISO images (osbuild org.osbuild.coreos.live-artifacts.mono stage)
+genisoimage squashfs-tools erofs-utils dosfstools
 
 # for clean reboot
 systemd
@@ -29,18 +23,8 @@ python3 python3-gobject-base buildah podman skopeo iptables-nft iptables-libs
 # legacy-oscontainer
 python3-pyyaml python3-botocore python3-flufl-lock python3-tenacity
 
-# luks
-cryptsetup
-# filesystems/storage
-gdisk xfsprogs e2fsprogs dosfstools btrfs-progs
-
 # needed for basic CA support
 ca-certificates
-
-tar
-
-# needed for extensions container build
-podman
 
 # For running osbuild
 osbuild osbuild-ostree osbuild-selinux osbuild-tools python3-pyrsistent zip


### PR DESCRIPTION
If we're on fedora-coreos there is no python in the OS itself so in
order to use the OS as the buildroot (which is good for tightly
coupling versions of userspace tools used to create the disk images,
like mkfs.xfs, to the versions actually in the disk images) we need
to generate a thin python layer tarball to layer on top of the OS
for the buildroot. This solves a long standing problem we have where
using COSA as the buildroot has caused issues over time.
