### PR TITLE
manifests/bootc: use install configs from the OCI

### DIFF
--- a/src/osbuild-manifests/build.raw-4k-image-bootc.ipp.yaml
+++ b/src/osbuild-manifests/build.raw-4k-image-bootc.ipp.yaml
@@ -211,16 +211,6 @@ pipelines:
             - mpp-format-string: '{extra_kargs}'
           target-imgref:
             mpp-format-string: '{container_imgref}'
-          stateroot:
-            mpp-format-string: '{osname}'
-          # Empty strings mean mount spec kargs are ommited entirely.
-          # See github.com/bootc-dev/bootc/issues/1441
-          boot-mount-spec: ""
-          root-mount-spec: ""
-          # We don't want bootupd to stamp the boot and UEFI paritions
-          # with the boot uuid because these will change at first boot.
-          # See https://github.com/coreos/fedora-coreos-config/pull/3898
-          bootupd-skip-boot-uuid: true
         devices:
           disk:
             type: org.osbuild.loopback

--- a/src/osbuild-manifests/build.raw-image-bootc.ipp.yaml
+++ b/src/osbuild-manifests/build.raw-image-bootc.ipp.yaml
@@ -197,16 +197,6 @@ pipelines:
             - mpp-format-string: '{extra_kargs}'
           target-imgref:
             mpp-format-string: '{container_imgref}'
-          stateroot:
-            mpp-format-string: '{osname}'
-          # Empty strings mean mount spec kargs are ommited entirely.
-          # See github.com/bootc-dev/bootc/issues/1441
-          boot-mount-spec: ""
-          root-mount-spec: ""
-          # We don't want bootupd to stamp the boot and UEFI paritions
-          # with the boot uuid because these will change at first boot.
-          # See https://github.com/coreos/fedora-coreos-config/pull/3898
-          bootupd-skip-boot-uuid: true
         devices:
           disk:
             type: org.osbuild.loopback


### PR DESCRIPTION
Instead of hard-coding some bootc install config here let's use the ones that are into the target container already.

Now that we use the target container as the buildroot the embedded configs will be sourced by bootc automatically : https://github.com/coreos/coreos-assembler/commit/364ccaebeb006c1653771158432541524954b604

Requires https://github.com/coreos/fedora-coreos-config/pull/4170