### PR TITLE
test: FIPS does not setup bind mounts

### DIFF
--- a/mantle/kola/cluster/cluster.go
+++ b/mantle/kola/cluster/cluster.go
@@ -209,6 +209,16 @@ func (t *TestCluster) AssertCmdOutputContains(m platform.Machine, cmd string, ex
 	}
 }
 
+// AssertCmdOutputDoesNotContain runs cmd via SSH and panics if stdout contains unexpected
+func (t *TestCluster) AssertCmdOutputDoesNotContain(m platform.Machine, cmd string, unexpected string) {
+	t.LogJournal(m, "+ "+cmd)
+	outputBuf := t.MustSSH(m, cmd)
+	output := string(outputBuf)
+	if strings.Contains(output, unexpected) {
+		t.Fatalf("cmd %s unexpectedly contained %s", cmd, unexpected)
+	}
+}
+
 // AssertCmdOutputContains runs cmd via SSH and panics if stdout does not contain expected
 func (t *TestCluster) AssertCmdOutputMatches(m platform.Machine, cmd string, expected *regexp.Regexp) {
 	t.LogJournal(m, "+ "+cmd)

--- a/mantle/kola/tests/fips/fips.go
+++ b/mantle/kola/tests/fips/fips.go
@@ -147,4 +147,11 @@ func fipsEnableTest(c cluster.TestCluster) {
 	m := c.Machines()[0]
 	c.AssertCmdOutputContains(m, `cat /proc/sys/crypto/fips_enabled`, "1")
 	c.AssertCmdOutputContains(m, `update-crypto-policies --show`, "FIPS")
+	// There should be no mounts over crypto-policies.
+	//
+	// Bind mounts are generated over /etc/crypto-policies/back-ends
+	// when FIPS is not setup correctly, and the FIPS dracut module
+	// fixes it.
+	// See: https://github.com/coreos/rhel-coreos-config/pull/259
+	c.AssertCmdOutputDoesNotContain(m, `cat /proc/self/mountinfo`, "crypto-policies")
 }


### PR DESCRIPTION
On RHEL10, fips-mode-setup was removed. If the FIPS dracut module
doesn't call update-crypto-policies directly, the fips-crypto-policies
dracut module falls back to setting up read-only bind mounts over
/etc/crypto-policies, leading to issues.

Add a test assertion to verify that /etc/crypto-policies is configured
on-disk and not via bind mounts, ensuring the fix[1] in
rhel-coreos-config is working correctly.

[1] coreos/rhel-coreos-config#259