### PR TITLE
.tekton: build all archs in Konflux

### DIFF
--- a/.tekton/coreos-assembler-pull-request.yaml
+++ b/.tekton/coreos-assembler-pull-request.yaml
@@ -30,6 +30,9 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/arm64
+    - linux/s390x
+    - linux/ppc64le
   - name: dockerfile
     value: Dockerfile
   - name: path-context

--- a/.tekton/coreos-assembler-push.yaml
+++ b/.tekton/coreos-assembler-push.yaml
@@ -27,6 +27,9 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/arm64
+    - linux/s390x
+    - linux/ppc64le
   - name: dockerfile
     value: Dockerfile
   - name: path-context

--- a/.tekton/coreos-assembler-renovate-push.yaml
+++ b/.tekton/coreos-assembler-renovate-push.yaml
@@ -30,6 +30,9 @@ spec:
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/arm64
+    - linux/s390x
+    - linux/ppc64le
   - name: dockerfile
     value: Dockerfile
   - name: path-context


### PR DESCRIPTION
We added firt x86_64 to speed the Konflux integration development. We can now add the remaning args to build.