### PR TITLE
kola-junit: switch python-junit-xml to junitparser

### DIFF
--- a/rpms.in.yaml
+++ b/rpms.in.yaml
@@ -132,7 +132,7 @@ packages:
   - python3-flufl-lock
   - python3-gobject-base
   - python3-jsonschema
-  - python3-junit_xml
+  - python3-junitparser
   - python3-koji
   - python3-koji-cli-plugins
   - python3-libvirt

--- a/src/deps.txt
+++ b/src/deps.txt
@@ -74,7 +74,7 @@ python3-resultsdb_conventions-fedora
 python3-fedfind
 
 # For creating JUnit test results for Jenkins
-python3-junit_xml
+python3-junitparser
 
 # For debugging running processes in the pipelines
 strace

--- a/src/kola-junit
+++ b/src/kola-junit
@@ -9,9 +9,8 @@ import argparse
 import json
 import os
 import re
-import sys
 
-from junit_xml import TestSuite, TestCase
+from junitparser import TestSuite, TestCase, JUnitXml, Failure, Skipped
 
 
 parser = argparse.ArgumentParser()
@@ -91,9 +90,12 @@ for test in report['tests']:
         test['output'] += f"\n---\n{ext_test_out}"
     test['output'] = strip_ansi(test['output'])
 
+    tc = TestCase(test['name'])
+    tc.classname = args.classname + ".tests"
+    tc.time = test['duration'] / 10**9
+
     if test['result'] == 'PASS':
-        tc = TestCase(test['name'], args.classname + ".tests",
-                      test['duration'] / 10**9, test["output"])
+        tc.system_out = test["output"]
     else:
         # we only add console/journal for failing tests
         console_txt = None
@@ -108,19 +110,25 @@ for test in report['tests']:
                 with open(journal_fn, encoding='utf-8') as f:
                     journal_txt = f.read()
 
-        tc = TestCase(test['name'], args.classname + ".tests",
-                      test['duration'] / 10**9, console_txt, journal_txt)
+        tc.system_out = console_txt
+        tc.system_err = journal_txt
 
         if test["result"] == 'FAIL':
-            tc.add_failure_info(message="Test failed", output=test["output"])
+            fail = Failure("Test failed")
+            fail.text = test["output"]
+            tc.result = [fail]
         elif test["result"] == 'SKIP':
-            tc.add_skipped_info(message="Test skipped", output=test["output"])
+            skip = Skipped("Test skipped")
+            skip.text = test["output"]
+            tc.result = [skip]
 
     test_cases.append(tc)
 
-ts = TestSuite(args.classname, test_cases)
+ts = TestSuite(args.classname)
+ts.add_testcases(test_cases)
+xml = JUnitXml()
+xml.add_testsuite(ts)
 if args.output == '-':
-    TestSuite.to_file(sys.stdout, [ts])
+    xml.write('/dev/stdout')
 else:
-    with open(args.outputxml, "w", encoding='utf-8') as f:
-        TestSuite.to_file(f, [ts])
+    xml.write(args.output)

--- a/src/kola-junit
+++ b/src/kola-junit
@@ -30,6 +30,12 @@ def strip_ansi(text):
     return ansi_escape.sub('', text)
 
 
+def strip_control_chars(text):
+    if text is None:
+        return text
+    return re.sub(r'[\x00-\x08\x0b\x0c\x0e-\x1f]', '', text)
+
+
 # In a {kola_outputdir}/{testname}/ dir, there can be multiple directories; one
 # per host that was brought up. e.g. the Tang test brings up a Tang server in a
 # separate host. We can only report one host, so we choose the one whose dir
@@ -88,7 +94,7 @@ for test in report['tests']:
     # for external tests; we append the kola-runext.service output
     if ext_test_out is not None:
         test['output'] += f"\n---\n{ext_test_out}"
-    test['output'] = strip_ansi(test['output'])
+    test['output'] = strip_control_chars(strip_ansi(test['output']))
 
     tc = TestCase(test['name'])
     tc.classname = args.classname + ".tests"
@@ -104,11 +110,11 @@ for test in report['tests']:
             console_fn = os.path.join(host_dir, "console.txt")
             if os.path.isfile(console_fn):
                 with open(console_fn, encoding='utf-8') as f:
-                    console_txt = strip_ansi(f.read())
+                    console_txt = strip_control_chars(strip_ansi(f.read()))
             journal_fn = os.path.join(host_dir, "journal.txt")
             if os.path.isfile(journal_fn):
                 with open(journal_fn, encoding='utf-8') as f:
-                    journal_txt = f.read()
+                    journal_txt = strip_control_chars(f.read())
 
         tc.system_out = console_txt
         tc.system_err = journal_txt


### PR DESCRIPTION
python-junit-xml was orphaned in Fedora 44, blocking the COSA rebase. Replacing it here with junitparser, which is actively maintained.

Closes #4573