### PR TITLE
docs: Update docs for the test "CreationDate" field

### DIFF
--- a/docs/kola/external-tests.md
+++ b/docs/kola/external-tests.md
@@ -306,9 +306,10 @@ This key can only be specified if `exclusive` is marked `false` since
 `exclusive: true` tests are run exclusively in their own VM.  At runtime,
 this test will be separated from the tests it is conflicting with.
 
-If a test specifies a `creationDate`, kola will treat failures as warnings for 30 days
-after that date. This allows for new tests to be monitored without blocking CI. This
-date should be formatted as `YYYY-MM-DD`.
+If a test specifies a `creationDate`, kola will treat failures as
+warnings for a grace period (see `gracePeriod` in
+`mantle/kola/harness.go`). This allows for new tests to be monitored
+without blocking CI. This date should be formatted as `YYYY-MM-DD`.
 
 More recently, you can also (useful for shell scripts) include the JSON file
 inline per test, like this:

--- a/mantle/kola/register/register.go
+++ b/mantle/kola/register/register.go
@@ -71,7 +71,7 @@ type Test struct {
 	Timeout              time.Duration // the duration for which a test will be allowed to run
 	RequiredTag          string        // if specified, test is filtered by default unless tag is provided -- defaults to none
 	Description          string        // test description
-	CreationDate         string        // the date (YYYY-MM-DD) when the test was created, if this parameter is set, then errors will be treated as warnings for the first 30 days
+	CreationDate         string        // the date (YYYY-MM-DD) when the test was created, if set, errors will be treated as warnings for a period of time after this date (see gracePeriod in mantle/kola/harness.go)
 
 	// MachineOptions contains options for machine creation (disks, memory,
 	// kernel args, etc.). The test harness passes these to


### PR DESCRIPTION
Some of the docs introduced in #4518 contain hard coded values, which may in the future change leaving us with inaccurate docs. Instead, reference the file where the constant is located.

See: https://github.com/coreos/coreos-assembler/pull/4518#pullrequestreview-4083112698