### PR TITLE
kola/harness: Adjust stream-based denylist filtering for --qemu-image and unknown streams

### DIFF
--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -346,6 +346,8 @@ func syncOptionsImpl(useCosa bool) error {
 		}
 	}
 
+	kola.QEMUOptions.DiskImageIsUserProvided = kola.QEMUOptions.DiskImage != ""
+
 	if foundCosa && useCosa {
 		if err := syncCosaOptions(); err != nil {
 			return err

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -125,7 +125,7 @@ var (
 
 	CosaBuild *util.LocalBuild // this is a parsed cosa build
 
-	TestParallelism int    //glue var to set test parallelism from main
+	TestParallelism int    // glue var to set test parallelism from main
 	TAPFile         string // if not "", write TAP results here
 	NoNet           bool   // Disable tests requiring Internet
 
@@ -143,7 +143,7 @@ var (
 	// SkipConsoleWarnings is set via SkipConsoleWarningsTag in kola-denylist.yaml
 	SkipConsoleWarnings bool
 	DenylistedTests     []string // tests which are on the denylist
-	DenylistStream      string   //denylist-stream
+	DenylistStream      string   // denylist-stream
 	WarnOnErrorTests    []string // denylisted tests we are going to run and warn in case of error
 	Tags                []string // tags to be ran
 
@@ -277,8 +277,10 @@ type KoletResult struct {
 	SoftReboot string
 }
 
-const KoletExtTestUnit = "kola-runext"
-const KoletRebootAckFifo = "/run/kolet-reboot-ack"
+const (
+	KoletExtTestUnit   = "kola-runext"
+	KoletRebootAckFifo = "/run/kolet-reboot-ack"
+)
 
 // Records failed tests for reruns
 type protectedTestResults struct {
@@ -940,6 +942,7 @@ func allTestsAllowRerunSuccess(testsToRerun map[string]*register.Test, rerunSucc
 	}
 	return true
 }
+
 func GetBaseTestName(testName string) string {
 	// If this is a non-exclusive wrapper then just return the empty string
 	if nonexclusiveWrapperMatch.MatchString(testName) {
@@ -1541,7 +1544,6 @@ func collectLogsExternalTest(h *harness.H, t *register.Test, tcluster cluster.Te
 }
 
 func createTestBuckets(tests []*register.Test) [][]*register.Test {
-
 	// Make an array of maps. Each entry in the array represents a
 	// test bucket. Each corresponding map is the test.Name -> *register.Test
 	// mapping for tests to be executed

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -403,15 +403,21 @@ func ParseDenyListYaml(pltfrm string) error {
 
 	var stream string
 
-	// Get the stream variable from meta.json since DenylistStream is not specified
+	// Get the stream variable from meta.json if DenylistStream is not specified
 	if len(DenylistStream) > 0 {
 		stream = DenylistStream
-	} else if CosaBuild != nil && CosaBuild.Meta != nil && CosaBuild.Meta.OciLabels != nil {
+	} else if !QEMUOptions.DiskImageIsUserProvided &&
+		CosaBuild != nil && CosaBuild.Meta != nil && CosaBuild.Meta.OciLabels != nil {
 		s := CosaBuild.Meta.OciLabels["com.coreos.stream"]
 		stream = string(s)
 	}
 	if stream == "" {
-		plog.Warningf("Stream could not be determined from '--denylist-stream' or meta.json. Stream-scoped denylist entries will not be applied (tests will not be skipped).")
+		commonLog := "Stream-scoped denylist entries will not be applied (tests will not be skipped)."
+		if QEMUOptions.DiskImageIsUserProvided {
+			plog.Warningf("Stream not set. Use '--denylist-stream' when using '--qemu-image'. %s", commonLog)
+		} else {
+			plog.Warningf("Stream could not be determined from '--denylist-stream' or meta.json. %s", commonLog)
+		}
 	}
 
 	// Get the current arch & current time

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -411,8 +411,7 @@ func ParseDenyListYaml(pltfrm string) error {
 		stream = string(s)
 	}
 	if stream == "" {
-		// In this case no stream was detected so we'll just continue best effort
-		plog.Warningf("Unable to determine stream from '--denylist-stream' or meta.json. Won't consider denials based on stream.")
+		plog.Warningf("Stream could not be determined from '--denylist-stream' or meta.json. Stream-scoped denylist entries will not be applied (tests will not be skipped).")
 	}
 
 	// Get the current arch & current time
@@ -432,7 +431,7 @@ func ParseDenyListYaml(pltfrm string) error {
 			continue
 		}
 
-		if len(stream) > 0 && len(obj.Streams) > 0 && !HasString(stream, obj.Streams) {
+		if len(obj.Streams) > 0 && !HasString(stream, obj.Streams) {
 			continue
 		}
 

--- a/mantle/platform/machine/qemu/flight.go
+++ b/mantle/platform/machine/qemu/flight.go
@@ -29,6 +29,8 @@ const (
 type Options struct {
 	// DiskImage is the full path to the disk image to boot in QEMU.
 	DiskImage string
+	// DiskImageIsUserProvided is true when DiskImage was explicitly set via --qemu-image
+	DiskImageIsUserProvided bool
 	// DiskSize if non-empty will expand the disk
 	DiskSize string
 	// DriveOpts is arbitrary comma-separated list of options


### PR DESCRIPTION
This one may be a bit opinionated so I'm very open to differing opinions and/or feedback.

I ran into a scenario I found confusing with `kola`. I tried running `kola run '*-rt-*' --qemu-image <rhel-10.2 image>` and found that denylist entries for c10s were getting applied, which I found very unintuitive. This was because even when `--qemu-image` is passed by the user, the stream is still taken from the local build's `meta.json`.

While changing this behaviour, I also realised that when the stream can't be determined, the default is to apply stream-scoped entries anyway (skip the tests).

With these changes:

1. When the user specifies `--qemu-image`, the stream is not read from the local build's `meta.json`
2. When the stream can't be determined, stream-scoped denylist entries are not applied (tests are not skipped)

I think 2. makes more sense in most scenarios, not just when running a `--qemu-image`. If the stream can't be determined, the issue should probably be investigated (or if using a QEMU image, `--denylist-stream` should be used). The lone log line can easily be missed when the tests are just skipped by default, but is a lot more likely to get seen when tests are failing.

Also worth noting that this shouldn't affect the pipelines since we don't use `--qemu-image` and we always pass `--build` (always has stream from `meta.json`): https://github.com/coreos/coreos-ci-lib/blob/e570b12f44b28e69f18eac336c93b45e59466af3/vars/kola.groovy#L57