### PR TITLE
mantle/kola: remove --allow-rerun-success feature, keep flag as no-op

### DIFF
--- a/mantle/cmd/kola/kola.go
+++ b/mantle/cmd/kola/kola.go
@@ -22,7 +22,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
-	"strings"
 	"text/tabwriter"
 
 	"github.com/coreos/pkg/capnslog"
@@ -134,8 +133,8 @@ func init() {
 	root.AddCommand(cmdRun)
 	cmdRun.Flags().StringArrayVarP(&runExternals, "exttest", "E", nil, "Externally defined tests (will be found in DIR/tests/kola)")
 	cmdRun.Flags().IntVar(&runMultiply, "multiply", 0, "Run the provided tests N times (useful to find race conditions)")
-	cmdRun.Flags().BoolVar(&runRerunFlag, "rerun", false, "re-run failed tests once")
-	cmdRun.Flags().StringVar(&allowRerunSuccess, "allow-rerun-success", "", "Allow kola test run to be successful when tests with given 'tags=...[,...]' pass during re-run")
+	cmdRun.Flags().BoolVar(&runRerunFlag, "rerun", false, "re-run failed tests once (succeeds if tests pass on rerun)")
+	cmdRun.Flags().StringVar(&allowRerunSuccess, "allow-rerun-success", "", "Deprecated: this option is no longer supported and has no effect")
 
 	root.AddCommand(cmdList)
 	cmdList.Flags().StringArrayVarP(&runExternals, "exttest", "E", nil, "Externally defined tests in directory")
@@ -149,8 +148,8 @@ func init() {
 	root.AddCommand(cmdRunUpgrade)
 	cmdRunUpgrade.Flags().BoolVar(&findParentImage, "find-parent-image", false, "automatically find parent image if not provided -- note on qemu, this will download the image")
 	cmdRunUpgrade.Flags().StringVar(&qemuImageDir, "qemu-image-dir", "", "directory in which to cache QEMU images if --fetch-parent-image is enabled")
-	cmdRunUpgrade.Flags().BoolVar(&runRerunFlag, "rerun", false, "re-run failed tests once")
-	cmdRunUpgrade.Flags().StringVar(&allowRerunSuccess, "allow-rerun-success", "", "Allow kola test run to be successful when tests with given 'tags=...[,...]' pass during re-run")
+	cmdRunUpgrade.Flags().BoolVar(&runRerunFlag, "rerun", false, "re-run failed tests once (succeeds if tests pass on rerun)")
+	cmdRunUpgrade.Flags().StringVar(&allowRerunSuccess, "allow-rerun-success", "", "Deprecated: this option is no longer supported and has no effect")
 
 	root.AddCommand(cmdRerun)
 
@@ -237,27 +236,6 @@ func runRerun(cmd *cobra.Command, args []string) error {
 	return kolaRunPatterns(patterns, false)
 }
 
-// parseRerunSuccess converts rerun specification into a tags
-func parseRerunSuccess() ([]string, error) {
-	// In the future we may extend format to something like: <SELECTOR>[:<OPTIONS>]
-	//   SELECTOR
-	//     tags=...,...,...
-	//     tests=...,...,...
-	//   OPTIONS
-	//     n=...
-	//     allow-single=..
-	tags := []string{}
-	if len(allowRerunSuccess) == 0 {
-		return tags, nil
-	}
-	if !strings.HasPrefix(allowRerunSuccess, "tags=") {
-		return nil, fmt.Errorf("invalid rerun spec %s", allowRerunSuccess)
-	}
-	split := strings.TrimPrefix(allowRerunSuccess, "tags=")
-	tags = append(tags, strings.Split(split, ",")...)
-	return tags, nil
-}
-
 func kolaRunPatterns(patterns []string, rerun bool) error {
 	var err error
 	outputDir, err = kola.SetupOutputDir(outputDir, kolaPlatform)
@@ -269,12 +247,7 @@ func kolaRunPatterns(patterns []string, rerun bool) error {
 		return err
 	}
 
-	rerunSuccessTags, err := parseRerunSuccess()
-	if err != nil {
-		return err
-	}
-
-	runErr := kola.RunTests(patterns, runMultiply, rerun, rerunSuccessTags, kolaPlatform, outputDir)
+	runErr := kola.RunTests(patterns, runMultiply, rerun, kolaPlatform, outputDir)
 
 	// needs to be after RunTests() because harness empties the directory
 	if err := writeProps(); err != nil {

--- a/mantle/harness/harness.go
+++ b/mantle/harness/harness.go
@@ -79,7 +79,6 @@ type H struct {
 	warningOnFailure         bool
 
 	timeout   time.Duration // Duration for which the test will be allowed to run
-	timedout  bool          // A timeout was reached
 	execTimer *time.Timer   // Used to interrupt the test after timeout
 	// To signal that a timeout has occured to observers
 	timeoutContext context.Context
@@ -102,7 +101,6 @@ func (t *H) runTimeoutCheck(ctx context.Context, timeout time.Duration, f func()
 	// Timeout if call to function f takes too long
 	select {
 	case <-ctx.Done():
-		t.timedout = true
 		t.Fatalf("TIMEOUT[%v]: %s\n", timeout, errMsg)
 	case <-ioCompleted:
 		// Finish the test
@@ -312,11 +310,6 @@ func (c *H) Failed() bool {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.failed
-}
-
-// Reports if the test was stopped because a timeout was reached.
-func (c *H) TimedOut() bool {
-	return c.timedout
 }
 
 // FailNow marks the function as having failed and stops its execution.

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -184,17 +184,6 @@ var (
 			match: regexp.MustCompile("Oops:"),
 		},
 		{
-			// For this one we see it sometimes when I/O is really slow, which is often
-			// more of an indication of a problem with resources in our pipeline rather
-			// than a problem with the software we are testing. We'll mark it as warnOnly
-			// so it's non-fatal and also allow for a rerun of a test that goes on to
-			// fail that had this problem to ultimately result in success.
-			desc:              "kernel soft lockup",
-			match:             regexp.MustCompile("watchdog: BUG: soft lockup - CPU"),
-			warnOnly:          true,
-			allowRerunSuccess: true,
-		},
-		{
 			desc:  "kernel warning",
 			match: regexp.MustCompile(`WARNING: CPU: \d+ PID: \d+ at (.+)`),
 		},

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -84,11 +84,6 @@ const NeedsInternetTag = "needs-internet"
 // For more, see the doc in external-tests.md.
 const PlatformIndependentTag = "platform-independent"
 
-// The string for the tag that indicates a test has been marked as allowing rerun success.
-// In some cases the internal test framework will add this tag to a test to indicate if
-// the test passes a rerun to allow the run to succeed.
-const AllowRerunSuccessTag = "allow-rerun-success"
-
 // defaultPlatformIndependentPlatform is the platform where we run tests that claim platform independence
 const defaultPlatformIndependentPlatform = "qemu"
 
@@ -157,18 +152,16 @@ var (
 	nonexclusiveWrapperMatch = regexp.MustCompile(`^non-exclusive-test-bucket-[0-9]$`)
 
 	consoleChecks = []struct {
-		desc              string
-		match             *regexp.Regexp
-		warnOnly          bool
-		allowRerunSuccess bool
-		skipFlag          *register.Flag
+		desc     string
+		match    *regexp.Regexp
+		warnOnly bool
+		skipFlag *register.Flag
 	}{
 		{
-			desc:              "emergency shell",
-			match:             regexp.MustCompile("Press Enter for emergency shell|Starting Emergency Shell|You are in emergency mode"),
-			warnOnly:          false,
-			allowRerunSuccess: false,
-			skipFlag:          &[]register.Flag{register.NoEmergencyShellCheck}[0],
+			desc:     "emergency shell",
+			match:    regexp.MustCompile("Press Enter for emergency shell|Starting Emergency Shell|You are in emergency mode"),
+			warnOnly: false,
+			skipFlag: &[]register.Flag{register.NoEmergencyShellCheck}[0],
 		},
 		{
 			desc:     "dracut fatal",
@@ -353,13 +346,6 @@ func testRequiresInternet(test *register.Test) bool {
 
 func testSecureBoot(test *register.Test) bool {
 	return HasString(secureBoot, test.Tags)
-}
-
-func markTestForRerunSuccess(test *register.Test, msg string) {
-	if !HasString(AllowRerunSuccessTag, test.Tags) {
-		plog.Warningf("%s Adding as candidate for rerun success: %s", msg, test.Name)
-		test.Tags = append(test.Tags, AllowRerunSuccessTag)
-	}
 }
 
 type DenyListObj struct {
@@ -687,7 +673,7 @@ func applyGracePeriodWarnings(tests map[string]*register.Test) error {
 // register tests in their init() function.  outputDir is where various test
 // logs and data will be written for analysis after the test run. If it already
 // exists it will be erased!
-func runProvidedTests(testsBank map[string]*register.Test, patterns []string, multiply int, rerun bool, rerunSuccessTags []string, pltfrm, outputDir string) error {
+func runProvidedTests(testsBank map[string]*register.Test, patterns []string, multiply int, rerun bool, pltfrm, outputDir string) error {
 	var versionStr string
 
 	// Avoid incurring cost of starting machine in getClusterSemver when
@@ -867,14 +853,10 @@ func runProvidedTests(testsBank map[string]*register.Test, patterns []string, mu
 	if len(testsToRerun) > 0 && rerun {
 		newOutputDir := filepath.Join(outputDir, "rerun")
 		fmt.Printf("\n\n======== Re-running failed tests (flake detection) ========\n\n")
-		reRunErr := runProvidedTests(testsToRerun, []string{"*"}, multiply, false, rerunSuccessTags, pltfrm, newOutputDir)
-		if reRunErr == nil && allTestsAllowRerunSuccess(testsToRerun, rerunSuccessTags) {
-			runErr = nil       // reset to success since all tests allowed rerun success
+		runErr = runProvidedTests(testsToRerun, []string{"*"}, multiply, false, pltfrm, newOutputDir)
+		if runErr == nil {
 			numFailedTests = 0 // zero out the tally of failed tests
-		} else {
-			runErr = reRunErr
 		}
-
 	}
 
 	// Return ErrWarnOnTestFail when ONLY tests with warn:true feature failed
@@ -900,36 +882,6 @@ func getWarnTrueFailedTests(tests []*harness.H) []string {
 		}
 	}
 	return warnTrueFailedTests
-}
-
-func allTestsAllowRerunSuccess(testsToRerun map[string]*register.Test, rerunSuccessTags []string) bool {
-	// Always consider the special AllowRerunSuccessTag that is added
-	// by the test harness in some failure scenarios.
-	rerunSuccessTags = append(rerunSuccessTags, AllowRerunSuccessTag)
-	// Build up a map of rerunSuccessTags so that we can easily check
-	// if a given tag is in the map.
-	rerunSuccessTagMap := make(map[string]bool)
-	for _, tag := range rerunSuccessTags {
-		if tag == "all" || tag == "*" {
-			// If `all` or `*` is in rerunSuccessTags then we can return early
-			return true
-		}
-		rerunSuccessTagMap[tag] = true
-	}
-	// Iterate over the tests that were re-ran. If any of them don't
-	// allow rerun success then just exit early.
-	for _, test := range testsToRerun {
-		testAllowsRerunSuccess := false
-		for _, tag := range test.Tags {
-			if rerunSuccessTagMap[tag] {
-				testAllowsRerunSuccess = true
-			}
-		}
-		if !testAllowsRerunSuccess {
-			return false
-		}
-	}
-	return true
 }
 
 func GetBaseTestName(testName string) string {
@@ -1011,12 +963,12 @@ func getRerunnable(testsBank map[string]*register.Test, testResults []*harness.H
 	return testsToRerun
 }
 
-func RunTests(patterns []string, multiply int, rerun bool, rerunSuccessTags []string, pltfrm, outputDir string) error {
-	return runProvidedTests(register.Tests, patterns, multiply, rerun, rerunSuccessTags, pltfrm, outputDir)
+func RunTests(patterns []string, multiply int, rerun bool, pltfrm, outputDir string) error {
+	return runProvidedTests(register.Tests, patterns, multiply, rerun, pltfrm, outputDir)
 }
 
 func RunUpgradeTests(patterns []string, rerun bool, pltfrm, outputDir string) error {
-	return runProvidedTests(register.UpgradeTests, patterns, 0, rerun, nil, pltfrm, outputDir)
+	return runProvidedTests(register.UpgradeTests, patterns, 0, rerun, pltfrm, outputDir)
 }
 
 // externalTestMeta is parsed from kola.json in external tests
@@ -1861,10 +1813,6 @@ func runTest(h *harness.H, t *register.Test, pltfrm string, flight platform.Flig
 		c.Destroy()
 		// Release the memory reservation (if there was one) now that the VM is gone.
 		releaseMemoryCount(flight, t)
-		if h.TimedOut() {
-			// We'll allow tests that time out to succeed on rerun.
-			markTestForRerunSuccess(t, "Test timed out.")
-		}
 		if testSkipBaseChecks(t) {
 			plog.Debugf("Skipping base checks for %s", t.Name)
 			return
@@ -1911,9 +1859,6 @@ func runTest(h *harness.H, t *register.Test, pltfrm string, flight platform.Flig
 			return err
 		})
 		if err != nil {
-			// The platform failed starting machines, which usually isn't *CoreOS
-			// fault. Maybe it will have better luck in the rerun.
-			markTestForRerunSuccess(t, "Platform failed starting machines.")
 			h.Fatalf("Cluster failed starting machines: %v", err)
 		}
 	}
@@ -2059,11 +2004,10 @@ func ScpKolet(machines []platform.Machine) error {
 // descriptions of any bad lines it finds along with a boolean
 // indicating if the configuration has the bad lines marked as
 // warnOnly or not (for things we don't want to error for). If t is
-// specified, its flags are respected and tags possibly updated for
-// rerun success.
+// specified, its flags are respected.
 func CheckConsole(output []byte, t *register.Test) (bool, []string) {
 	var badlines []string
-	warnOnly, allowRerunSuccess := true, true
+	warnOnly := true
 	for _, check := range consoleChecks {
 		if check.skipFlag != nil && t != nil && t.HasFlag(*check.skipFlag) {
 			continue
@@ -2080,13 +2024,7 @@ func CheckConsole(output []byte, t *register.Test) (bool, []string) {
 			if !check.warnOnly {
 				warnOnly = false
 			}
-			if !check.allowRerunSuccess {
-				allowRerunSuccess = false
-			}
 		}
-	}
-	if len(badlines) > 0 && allowRerunSuccess && t != nil {
-		markTestForRerunSuccess(t, "CheckConsole:")
 	}
 	return warnOnly, badlines
 }


### PR DESCRIPTION
Remove all code implementing the `--allow-rerun-success` feature while keeping the flag
for backward compatibility (it now does nothing).
    
With this change, `--rerun` now always succeeds if failed tests pass on retry, effectively
behaving as the old `--rerun --allow-rerun-success tags=all` combination.

Issue: https://github.com/coreos/coreos-assembler/issues/4546