### PR TITLE
mantle/platform: fix timeout parameter propagation in reboot functions

### DIFF
--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -1055,11 +1055,22 @@ func metadataFromTestBinary(executable string) (*externalTestMeta, error) {
 	return meta, nil
 }
 
+// getRemainingTimeout calculates the remaining timeout and returns an error if it's exceeded
+func getRemainingTimeout(started time.Time, timeout time.Duration) (time.Duration, error) {
+	elapsed := time.Since(started)
+	remaining := timeout - elapsed
+	if remaining <= 0 {
+		return 0, fmt.Errorf("timeout exceeded: elapsed=%v, timeout=%v", elapsed, timeout)
+	}
+	return remaining, nil
+}
+
 // runExternalTest is an implementation of the "external" test framework.
 // See README-kola-ext.md as well as the comments in kolet.go for reboot
 // handling.
-func runExternalTest(c cluster.TestCluster, mach platform.Machine, testNum int) error {
+func runExternalTest(c cluster.TestCluster, mach platform.Machine, testNum int, timeout time.Duration) error {
 	var previousRebootState string
+	started := time.Now()
 	for {
 		bootID, err := platform.GetMachineBootId(mach)
 		if err != nil {
@@ -1118,7 +1129,11 @@ func runExternalTest(c cluster.TestCluster, mach platform.Machine, testNum int) 
 				return errors.Wrapf(err, "failed to acknowledge reboot")
 			}
 			plog.Debug("Waiting for reboot")
-			err = mach.WaitForReboot(120*time.Second, bootID)
+			remainingTimeout, err := getRemainingTimeout(started, timeout)
+			if err != nil {
+				return errors.Wrapf(err, "Waiting for reboot")
+			}
+			err = mach.WaitForReboot(remainingTimeout, bootID)
 			if err != nil {
 				return errors.Wrapf(err, "Waiting for reboot")
 			}
@@ -1136,7 +1151,11 @@ func runExternalTest(c cluster.TestCluster, mach platform.Machine, testNum int) 
 				return errors.Wrapf(err, "failed to acknowledge soft-reboot")
 			}
 			plog.Debug("Waiting for soft-reboot")
-			err = mach.WaitForSoftReboot(120*time.Second, softrebootCount)
+			remainingTimeout, err := getRemainingTimeout(started, timeout)
+			if err != nil {
+				return errors.Wrapf(err, "Waiting for soft-reboot")
+			}
+			err = mach.WaitForSoftReboot(remainingTimeout, softrebootCount)
 			if err != nil {
 				return errors.Wrapf(err, "Waiting for soft-reboot")
 			}
@@ -1240,7 +1259,7 @@ ExecStart=%s
 			mach := c.Machines()[0]
 			plog.Debugf("Running kolet")
 
-			err := runExternalTest(c, mach, num)
+			err := runExternalTest(c, mach, num, time.Duration(targetMeta.TimeoutMin)*time.Minute)
 			if err != nil {
 				out, stderr, suberr := mach.SSH(fmt.Sprintf("sudo systemctl status --lines=40 %s", shellquote.Join(unitName)))
 				if len(out) > 0 {

--- a/mantle/platform/util.go
+++ b/mantle/platform/util.go
@@ -117,7 +117,7 @@ func RebootMachine(m Machine, j *Journal) error {
 	if err := StartReboot(m); err != nil {
 		return fmt.Errorf("machine %q failed to begin rebooting: %v", m.ID(), err)
 	}
-	return StartMachineAfterReboot(m, j, bootId)
+	return StartMachineAfterReboot(m, j, 10*time.Minute, bootId)
 }
 
 // WaitForMachineReboot will wait for the machine to reboot, i.e. it is assumed
@@ -141,6 +141,7 @@ func WaitForMachineReboot(m Machine, j *Journal, timeout time.Duration, oldBootI
 	// This is intended to be "best effort", there are a wide variety of potential
 	// failure modes.  In the future we should probably have a relatively short
 	// timeout here and not make it fatal, and instead only do a timeout inside StartMachineAfterReboot().
+	started := time.Now()
 	c := make(chan error)
 	go func() {
 		out, stderr, err := m.SSH(fmt.Sprintf("if [ $(cat /proc/sys/kernel/random/boot_id) == '%s' ]; then echo waiting for reboot | logger && sleep infinity; fi", oldBootId))
@@ -172,14 +173,19 @@ func WaitForMachineReboot(m Machine, j *Journal, timeout time.Duration, oldBootI
 		if err != nil {
 			return err
 		}
-		return StartMachineAfterReboot(m, j, oldBootId)
+		elapsed := time.Since(started)
+		remainingTimeout := timeout - elapsed
+		if remainingTimeout <= 0 {
+			return fmt.Errorf("timeout exceeded before starting machine after reboot: elapsed=%v, timeout=%v", elapsed, timeout)
+		}
+		return StartMachineAfterReboot(m, j, remainingTimeout, oldBootId)
 	case <-time.After(timeout):
 		return fmt.Errorf("timed out after %v waiting for machine to reboot", timeout)
 	}
 }
 
-func StartMachineAfterReboot(m Machine, j *Journal, oldBootId string) error {
-	if err := WaitForSshAfterReboot(m, oldBootId); err != nil {
+func StartMachineAfterReboot(m Machine, j *Journal, timeout time.Duration, oldBootId string) error {
+	if err := WaitForSshAfterReboot(m, timeout, oldBootId); err != nil {
 		return fmt.Errorf("machine %q failed waiting for reboot: %v", m.ID(), err)
 	}
 	return startMachineAfterBoot(m, j)
@@ -228,7 +234,7 @@ func GetMachineBootId(m Machine) (string, error) {
 
 // WaitForSshAfterReboot retries SSH until the machine's boot ID differs from
 // oldBootId, indicating the reboot has completed.
-func WaitForSshAfterReboot(m Machine, oldBootId string) error {
+func WaitForSshAfterReboot(m Machine, timeout time.Duration, oldBootId string) error {
 	if oldBootId == "" {
 		panic("WaitForSshAfterReboot called with empty oldBootId")
 	}
@@ -249,7 +255,7 @@ func WaitForSshAfterReboot(m Machine, oldBootId string) error {
 		return nil
 	}
 
-	if err := util.RetryUntilTimeoutWithContext(ctx, 10*time.Minute, 10*time.Second, check); err != nil {
+	if err := util.RetryUntilTimeoutWithContext(ctx, timeout, 10*time.Second, check); err != nil {
 		return errors.Wrapf(err, "waiting for SSH after reboot")
 	}
 	return nil


### PR DESCRIPTION
Long running tests such as 'upgrade' use 50 minutes as timeout, but were failing after 10 minutes on establishing SSH connection in the pipeline. The timeout parameter wasn't being properly propagated through the reboot function chain, causing WaitForSshAfterReboot to use a hardcoded 10 minute timeout instead of respecting the caller's timeout.