### PR TITLE
Allow RetryUntilTimeout to be passed a context

### DIFF
--- a/mantle/platform/cluster.go
+++ b/mantle/platform/cluster.go
@@ -100,6 +100,15 @@ func (bc *BaseCluster) PasswordSSHClient(ip string, user string, password string
 func (bc *BaseCluster) SSH(m Machine, cmd string) ([]byte, []byte, error) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
+
+	ctx := bc.rconf.TestExecTimeout
+	if ctx == nil {
+		ctx = context.Background()
+	} else if err := ctx.Err(); err != nil {
+		// context has already been canceled
+		return nil, nil, err
+	}
+
 	client, err := bc.SSHClient(m.IP())
 	if err != nil {
 		return nil, nil, err
@@ -114,11 +123,6 @@ func (bc *BaseCluster) SSH(m Machine, cmd string) ([]byte, []byte, error) {
 
 	session.Stdout = &stdout
 	session.Stderr = &stderr
-
-	ctx := bc.rconf.TestExecTimeout
-	if ctx == nil {
-		ctx = context.Background()
-	}
 
 	// Use Start()+Wait() so we can select on context cancellation.
 	if err := session.Start(cmd); err != nil {

--- a/mantle/platform/journal.go
+++ b/mantle/platform/journal.go
@@ -89,11 +89,15 @@ func NewJournal(dir string) (*Journal, error) {
 }
 
 // Start begins/resumes streaming the system journal to journal.txt.
-func (j *Journal) Start(ctx context.Context, m Machine, oldBootId string) error {
+func (j *Journal) Start(m Machine, oldBootId string) error {
 	if j.cancel != nil {
 		j.cancel()
 		j.cancel = nil
 		_ = j.recorder.Wait() // Just need to consume the status.
+	}
+	ctx := m.RuntimeConf().TestExecTimeout
+	if ctx == nil {
+		ctx = context.Background()
 	}
 	ctx, cancel := context.WithCancel(ctx)
 
@@ -117,7 +121,7 @@ func (j *Journal) Start(ctx context.Context, m Machine, oldBootId string) error 
 
 	// Retry for a while because the machine is likely still booting
 	// and some Ignition configs take a long time to apply.
-	if err := util.RetryUntilTimeout(10*time.Minute, 10*time.Second, start); err != nil {
+	if err := util.RetryUntilTimeoutWithContext(ctx, 10*time.Minute, 10*time.Second, start); err != nil {
 		cancel()
 		return errors.Wrapf(err, "ssh journalctl failed")
 	}

--- a/mantle/platform/platform.go
+++ b/mantle/platform/platform.go
@@ -514,8 +514,14 @@ func checkSystemdUnitStuck(output string, m Machine) error {
 // CheckMachine tests a machine for various error conditions such as ssh
 // being available and no systemd units failing at the time ssh is reachable.
 // It also ensures the remote system is running Container Linux by CoreOS or
-// Red Hat CoreOS.
-func CheckMachine(ctx context.Context, m Machine) error {
+// Red Hat CoreOS. There is a 10m time limit for the SSH connection, to make this
+// time limit shorter, machines RuntimeConf TestExecTimeout can be used.
+func CheckMachine(m Machine) error {
+	ctx := m.RuntimeConf().TestExecTimeout
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	// ensure ssh works and the system is ready
 	sshChecker := func() error {
 		if err := ctx.Err(); err != nil {
@@ -534,7 +540,7 @@ func CheckMachine(ctx context.Context, m Machine) error {
 		return nil
 	}
 
-	if err := util.RetryUntilTimeout(10*time.Minute, 10*time.Second, sshChecker); err != nil {
+	if err := util.RetryUntilTimeoutWithContext(ctx, 10*time.Minute, 10*time.Second, sshChecker); err != nil {
 		return errors.Wrapf(err, "ssh unreachable")
 	}
 

--- a/mantle/platform/util.go
+++ b/mantle/platform/util.go
@@ -15,7 +15,6 @@
 package platform
 
 import (
-	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"fmt"
@@ -177,10 +176,10 @@ func WaitForMachineReboot(m Machine, j *Journal, timeout time.Duration, oldBootI
 }
 
 func StartMachineAfterReboot(m Machine, j *Journal, oldBootId string) error {
-	if err := j.Start(context.TODO(), m, oldBootId); err != nil {
+	if err := j.Start(m, oldBootId); err != nil {
 		return fmt.Errorf("machine %q failed to start: %v", m.ID(), err)
 	}
-	if err := CheckMachine(context.TODO(), m); err != nil {
+	if err := CheckMachine(m); err != nil {
 		return fmt.Errorf("machine %q failed basic checks: %v", m.ID(), err)
 	}
 	return nil
@@ -265,7 +264,7 @@ func WaitForMachineSoftReboot(m Machine, j *Journal, timeout time.Duration, oldS
 		}
 		// Give it a moment for systemd to stabilize after soft-reboot
 		time.Sleep(2 * time.Second)
-		if err := CheckMachine(context.TODO(), m); err != nil {
+		if err := CheckMachine(m); err != nil {
 			return fmt.Errorf("machine %q failed basic checks after soft-reboot: %v", m.ID(), err)
 		}
 		return nil

--- a/mantle/util/retry.go
+++ b/mantle/util/retry.go
@@ -15,6 +15,7 @@
 package util
 
 import (
+	"context"
 	"fmt"
 	"time"
 )
@@ -48,18 +49,13 @@ func RetryConditional(attempts int, delay time.Duration, shouldRetry func(err er
 	return err
 }
 
-// RetryUntilTimeout calls function f until it succeeds or until
-// the given timeout is reached. It will wait a given amount of time
-// between each try based on the given delay.
-func RetryUntilTimeout(timeout, delay time.Duration, f func() error) error {
+// RetryUntilTimeoutWithContext calls function f until it succeeds, until
+// the given timeout is reached, or the context is done. It will wait
+// a given amount of time between each try based on the given delay.
+func RetryUntilTimeoutWithContext(ctx context.Context, timeout, delay time.Duration, f func() error) error {
 	after := time.After(timeout)
 	deadline := time.Now().Add(timeout)
 	for {
-		select {
-		case <-after:
-			return fmt.Errorf("time limit exceeded")
-		default:
-		}
 		// Log how long it took the function to run. This will help gather information about
 		// how long it takes remote network requests to finish.
 		start := time.Now()
@@ -70,9 +66,22 @@ func RetryUntilTimeout(timeout, delay time.Duration, f func() error) error {
 		} else {
 			plog.Debugf("RetryUntilTimeout: f() returned error: %s", err)
 		}
-		time.Sleep(delay)
+		select {
+		case <-after:
+			return fmt.Errorf("time limit exceeded")
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(delay):
+		}
 	}
 	return nil
+}
+
+// RetryUntilTimeout calls function f until it succeeds or until
+// the given timeout is reached. It will wait a given amount of time
+// between each try based on the given delay.
+func RetryUntilTimeout(timeout, delay time.Duration, f func() error) error {
+	return RetryUntilTimeoutWithContext(context.Background(), timeout, delay, f)
 }
 
 func WaitUntilReady(timeout, delay time.Duration, checkFunction func() (bool, error)) error {


### PR DESCRIPTION
The `RetryUntilTimeout` function does not take in a context. Because of this, it may be the case that a test with a time limit will take 10m + to run.