### PR TITLE
deps-s390x: bring lorax dependency back

### DIFF
--- a/src/vmdeps-s390x.txt
+++ b/src/vmdeps-s390x.txt
@@ -2,3 +2,6 @@ s390utils-base
 
 # for Secure Execution
 veritysetup
+
+# for building iso image (see org.osbuild.coreos.live-artifacts.mono)
+lorax


### PR DESCRIPTION
On s390x lorax is required for building live iso images, for more details see https://github.com/osbuild/osbuild/blob/main/stages/org.osbuild.coreos.live-artifacts.mono