### PR TITLE
cmd-buildfetch: add --decompress option

### DIFF
--- a/src/cmd-buildfetch
+++ b/src/cmd-buildfetch
@@ -193,6 +193,9 @@ def main():
         rm_allow_noent('builds/latest')
         os.symlink(buildid, 'builds/latest')
 
+    if args.decompress:
+        subprocess.check_call(['cosa', 'decompress', '--build', buildid])
+
 
 def parse_args():
     parser = argparse.ArgumentParser()
@@ -214,6 +217,8 @@ def parse_args():
                         help="Path to AWS config file")
     parser.add_argument("--find-build-for-arch", action='store_true',
                         help="Traverse build history to find latest for given architecture")
+    parser.add_argument("--decompress", action='store_true',
+                        help="Decompress fetched artifacts after downloading")
     return parser.parse_args()
 
 


### PR DESCRIPTION
Add a --decompress flag to 'cosa buildfetch' that calls 'cosa decompress --build <buildid>' after fetching. This addresses two problems.

1. You now run one command instead of two
2. You no longer have to guess the build ID for decompress

For 2. this is the issue 'cosa decompress' only operates on the latest build in builds/builds.json, making it difficult to decompress artifacts from older builds fetched via 'cosa buildfetch -b <older-build>'.

With this option, users can now run:

  cosa buildfetch --url URL -b 9.6.20250716-0 --artifact qemu --decompress

and have the fetched artifacts automatically decompressed.

Closes: https://github.com/coreos/coreos-assembler/issues/4225
Assisted-by: <anthropic/claude-opus-4.6>