### PR TITLE
deps: drop python3-pyrsistent

### DIFF
--- a/rpms.in.yaml
+++ b/rpms.in.yaml
@@ -136,7 +136,6 @@ packages:
   - python3-koji
   - python3-koji-cli-plugins
   - python3-libvirt
-  - python3-pyrsistent
   - python3-pytest
   - python3-pytest-cov
   - python3-pyyaml

--- a/src/vmdeps.txt
+++ b/src/vmdeps.txt
@@ -27,7 +27,7 @@ python3-pyyaml python3-botocore python3-flufl-lock python3-tenacity
 ca-certificates
 
 # For running osbuild
-osbuild osbuild-ostree osbuild-selinux osbuild-tools python3-pyrsistent zip
+osbuild osbuild-ostree osbuild-selinux osbuild-tools zip
 
 # For resetting the terminal inside supermin shell
 /usr/bin/reset


### PR DESCRIPTION
This one have been included with the initial osbuild work but appears to no longer be used by osbuild and is orphaned in F44, so let's drop it.

See https://github.com/coreos/coreos-assembler/pull/4541