### PR TITLE
test/network: Skip coreos.network.intramfs.second-boot on scos

### DIFF
--- a/mantle/kola/tests/misc/network.go
+++ b/mantle/kola/tests/misc/network.go
@@ -46,7 +46,7 @@ func init() {
 		ClusterSize:    1,
 		Name:           "coreos.network.initramfs.second-boot",
 		Description:    "Verify that networking is not started in the initramfs on the second boot.",
-		ExcludeDistros: []string{"fcos", "rhcos"},
+		ExcludeDistros: []string{"fcos", "rhcos", "scos"},
 	})
 	// This test follows the same network configuration used on https://github.com/RHsyseng/rhcos-slb
 	register.RegisterTest(&register.Test{


### PR DESCRIPTION
Since #4580 we now treat scos as its own different distro. Before, excluding `rhcos` would automatically also exclude `scos`, this is no longer true, because of this, scos now runs `coreos.network.intramfs.second-boot` and fails.

If we are excluding the test for `fcos`, `rhcos`, and `scos`, is this test every running ? I seein options.go that:

```
kolaDistros       = []string{"fcos", "rhcos", "scos"}
```

But we also have some tests that use "cl" as a Distro string:

```
register.RegisterTest(&register.Test{
	Run:         dockerOldClient,
	ClusterSize: 0,
	Name:        "docker.oldclient",
	Distros:     []string{"cl"},
})
```

I assume that this test should be deleted since its not running on fcos/rhcos/scos and "cl" is legacy, some context would be appreciated.