### PR TITLE
cmd-koji-upload: fix IndexError in supported_upload extension check

### DIFF
--- a/src/cmd-koji-upload
+++ b/src/cmd-koji-upload
@@ -298,10 +298,10 @@ class Build(_Build):
         The return is tuple is used if the file is found and a message.
         """
         base = os.path.basename(fname)
-        check_extension = base.split(".")[-1]
-        for extension in COMPRESSION_EXT:
-            if fname.endswith(f".{extension}"):
-                check_extension = base.split(".")[-2]
+        parts = base.split(".")
+        check_extension = parts[-1]
+        if len(parts) > 1 and check_extension in COMPRESSION_EXT:
+            check_extension = parts[-2]
 
         (found, _, arch, _) = KOJI_CG_TYPES.get(
             check_extension, [None, None, None, None])

--- a/src/cmd-koji-upload
+++ b/src/cmd-koji-upload
@@ -189,7 +189,7 @@ class Build(_Build):
         :return file
         """
         for x in COMPRESSION_EXT:
-            if not fname.endswith(x):
+            if not fname.endswith(f".{x}"):
                 continue
 
             base_name = os.path.basename(fname)
@@ -300,7 +300,7 @@ class Build(_Build):
         base = os.path.basename(fname)
         check_extension = base.split(".")[-1]
         for extension in COMPRESSION_EXT:
-            if fname.endswith(extension):
+            if fname.endswith(f".{extension}"):
                 check_extension = base.split(".")[-2]
 
         (found, _, arch, _) = KOJI_CG_TYPES.get(


### PR DESCRIPTION
## Summary

- Fix `IndexError: list index out of range` crash in `supported_upload()` during Brew upload in node-image mode
- Add dot prefix to `endswith()` checks against `COMPRESSION_EXT` so only actual `.gz`/`.xz` file extensions match, not arbitrary filenames ending in those letters
- Apply the same fix to `decompress_mutator()` which has the identical pattern

## Root Cause

In node-image mode, `__init__` creates a temp directory (`koji-buildXXXXXXXX` via `tempfile.mkdtemp`) inside the workspace, and `_build_artifacts()` later scans that same workspace. `supported_upload()` checks filenames against `COMPRESSION_EXT = ["gz", "xz"]` using `fname.endswith(extension)` — without a dot prefix. When the random suffix of the temp directory name ends with "xz" or "gz" (~1 in 685 runs), the check matches and `base.split(".")[-2]` crashes because the directory name has no dots.

## Test plan

- [x] Verified that `.tar.xz` and `.tar.gz` files still correctly resolve to extension `"tar"`
- [x] Verified that dotless filenames like `koji-buildabcde_xz` no longer crash
- [x] Verified that normal files like `meta.json` are unaffected