### PR TITLE
kola/harness: ensure CosaBuild is not nil

### DIFF
--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -406,7 +406,7 @@ func ParseDenyListYaml(pltfrm string) error {
 	// Get the stream variable from meta.json since DenylistStream is not specified
 	if len(DenylistStream) > 0 {
 		stream = DenylistStream
-	} else if CosaBuild.Meta.OciLabels != nil {
+	} else if CosaBuild != nil && CosaBuild.Meta != nil && CosaBuild.Meta.OciLabels != nil {
 		s := CosaBuild.Meta.OciLabels["com.coreos.stream"]
 		stream = string(s)
 	}


### PR DESCRIPTION
When running kola tests with `--qemu-image` directly (without a cosa build context), `CosaBuild` is nil. The `ParseDenyListYaml` function was attempting to access `CosaBuild.Meta.OciLabels`, causing a segmentation fault:
```
$ cosa kola run  --qemu-image fedora-coreos-44.20260505.20.dev0-qemu.x86_64.qcow2 
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x3699ed2]

goroutine 1 [running]:
github.com/coreos/coreos-assembler/mantle/kola.ParseDenyListYaml({0x7ffc704d9eab, 0x4})
        /root/containerbuild/mantle/kola/harness.go:409 +0x212
github.com/coreos/coreos-assembler/mantle/kola.runProvidedTests(0xc0007039e0, {0xc0004f3be8, 0x1, 0x1}, 0x0, 0x0, {0x6393ae0, 0x0, 0x0}, {0x7ffc704d9eab, ...}, ...)
        /root/containerbuild/mantle/kola/harness.go:704 +0x95
github.com/coreos/coreos-assembler/mantle/kola.RunTests(...)
        /root/containerbuild/mantle/kola/harness.go:1018
main.kolaRunPatterns({0xc0004f3be8, 0x1, 0x1}, 0x0)
        /root/containerbuild/mantle/cmd/kola/kola.go:277 +0x118
main.runRun(0x63615a0?, {0xc00054f860?, 0x0?, 0x6?})
        /root/containerbuild/mantle/cmd/kola/kola.go:211 +0x53
github.com/spf13/cobra.(*Command).execute(0x63615a0, {0xc00054f800, 0x6, 0x6})
        /root/containerbuild/vendor/github.com/spf13/cobra/command.go:1015 +0xb02
github.com/spf13/cobra.(*Command).ExecuteC(0x6360740)
        /root/containerbuild/vendor/github.com/spf13/cobra/command.go:1148 +0x465
github.com/spf13/cobra.(*Command).Execute(...)
        /root/containerbuild/vendor/github.com/spf13/cobra/command.go:1071
github.com/coreos/coreos-assembler/mantle/cli.Execute(0x6360740)
        /root/containerbuild/mantle/cli/cli.go:68 +0x1ea
main.main()
        /root/containerbuild/mantle/cmd/kola/kola.go:161 +0x1a
failed to execute cmd-kola: exit status 2

```