### PR TITLE
kola/tests: iso/iscsi: adjust volume mount for boot.ipxe

### DIFF
--- a/mantle/kola/tests/iso/iscsi_butane_setup.yaml
+++ b/mantle/kola/tests/iso/iscsi_butane_setup.yaml
@@ -103,7 +103,7 @@ storage:
           # saves us pulling 4+ GiB COSA container from quay.
           # makes it so we don't have to pull down COSA from quay
           Rootfs=/var/cosaroot
-          Volume=/srv/boot.ipxe:/srv/boot.ipxe
+          Volume=/srv/boot.ipxe:/root/boot.ipxe
           # Add the testisocompletion virtio-serial device. Usually
           # you don't need to explicitly specify devices when running
           # as --privileged, but without this the /dev/virtio-ports/*
@@ -119,7 +119,7 @@ storage:
           PodmanArgs=--privileged
           Network=host
           LogDriver=passthrough
-          Exec=kola qemuexec --netboot /srv/boot.ipxe --qemu-swtpm=false --usernet-addr 10.0.3.0/24 -- -device virtio-serial -chardev file,id=iscsi-completion-virtio,path=/dev/virtio-ports/testisocompletion,append=on -device virtserialport,chardev=iscsi-completion-virtio,name=testisocompletion
+          Exec=kola qemuexec --netboot /root/boot.ipxe --qemu-swtpm=false --usernet-addr 10.0.3.0/24 -- -device virtio-serial -chardev file,id=iscsi-completion-virtio,path=/dev/virtio-ports/testisocompletion,append=on -device virtserialport,chardev=iscsi-completion-virtio,name=testisocompletion
           [Install]
           # Start by default on boot
           WantedBy=multi-user.target


### PR DESCRIPTION
Using /srv here in the past was special. In some cases the COSA workdir is `/srv` and in others (like in prow) it's some directory in /tmp/ (like /tmp/cosa), which somehow made the test pass in jenkins/local but fail in prow.

To reproduce the issue locally you could try to change it to `Volume=/srv/boot.ipxe:/mnt/boot.ipxe` to observe the same failure as viewed in prow, which is something like:

```
open `/var/cosaroot/srv/boot.ipxe`: No such file or directory
Error: crun: open `/var/cosaroot/srv/boot.ipxe`: No such file or directory: OCI runtime attempted to invoke a command that was not found
```

in the `nested_vm_console.txt`.

The fix here is to just use a directory we know will be writable. Since we use /root as our workdir here let's just put it there.