### PR TITLE
kola/tests/iso: live-login: poll console for automatic login

### DIFF
--- a/mantle/kola/tests/fips/failure.go
+++ b/mantle/kola/tests/fips/failure.go
@@ -17,8 +17,6 @@ package fips
 import (
 	"context"
 	"fmt"
-	"os"
-	"regexp"
 	"time"
 
 	"github.com/pkg/errors"
@@ -30,6 +28,7 @@ import (
 	"github.com/coreos/coreos-assembler/mantle/kola/register"
 	"github.com/coreos/coreos-assembler/mantle/platform"
 	"github.com/coreos/coreos-assembler/mantle/platform/conf"
+	"github.com/coreos/coreos-assembler/mantle/util"
 )
 
 var failConfig = conf.Ignition(`{
@@ -100,24 +99,6 @@ func runFipsFailure(c cluster.TestCluster) {
 	}
 }
 
-// Read file and verify if it contains a pattern
-// 1. Read file, make sure it exists
-// 2. regex for pattern
-func fileContainsPattern(path string, searchPattern string) (bool, error) {
-	file, err := os.ReadFile(path)
-	if err != nil {
-		return false, err
-	}
-	// File has content, but the pattern is not present
-	match := regexp.MustCompile(searchPattern).Match(file)
-	if match {
-		// Pattern found
-		return true, nil
-	}
-	// Pattern not found
-	return false, nil
-}
-
 // Start the VM, take string and grep for it in the temporary console logs
 func verifyError(builder *platform.QemuBuilder, searchPattern string) error {
 	inst, err := builder.Exec()
@@ -137,7 +118,7 @@ func verifyError(builder *platform.QemuBuilder, searchPattern string) error {
 		} else if resultingError == platform.ErrInitramfsEmergency {
 			// Expected initramfs failure, checking the console file to ensure
 			// that it failed the expected way
-			found, err := fileContainsPattern(builder.ConsoleFile, searchPattern)
+			found, err := util.FileContainsPattern(builder.ConsoleFile, searchPattern)
 			if err != nil {
 				resultingError = errors.Wrapf(err, "looking for pattern '%s' in file '%s' failed", searchPattern, builder.ConsoleFile)
 			} else if !found {

--- a/mantle/kola/tests/ignition/qemufailure.go
+++ b/mantle/kola/tests/ignition/qemufailure.go
@@ -17,9 +17,7 @@ package ignition
 import (
 	"context"
 	"fmt"
-	"os"
 	"os/exec"
-	"regexp"
 	"time"
 
 	"github.com/pkg/errors"
@@ -81,24 +79,6 @@ func runDualBootfsIgnitionFailure(c cluster.TestCluster) {
 	}
 }
 
-// Read file and verify if it contains a pattern
-// 1. Read file, make sure it exists
-// 2. regex for pattern
-func fileContainsPattern(path string, searchPattern string) (bool, error) {
-	file, err := os.ReadFile(path)
-	if err != nil {
-		return false, err
-	}
-	// File has content, but the pattern is not present
-	match := regexp.MustCompile(searchPattern).Match(file)
-	if match {
-		// Pattern found
-		return true, nil
-	}
-	// Pattern not found
-	return false, nil
-}
-
 // Start the VM, take string and grep for it in the temporary console logs
 func verifyError(builder *platform.QemuBuilder, searchPattern string) error {
 	inst, err := builder.Exec()
@@ -113,7 +93,7 @@ func verifyError(builder *platform.QemuBuilder, searchPattern string) error {
 	checkConsole := func(path string, searchPattern string) error {
 		// Expected initramfs failure, checking the console file to ensure
 		// that it failed the expected way
-		found, err := fileContainsPattern(path, searchPattern)
+		found, err := util.FileContainsPattern(path, searchPattern)
 		if err != nil {
 			return errors.Wrapf(err, "looking for pattern '%s' in file '%s' failed", searchPattern, path)
 		} else if !found {
@@ -150,7 +130,7 @@ func verifyError(builder *platform.QemuBuilder, searchPattern string) error {
 		// we are searching for comes from ignition-virtio-dump-journal
 		// [1] https://github.com/coreos/fedora-coreos-tracker/issues/2019
 		virtioPortSearchPattern := "Didn't find virtio port /dev/virtio-ports/com.coreos.ignition.journal"
-		found, _ := fileContainsPattern(builder.ConsoleFile, virtioPortSearchPattern)
+		found, _ := util.FileContainsPattern(builder.ConsoleFile, virtioPortSearchPattern)
 		if found {
 			plog.Warning("Journal dumping during emergency.target failed. Continuing best effort.")
 			// Check the log even though there was a timeout

--- a/mantle/kola/tests/iso/live-login.go
+++ b/mantle/kola/tests/iso/live-login.go
@@ -1,17 +1,18 @@
 package iso
 
 import (
+	"context"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/coreos/coreos-assembler/mantle/kola"
-	"github.com/coreos/coreos-assembler/mantle/platform"
-	coreosarch "github.com/coreos/stream-metadata-go/arch"
-	"github.com/pkg/errors"
-
 	"github.com/coreos/coreos-assembler/mantle/kola/cluster"
 	"github.com/coreos/coreos-assembler/mantle/kola/register"
+	"github.com/coreos/coreos-assembler/mantle/platform"
 	"github.com/coreos/coreos-assembler/mantle/platform/machine/qemu"
+	"github.com/coreos/coreos-assembler/mantle/util"
+	coreosarch "github.com/coreos/stream-metadata-go/arch"
 )
 
 var (
@@ -75,32 +76,21 @@ func init() {
 func testLiveLogin(c cluster.TestCluster, firmware string) {
 	EnsureLiveArtifactsExist(c)
 
-	errchan := make(chan error)
-
 	setupDisks := func(_ platform.MachineOptions, builder *platform.QemuBuilder) error {
-		// https://github.com/coreos/fedora-coreos-config/blob/testing-devel/overlay.d/05core/usr/lib/systemd/system/coreos-liveiso-success.service
-		output, err := builder.VirtioChannelRead("coreos.liveiso-success")
-		if err != nil {
-			return errors.Wrap(err, "setting up virtio-serial channel")
-		}
-
-		// Read line in a goroutine and send errors to channel
-		go func() {
-			errchan <- CheckTestOutput(output, []string{"coreos-liveiso-success"})
-		}()
-
 		isopath := filepath.Join(kola.CosaBuild.Dir, kola.CosaBuild.Meta.BuildArtifacts.LiveIso.Path)
 		// Drop the bootindex bit (applicable to all arches except s390x and ppc64le); we want it to be the default
 		return builder.AddIso(isopath, "", false)
 	}
 
+	var m platform.Machine
 	switch pc := c.Cluster.(type) {
 	case *qemu.Cluster:
 		options := platform.MachineOptions{Firmware: firmware}
 		builder := &qemu.MachineBuilder{
 			SetupDisks: setupDisks,
 		}
-		_, err := pc.NewMachineWithBuilder(nil, options, builder)
+		var err error
+		m, err = pc.NewMachineWithBuilder(nil, options, builder)
 		if err != nil {
 			c.Fatalf("Unable to create test machine: %v", err)
 		}
@@ -108,7 +98,10 @@ func testLiveLogin(c cluster.TestCluster, firmware string) {
 		c.Fatalf("Unsupported cluster type")
 	}
 
-	if err := <-errchan; err != nil {
-		c.Fatal(err)
+	// Wait for the automatic login prompt to appear in the console output
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	if err := util.WaitForConsoleOutput(ctx, m.ConsolePath(), "login: core (automatic login)"); err != nil {
+		c.Fatalf("Failed waiting for automatic login: %v", err)
 	}
 }

--- a/mantle/kola/tests/iso/live-login.go
+++ b/mantle/kola/tests/iso/live-login.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/coreos/coreos-assembler/mantle/kola/cluster"
 	"github.com/coreos/coreos-assembler/mantle/kola/register"
-	"github.com/coreos/coreos-assembler/mantle/platform/conf"
 	"github.com/coreos/coreos-assembler/mantle/platform/machine/qemu"
 )
 
@@ -76,10 +75,6 @@ func init() {
 func testLiveLogin(c cluster.TestCluster, firmware string) {
 	EnsureLiveArtifactsExist(c)
 
-	butane := conf.Butane(`
-variant: fcos
-version: 1.1.0`)
-
 	errchan := make(chan error)
 
 	setupDisks := func(_ platform.MachineOptions, builder *platform.QemuBuilder) error {
@@ -105,7 +100,7 @@ version: 1.1.0`)
 		builder := &qemu.MachineBuilder{
 			SetupDisks: setupDisks,
 		}
-		_, err := pc.NewMachineWithBuilder(butane, options, builder)
+		_, err := pc.NewMachineWithBuilder(nil, options, builder)
 		if err != nil {
 			c.Fatalf("Unable to create test machine: %v", err)
 		}

--- a/mantle/platform/machine/aws/machine.go
+++ b/mantle/platform/machine/aws/machine.go
@@ -106,6 +106,10 @@ func (am *machine) Destroy() {
 	am.cluster.DelMach(am)
 }
 
+func (am *machine) ConsolePath() string {
+	return ""
+}
+
 func (am *machine) ConsoleOutput() string {
 	return am.console
 }

--- a/mantle/platform/machine/azure/machine.go
+++ b/mantle/platform/machine/azure/machine.go
@@ -134,6 +134,10 @@ func (am *machine) Destroy() {
 	am.cluster.DelMach(am)
 }
 
+func (am *machine) ConsolePath() string {
+	return ""
+}
+
 func (am *machine) ConsoleOutput() string {
 	return string(am.console)
 }

--- a/mantle/platform/machine/do/machine.go
+++ b/mantle/platform/machine/do/machine.go
@@ -93,6 +93,10 @@ func (dm *machine) Destroy() {
 	dm.cluster.DelMach(dm)
 }
 
+func (dm *machine) ConsolePath() string {
+	return ""
+}
+
 func (dm *machine) ConsoleOutput() string {
 	// DigitalOcean provides no API for retrieving ConsoleOutput
 	return ""

--- a/mantle/platform/machine/esx/machine.go
+++ b/mantle/platform/machine/esx/machine.go
@@ -102,6 +102,10 @@ func (em *machine) Destroy() {
 	em.cluster.DelMach(em)
 }
 
+func (em *machine) ConsolePath() string {
+	return ""
+}
+
 func (em *machine) ConsoleOutput() string {
 	return em.console
 }

--- a/mantle/platform/machine/gcloud/machine.go
+++ b/mantle/platform/machine/gcloud/machine.go
@@ -98,6 +98,10 @@ func (gm *machine) Destroy() {
 	gm.gc.DelMach(gm)
 }
 
+func (gm *machine) ConsolePath() string {
+	return ""
+}
+
 func (gm *machine) ConsoleOutput() string {
 	return gm.console
 }

--- a/mantle/platform/machine/openstack/machine.go
+++ b/mantle/platform/machine/openstack/machine.go
@@ -119,6 +119,10 @@ func (om *machine) Destroy() {
 	om.cluster.DelMach(om)
 }
 
+func (om *machine) ConsolePath() string {
+	return ""
+}
+
 func (om *machine) ConsoleOutput() string {
 	return om.console
 }

--- a/mantle/platform/machine/qemu/cluster.go
+++ b/mantle/platform/machine/qemu/cluster.go
@@ -146,10 +146,13 @@ func (qc *Cluster) NewMachineWithBuilder(userdata any, options platform.MachineO
 	}
 
 	// Run StartMachine, which blocks on the machine being booted up enough
-	// for SSH access.
-	if err := platform.StartMachine(qm, qm.journal); err != nil {
-		qm.Destroy()
-		return nil, err
+	// for SSH access, but only if we have a config, else there's no
+	// SSH key for us to use to get in so don't bother.
+	if config != nil {
+		if err := platform.StartMachine(qm, qm.journal); err != nil {
+			qm.Destroy()
+			return nil, err
+		}
 	}
 
 	qc.AddMach(qm)

--- a/mantle/platform/machine/qemu/machine.go
+++ b/mantle/platform/machine/qemu/machine.go
@@ -119,6 +119,10 @@ func (m *machine) Destroy() {
 	}
 }
 
+func (m *machine) ConsolePath() string {
+	return m.consolePath
+}
+
 func (m *machine) ConsoleOutput() string {
 	return m.console
 }

--- a/mantle/platform/machine/qemuiso/machine.go
+++ b/mantle/platform/machine/qemuiso/machine.go
@@ -105,6 +105,10 @@ func (m *machine) Destroy() {
 	m.qc.DelMach(m)
 }
 
+func (m *machine) ConsolePath() string {
+	return m.consolePath
+}
+
 func (m *machine) ConsoleOutput() string {
 	return m.console
 }

--- a/mantle/platform/platform.go
+++ b/mantle/platform/platform.go
@@ -85,6 +85,10 @@ type Machine interface {
 	// any failures; since they are not actionable, it does not return an error.
 	Destroy()
 
+	// ConsolePath returns the path to the machine's console log file,
+	// suitable for live monitoring while the machine is running.
+	ConsolePath() string
+
 	// ConsoleOutput returns the machine's console output if available,
 	// or an empty string.  Only expected to be valid after Destroy().
 	ConsoleOutput() string

--- a/mantle/util/common.go
+++ b/mantle/util/common.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -164,6 +165,16 @@ func ParseDiskSpec(spec string, allowNoSize bool) (int64, map[string]string, err
 		}
 	}
 	return size, diskmap, nil
+}
+
+// FileContainsPattern reads a file and returns whether its content
+// matches the given regex pattern.
+func FileContainsPattern(path string, searchPattern string) (bool, error) {
+	file, err := os.ReadFile(path)
+	if err != nil {
+		return false, err
+	}
+	return regexp.MustCompile(searchPattern).Match(file), nil
 }
 
 func RandomName(prefix string) string {

--- a/mantle/util/common.go
+++ b/mantle/util/common.go
@@ -15,6 +15,7 @@
 package util
 
 import (
+	"context"
 	"crypto/rand"
 	"fmt"
 	"os"
@@ -175,6 +176,30 @@ func FileContainsPattern(path string, searchPattern string) (bool, error) {
 		return false, err
 	}
 	return regexp.MustCompile(searchPattern).Match(file), nil
+}
+
+// WaitForConsoleOutput polls a console log file every 2 seconds until
+// the target string appears or the context is done. This is useful for
+// tests that need to verify specific output on the serial console while
+// the machine is still running.
+func WaitForConsoleOutput(ctx context.Context, consolePath string, searchString string) error {
+	for {
+		found, err := FileContainsPattern(consolePath, regexp.QuoteMeta(searchString))
+		if err != nil {
+			// File may not exist yet if QEMU hasn't started writing.
+			// Return any other errors than ENOEXIST.
+			if !os.IsNotExist(err) {
+				return err
+			}
+		} else if found {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("context canceled waiting for %q in %s: %w", searchString, consolePath, ctx.Err())
+		case <-time.After(2 * time.Second):
+		}
+	}
 }
 
 func RandomName(prefix string) string {


### PR DESCRIPTION
This changes the test to not pass in an Ignition config and also inspect the console to see if autologin occurred rather than depending on the [coreos-liveiso-success.service](https://github.com/coreos/fedora-coreos-config/blob/45c053c51f1e977d990af4b0c7647416e7a59b1f/overlay.d/05core/usr/lib/systemd/system/coreos-liveiso-success.service), which has stopped working properly over time.

Fixes https://github.com/coreos/coreos-assembler/issues/4581