### PR TITLE
kola/tests/iso: fix SwitchBootOrder issue on aarch64

### DIFF
--- a/mantle/kola/tests/iso/live-iso.go
+++ b/mantle/kola/tests/iso/live-iso.go
@@ -335,32 +335,35 @@ func runIsoTest(qc *qemu.Cluster, opts IsoTestOpts, tempdir string) error {
 		Firmware:         opts.firmware,
 	}
 
-	machineBuilder := &qemu.MachineBuilder{
-		SetupDisks:   setupDisks,
-		SetupNetwork: setupNet,
+	switchBootOrder := func(inst *platform.QemuInstance) error {
+		// Start a goroutine to monitor installation progress and switch boot order.
+		// We check the boot signal on all architectures, but only aarch64 and s390x
+		// need to switch boot order via QMP because their QEMU firmware doesn't support
+		// the -boot once=n option.
+		go func() {
+			if err := CheckTestOutput(bootStartedOutput, []string{bootStartedSignal}); err != nil {
+				errchan <- err
+				return
+			}
+			// SwitchBootOrder is a no-op on architectures other than aarch64 and s390x
+			if err := inst.SwitchBootOrder(); err != nil {
+				errchan <- errors.Wrapf(err, "switching boot order failed")
+				return
+			}
+		}()
+		return nil
 	}
 
-	qm, err := qc.NewMachineWithBuilder(liveConfig, options, machineBuilder)
+	machineBuilder := &qemu.MachineBuilder{
+		SetupDisks:        setupDisks,
+		SetupNetwork:      setupNet,
+		PostInstanceStart: switchBootOrder,
+	}
+
+	_, err = qc.NewMachineWithBuilder(liveConfig, options, machineBuilder)
 	if err != nil {
 		return errors.Wrap(err, "unable to create test machine")
 	}
-
-	inst := qc.Instance(qm)
-	if inst == nil {
-		return errors.New("failed to get QemuInstance from machine")
-	}
-
-	//check for error when switching boot order
-	go func() {
-		if err := CheckTestOutput(bootStartedOutput, []string{bootStartedSignal}); err != nil {
-			errchan <- err
-			return
-		}
-		if err := inst.SwitchBootOrder(); err != nil {
-			errchan <- errors.Wrapf(err, "switching boot order failed")
-			return
-		}
-	}()
 
 	return <-errchan
 }

--- a/mantle/kola/tests/iso/live-pxe.go
+++ b/mantle/kola/tests/iso/live-pxe.go
@@ -214,6 +214,25 @@ func testLivePXE(c cluster.TestCluster, opts IsoTestOpts) {
 		return nil
 	}
 
+	switchBootOrder := func(inst *platform.QemuInstance) error {
+		// Start a goroutine to monitor installation progress and switch boot order.
+		// We check the boot signal on all architectures, but only aarch64 and s390x
+		// need to switch boot order via QMP because their QEMU firmware doesn't support
+		// the -boot once=n option.
+		go func() {
+			if err := CheckTestOutput(bootStartedOutput, []string{bootStartedSignal}); err != nil {
+				errchan <- err
+				return
+			}
+			// SwitchBootOrder is a no-op on architectures other than aarch64 and s390x
+			if err := inst.SwitchBootOrder(); err != nil {
+				errchan <- errors.Wrapf(err, "switching boot order failed")
+				return
+			}
+		}()
+		return nil
+	}
+
 	options := platform.MachineOptions{
 		MinMemory: 4096,
 		Firmware:  opts.firmware,
@@ -226,31 +245,15 @@ func testLivePXE(c cluster.TestCluster, opts IsoTestOpts) {
 	}
 
 	builder := &qemu.MachineBuilder{
-		InitBuilder:  initBuilder,
-		SetupDisks:   setupDisks,
-		SetupNetwork: setupNet,
+		InitBuilder:       initBuilder,
+		SetupDisks:        setupDisks,
+		SetupNetwork:      setupNet,
+		PostInstanceStart: switchBootOrder,
 	}
-	qm, err := qc.NewMachineWithBuilder(nil, options, builder)
+	_, err = qc.NewMachineWithBuilder(nil, options, builder)
 	if err != nil {
 		c.Fatal(errors.Wrap(err, "unable to create test machine"))
 	}
-	inst := qc.Instance(qm)
-	if inst == nil {
-		c.Fatalf("Failed to get QemuInstance from machine")
-	}
-
-	//check for error when switching boot order
-	go func() {
-		if err := CheckTestOutput(bootStartedOutput, []string{bootStartedSignal}); err != nil {
-			errchan <- err
-			return
-		}
-		if err := inst.SwitchBootOrder(); err != nil {
-			errchan <- errors.Wrapf(err, "switching boot order failed")
-			return
-		}
-	}()
-
 	if err := <-errchan; err != nil {
 		c.Fatal(err)
 	}

--- a/mantle/platform/machine/qemu/cluster.go
+++ b/mantle/platform/machine/qemu/cluster.go
@@ -351,13 +351,3 @@ func (qc *Cluster) SetupDefaultNetwork(options platform.MachineOptions, builder 
 	}
 	return nil
 }
-
-// Instance returns the underlying QemuInstance for a given Machine.
-// This allows tests to access QEMU-specific functionality.
-func (qc *Cluster) Instance(m platform.Machine) *platform.QemuInstance {
-	qm, ok := m.(*machine)
-	if !ok {
-		return nil
-	}
-	return qm.inst
-}

--- a/mantle/platform/machine/qemu/cluster.go
+++ b/mantle/platform/machine/qemu/cluster.go
@@ -51,6 +51,10 @@ type MachineBuilder struct {
 	SetupDisks func(options platform.MachineOptions, builder *platform.QemuBuilder) error
 	// SetupNetwork configures networking including port forwarding and additional NICs.
 	SetupNetwork func(options platform.MachineOptions, builder *platform.QemuBuilder) error
+	// PostInstanceStart is called after the QEMU instance is started but before waiting for SSH.
+	// This allows tests to perform actions like switching boot order or starting background
+	// monitoring tasks that need access to the running instance.
+	PostInstanceStart func(inst *platform.QemuInstance) error
 }
 
 func (qc *Cluster) NewMachine(userdata *conf.UserData) (platform.Machine, error) {
@@ -129,8 +133,14 @@ func (qc *Cluster) NewMachineWithBuilder(userdata any, options platform.MachineO
 	}
 	qm.inst = inst
 
+	if err := builder.PostInstanceStart(inst); err != nil {
+		qm.Destroy()
+		return nil, err
+	}
+
 	if qemuBuilder.UsermodeNetworking {
 		if err := qc.waitForSSHAddress(qm, inst); err != nil {
+			qm.Destroy()
 			return nil, err
 		}
 	}
@@ -201,6 +211,9 @@ func (qc *Cluster) ensureBuilderDefaults(builder *MachineBuilder) *MachineBuilde
 	}
 	if builder.SetupNetwork == nil {
 		builder.SetupNetwork = qc.SetupDefaultNetwork
+	}
+	if builder.PostInstanceStart == nil {
+		builder.PostInstanceStart = func(_ *platform.QemuInstance) error { return nil }
 	}
 
 	return builder


### PR DESCRIPTION
aarch64 and s390 do not support QEMU's `boot once=n`, so several tests must rely on `bootindex`. After a reboot, s390 boots from disk, but aarch64 starts again from the device with `bootindex=1`. This causes a problem: `StartMachine` blocks until SSH is available (or VM failed), so during PXE tests `SwitchBootOrder` is never called, leading to timeouts.