### PR TITLE
drop journal.txt.gz; use virtio journal on qemu

### DIFF
--- a/docs/kola.md
+++ b/docs/kola.md
@@ -196,7 +196,6 @@ After you run the kola test, you can find more information in `tmp/kola/<test-na
 1. `journal.txt`
 2. `console.txt`
 3. `ignition.json`
-4. `journal-raw.txt.gz`
 
 ## Extended artifacts
 

--- a/mantle/cmd/kola/devshell.go
+++ b/mantle/cmd/kola/devshell.go
@@ -65,7 +65,7 @@ func displayStatusMsg(ontty bool, status, msg string, termMaxWidth int) {
 	fmt.Printf("\033[2K\r%s", s)
 }
 
-func runDevShellSSH(ctx context.Context, builder *platform.QemuBuilder, conf *conf.Conf, sshCommand string) error {
+func runDevShellSSH(ctx context.Context, builder *platform.QemuBuilder, config *conf.Conf, sshCommand string) error {
 	ontty := term.IsTerminal(0)
 	if sshCommand == "" {
 		if !ontty {
@@ -95,8 +95,8 @@ func runDevShellSSH(ctx context.Context, builder *platform.QemuBuilder, conf *co
 		return err
 	}
 
-	conf.CopyKeys(keys)
-	builder.SetConfig(conf)
+	config.CopyKeys(keys)
+	builder.SetConfig(config)
 
 	// errChan communicates errors from go routines
 	errChan := make(chan error)
@@ -105,7 +105,7 @@ func runDevShellSSH(ctx context.Context, builder *platform.QemuBuilder, conf *co
 	// stateChan reports in-instance state such as shutdown, reboot, etc.
 	stateChan := make(chan guestState)
 
-	if err = watchJournal(builder, conf, stateChan, errChan); err != nil {
+	if err = watchJournal(builder, config, stateChan, errChan); err != nil {
 		return err
 	}
 
@@ -400,7 +400,7 @@ const (
 
 // watchJournal watches the virtio journal to monitor for events. This method is NOT 100%
 // reliable as the journal may not have started or stopped in time.
-func watchJournal(builder *platform.QemuBuilder, conf *conf.Conf, stateChan chan<- guestState, errChan chan<- error) error {
+func watchJournal(builder *platform.QemuBuilder, config *conf.Conf, stateChan chan<- guestState, errChan chan<- error) error {
 	checkList := []systemdMessageCheck{
 		{
 			unit:       "sshd.service",
@@ -442,7 +442,7 @@ func watchJournal(builder *platform.QemuBuilder, conf *conf.Conf, stateChan chan
 		},
 	}
 
-	r, err := builder.VirtioJournal(conf, "-o json --system")
+	r, err := builder.VirtioJournal(config, "-o json --system")
 	if err != nil {
 		return err
 	}

--- a/mantle/kola/tests/iso/live-iso.go
+++ b/mantle/kola/tests/iso/live-iso.go
@@ -140,6 +140,7 @@ func runIsoTest(qc *qemu.Cluster, opts IsoTestOpts, tempdir string) error {
 	}
 
 	targetConfig.CopyKeys(keys)
+	targetConfig.AddVirtioJournalUnit() // print journal to virtio in installed system
 	targetConfig.AddSystemdUnit("coreos-test-installer.service", signalCompletionUnit, conf.Enable)
 	targetConfig.AddSystemdUnit("coreos-test-entered-emergency-target.service", signalFailureUnit, conf.Enable)
 	targetConfig.AddSystemdUnit("coreos-test-installer-no-ignition.service", checkNoIgnition, conf.Enable)

--- a/mantle/kola/tests/iso/live-pxe.go
+++ b/mantle/kola/tests/iso/live-pxe.go
@@ -117,6 +117,7 @@ func testLivePXE(c cluster.TestCluster, opts IsoTestOpts) {
 		c.Fatal(err)
 	}
 	targetConfig.CopyKeys(keys)
+	targetConfig.AddVirtioJournalUnit() // print journal to virtio in installed system
 	targetConfig.AddSystemdUnit("coreos-test-installer.service", signalCompletionUnit, conf.Enable)
 	targetConfig.AddSystemdUnit("coreos-test-entered-emergency-target.service", signalFailureUnit, conf.Enable)
 	targetConfig.AddSystemdUnit("coreos-test-installer-no-ignition.service", checkNoIgnition, conf.Enable)

--- a/mantle/network/journal/record.go
+++ b/mantle/network/journal/record.go
@@ -114,6 +114,15 @@ func (r *Recorder) StartSSH(ctx context.Context, client *ssh.Client) error {
 	return nil
 }
 
+func (r *Recorder) StartFile(journalInputPipe io.Reader) error {
+	go func() {
+		err := r.record(journalInputPipe)
+		r.status <- err
+	}()
+
+	return nil
+}
+
 func (r *Recorder) StartLocal(ctx context.Context) error {
 	cmd := r.journalctl()
 	journal := exec.CommandContext(ctx, cmd[0], cmd[1:]...)

--- a/mantle/network/journal/record.go
+++ b/mantle/network/journal/record.go
@@ -29,13 +29,11 @@ type Recorder struct {
 	formatter Formatter
 	cursor    string
 	status    chan error
-	rawFile   io.WriteCloser
 }
 
-func NewRecorder(f Formatter, rawFile io.WriteCloser) *Recorder {
+func NewRecorder(f Formatter) *Recorder {
 	return &Recorder{
 		formatter: f,
-		rawFile:   rawFile,
 		status:    make(chan error, 1),
 	}
 }
@@ -52,8 +50,7 @@ func (r *Recorder) journalctl() []string {
 }
 
 func (r *Recorder) record(export io.Reader) error {
-	exportTee := io.TeeReader(export, r.rawFile)
-	src := NewExportReader(exportTee)
+	src := NewExportReader(export)
 	for {
 		entry, err := src.ReadEntry()
 		if err != nil {

--- a/mantle/network/journal/record_test.go
+++ b/mantle/network/journal/record_test.go
@@ -42,16 +42,6 @@ func (n nullFormatter) WriteEntry(entry Entry) error {
 	return nil
 }
 
-type discardCloser struct{}
-
-func (d discardCloser) Close() error {
-	return nil
-}
-
-func (d discardCloser) Write(b []byte) (int, error) {
-	return io.Discard.Write(b)
-}
-
 // Escapes ; chars in cursor with \
 // May need tweaking if the shellquote library behavior ever changes.
 func journalAfterEsc(cursor string) string {
@@ -72,7 +62,7 @@ func TestRecorderSSH(t *testing.T) {
 		}
 	})
 
-	recorder := NewRecorder(nullFormatter{}, discardCloser{})
+	recorder := NewRecorder(nullFormatter{})
 	if err := recorder.RunSSH(ctx, client); err != nil {
 		t.Fatal(err)
 	}
@@ -127,7 +117,7 @@ func TestRecorderSSHCancel(t *testing.T) {
 		// Skip close, let the connection hang.
 	})
 
-	recorder := NewRecorder(nullFormatter{}, discardCloser{})
+	recorder := NewRecorder(nullFormatter{})
 	if err := recorder.StartSSH(ctx, client); err != nil {
 		t.Fatal(err)
 	}

--- a/mantle/platform/api/esx/api.go
+++ b/mantle/platform/api/esx/api.go
@@ -313,12 +313,12 @@ func (a *API) CleanupDevice(name string) error {
 	return nil
 }
 
-func (a *API) CreateDevice(name string, conf *conf.Conf) (*ESXMachine, error) {
+func (a *API) CreateDevice(name string, config *conf.Conf) (*ESXMachine, error) {
 	if a.options.BaseVMName == "" {
 		return nil, fmt.Errorf("Base VM Name must be supplied")
 	}
 
-	userdata := base64.StdEncoding.EncodeToString(conf.Bytes())
+	userdata := base64.StdEncoding.EncodeToString(config.Bytes())
 
 	defaults, err := a.getServerDefaults()
 	if err != nil {

--- a/mantle/platform/conf/conf.go
+++ b/mantle/platform/conf/conf.go
@@ -78,6 +78,10 @@ const (
 	FailWarnings
 )
 
+// VirtioJournalDeviceName is the name of the virtio-serial device used
+// for streaming the systemd journal out of a guest VM.
+const VirtioJournalDeviceName = "mantlejournal"
+
 var plog = capnslog.NewPackageLogger("github.com/coreos/coreos-assembler/mantle", "platform/conf")
 
 // UserData is an immutable, unvalidated configuration for a CoreOS
@@ -1664,6 +1668,47 @@ Options=%s
 WantedBy=multi-user.target
 `, dest, dest, mountType, options)
 	c.AddSystemdUnit(fmt.Sprintf("%s.mount", systemdunit.UnitNameEscape(dest[1:])), content, Enable)
+}
+
+// AddVirtioJournalUnit adds a systemd unit that streams the systemd journal
+// to a virtio-serial device name defined by the VirtioJournalDeviceName constant.
+//   - queryArguments is an optional override for the journalctl arguments.
+//     By default the journal is streamed in systemd export format with all
+//     lines (--output=export --lines=all). See `man journalctl` for more
+//     information.
+func (c *Conf) AddVirtioJournalUnit(queryArguments ...string) {
+	args := "--output=export --lines=all"
+	if len(queryArguments) > 0 {
+		args = strings.Join(queryArguments, " ")
+	}
+	var streamJournalUnit = fmt.Sprintf(`[Unit]
+	Requires=dev-virtio\\x2dports-%s.device
+	IgnoreOnIsolate=true
+	# DefaultDependencies=false so that Requires=sysinit.target
+	# won't be added to this unit, which would cause it to get
+	# taken down when isolating to emergency.target
+	DefaultDependencies=no
+	After=systemd-journald.socket
+	# Do however ensure we get killed before /var is going to be
+	# unmounted, otherwise we keep it open.
+	After=local-fs.target
+	# Do get killed on shutdown
+	Conflicts=shutdown.target
+	# After systemd-journal-flush because otherwise the journalctl -f
+	# below will stop when the journal is flushed. Not sure if this is
+	# a bug or intended behavior.
+	After=systemd-journal-flush.service
+	[Service]
+	Type=simple
+	StandardOutput=file:/dev/virtio-ports/%s
+	# Wrap in /bin/bash to hack around SELinux
+	# https://bugzilla.redhat.com/show_bug.cgi?id=1942198
+	ExecStart=/usr/bin/bash -c "journalctl -q -b -f --no-tail %s"
+	[Install]
+	RequiredBy=basic.target
+	`, VirtioJournalDeviceName, VirtioJournalDeviceName, args)
+
+	c.AddSystemdUnit("mantle-virtio-journal-stream.service", streamJournalUnit, Enable)
 }
 
 func makeGzipDataUrl(data []byte) (string, error) {

--- a/mantle/platform/journal.go
+++ b/mantle/platform/journal.go
@@ -15,14 +15,12 @@
 package platform
 
 import (
-	"compress/gzip"
 	"context"
 	"io"
 	"os"
 	"path/filepath"
 	"time"
 
-	"github.com/coreos/pkg/multierror"
 	"github.com/pkg/errors"
 
 	"github.com/coreos/coreos-assembler/mantle/network/journal"
@@ -36,31 +34,13 @@ type Journal struct {
 	// the recorder goroutine persists across guest reboots.
 	journalInputPipe io.ReadCloser
 	journal          io.WriteCloser
-	journalRaw       io.WriteCloser
 	journalPath      string
 	recorder         *journal.Recorder
 	cancel           context.CancelFunc
 }
 
-// wrapper that also closes the underlying file
-type gzWriteCloser struct {
-	*gzip.Writer
-	underlying io.Closer
-}
-
-func (g gzWriteCloser) Close() error {
-	var err multierror.Error
-	if e := g.Writer.Close(); e != nil {
-		err = append(err, e)
-	}
-	if e := g.underlying.Close(); e != nil {
-		err = append(err, e)
-	}
-	return err.AsError()
-}
-
 // NewJournal creates a Journal recorder that will log to "journal.txt"
-// and "journal-raw.txt.gz" inside the given output directory.
+// inside the given output directory.
 func NewJournal(dir string) (*Journal, error) {
 	p := filepath.Join(dir, "journal.txt")
 	j, err := os.OpenFile(p, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0666)
@@ -68,25 +48,9 @@ func NewJournal(dir string) (*Journal, error) {
 		return nil, err
 	}
 
-	pr := filepath.Join(dir, "journal-raw.txt.gz")
-	jr, err := os.OpenFile(pr, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0666)
-	if err != nil {
-		return nil, err
-	}
-	// gzip to save space; a single test can generate well over 1M of logs
-	jrz, err := gzip.NewWriterLevel(jr, gzip.BestCompression)
-	if err != nil {
-		return nil, err
-	}
-	jrzc := gzWriteCloser{
-		underlying: jr,
-		Writer:     jrz,
-	}
-
 	return &Journal{
 		journal:     j,
-		journalRaw:  jrzc,
-		recorder:    journal.NewRecorder(journal.ShortWriter(j), jrzc),
+		recorder:    journal.NewRecorder(journal.ShortWriter(j)),
 		journalPath: p,
 	}, nil
 }
@@ -168,8 +132,5 @@ func (j *Journal) Destroy() {
 	}
 	if err := j.journal.Close(); err != nil {
 		plog.Errorf("Failed to close journal: %v", err)
-	}
-	if err := j.journalRaw.Close(); err != nil {
-		plog.Errorf("Failed to close raw journal: %v", err)
 	}
 }

--- a/mantle/platform/journal.go
+++ b/mantle/platform/journal.go
@@ -17,7 +17,6 @@ package platform
 import (
 	"compress/gzip"
 	"context"
-	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -89,7 +88,7 @@ func NewJournal(dir string) (*Journal, error) {
 }
 
 // Start begins/resumes streaming the system journal to journal.txt.
-func (j *Journal) Start(m Machine, oldBootId string) error {
+func (j *Journal) Start(m Machine) error {
 	if j.cancel != nil {
 		j.cancel()
 		j.cancel = nil
@@ -102,15 +101,6 @@ func (j *Journal) Start(m Machine, oldBootId string) error {
 	ctx, cancel := context.WithCancel(ctx)
 
 	start := func() error {
-		if oldBootId != "" {
-			bootId, err := GetMachineBootId(m)
-			if err != nil {
-				return err
-			} else if bootId == oldBootId {
-				return fmt.Errorf("found old boot ID %s (likely still rebooting)", oldBootId)
-			}
-		}
-
 		client, err := m.SSHClient()
 		if err != nil {
 			return err

--- a/mantle/platform/journal.go
+++ b/mantle/platform/journal.go
@@ -31,11 +31,15 @@ import (
 
 // Journal manages recording the journal of a Machine.
 type Journal struct {
-	journal     io.WriteCloser
-	journalRaw  io.WriteCloser
-	journalPath string
-	recorder    *journal.Recorder
-	cancel      context.CancelFunc
+	// journalInputPipe, when non-nil, indicates journal recording is
+	// handled via a virtio pipe rather than SSH. Once set and started,
+	// the recorder goroutine persists across guest reboots.
+	journalInputPipe io.ReadCloser
+	journal          io.WriteCloser
+	journalRaw       io.WriteCloser
+	journalPath      string
+	recorder         *journal.Recorder
+	cancel           context.CancelFunc
 }
 
 // wrapper that also closes the underlying file
@@ -87,8 +91,22 @@ func NewJournal(dir string) (*Journal, error) {
 	}, nil
 }
 
+// StartVirtioJournal begins recording the journal from a virtio pipe.
+// The pipe persists across guest reboots, so this only needs to be
+// called once. Subsequent calls to Start() will be no-ops.
+func (j *Journal) StartVirtioJournal(pipe io.ReadCloser) error {
+	j.journalInputPipe = pipe
+	return j.recorder.StartFile(pipe)
+}
+
 // Start begins/resumes streaming the system journal to journal.txt.
 func (j *Journal) Start(m Machine) error {
+	// If a virtio pipe journal is active, it persists across reboots
+	// and there is nothing to do.
+	if j.journalInputPipe != nil {
+		return nil
+	}
+
 	if j.cancel != nil {
 		j.cancel()
 		j.cancel = nil
@@ -133,6 +151,17 @@ func (j *Journal) Read() ([]byte, error) {
 func (j *Journal) Destroy() {
 	if j.cancel != nil {
 		j.cancel()
+		if err := j.recorder.Wait(); err != nil {
+			plog.Errorf("j.recorder.Wait() failed: %v", err)
+		}
+	}
+	if j.journalInputPipe != nil {
+		if err := j.journalInputPipe.Close(); err != nil {
+			plog.Errorf("Failed to close journal input pipe: %v", err)
+		}
+		// Wait for the recorder goroutine to exit after closing the virtio
+		// journal input pipe. Without this, the goroutine may still be writing
+		// to j.journal when j.journal.Close() is called.
 		if err := j.recorder.Wait(); err != nil {
 			plog.Errorf("j.recorder.Wait() failed: %v", err)
 		}

--- a/mantle/platform/machine/qemu/cluster.go
+++ b/mantle/platform/machine/qemu/cluster.go
@@ -131,7 +131,7 @@ func (qc *Cluster) NewMachineWithBuilder(userdata any, options platform.MachineO
 	// (if we have a config to add it to) so that we'll get it even
 	// if offline OR if networking for some reason doesn't come up.
 	if config != nil {
-		journalPipe, err := qemuBuilder.VirtioJournal(config, "--output=export --lines=all")
+		journalPipe, err := qemuBuilder.VirtioJournal(config)
 		if err != nil {
 			qm.Destroy()
 			return nil, err

--- a/mantle/platform/machine/qemu/cluster.go
+++ b/mantle/platform/machine/qemu/cluster.go
@@ -127,6 +127,21 @@ func (qc *Cluster) NewMachineWithBuilder(userdata any, options platform.MachineO
 		}
 	}
 
+	// Since we are on qemu let's just use non-network based journal
+	// (if we have a config to add it to) so that we'll get it even
+	// if offline OR if networking for some reason doesn't come up.
+	if config != nil {
+		journalPipe, err := qemuBuilder.VirtioJournal(config, "--output=export --lines=all")
+		if err != nil {
+			qm.Destroy()
+			return nil, err
+		}
+		if err := qm.journal.StartVirtioJournal(journalPipe); err != nil {
+			qm.Destroy()
+			return nil, err
+		}
+	}
+
 	inst, err := qemuBuilder.Exec()
 	if err != nil {
 		return nil, err

--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -1752,44 +1752,16 @@ func (builder *QemuBuilder) SerialPipe() (*os.File, error) {
 
 // VirtioJournal configures the OS and VM to stream the systemd journal
 // (post-switchroot) over a virtio-serial channel.
-//   - The first parameter is a poitner to the configuration of the target VM.
-//   - The second parameter is an optional queryArguments to filter the stream -
-//     see `man journalctl` for more information.
+//   - The first parameter is a pointer to the configuration of the target VM.
+//   - The second parameter (optional) is queryArguments to filter the stream -
+//     passed through to AddVirtioJournalUnit(queryArguments...)
 //   - The return value is a file stream which will be newline-separated JSON.
-func (builder *QemuBuilder) VirtioJournal(config *conf.Conf, queryArguments string) (*os.File, error) {
-	stream, err := builder.VirtioChannelRead("mantlejournal")
+func (builder *QemuBuilder) VirtioJournal(config *conf.Conf, queryArguments ...string) (*os.File, error) {
+	stream, err := builder.VirtioChannelRead(conf.VirtioJournalDeviceName)
 	if err != nil {
 		return nil, err
 	}
-	var streamJournalUnit = fmt.Sprintf(`[Unit]
-	Requires=dev-virtio\\x2dports-mantlejournal.device
-	IgnoreOnIsolate=true
-	# DefaultDependencies=false so that Requires=sysinit.target
-	# won't be added to this unit, which would cause it to get
-	# taken down when isolating to emergency.target
-	DefaultDependencies=no
-	After=systemd-journald.socket
-	# Do however ensure we get killed before /var is going to be
-	# unmounted, otherwise we keep it open.
-	After=local-fs.target
-	# Do get killed on shutdown
-	Conflicts=shutdown.target
-	# After systemd-journal-flush because otherwise the journalctl -f
-	# below will stop when the journal is flushed. Not sure if this is
-	# a bug or intended behavior.
-	After=systemd-journal-flush.service
-	[Service]
-	Type=simple
-	StandardOutput=file:/dev/virtio-ports/mantlejournal
-	# Wrap in /bin/bash to hack around SELinux
-	# https://bugzilla.redhat.com/show_bug.cgi?id=1942198
-	ExecStart=/usr/bin/bash -c "journalctl -q -b -f --no-tail %s"
-	[Install]
-	RequiredBy=basic.target
-	`, queryArguments)
-
-	config.AddSystemdUnit("mantle-virtio-journal-stream.service", streamJournalUnit, conf.Enable)
-
+	config.AddVirtioJournalUnit(queryArguments...)
 	return stream, nil
 }
 

--- a/mantle/platform/util.go
+++ b/mantle/platform/util.go
@@ -15,6 +15,7 @@
 package platform
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"fmt"
@@ -26,6 +27,8 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/term"
+
+	"github.com/coreos/coreos-assembler/mantle/util"
 )
 
 // Manhole connects os.Stdin, os.Stdout, and os.Stderr to an interactive shell
@@ -130,7 +133,7 @@ func WaitForMachineReboot(m Machine, j *Journal, timeout time.Duration, oldBootI
 	// we *require* the old boot ID, otherwise there's no way to know if the
 	// machine already rebooted
 	if oldBootId == "" {
-		panic("unreachable: oldBootId empty")
+		return fmt.Errorf("Need to pass in oldBootId to WaitForMachineReboot()")
 	}
 
 	// Run a command that stays blocked until we're killed by the reboot process
@@ -176,8 +179,17 @@ func WaitForMachineReboot(m Machine, j *Journal, timeout time.Duration, oldBootI
 }
 
 func StartMachineAfterReboot(m Machine, j *Journal, oldBootId string) error {
-	if err := j.Start(m, oldBootId); err != nil {
-		return fmt.Errorf("machine %q failed to start: %v", m.ID(), err)
+	if err := WaitForSshAfterReboot(m, oldBootId); err != nil {
+		return fmt.Errorf("machine %q failed waiting for reboot: %v", m.ID(), err)
+	}
+	return startMachineAfterBoot(m, j)
+}
+
+// startMachineAfterBoot starts the journal and runs basic machine checks.
+// It is the common path for both initial boot and reboot.
+func startMachineAfterBoot(m Machine, j *Journal) error {
+	if err := j.Start(m); err != nil {
+		return fmt.Errorf("machine %q failed to start journal: %v", m.ID(), err)
 	}
 	if err := CheckMachine(m); err != nil {
 		return fmt.Errorf("machine %q failed basic checks: %v", m.ID(), err)
@@ -201,8 +213,7 @@ func StartMachine(m Machine, j *Journal) error {
 		}
 	}()
 	go func() {
-		// This one ends up connecting to the journal via ssh
-		errchan <- StartMachineAfterReboot(m, j, "")
+		errchan <- startMachineAfterBoot(m, j)
 	}()
 	return <-errchan
 }
@@ -213,6 +224,35 @@ func GetMachineBootId(m Machine) (string, error) {
 		return "", fmt.Errorf("failed to retrieve boot ID: %s: %s: %s", stdout, err, stderr)
 	}
 	return strings.TrimSpace(string(stdout)), nil
+}
+
+// WaitForSshAfterReboot retries SSH until the machine's boot ID differs from
+// oldBootId, indicating the reboot has completed.
+func WaitForSshAfterReboot(m Machine, oldBootId string) error {
+	if oldBootId == "" {
+		panic("WaitForSshAfterReboot called with empty oldBootId")
+	}
+
+	ctx := m.RuntimeConf().TestExecTimeout
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	check := func() error {
+		bootId, err := GetMachineBootId(m)
+		if err != nil {
+			return err
+		}
+		if bootId == oldBootId {
+			return fmt.Errorf("found old boot ID %s (likely still rebooting)", oldBootId)
+		}
+		return nil
+	}
+
+	if err := util.RetryUntilTimeoutWithContext(ctx, 10*time.Minute, 10*time.Second, check); err != nil {
+		return errors.Wrapf(err, "waiting for SSH after reboot")
+	}
+	return nil
 }
 
 // GetMachineSoftRebootCount retrieves the systemd SoftRebootsCount (for soft-reboot detection)


### PR DESCRIPTION
commit d17a1bc80c3f652e474a8be58200dbd47ea5b33a
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Fri Jun 12 21:39:22 2026 +0000

    journal: drop journal-raw.txt.gz output
    
    The raw journal export (journal-raw.txt.gz) was a gzip-compressed copy
    of the journalctl --output=export stream. Nothing consumes it, and the
    human-readable journal.txt already captures all the same information in
    a more useful format.
    
    Remove the rawFile plumbing from the Recorder, the gzWriteCloser
    wrapper, and all associated file creation/teardown in journal.go.
    
    Assisted-by: <anthropic/claude-opus-4.6>

commit 3bfaac5cac33a5d2a956589a88e124a001b0e48c
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Wed Jun 10 22:32:57 2026 -0400

    mantle/qemu: use virtio journal for install tests
    
    This refactors VirtioJournal so that the unit can be added independently
    (via conf.AddVirtioJournalUnit()) of the creation of the channel. It
    then adds the creation of the journal unit to the live-iso and live-pxe
    tests where installs happen.
    
    Also let's store the name of the virtio journal device to a constant.
    
    Assisted-by: <anthropic/claude-opus-4.6>

commit 2916f8f526a6cf677c1cc283279bc35f0df206dc
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Fri Apr 24 15:41:19 2026 -0400

    mantle/qemu: create/use virtio journal implementation
    
    Let's get the journal via a virtio pipe when we are on qemu
    which should help in some situations where SSH fails for whatever
    reason and the console.txt doesn't have enough information.
    
    Assisted-by: <anthropic/claude-opus-4.6>
