### PR TITLE
mantle/cmd/kola: skip blank disk when user provides custom disks

### DIFF
--- a/mantle/cmd/kola/qemuexec.go
+++ b/mantle/cmd/kola/qemuexec.go
@@ -335,9 +335,11 @@ func runQemuExec(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		// Add a blank disk (this is a disk we can install to)
-		if err := builder.AddBootDisk(buildDiskFromOptions()); err != nil {
-			return err
+		// Add a blank disk (this is a disk we can install to) if the user hasn't set any disks manually
+		if len(addDisks) == 0 && kola.QEMUOptions.DiskImage == "" {
+			if err := builder.AddBootDisk(buildDiskFromOptions()); err != nil {
+				return err
+			}
 		}
 	}
 	builder.Hostname = hostname


### PR DESCRIPTION
When using qemuexec with ISO images, a blank boot disk was always added automatically for installation purposes. However, if the user explicitly provides custom disks via --add-disk, this automatic blank disk becomes unnecessary and may interfere with the intended disk configuration.

For example, when running:
```
  $ kola qemuexec -c --qemu-iso coreos.iso --add-disk 10G:mpath --kargs "rd.multipath=default"
```
We ended up with requested multipath disks(sda,sdb) and blank vda
```
  core@cosa-devsh:~$ lsblk
  NAME                 MAJ:MIN RM   SIZE RO TYPE  MOUNTPOINTS
  sda                    8:0    0    10G  0 disk
  └─0x76e2dbd88aa56303 252:0    0    10G  0 mpath
  sdb                    8:16   0    10G  0 disk
  └─0x76e2dbd88aa56303 252:0    0    10G  0 mpath
  sr0                   11:0    1  1020M  1 rom   /run/media/iso
  vda                  253:0    0    12G  0 disk
```

This allows commands like:
```
  $ qemu-img create img.raw 2G && mkfs.xfs -f img.raw
  $ kola qemuexec -c --qemu-iso coreos.iso --qemu-image img.raw --add-disk 10G:mpath --kargs "rd.multipath=default"
```
to work without encountering the "Multiple primary disks specified" error.

Only add the automatic blank boot disk when no custom disks have been specified by the user.