### PR TITLE
osbuild: use FCOS+python as buildroot for FCOS builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,6 @@ COPY ./build.sh /root/containerbuild/
 RUN ./build.sh configure_yum_repos
 RUN ./build.sh install_rpms
 RUN ./build.sh install_ocp_tools
-RUN ./build.sh trust_redhat_gpg_keys
 
 COPY ./ /root/containerbuild/
 RUN ./build.sh write_archive_info

--- a/build.sh
+++ b/build.sh
@@ -102,17 +102,6 @@ install_rpms() {
     chmod 755 /usr/lib/containers/storage/overlay-images
     chmod 755 /usr/lib/containers/storage/overlay-layers
 
-    # Symlink the CentOS Stream GPG keys to /etc to make it easier to build
-    # CentOS-based artifacts.
-    if [ ! -e "/etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial" ]; then
-        ln -s /usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
-        ln -s /usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official-SHA256 /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial-SHA256
-        ln -s {/usr/share/distribution-gpg-keys/centos,/etc/pki/rpm-gpg}/RPM-GPG-KEY-CentOS-SIG-Cloud
-        ln -s {/usr/share/distribution-gpg-keys/centos,/etc/pki/rpm-gpg}/RPM-GPG-KEY-CentOS-SIG-Extras-SHA512
-        ln -s {/usr/share/distribution-gpg-keys/centos,/etc/pki/rpm-gpg}/RPM-GPG-KEY-CentOS-SIG-NFV
-        ln -s {/usr/share/distribution-gpg-keys/centos,/etc/pki/rpm-gpg}/RPM-GPG-KEY-CentOS-SIG-Virtualization
-    fi
-
     # Further cleanup
     yum clean all
 }
@@ -242,7 +231,6 @@ else
     write_archive_info
     make_and_makeinstall
     install_ocp_tools
-    trust_redhat_gpg_keys
     configure_user
     patch_osbuild
     fixup_file_permissions

--- a/src/Containerfile-osbuild-buildroot
+++ b/src/Containerfile-osbuild-buildroot
@@ -1,0 +1,12 @@
+# Overridden by build-args.conf. The value here is invalid on purpose.
+ARG BUILDER_IMG=overridden
+ARG FCOS_IMAGE=overridden
+
+FROM ${BUILDER_IMG} as builder
+RUN tar -c --ignore-failed-read --warning=no-failed-read \
+    --files-from=<(rpm -ql python3 python3-libs) --file=/python-tarball.tar
+
+ARG FCOS_IMAGE
+FROM ${FCOS_IMAGE} as fcos-python
+
+RUN --mount=type=bind,from=builder,source=/python-tarball.tar,target=/var/builder/python.tar tar xf /var/builder/python.tar -C /

--- a/src/deps.txt
+++ b/src/deps.txt
@@ -12,12 +12,14 @@ sudo
 # libvirt forking qemu and assuming the process gets reaped on shutdown.
 dumb-init
 
-# For composes
-rpm-ostree createrepo_c openssh-clients python3-createrepo_c composefs
-dnf-utils
+# For connectivity
+openssh-clients
 
 # Standard build tools
-make git rpm-build
+make git rpm-build dnf-utils
+
+# For cmd-build
+createrepo_c
 
 # virt dependencies
 libguestfs-tools libguestfs-tools-c virtiofsd /usr/bin/qemu-img qemu-kvm swtpm

--- a/src/osbuild-manifests/build.common.ipp.yaml
+++ b/src/osbuild-manifests/build.common.ipp.yaml
@@ -29,22 +29,17 @@ pipelines:
   # allows for this pipeline to be used as a buildroot for some stages
   # or as inputs for others (i.e. file_context input to the org.osbuild.selinux
   # stages). This pipeline isn't actually used for built artifacts but
-  # to help during build.
+  # to help during build as a buildroot or as inputs for some stages.
   #
-  # NOTE: this is only used as a buildroot on RHCOS (FCOS doesn't ship python).
+  # When a buildroot container is provided (for FCOS where we
+  # build a container with python on top of FCOS)
+  # it will be used as the source for this pipeline.
+  # For RHCOS/SCOS, the target container is used, as it already
+  # have python.
   - name: deployed-tree
     stages:
-      - mpp-if: ociarchive != ''
+      - mpp-if: buildroot_container_tag != ''
         then:
-          type: org.osbuild.container-deploy
-          inputs:
-            images:
-              type: org.osbuild.containers
-              origin: org.osbuild.pipeline
-              references:
-                name:oci-archive:
-                  name: coreos.ociarchive
-        else:
           type: org.osbuild.container-deploy
           inputs:
             images:
@@ -53,7 +48,28 @@ pipelines:
               mpp-resolve-images:
                 images:
                   - source: $container_repo
-                    tag: $container_tag
+                    tag: $buildroot_container_tag
+        else:
+          mpp-if: ociarchive != ''
+          then:
+            type: org.osbuild.container-deploy
+            inputs:
+              images:
+                type: org.osbuild.containers
+                origin: org.osbuild.pipeline
+                references:
+                  name:oci-archive:
+                    name: coreos.ociarchive
+          else:
+            type: org.osbuild.container-deploy
+            inputs:
+              images:
+                type: org.osbuild.containers-storage
+                origin: org.osbuild.source
+                mpp-resolve-images:
+                  images:
+                    - source: $container_repo
+                      tag: $container_tag
   # Build up the filesystem tree used to construct disk images later.
   # This is only needed for the non-bootc path; when using bootc install
   # the tree construction is handled by bootc install-to-filesystem.

--- a/src/osbuild-manifests/coreos.osbuild.aarch64.mpp.yaml
+++ b/src/osbuild-manifests/coreos.osbuild.aarch64.mpp.yaml
@@ -38,16 +38,11 @@ mpp-vars:
   # the host buildroot is the default if nothing is specified.
   # We're still defining it here in an attempt to be explicit.
   host_as_buildroot: ""
+  buildroot_container_tag: $buildroot_container_tag
   # Set the buildroot string to use for most operations here. We create
   # the buildroot from the target OSTree contents so we have version
-  # matches. Unfortunately for FCOS there is no python so we can't
-  # really use FCOS as the buildroot so we'll use the host as the
-  # buildroot there.
-  buildroot:
-    mpp-if: osname in ['rhcos', 'scos']
-    then: "name:deployed-tree"
-    else:
-      mpp-format-string: '{host_as_buildroot}'
+  # matches.
+  buildroot: "name:deployed-tree"
   # Set the names of the files to use to import raw and raw4k pipelines
   raw_image_pipeline_file:
     mpp-if: use_bootc_install == 'true'

--- a/src/osbuild-manifests/coreos.osbuild.ppc64le.mpp.yaml
+++ b/src/osbuild-manifests/coreos.osbuild.ppc64le.mpp.yaml
@@ -38,16 +38,11 @@ mpp-vars:
   # the host buildroot is the default if nothing is specified.
   # We're still defining it here in an attempt to be explicit.
   host_as_buildroot: ""
+  buildroot_container_tag: $buildroot_container_tag
   # Set the buildroot string to use for most operations here. We create
   # the buildroot from the target OSTree contents so we have version
-  # matches. Unfortunately for FCOS there is no python so we can't
-  # really use FCOS as the buildroot so we'll use the host as the
-  # buildroot there.
-  buildroot:
-    mpp-if: osname in ['rhcos', 'scos']
-    then: "name:deployed-tree"
-    else:
-      mpp-format-string: '{host_as_buildroot}'
+  # matches.
+  buildroot: "name:deployed-tree"
   # Set the names of the files to use to import raw and raw4k pipelines
   raw_image_pipeline_file:
     mpp-if: use_bootc_install == 'true'

--- a/src/osbuild-manifests/coreos.osbuild.riscv64.mpp.yaml
+++ b/src/osbuild-manifests/coreos.osbuild.riscv64.mpp.yaml
@@ -38,16 +38,11 @@ mpp-vars:
   # the host buildroot is the default if nothing is specified.
   # We're still defining it here in an attempt to be explicit.
   host_as_buildroot: ""
+  buildroot_container_tag: $buildroot_container_tag
   # Set the buildroot string to use for most operations here. We create
   # the buildroot from the target OSTree contents so we have version
-  # matches. Unfortunately for FCOS there is no python so we can't
-  # really use FCOS as the buildroot so we'll use the host as the
-  # buildroot there.
-  buildroot:
-    mpp-if: osname in ['rhcos', 'scos']
-    then: "name:deployed-tree"
-    else:
-      mpp-format-string: '{host_as_buildroot}'
+  # matches.
+  buildroot: "name:deployed-tree"
   # Set the names of the files to use to import raw and raw4k pipelines
   raw_image_pipeline_file:
     mpp-if: use_bootc_install == 'true'

--- a/src/osbuild-manifests/coreos.osbuild.s390x.mpp.yaml
+++ b/src/osbuild-manifests/coreos.osbuild.s390x.mpp.yaml
@@ -42,16 +42,11 @@ mpp-vars:
   # the host buildroot is the default if nothing is specified.
   # We're still defining it here in an attempt to be explicit.
   host_as_buildroot: ""
+  buildroot_container_tag: $buildroot_container_tag
   # Set the buildroot string to use for most operations here. We create
   # the buildroot from the target OSTree contents so we have version
-  # matches. Unfortunately for FCOS there is no python so we can't
-  # really use FCOS as the buildroot so we'll use the host as the
-  # buildroot there.
-  buildroot:
-    mpp-if: osname in ['rhcos', 'scos']
-    then: "name:deployed-tree"
-    else:
-      mpp-format-string: '{host_as_buildroot}'
+  # matches.
+  buildroot: "name:deployed-tree"
   # Set the names of the files to use to import raw and raw4k pipelines
   raw_image_pipeline_file:
     mpp-if: use_bootc_install == 'true'

--- a/src/osbuild-manifests/coreos.osbuild.x86_64.mpp.yaml
+++ b/src/osbuild-manifests/coreos.osbuild.x86_64.mpp.yaml
@@ -38,16 +38,11 @@ mpp-vars:
   # the host buildroot is the default if nothing is specified.
   # We're still defining it here in an attempt to be explicit.
   host_as_buildroot: ""
+  buildroot_container_tag: $buildroot_container_tag
   # Set the buildroot string to use for most operations here. We create
   # the buildroot from the target OSTree contents so we have version
-  # matches. Unfortunately for FCOS there is no python so we can't
-  # really use FCOS as the buildroot so we'll use the host as the
-  # buildroot there.
-  buildroot:
-    mpp-if: osname in ['rhcos', 'scos']
-    then: "name:deployed-tree"
-    else:
-      mpp-format-string: '{host_as_buildroot}'
+  # matches.
+  buildroot: "name:deployed-tree"
   # Set the names of the files to use to import raw and raw4k pipelines
   raw_image_pipeline_file:
     mpp-if: use_bootc_install == 'true'

--- a/src/runvm-osbuild
+++ b/src/runvm-osbuild
@@ -73,6 +73,27 @@ container_tag=$(getconfig_def "container-tag" "")
 extra_kargs=$(getconfig "extra-kargs-string" "")
 use_bootc_install=$(getconfig_def "use-bootc-install" "false")
 
+# On fedora-coreos there is no python so in order to use the FCOS image
+# as the buildroot (which offers tighter coupling of userspace tools
+# used to create the disk images like mkfs.xfs, and bootc)
+# we build a temporary container that layers python on top of the FCOS
+# container.
+# This container will be used as the deployed-tree in the
+# osbuild manifest, enabling it to serve as the buildroot.
+buildroot_container_tag=""
+if [ "${osname}" == 'fedora-coreos' ]; then
+    echo "Building FCOS buildroot container"
+    buildroot_container_tag="${build_version}-python"
+    if ! podman image exists "${container_repo}:${buildroot_container_tag}"; then
+        containerfile="/usr/lib/coreos-assembler/Containerfile-osbuild-buildroot"
+        podman build \
+            --build-arg-file src/config/build-args.conf \
+            --build-arg "FCOS_IMAGE=oci-archive:${ostree_container}" \
+            -t "${container_repo}:${buildroot_container_tag}" \
+            -f "${containerfile}" /
+    fi
+fi
+
 # Since the underlying osbuild manifests will prefer the ociarchive
 # if it exists then let's check here to see if the container exists
 # in local container storage. If it does then we'll just pass that
@@ -107,20 +128,21 @@ processed_json=$(mktemp -t osbuild-XXXX.json)
 
 # Run through the preprocessor
 # Note: don't quote the size arguements since they are numbers, not strings
-set -x; osbuild-mpp                                       \
-    -D arch=\""$(arch)"\"                                 \
-    -D artifact_name_prefix=\""${artifact_name_prefix}"\" \
-    -D build_version=\""${build_version}"\"               \
-    -D ociarchive=\""${ostree_container}"\"               \
-    -D osname=\""${osname}"\"                             \
-    -D container_imgref=\""${container_imgref}"\"         \
-    -D container_repo=\""${container_repo}"\"             \
-    -D container_tag=\""${container_tag}"\"               \
-    -D extra_kargs=\""${extra_kargs}"\"                   \
-    -D use_bootc_install=\""${use_bootc_install}"\"       \
-    -D metal_image_size_mb="${metal_image_size_mb}"       \
-    -D cloud_image_size_mb="${cloud_image_size_mb}"       \
-    -D rootfs_size_mb="${rootfs_size_mb}"                 \
+set -x; osbuild-mpp                                               \
+    -D arch=\""$(arch)"\"                                         \
+    -D artifact_name_prefix=\""${artifact_name_prefix}"\"         \
+    -D build_version=\""${build_version}"\"                       \
+    -D ociarchive=\""${ostree_container}"\"                       \
+    -D osname=\""${osname}"\"                                     \
+    -D container_imgref=\""${container_imgref}"\"                 \
+    -D container_repo=\""${container_repo}"\"                     \
+    -D container_tag=\""${container_tag}"\"                       \
+    -D extra_kargs=\""${extra_kargs}"\"                           \
+    -D use_bootc_install=\""${use_bootc_install}"\"               \
+    -D buildroot_container_tag=\""${buildroot_container_tag}"\"   \
+    -D metal_image_size_mb="${metal_image_size_mb}"               \
+    -D cloud_image_size_mb="${cloud_image_size_mb}"               \
+    -D rootfs_size_mb="${rootfs_size_mb}"                         \
     "${mppyaml}" "${processed_json}"
 set +x
 

--- a/src/supermin-init-prelude.sh
+++ b/src/supermin-init-prelude.sh
@@ -87,34 +87,3 @@ touch /etc/cosa-supermin
 # the missing link.
 update-alternatives --install /etc/alternatives/iptables iptables /usr/sbin/iptables-nft 1
 update-alternatives --install /etc/alternatives/ip6tables ip6tables /usr/sbin/ip6tables-nft 1
-
-# To build the disk image using osbuild and bootc install to-filesystem we need to
-# have a prepare-root config in the build environnement for bootc to read.
-# This workaround can be removed when https://github.com/bootc-dev/bootc/issues/1410
-# is fixed or we have python in all streams which allows us to use the OCI image as the buildroot.
-# Note that RHCOS and SCOS use the OCI as buildroot so they should not be affected by this.
-cat > /usr/lib/ostree/prepare-root.conf <<EOF
-[composefs]
-enabled = true
-EOF
-
-# Tell bootc to enforce that `/etc/containers/policy.json` include a default
-# policy that verify our images signature.
-# When moving to image-builder, this config can be moved into the container itself
-# but as long as we are using osbuild manually we have to carry this in the buildroot.
-# TODO: uncomment this when https://github.com/bootc-dev/bootc/pull/2116
-# is merged and released
-# cat > /usr/lib/bootc/install/10-sigpolicy.toml <<EOF
-# [install]
-# enforce-container-sigpolicy = true
-# EOF
-
-# TODO move this to an overlay in fedora-coreos-config
-# so it get baked into the container at build time. We
-# want the container to be the source of truth as much as possible.
-# Same as the entries above, we need to have this in cosa until
-# we move to image builder
-cat <<EOF > /usr/lib/bootc/install/10-grub-users.toml
-[install.ostree]
-bls-append-except-default = 'grub_users=""'
-EOF

--- a/src/supermin-init-prelude.sh
+++ b/src/supermin-init-prelude.sh
@@ -104,7 +104,7 @@ EOF
 # but as long as we are using osbuild manually we have to carry this in the buildroot.
 # TODO: uncomment this when https://github.com/bootc-dev/bootc/pull/2116
 # is merged and released
-# cat > usr/lib/bootc/install/10-sigpolicy.toml <<EOF
+# cat > /usr/lib/bootc/install/10-sigpolicy.toml <<EOF
 # [install]
 # enforce-container-sigpolicy = true
 # EOF

--- a/src/vmdeps-s390x.txt
+++ b/src/vmdeps-s390x.txt
@@ -1,7 +1,4 @@
 s390utils-base
 
-# for building iso image
-lorax
-
 # for Secure Execution
 veritysetup

--- a/src/vmdeps.txt
+++ b/src/vmdeps.txt
@@ -1,18 +1,12 @@
 # These packages will be included in the VM image created by
 # supermin that we use via `runvm`, which currently is mostly
-# rpm-ostree runs (when run unprivileged) and create-disk.sh.
+# podman/buildah runs (to build container) and osbuild.
 
 # bare essentials
-bash vim-minimal coreutils util-linux procps-ng kmod kernel-modules
+bash jq vim-minimal coreutils util-linux procps-ng kmod kernel-modules gzip tar
 
-# For generating ISO images
-genisoimage squashfs-tools erofs-utils
-
-# for composes
-rpm-ostree distribution-gpg-keys jq
-
-# to create disk images with bootc install to-filesystem
-bootc bootupd
+# For generating ISO images (osbuild org.osbuild.coreos.live-artifacts.mono stage)
+genisoimage squashfs-tools erofs-utils dosfstools
 
 # for clean reboot
 systemd
@@ -29,18 +23,8 @@ python3 python3-gobject-base buildah podman skopeo iptables-nft iptables-libs
 # legacy-oscontainer
 python3-pyyaml python3-botocore python3-flufl-lock python3-tenacity
 
-# luks
-cryptsetup
-# filesystems/storage
-gdisk xfsprogs e2fsprogs dosfstools btrfs-progs
-
 # needed for basic CA support
 ca-certificates
-
-tar
-
-# needed for extensions container build
-podman
 
 # For running osbuild
 osbuild osbuild-ostree osbuild-selinux osbuild-tools python3-pyrsistent zip


### PR DESCRIPTION
We create a temporary container image before invoking osbuild to simply
layer the python components that are in COSA on top of the FCOS image
that will be deployed.

This image is then used as a buildroot for osbuild. This closes some
gap between RHCOS/SCOS and FCOS, providing us a tight coupling for
the userspace tools we are using to build our disk image.
e.g a bootc fast-tracked in rawhide will be used to build the rawhide
disk image.

This also allow us to not carry FCOS config options in COSA.

This solves a long-standing issue where we had to do a lot of hacks to
use COSA as the buildroot for building FCOS.

This is inspired by Dusty Mabe work from [1] but using a container
native approach, which will ease the transition to Konflux and
image-builder.

[1] #4534

Another key difference with #4534 to note is that we use the python rpms that are from the bootc builder image that was used as a base image from the FCOS build. So we have nicer version coupling than using the one from COSA. 