### PR TITLE
kola/tests/iso: skip iso.iso-fips on non-rhcos streams

### DIFF
--- a/mantle/kola/tests/iso/live-fips.go
+++ b/mantle/kola/tests/iso/live-fips.go
@@ -54,6 +54,10 @@ ExecStart=grep FIPS etc/crypto-policies/config
 RequiredBy=fips-signal-ok.service`
 
 func testLiveFIPS(c cluster.TestCluster, opts IsoTestOpts) {
+	if kola.CosaBuild.Meta.Name != "rhcos" {
+		c.Skip("Skipping fips test on non-rhcos streams")
+	}
+
 	EnsureLiveArtifactsExist(c)
 
 	qc, ok := c.Cluster.(*qemu.Cluster)


### PR DESCRIPTION
CentOS CoreOS may be without '.vmlinuz.hmac', causing this test to fail with errors like:
```
[   27.532529] dracut-pre-pivot[935]: Warning: /boot//.vmlinuz-5.14.0-701.el9.x86_64.hmac does not exist
[   28.292545] dracut: FATAL: FIPS integrity test failed
```
Limit this test to RHEL-based CoreOS only (as it was [before](https://github.com/coreos/coreos-assembler/blob/4ed662ace8fb2af7fbbb4a9f2d6da0f15cb03253/mantle/cmd/kola/testiso.go#L385-L387)).
