### PR TITLE
kola: add luks.sss.t2.fips test for LUKS with FIPS mode

### DIFF
--- a/mantle/kola/register/register.go
+++ b/mantle/kola/register/register.go
@@ -71,7 +71,7 @@ type Test struct {
 	Timeout              time.Duration // the duration for which a test will be allowed to run
 	RequiredTag          string        // if specified, test is filtered by default unless tag is provided -- defaults to none
 	Description          string        // test description
-	CreationDate         string        // the date when the test was created, if this parameter is set, then errors will be treated as warnings for the first 30 days
+	CreationDate         string        // the date (YYYY-MM-DD) when the test was created, if this parameter is set, then errors will be treated as warnings for the first 30 days
 
 	// MachineOptions contains options for machine creation (disks, memory,
 	// kernel args, etc.). The test harness passes these to

--- a/mantle/kola/tests/ignition/luks.go
+++ b/mantle/kola/tests/ignition/luks.go
@@ -47,10 +47,22 @@ func init() {
 		Name:                 `luks.sss.t2`,
 		Description:          "Verify that the rootfs is encrypted with SSS with t=2.",
 		Flags:                []register.Flag{},
-		Distros:              []string{"rhcos"},
+		Distros:              []string{"fcos"},
 		Platforms:            []string{"qemu"},
 		ExcludeArchitectures: []string{"s390x"}, // no TPM backend support for s390x
 		Tags:                 []string{"luks", "tpm", "tang", "sss", kola.NeedsInternetTag, "reprovision"},
+	})
+	register.RegisterTest(&register.Test{
+		Run:                  luksSSST2FipsTest,
+		ClusterSize:          0,
+		Name:                 `luks.sss.t2.fips`,
+		Description:          "Verify that the rootfs is encrypted with SSS with t=2 and FIPS mode enabled.",
+		CreationDate:         "2026-05-01",
+		Flags:                []register.Flag{},
+		Distros:              []string{"rhcos"},
+		Platforms:            []string{"qemu"},
+		ExcludeArchitectures: []string{"s390x"}, // no TPM backend support for s390x
+		Tags:                 []string{"luks", "tpm", "tang", "sss", kola.NeedsInternetTag, "fips", "reprovision"},
 	})
 	register.RegisterTest(&register.Test{
 		Run:           runCexTest,
@@ -132,7 +144,7 @@ func setupTangMachine(c cluster.TestCluster) ut.TangServer {
 	}
 }
 
-func runTest(c cluster.TestCluster, tpm2 bool, threshold int, killTangAfterFirstBoot bool) {
+func runTest(c cluster.TestCluster, tpm2 bool, threshold int, killTangAfterFirstBoot bool, fips bool) {
 	tangd := setupTangMachine(c)
 	ignition := conf.Ignition(fmt.Sprintf(`{
 		"ignition": {
@@ -164,9 +176,9 @@ func runTest(c cluster.TestCluster, tpm2 bool, threshold int, killTangAfterFirst
 					"wipeFilesystem": true,
 					"label": "root"
 				}
-			]
+			]%s
 		}
-	}`, tpm2, tangd.Address, tangd.Thumbprint, threshold))
+	}`, tpm2, tangd.Address, tangd.Thumbprint, threshold, fipsFileSection(fips)))
 
 	opts := platform.MachineOptions{
 		MinMemory: 4096,
@@ -186,6 +198,10 @@ func runTest(c cluster.TestCluster, tpm2 bool, threshold int, killTangAfterFirst
 		rootPart = "/dev/disk/by-id/virtio-primary-disk-part4"
 	}
 	ut.LUKSSanityTest(c, tangd, m, tpm2, killTangAfterFirstBoot, rootPart)
+	if fips {
+		c.AssertCmdOutputContains(m, `cat /proc/sys/crypto/fips_enabled`, "1")
+		c.AssertCmdOutputContains(m, `update-crypto-policies --show`, "FIPS")
+	}
 }
 
 func runCexTest(c cluster.TestCluster) {
@@ -251,15 +267,39 @@ func runCexTest(c cluster.TestCluster) {
 
 // Verify that the rootfs is encrypted with Tang
 func luksTangTest(c cluster.TestCluster) {
-	runTest(c, false, 1, false)
+	runTest(c, false, 1, false, false)
 }
 
 // Verify that the rootfs is encrypted with SSS with t=1
 func luksSSST1Test(c cluster.TestCluster) {
-	runTest(c, true, 1, true)
+	runTest(c, true, 1, true, false)
 }
 
 // Verify that the rootfs is encrypted with SSS with t=2
 func luksSSST2Test(c cluster.TestCluster) {
-	runTest(c, true, 2, false)
+	runTest(c, true, 2, false, false)
+}
+
+// Verify that the rootfs is encrypted with SSS with t=2 and FIPS mode enabled
+func luksSSST2FipsTest(c cluster.TestCluster) {
+	runTest(c, true, 2, false, true)
+}
+
+// fipsFileSection returns the Ignition files section to enable FIPS mode
+// via the encapsulated MachineConfig, or an empty string if FIPS is not requested.
+func fipsFileSection(fips bool) string {
+	if !fips {
+		return ""
+	}
+	return `,
+			"files": [
+				{
+					"path": "/etc/ignition-machine-config-encapsulated.json",
+					"overwrite": true,
+					"contents": {
+						"source": "data:,%7B%22spec%22%3A%7B%22fips%22%3Atrue%7D%7D"
+					},
+					"mode": 420
+				}
+			]`
 }


### PR DESCRIPTION
We don't have a (positive) test that exercises both LUKS *and* FIPS together. Let's add coverage for this. For example, this would be useful in testing https://github.com/coreos/rhel-coreos-config/pull/248.

To avoid impact on test runtimes, let's just bundle this with an existing LUKS test we have. The `luks.sss.t1` and `luks.sss.t2` differ only in Clevis details and otherwise don't really differ in how LUKS is handled underneat or in the kernel, so it's a good candidate for this.

Make `luks.sss.t2` become FCOS-only, then add a `luks.sss.t2.fips` which is exactly the same but with FIPS enabled and RHCOS-only.

Assisted-by: Pi (Claude Opus 4.6)