### PR TITLE
osbuild: Update nvidiabluefield manifest to use up to date capsule file for secure boot

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -197,6 +197,7 @@ patch_osbuild() {
     # shellcheck disable=SC2002
     cat \
         /usr/lib/coreos-assembler/0003-buildroot-bind-mount-run-udev-for-partition-discovery.patch \
+        /usr/lib/coreos-assembler/0001-stages-bfb-use-RedHat-capsule-and-drop-mlxbf_pmc-blacklist.patch \
             | patch -d /usr/lib/osbuild -p1
     # And then move the files back; supermin appliance creation will need it back
     # in the places delivered by the RPM.

--- a/src/0001-stages-bfb-use-RedHat-capsule-and-drop-mlxbf_pmc-blacklist.patch
+++ b/src/0001-stages-bfb-use-RedHat-capsule-and-drop-mlxbf_pmc-blacklist.patch
@@ -1,0 +1,55 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Eli Elgaev <eelgaev@redhat.com>
+Date: Sun, 8 Jun 2026 00:00:00 +0000
+Subject: [PATCH] stages/bfb: use RedHat capsule and drop mlxbf_pmc blacklist
+
+Use the Red Hat secure boot capsule file instead of the Mellanox
+boot_update2.cap, and remove the modprobe.blacklist=mlxbf_pmc kernel
+argument which is no longer needed.
+
+https://github.com/osbuild/osbuild/pull/2470
+---
+ stages/org.osbuild.bfb           | 5 ++---
+ stages/org.osbuild.bfb.meta.json | 3 +--
+ 2 files changed, 3 insertions(+), 5 deletions(-)
+
+diff --git a/stages/org.osbuild.bfb b/stages/org.osbuild.bfb
+index 9f16ed58..4b43016e 100755
+--- a/stages/org.osbuild.bfb
++++ b/stages/org.osbuild.bfb
+@@ -17,7 +17,7 @@ import osbuild.api
+ #
+ # Hardcode some firmware file paths in constants that we use below
+ DEFAULT_BFB_PATH = "/lib/firmware/mellanox/boot/default.bfb"
+-BOOT_CAPSULE_PATH = "/lib/firmware/mellanox/boot/capsule/boot_update2.cap"
++BOOT_CAPSULE_PATH = "/usr/share/redhat-cap/RedHat.cap"
+
+
+ def parse_input(inputs, name):
+@@ -52,8 +52,7 @@ def main(inputs, output, options):
+         "console=hvc0",
+         "console=ttyAMA0",
+         "earlycon=pl011,0x13010000",
+-        "initrd=initramfs",
+-        "modprobe.blacklist=mlxbf_pmc"
++        "initrd=initramfs"
+     ]
+     boot_args_v0 = " ".join(options.get("boot_args_v0", default_args_v0))
+     boot_args_v2 = " ".join(options.get("boot_args_v2", default_args_v2))
+diff --git a/stages/org.osbuild.bfb.meta.json b/stages/org.osbuild.bfb.meta.json
+index c519a1f8..c40a9ee2 100644
+--- a/stages/org.osbuild.bfb.meta.json
++++ b/stages/org.osbuild.bfb.meta.json
+@@ -55,8 +55,7 @@
+             "console=hvc0",
+             "console=ttyAMA0",
+             "earlycon=pl011,0x13010000",
+-            "initrd=initramfs",
+-            "modprobe.blacklist=mlxbf_pmc"
++            "initrd=initramfs"
+           ]
+         },
+         "boot_path": {
+--
+2.49.0
+

--- a/src/osbuild-manifests/platform.nvidiabluefield.yaml
+++ b/src/osbuild-manifests/platform.nvidiabluefield.yaml
@@ -113,7 +113,6 @@ pipelines:
             - "console=ttyAMA0"
             - "earlycon=pl011,0x13010000"
             - "initrd=initramfs"
-            - "modprobe.blacklist=mlxbf_pmc"
             - "ignition.firstboot"
             - "ignition.platform.id=nvidiabluefield"
           filename:

--- a/src/osbuild-manifests/platform.nvidiabluefield.yaml
+++ b/src/osbuild-manifests/platform.nvidiabluefield.yaml
@@ -7,6 +7,8 @@ sources:
         url: https://linux.mellanox.com/public/repo/doca/3.3.0/rhel9.6/arm64-dpu/mlxbf-bfscripts-3.6.0-1.el9.noarch.rpm
       sha256:b35ad0f987fd3870e11ad5dbec3340a019a456b7879caa4b82c944c4ff6841b4:
         url: https://linux.mellanox.com/public/repo/doca/3.3.0/rhel9.6/arm64-dpu/mlxbf-bootimages-signed-4.14.0-13878.aarch64.rpm
+      sha256:bd317d7072824ad2e89c0bdc6ceb8759aedab76fff1fa580f6e17b0a38b7ae0e:
+        url: https://github.com/NVIDIA/doca-platform/releases/download/v25.7.1/redhat-cap-1.0.0-1.noarch.rpm
 pipelines:
   - name: nvidiabluefield-buildroot
     stages:
@@ -36,6 +38,9 @@ pipelines:
               # mlxbf-bootimages-signed contains the binary blobs we use to build the BFB
               # https://linux.mellanox.com/public/repo/doca/3.3.0/rhel9.6/arm64-dpu/mlxbf-bootimages-signed-4.14.0-13878.aarch64.rpm
               sha256:b35ad0f987fd3870e11ad5dbec3340a019a456b7879caa4b82c944c4ff6841b4: {}
+              # redhat-cap contains NVIDIA capsule file with up to date Red Hat secure-boot certificates
+              # https://github.com/NVIDIA/doca-platform/releases/download/v25.7.1/redhat-cap-1.0.0-1.noarch.rpm
+              sha256:bd317d7072824ad2e89c0bdc6ceb8759aedab76fff1fa580f6e17b0a38b7ae0e: {}
         options:
           # The two RPMS above pull in more deps than we actually need for  mlx-mkbfb.py like
           # binutils and mlxbf-bootctl. Let's just install them without considering missing deps.
@@ -113,4 +118,3 @@ pipelines:
             - "ignition.platform.id=nvidiabluefield"
           filename:
               mpp-format-string: '{artifact_name_prefix}-nvidiabluefield.{arch}.bfb'
-

--- a/src/osbuild-manifests/platform.nvidiabluefield.yaml
+++ b/src/osbuild-manifests/platform.nvidiabluefield.yaml
@@ -3,10 +3,10 @@ version: '2'
 sources:
   org.osbuild.curl:
     items:
-      sha256:31291585b25881f633e9f4d7e97367d10413dd7877117fbf16b8eda5cb425ccc:
-        url: https://linux.mellanox.com/public/repo/doca/3.3.0/rhel9.6/arm64-dpu/mlxbf-bfscripts-3.6.0-1.el9.noarch.rpm
-      sha256:b35ad0f987fd3870e11ad5dbec3340a019a456b7879caa4b82c944c4ff6841b4:
-        url: https://linux.mellanox.com/public/repo/doca/3.3.0/rhel9.6/arm64-dpu/mlxbf-bootimages-signed-4.14.0-13878.aarch64.rpm
+      sha256:3dd8541c3d0cf527e71f861ff76967a90bc50f9181099022384621bb9fd5b461:
+        url: https://linux.mellanox.com/public/repo/doca/latest-3.2-LTS/rhel9.6/arm64-dpu/mlxbf-bfscripts-3.6.0-1.el9.noarch.rpm
+      sha256:40d3b4b048d4e9ed13892eeeeee5faed5c853bcd2ff7d4e8ee2a20e7d25ed0b2:
+        url: https://linux.mellanox.com/public/repo/doca/latest-3.2-LTS/rhel9.6/arm64-dpu/mlxbf-bootimages-signed-4.13.1-13827.aarch64.rpm
       sha256:bd317d7072824ad2e89c0bdc6ceb8759aedab76fff1fa580f6e17b0a38b7ae0e:
         url: https://github.com/NVIDIA/doca-platform/releases/download/v25.7.1/redhat-cap-1.0.0-1.noarch.rpm
 pipelines:
@@ -33,11 +33,11 @@ pipelines:
             references:
               # mlxbf-bfscripts contains the mlx-mkbfb.py, a python script that runs well with the stdlib
               # Using `rhel-9.6` here because the packages we need aren't in the rhel 10 versions of the repos yet.
-              # https://linux.mellanox.com/public/repo/doca/3.3.0/rhel9.6/arm64-dpu/mlxbf-bfscripts-3.6.0-1.el9.noarch.rpm
-              sha256:31291585b25881f633e9f4d7e97367d10413dd7877117fbf16b8eda5cb425ccc: {}
-              # mlxbf-bootimages-signed contains the binary blobs we use to build the BFB
-              # https://linux.mellanox.com/public/repo/doca/3.3.0/rhel9.6/arm64-dpu/mlxbf-bootimages-signed-4.14.0-13878.aarch64.rpm
-              sha256:b35ad0f987fd3870e11ad5dbec3340a019a456b7879caa4b82c944c4ff6841b4: {}
+              # https://linux.mellanox.com/public/repo/doca/latest-3.2-LTS/rhel9.6/arm64-dpu/mlxbf-bfscripts-3.6.0-1.el9.noarch.rpm
+              sha256:3dd8541c3d0cf527e71f861ff76967a90bc50f9181099022384621bb9fd5b461: {}
+              # mlxbf-bootimages-signed contains the default.bfb binary blob we use to build the BFB
+              # https://linux.mellanox.com/public/repo/doca/latest-3.2-LTS/rhel9.6/arm64-dpu/mlxbf-bootimages-signed-4.13.1-13827.aarch64.rpm
+              sha256:40d3b4b048d4e9ed13892eeeeee5faed5c853bcd2ff7d4e8ee2a20e7d25ed0b2: {}
               # redhat-cap contains NVIDIA capsule file with up to date Red Hat secure-boot certificates
               # https://github.com/NVIDIA/doca-platform/releases/download/v25.7.1/redhat-cap-1.0.0-1.noarch.rpm
               sha256:bd317d7072824ad2e89c0bdc6ceb8759aedab76fff1fa580f6e17b0a38b7ae0e: {}


### PR DESCRIPTION
Secure Boot Support: Added the `redhat-cap-1.0.0-1.noarch.rpm` package (hosted in an official NVIDIA github repository). This includes an updated capsule file with `CA-5`, `CA-6`, and `CA-8` certificates required for RHEL9 and RHEL10 secure boot.

DOCA Version Shift: Switched the dependency from DOCA 3.3.0 to the DOCA 3.2.x LTS versions.

Kernel Argument Cleanup: Removed `modprobe.blacklist=mlxbf_pmc` from the kernel arguments, as this issue has been resolved in recent RHEL10 kernels. 
[mlxbf-pmc: driver update to Linux v6.16 [Nvidia 10.2 FEAT]
](https://gitlab.com/redhat/centos-stream/src/kernel/centos-stream-10/-/merge_requests/1894
)

Linked PR: https://github.com/osbuild/osbuild/pull/2470