### PR TITLE
kola/tests/iso: fold iso live-login, live-as-disk, live-fips tests into harness

### DIFF
--- a/docs/kola/external-tests.md
+++ b/docs/kola/external-tests.md
@@ -232,7 +232,8 @@ Here's an example `kola.json`:
     "timeoutMin": 8,
     "exclusive": true,
     "conflicts": ["ext.config.some-test", "podman.some-other-test"],
-    "description": "test description"
+    "description": "test description",
+    "bootFrom": ""
 }
 ```
 
@@ -305,6 +306,13 @@ The `conflicts` key takes a list of test names that conflict with this test.
 This key can only be specified if `exclusive` is marked `false` since
 `exclusive: true` tests are run exclusively in their own VM.  At runtime,
 this test will be separated from the tests it is conflicting with.
+
+The `bootFrom` string if set will cause the test VM to boot from the
+specified media instead of the default disk image. Supported values are
+`"iso"` (boot from the live ISO as a CD-ROM) and `"iso-as-disk"` (boot
+from the live ISO as if written to a USB stick). The test will be skipped
+if no live ISO artifact is available in the build. It is currently only
+supported on `qemu`.
 
 If a test specifies a `creationDate`, kola will treat failures as
 warnings for a grace period (see `gracePeriod` in

--- a/mantle/cmd/kola/options.go
+++ b/mantle/cmd/kola/options.go
@@ -394,6 +394,9 @@ func syncCosaOptions() error {
 		if kola.QEMUOptions.DiskImage == "" && kola.CosaBuild.Meta.BuildArtifacts.Qemu != nil {
 			kola.QEMUOptions.DiskImage = filepath.Join(kola.CosaBuild.Dir, kola.CosaBuild.Meta.BuildArtifacts.Qemu.Path)
 		}
+		if kola.QEMUOptions.IsoImage == "" && kola.CosaBuild.Meta.BuildArtifacts.LiveIso != nil {
+			kola.QEMUOptions.IsoImage = filepath.Join(kola.CosaBuild.Dir, kola.CosaBuild.Meta.BuildArtifacts.LiveIso.Path)
+		}
 	case "qemu-iso":
 		if kola.QEMUIsoOptions.IsoPath == "" && kola.CosaBuild.Meta.BuildArtifacts.LiveIso != nil {
 			kola.QEMUIsoOptions.IsoPath = filepath.Join(kola.CosaBuild.Dir, kola.CosaBuild.Meta.BuildArtifacts.LiveIso.Path)

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -996,6 +996,7 @@ type externalTestMeta struct {
 	Description               string   `json:"description"                         yaml:"description"`
 	BindMountHostRO           []string `json:"bindMountHostRO,omitempty"           yaml:"bindMountHostRO,omitempty"`
 	CreationDate              string   `json:"creationDate,omitempty"              yaml:"creationDate,omitempty"`
+	BootFrom                  string   `json:"bootFrom,omitempty"                  yaml:"bootFrom,omitempty"`
 }
 
 // metadataFromTestBinary extracts JSON-in-comment like:
@@ -1230,6 +1231,7 @@ ExecStart=%s
 			AppendKernelArgs:          targetMeta.AppendKernelArgs,
 			AppendFirstbootKernelArgs: targetMeta.AppendFirstbootKernelArgs,
 			InstanceType:              targetMeta.InstanceType,
+			BootFrom:                  targetMeta.BootFrom,
 		},
 		InjectContainer: targetMeta.InjectContainer,
 		NonExclusive:    !targetMeta.Exclusive,
@@ -1845,6 +1847,18 @@ func runTest(h *harness.H, t *register.Test, pltfrm string, flight platform.Flig
 
 		if testSecureBoot(t) {
 			options.Firmware = "uefi-secure"
+		}
+
+		// Skip tests that request ISO boot when no live ISO artifact is available,
+		// consistent with how internal ISO tests use EnsureLiveArtifactsExist().
+		if (options.BootFrom == platform.BootFromISO || options.BootFrom == platform.BootFromISOAsDisk) &&
+			(CosaBuild == nil || CosaBuild.Meta.BuildArtifacts.LiveIso == nil) {
+			buildID := "unknown"
+			if CosaBuild != nil {
+				buildID = CosaBuild.Meta.BuildID
+			}
+			h.Skipf("bootFrom %q requested but build %s has no live ISO artifact", options.BootFrom, buildID)
+			return
 		}
 
 		// Providers sometimes fail to bring up a machine within a

--- a/mantle/kola/tests/iso/common.go
+++ b/mantle/kola/tests/iso/common.go
@@ -81,7 +81,6 @@ func startHTTPServer(listener net.Listener, dir string) *http.Server {
 }
 
 type IsoTestOpts struct {
-	instInsecure    bool
 	addNmKeyfile    bool
 	enable4k        bool
 	enableMultipath bool
@@ -91,7 +90,7 @@ type IsoTestOpts struct {
 	enableIbft      bool
 	manual          bool
 	pxeAppendRootfs bool
-	firmware        string
+	machineOpts     platform.MachineOptions
 }
 
 func getIsoTestOpts(testName string) IsoTestOpts {
@@ -102,9 +101,9 @@ func getIsoTestOpts(testName string) IsoTestOpts {
 		opts.enable4k = true
 	}
 	if strings.Contains(testName, "uefi-secure") {
-		opts.firmware = "uefi-secure"
+		opts.machineOpts.Firmware = "uefi-secure"
 	} else if strings.Contains(testName, "uefi") {
-		opts.firmware = "uefi"
+		opts.machineOpts.Firmware = "uefi"
 	}
 	if strings.Contains(testName, "mpath") {
 		opts.enableMultipath = true
@@ -131,7 +130,6 @@ func getIsoTestOpts(testName string) IsoTestOpts {
 		opts.manual = true
 	}
 
-	opts.instInsecure = kola.QEMUOptions.InstInsecure || IsDevBuild()
 	return opts
 }
 
@@ -139,6 +137,10 @@ func EnsureLiveArtifactsExist(c cluster.TestCluster) {
 	if kola.CosaBuild.Meta.BuildArtifacts.LiveIso == nil || kola.CosaBuild.Meta.BuildArtifacts.LiveKernel == nil || kola.CosaBuild.Meta.BuildArtifacts.LiveInitramfs == nil || kola.CosaBuild.Meta.BuildArtifacts.LiveRootfs == nil {
 		c.Skipf("Build %s is missing live artifacts", kola.CosaBuild.Meta.BuildID)
 	}
+}
+
+func ShouldUseInsecureInstallOption() bool {
+	return kola.QEMUOptions.InstInsecure || IsDevBuild()
 }
 
 func IsDevBuild() bool {

--- a/mantle/kola/tests/iso/common.go
+++ b/mantle/kola/tests/iso/common.go
@@ -203,6 +203,26 @@ func WaitToSwitchBootOrderAndReboot(c cluster.TestCluster, qc *qemu.Cluster, m p
 	}
 }
 
+// VerifyNoEfiBootEntry checks that the EFI boot entries contain an
+// auto-created entry for the booted removable media (CD-ROM/DVD/Misc
+// Device) and that no persistent hard-drive entry was created for it.
+// Originally implemented in bf6d88e.
+func VerifyNoEfiBootEntry(c cluster.TestCluster, m platform.Machine) {
+	c.RunCmdSync(m, `
+		test -e /sys/firmware/efi
+		# Skip test on EL9 because efibootmgr didn't denote back then
+		# which entries were autocreated.
+		source /etc/os-release
+		if [ "${PLATFORM_ID:-}" != "platform:el9" ]; then
+			entries=$(efibootmgr)
+			# Check that there is an entry for the media we booted from
+			bootmediaentries=$(grep -E '(UEFI Misc Device|CDROM|DVD-ROM)' <<< "${entries}")
+			test -n "${bootmediaentries}"
+			# And that it was autocreated
+			grep auto_created_boot_option <<< "${bootmediaentries}"
+		fi`)
+}
+
 func cat(outfile string, infiles ...string) error {
 	out, err := os.OpenFile(outfile, os.O_WRONLY|os.O_CREATE, 0644)
 	if err != nil {
@@ -299,25 +319,6 @@ Type=oneshot
 RemainAfterExit=yes
 ExecStart=/bin/sh -c '[ ! -e /boot/ignition ]'
 [Install]
-RequiredBy=multi-user.target`
-
-// This test is broken. Please fix!
-// https://github.com/coreos/coreos-assembler/issues/3554
-var verifyNoEFIBootEntry = `
-[Unit]
-Description=TestISO Verify No EFI Boot Entry
-OnFailure=emergency.target
-OnFailureJobMode=isolate
-ConditionPathExists=/sys/firmware/efi
-Before=live-signal-ok.service
-[Service]
-Type=oneshot
-RemainAfterExit=yes
-ExecStart=/bin/sh -c '! efibootmgr -v | grep -E "(HD|CDROM)\("'
-[Install]
-# for install tests
-RequiredBy=coreos-installer.target
-# for iso-as-disk
 RequiredBy=multi-user.target`
 
 // Verify that the volume ID is the OS name. See also

--- a/mantle/kola/tests/iso/live-as-disk.go
+++ b/mantle/kola/tests/iso/live-as-disk.go
@@ -40,7 +40,7 @@ func init() {
 			Platforms:   []string{"qemu"},
 			// Skip base checks (looks at journal for failures) until bootupd fix lands
 			// https://github.com/coreos/fedora-coreos-tracker/issues/2136
-			Tags:           []string{kola.SkipBaseChecksTag, "reprovision"},
+			Tags:           []string{kola.SkipBaseChecksTag},
 			MachineOptions: opts.machineOpts,
 		})
 	}

--- a/mantle/kola/tests/iso/live-as-disk.go
+++ b/mantle/kola/tests/iso/live-as-disk.go
@@ -1,17 +1,13 @@
 package iso
 
 import (
-	"path/filepath"
 	"time"
 
 	"github.com/coreos/coreos-assembler/mantle/kola"
 	"github.com/coreos/coreos-assembler/mantle/kola/cluster"
 	"github.com/coreos/coreos-assembler/mantle/kola/register"
 	"github.com/coreos/coreos-assembler/mantle/platform"
-	"github.com/coreos/coreos-assembler/mantle/platform/conf"
-	"github.com/coreos/coreos-assembler/mantle/platform/machine/qemu"
 	coreosarch "github.com/coreos/stream-metadata-go/arch"
-	"github.com/pkg/errors"
 )
 
 // The iso-as-disk tests are only supported in x86_64 because other
@@ -28,70 +24,35 @@ func init() {
 		return
 	}
 	for _, testName := range tests_as_disk_x86_64 {
+		opts := getIsoTestOpts(testName)
+
 		register.RegisterTest(&register.Test{
 			Run: func(c cluster.TestCluster) {
-				opts := getIsoTestOpts(testName)
 				testLiveAsDisk(c, opts)
 			},
-			ClusterSize: 0,
+			ClusterSize: 1,
 			Name:        "iso." + testName,
-			Description: "Verify ISO-as-disk install works.",
-			Timeout:     installTimeoutMins * time.Minute,
+			Description: "Verify ISO-as-disk boot works.",
+			Timeout:     3 * time.Minute, // Just boots the ISO -> quick
 			Flags:       []register.Flag{},
 			Platforms:   []string{"qemu"},
 			// Skip base checks (looks at journal for failures) until bootupd fix lands
 			// https://github.com/coreos/fedora-coreos-tracker/issues/2136
 			Tags: []string{kola.SkipBaseChecksTag, "reprovision"},
+			MachineOptions: platform.MachineOptions{
+				Firmware: opts.firmware,
+				BootFrom: platform.BootFromISOAsDisk,
+			},
 		})
 	}
 }
 
 func testLiveAsDisk(c cluster.TestCluster, opts IsoTestOpts) {
-	EnsureLiveArtifactsExist(c)
-
-	qc, ok := c.Cluster.(*qemu.Cluster)
-	if !ok {
-		c.Fatalf("Unsupported cluster type")
-	}
-
-	config, err := conf.EmptyIgnition().Render(conf.FailWarnings)
-	if err != nil {
-		c.Fatal(err)
-	}
-	config.AddSystemdUnit("live-signal-ok.service", liveSignalOKUnit, conf.Enable)
-	config.AddSystemdUnit("verify-no-efi-boot-entry.service", verifyNoEFIBootEntry, conf.Enable)
-	keys, err := qc.Keys()
-	if err != nil {
-		c.Fatal(err)
-	}
-	config.CopyKeys(keys)
-
-	errchan := make(chan error)
-	setupDisks := func(_ platform.MachineOptions, builder *platform.QemuBuilder) error {
-		isopath := filepath.Join(kola.CosaBuild.Dir, kola.CosaBuild.Meta.BuildArtifacts.LiveIso.Path)
-		if err := builder.AddIso(isopath, "", true); err != nil {
-			return err
-		}
-		completionChannel, err := builder.VirtioChannelRead("testisocompletion")
-		if err != nil {
-			return errors.Wrap(err, "setting up virtio-serial channel")
-		}
-		go func() {
-			errchan <- CheckTestOutput(completionChannel, []string{liveOKSignal})
-		}()
-		return nil
-	}
-
-	options := platform.MachineOptions{Firmware: opts.firmware}
-	machineBuilder := &qemu.MachineBuilder{
-		SetupDisks: setupDisks,
-	}
-	_, err = qc.NewMachineWithBuilder(config, options, machineBuilder)
-	if err != nil {
-		c.Fatalf("Unable to create test machine: %v", err)
-	}
-
-	if err := <-errchan; err != nil {
-		c.Fatal(err)
+	m := c.Machines()[0]
+	// Verify we are on Live ISO
+	c.RunCmdSync(m, "test -f /run/ostree-live")
+	// And that no efi boot entry exists if on UEFI
+	if opts.firmware == "uefi" || opts.firmware == "uefi-secure" {
+		VerifyNoEfiBootEntry(c, m)
 	}
 }

--- a/mantle/kola/tests/iso/live-as-disk.go
+++ b/mantle/kola/tests/iso/live-as-disk.go
@@ -25,6 +25,8 @@ func init() {
 	}
 	for _, testName := range tests_as_disk_x86_64 {
 		opts := getIsoTestOpts(testName)
+		// Set machine to boot from the ISO as disk
+		opts.machineOpts.BootFrom = platform.BootFromISOAsDisk
 
 		register.RegisterTest(&register.Test{
 			Run: func(c cluster.TestCluster) {
@@ -38,11 +40,8 @@ func init() {
 			Platforms:   []string{"qemu"},
 			// Skip base checks (looks at journal for failures) until bootupd fix lands
 			// https://github.com/coreos/fedora-coreos-tracker/issues/2136
-			Tags: []string{kola.SkipBaseChecksTag, "reprovision"},
-			MachineOptions: platform.MachineOptions{
-				Firmware: opts.firmware,
-				BootFrom: platform.BootFromISOAsDisk,
-			},
+			Tags:           []string{kola.SkipBaseChecksTag, "reprovision"},
+			MachineOptions: opts.machineOpts,
 		})
 	}
 }
@@ -52,7 +51,7 @@ func testLiveAsDisk(c cluster.TestCluster, opts IsoTestOpts) {
 	// Verify we are on Live ISO
 	c.RunCmdSync(m, "test -f /run/ostree-live")
 	// And that no efi boot entry exists if on UEFI
-	if opts.firmware == "uefi" || opts.firmware == "uefi-secure" {
+	if opts.machineOpts.Firmware == "uefi" || opts.machineOpts.Firmware == "uefi-secure" {
 		VerifyNoEfiBootEntry(c, m)
 	}
 }

--- a/mantle/kola/tests/iso/live-fips.go
+++ b/mantle/kola/tests/iso/live-fips.go
@@ -17,6 +17,10 @@ var tests_RHCOS_uefi = []string{
 func init() {
 	for _, testName := range tests_RHCOS_uefi {
 		opts := getIsoTestOpts(testName)
+		// Set fips=1 kernel argument
+		opts.machineOpts.AppendKernelArgs = "fips=1"
+		// Set machine to boot from the ISO
+		opts.machineOpts.BootFrom = platform.BootFromISO
 
 		register.RegisterTest(&register.Test{
 			Run:           testLiveFIPS,
@@ -29,12 +33,8 @@ func init() {
 			Architectures: []string{"x86_64", "aarch64"},
 			// Skip base checks (looks at journal for failures) until bootupd fix lands
 			// https://github.com/coreos/fedora-coreos-tracker/issues/2136
-			Tags: []string{kola.SkipBaseChecksTag, "reprovision"},
-			MachineOptions: platform.MachineOptions{
-				AppendKernelArgs: "fips=1",
-				Firmware:         opts.firmware,
-				BootFrom:         platform.BootFromISO,
-			},
+			Tags:           []string{kola.SkipBaseChecksTag, "reprovision"},
+			MachineOptions: opts.machineOpts,
 		})
 	}
 }

--- a/mantle/kola/tests/iso/live-fips.go
+++ b/mantle/kola/tests/iso/live-fips.go
@@ -33,7 +33,7 @@ func init() {
 			Architectures: []string{"x86_64", "aarch64"},
 			// Skip base checks (looks at journal for failures) until bootupd fix lands
 			// https://github.com/coreos/fedora-coreos-tracker/issues/2136
-			Tags:           []string{kola.SkipBaseChecksTag, "reprovision"},
+			Tags:           []string{kola.SkipBaseChecksTag},
 			MachineOptions: opts.machineOpts,
 		})
 	}

--- a/mantle/kola/tests/iso/live-fips.go
+++ b/mantle/kola/tests/iso/live-fips.go
@@ -1,16 +1,12 @@
 package iso
 
 import (
-	"path/filepath"
 	"time"
 
 	"github.com/coreos/coreos-assembler/mantle/kola"
 	"github.com/coreos/coreos-assembler/mantle/kola/cluster"
 	"github.com/coreos/coreos-assembler/mantle/kola/register"
 	"github.com/coreos/coreos-assembler/mantle/platform"
-	"github.com/coreos/coreos-assembler/mantle/platform/conf"
-	"github.com/coreos/coreos-assembler/mantle/platform/machine/qemu"
-	"github.com/pkg/errors"
 )
 
 // These tests only run on RHCOS
@@ -20,90 +16,34 @@ var tests_RHCOS_uefi = []string{
 
 func init() {
 	for _, testName := range tests_RHCOS_uefi {
+		opts := getIsoTestOpts(testName)
+
 		register.RegisterTest(&register.Test{
-			Run: func(c cluster.TestCluster) {
-				opts := getIsoTestOpts(testName)
-				testLiveFIPS(c, opts)
-			},
-			ClusterSize:   0,
+			Run:           testLiveFIPS,
+			ClusterSize:   1,
 			Name:          "iso." + testName,
 			Description:   "verifies that adding fips=1 to the ISO results in a FIPS mode system",
-			Timeout:       installTimeoutMins * time.Minute,
+			Timeout:       3 * time.Minute, // Just boots the ISO -> quick
 			Distros:       []string{"rhcos"},
 			Platforms:     []string{"qemu"},
 			Architectures: []string{"x86_64", "aarch64"},
 			// Skip base checks (looks at journal for failures) until bootupd fix lands
 			// https://github.com/coreos/fedora-coreos-tracker/issues/2136
 			Tags: []string{kola.SkipBaseChecksTag, "reprovision"},
+			MachineOptions: platform.MachineOptions{
+				AppendKernelArgs: "fips=1",
+				Firmware:         opts.firmware,
+				BootFrom:         platform.BootFromISO,
+			},
 		})
 	}
 }
 
-var fipsVerify = `[Unit]
-OnFailure=emergency.target
-OnFailureJobMode=isolate
-Before=fips-signal-ok.service
-
-[Service]
-Type=oneshot
-RemainAfterExit=yes
-ExecStart=grep 1 /proc/sys/crypto/fips_enabled
-ExecStart=grep FIPS etc/crypto-policies/config
-
-[Install]
-RequiredBy=fips-signal-ok.service`
-
-func testLiveFIPS(c cluster.TestCluster, opts IsoTestOpts) {
-	EnsureLiveArtifactsExist(c)
-
-	qc, ok := c.Cluster.(*qemu.Cluster)
-	if !ok {
-		c.Fatalf("Unsupported cluster type")
-	}
-
-	config, err := conf.EmptyIgnition().Render(conf.FailWarnings)
-	if err != nil {
-		c.Fatal(err)
-	}
-	config.AddSystemdUnit("fips-verify.service", fipsVerify, conf.Enable)
-	config.AddSystemdUnit("fips-signal-ok.service", liveSignalOKUnit, conf.Enable)
-	config.AddSystemdUnit("fips-emergency-target.service", signalFailureUnit, conf.Enable)
-	keys, err := qc.Keys()
-	if err != nil {
-		c.Fatal(err)
-	}
-	config.CopyKeys(keys)
-
-	errchan := make(chan error)
-	setupDisks := func(_ platform.MachineOptions, builder *platform.QemuBuilder) error {
-		isopath := filepath.Join(kola.CosaBuild.Dir, kola.CosaBuild.Meta.BuildArtifacts.LiveIso.Path)
-		if err := builder.AddIso(isopath, "", false); err != nil {
-			return err
-		}
-		completionChannel, err := builder.VirtioChannelRead("testisocompletion")
-		if err != nil {
-			return errors.Wrap(err, "setting up virtio-serial channel")
-		}
-		go func() {
-			errchan <- CheckTestOutput(completionChannel, []string{liveOKSignal})
-		}()
-		return nil
-	}
-
-	options := platform.MachineOptions{
-		AppendKernelArgs: "fips=1",
-		Firmware:         opts.firmware,
-	}
-
-	machineBuilder := &qemu.MachineBuilder{
-		SetupDisks: setupDisks,
-	}
-	_, err = qc.NewMachineWithBuilder(config, options, machineBuilder)
-	if err != nil {
-		c.Fatalf("Unable to create test machine: %v", err)
-	}
-
-	if err := <-errchan; err != nil {
-		c.Fatal(err)
-	}
+func testLiveFIPS(c cluster.TestCluster) {
+	m := c.Machines()[0]
+	// Verify we are on Live ISO
+	c.RunCmdSync(m, "test -f /run/ostree-live")
+	// And that FIPS is enabled
+	c.RunCmdSync(m, "grep 1 /proc/sys/crypto/fips_enabled")
+	c.RunCmdSync(m, "grep FIPS /etc/crypto-policies/config")
 }

--- a/mantle/kola/tests/iso/live-iscsi.go
+++ b/mantle/kola/tests/iso/live-iscsi.go
@@ -62,9 +62,11 @@ func getAllIscsiTests() []string {
 
 func init() {
 	for _, testName := range getAllIscsiTests() {
+		opts := getIsoTestOpts(testName)
+		// We need more memory to start another VM within.
+		opts.machineOpts.MinMemory = 2048
 		register.RegisterTest(&register.Test{
 			Run: func(c cluster.TestCluster) {
-				opts := getIsoTestOpts(testName)
 				testLiveSCSI(c, opts)
 			},
 			ClusterSize: 0,
@@ -76,6 +78,9 @@ func init() {
 			Timeout:   installTimeoutMins * time.Minute,
 			Flags:     []register.Flag{},
 			Platforms: []string{"qemu"},
+			// With ClusterSize: 0 we create the machine manually below, but at least
+			// MinMemory will be considered by the test harness for scheduling.
+			MachineOptions: opts.machineOpts,
 		})
 	}
 }
@@ -182,15 +187,10 @@ func testLiveSCSI(c cluster.TestCluster, opts IsoTestOpts) {
 		return nil
 	}
 
-	// We need more memory to start another VM within !
-	options := platform.MachineOptions{
-		MinMemory: 2048,
-		Firmware:  opts.firmware,
-	}
 	machineBuilder := &qemu.MachineBuilder{
 		SetupDisks: setupDisks,
 	}
-	_, err = qc.NewMachineWithBuilder(config, options, machineBuilder)
+	_, err = qc.NewMachineWithBuilder(config, opts.machineOpts, machineBuilder)
 	if err != nil {
 		c.Fatalf("Unable to create test machine: %v", err)
 	}

--- a/mantle/kola/tests/iso/live-iscsi.go
+++ b/mantle/kola/tests/iso/live-iscsi.go
@@ -74,7 +74,7 @@ func init() {
 			Description: "Verify iSCSI install works.",
 			// Skip base checks (looks at journal for failures) until bootupd fix lands
 			// https://github.com/coreos/fedora-coreos-tracker/issues/2136
-			Tags:      []string{kola.NeedsInternetTag, kola.SkipBaseChecksTag, "reprovision"},
+			Tags:      []string{kola.NeedsInternetTag, kola.SkipBaseChecksTag},
 			Timeout:   installTimeoutMins * time.Minute,
 			Flags:     []register.Flag{},
 			Platforms: []string{"qemu"},

--- a/mantle/kola/tests/iso/live-iso.go
+++ b/mantle/kola/tests/iso/live-iso.go
@@ -240,7 +240,6 @@ func testLiveIso(c cluster.TestCluster, opts IsoTestOpts) {
 	}
 	liveConfig.CopyKeys(keys)
 	liveConfig.AddSystemdUnit("live-signal-ok.service", liveSignalOKUnit, conf.Enable)
-	liveConfig.AddSystemdUnit("verify-no-efi-boot-entry.service", verifyNoEFIBootEntry, conf.Enable)
 	liveConfig.AddSystemdUnit("iso-not-mounted-when-fromram.service", isoNotMountedUnit, conf.Enable)
 	liveConfig.AddSystemdUnit("coreos-test-entered-emergency-target.service", signalFailureUnit, conf.Enable)
 	volumeIdUnitContents := fmt.Sprintf(verifyIsoVolumeId, kola.CosaBuild.Meta.Name)
@@ -334,6 +333,11 @@ func testLiveIso(c cluster.TestCluster, opts IsoTestOpts) {
 	// Verify the machine came up (uses SSH)
 	if err := platform.CheckMachine(m); err != nil {
 		c.Fatal(err)
+	}
+
+	// While booted into the live ISO verify no efi bootentry was created
+	if opts.firmware == "uefi" || opts.firmware == "uefi-secure" {
+		VerifyNoEfiBootEntry(c, m)
 	}
 
 	// Wait for install to complete, then switch the boot order and reboot.

--- a/mantle/kola/tests/iso/live-iso.go
+++ b/mantle/kola/tests/iso/live-iso.go
@@ -86,7 +86,7 @@ func init() {
 		opts.machineOpts.MinMemory = 4096
 		// Skip base checks (looks at journal for failures) until bootupd fix lands
 		// https://github.com/coreos/fedora-coreos-tracker/issues/2136
-		tags := []string{kola.SkipBaseChecksTag, "reprovision"}
+		tags := []string{kola.SkipBaseChecksTag}
 		if !strings.Contains(testName, "offline") {
 			tags = append(tags, kola.NeedsInternetTag)
 		}

--- a/mantle/kola/tests/iso/live-iso.go
+++ b/mantle/kola/tests/iso/live-iso.go
@@ -81,6 +81,9 @@ func getAllLiveIsoTests() []string {
 
 func init() {
 	for _, testName := range getAllLiveIsoTests() {
+		opts := getIsoTestOpts(testName)
+		// Doing an install. Allocate more memory.
+		opts.machineOpts.MinMemory = 4096
 		// Skip base checks (looks at journal for failures) until bootupd fix lands
 		// https://github.com/coreos/fedora-coreos-tracker/issues/2136
 		tags := []string{kola.SkipBaseChecksTag, "reprovision"}
@@ -89,7 +92,6 @@ func init() {
 		}
 		register.RegisterTest(&register.Test{
 			Run: func(c cluster.TestCluster) {
-				opts := getIsoTestOpts(testName)
 				testLiveIso(c, opts)
 			},
 			ClusterSize: 0,
@@ -99,6 +101,9 @@ func init() {
 			Tags:        tags,
 			Flags:       []register.Flag{},
 			Platforms:   []string{"qemu"},
+			// With ClusterSize: 0 we create the machine manually below, but at least
+			// MinMemory will be considered by the test harness for scheduling.
+			MachineOptions: opts.machineOpts,
 		})
 	}
 }
@@ -150,7 +155,7 @@ func testLiveIso(c cluster.TestCluster, opts IsoTestOpts) {
 	installerConfig := coreosInstallerConfig{
 		DestDevice:  "/dev/vda",
 		AppendKargs: renderCosaTestIsoDebugKargs(),
-		Insecure:    opts.instInsecure,
+		Insecure:    ShouldUseInsecureInstallOption(),
 		CopyNetwork: opts.addNmKeyfile, // force networking on in the initrd to verify the keyfile was used
 	}
 
@@ -314,18 +319,14 @@ func testLiveIso(c cluster.TestCluster, opts IsoTestOpts) {
 	// install so we can synchronously switch the boot order below.
 	kargs = append(kargs, "coreos.inst.skip_reboot")
 
-	options := platform.MachineOptions{
-		MinMemory:        4096,
-		MultiPathDisk:    opts.enableMultipath,
-		AppendKernelArgs: strings.Join(kargs, " "),
-		Firmware:         opts.firmware,
-	}
+	opts.machineOpts.AppendKernelArgs = strings.Join(kargs, " ")
+	opts.machineOpts.MultiPathDisk = opts.enableMultipath
 
 	machineBuilder := &qemu.MachineBuilder{
 		SetupDisks: setupDisks,
 	}
 
-	m, err := qc.NewMachineWithBuilder(liveConfig, options, machineBuilder)
+	m, err := qc.NewMachineWithBuilder(liveConfig, opts.machineOpts, machineBuilder)
 	if err != nil {
 		c.Fatal(errors.Wrap(err, "unable to create test machine"))
 	}
@@ -336,7 +337,7 @@ func testLiveIso(c cluster.TestCluster, opts IsoTestOpts) {
 	}
 
 	// While booted into the live ISO verify no efi bootentry was created
-	if opts.firmware == "uefi" || opts.firmware == "uefi-secure" {
+	if opts.machineOpts.Firmware == "uefi" || opts.machineOpts.Firmware == "uefi-secure" {
 		VerifyNoEfiBootEntry(c, m)
 	}
 

--- a/mantle/kola/tests/iso/live-login.go
+++ b/mantle/kola/tests/iso/live-login.go
@@ -2,7 +2,6 @@ package iso
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"github.com/coreos/coreos-assembler/mantle/kola"
@@ -48,12 +47,12 @@ func getAllLiveLoginTests() []string {
 
 func init() {
 	for _, testName := range getAllLiveLoginTests() {
-		var firmware string
-		if strings.Contains(testName, "uefi-secure") {
-			firmware = "uefi-secure"
-		} else if strings.Contains(testName, "uefi") {
-			firmware = "uefi"
-		}
+		opts := getIsoTestOpts(testName)
+		// Set machine to boot from the ISO
+		opts.machineOpts.BootFrom = platform.BootFromISO
+		// Set machine to not pass an Ignition config since we want to
+		// verify autologin works (which only triggers with no config)
+		opts.machineOpts.NoIgnition = true
 
 		register.RegisterTest(&register.Test{
 			Run:         testLiveLogin,
@@ -65,12 +64,8 @@ func init() {
 			Platforms:   []string{"qemu"},
 			// Skip base checks (looks at journal for failures) until bootupd fix lands
 			// https://github.com/coreos/fedora-coreos-tracker/issues/2136
-			Tags: []string{kola.SkipBaseChecksTag, "reprovision"},
-			MachineOptions: platform.MachineOptions{
-				Firmware:   firmware,
-				BootFrom:   platform.BootFromISO,
-				NoIgnition: true,
-			},
+			Tags:           []string{kola.SkipBaseChecksTag, "reprovision"},
+			MachineOptions: opts.machineOpts,
 		})
 	}
 }

--- a/mantle/kola/tests/iso/live-login.go
+++ b/mantle/kola/tests/iso/live-login.go
@@ -2,7 +2,6 @@ package iso
 
 import (
 	"context"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -10,7 +9,6 @@ import (
 	"github.com/coreos/coreos-assembler/mantle/kola/cluster"
 	"github.com/coreos/coreos-assembler/mantle/kola/register"
 	"github.com/coreos/coreos-assembler/mantle/platform"
-	"github.com/coreos/coreos-assembler/mantle/platform/machine/qemu"
 	"github.com/coreos/coreos-assembler/mantle/util"
 	coreosarch "github.com/coreos/stream-metadata-go/arch"
 )
@@ -58,45 +56,27 @@ func init() {
 		}
 
 		register.RegisterTest(&register.Test{
-			Run: func(c cluster.TestCluster) {
-				testLiveLogin(c, firmware)
-			},
-			ClusterSize: 0,
+			Run:         testLiveLogin,
+			ClusterSize: 1,
 			Name:        "iso." + testName,
 			Description: "Verify ISO live login works.",
+			Timeout:     3 * time.Minute, // Just boots the ISO -> quick
 			Flags:       []register.Flag{},
 			Platforms:   []string{"qemu"},
 			// Skip base checks (looks at journal for failures) until bootupd fix lands
 			// https://github.com/coreos/fedora-coreos-tracker/issues/2136
 			Tags: []string{kola.SkipBaseChecksTag, "reprovision"},
+			MachineOptions: platform.MachineOptions{
+				Firmware:   firmware,
+				BootFrom:   platform.BootFromISO,
+				NoIgnition: true,
+			},
 		})
 	}
 }
 
-func testLiveLogin(c cluster.TestCluster, firmware string) {
-	EnsureLiveArtifactsExist(c)
-
-	setupDisks := func(_ platform.MachineOptions, builder *platform.QemuBuilder) error {
-		isopath := filepath.Join(kola.CosaBuild.Dir, kola.CosaBuild.Meta.BuildArtifacts.LiveIso.Path)
-		// Drop the bootindex bit (applicable to all arches except s390x and ppc64le); we want it to be the default
-		return builder.AddIso(isopath, "", false)
-	}
-
-	var m platform.Machine
-	switch pc := c.Cluster.(type) {
-	case *qemu.Cluster:
-		options := platform.MachineOptions{Firmware: firmware}
-		builder := &qemu.MachineBuilder{
-			SetupDisks: setupDisks,
-		}
-		var err error
-		m, err = pc.NewMachineWithBuilder(nil, options, builder)
-		if err != nil {
-			c.Fatalf("Unable to create test machine: %v", err)
-		}
-	default:
-		c.Fatalf("Unsupported cluster type")
-	}
+func testLiveLogin(c cluster.TestCluster) {
+	m := c.Machines()[0]
 
 	// Wait for the automatic login prompt to appear in the console output
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)

--- a/mantle/kola/tests/iso/live-login.go
+++ b/mantle/kola/tests/iso/live-login.go
@@ -64,7 +64,7 @@ func init() {
 			Platforms:   []string{"qemu"},
 			// Skip base checks (looks at journal for failures) until bootupd fix lands
 			// https://github.com/coreos/fedora-coreos-tracker/issues/2136
-			Tags:           []string{kola.SkipBaseChecksTag, "reprovision"},
+			Tags:           []string{kola.SkipBaseChecksTag},
 			MachineOptions: opts.machineOpts,
 		})
 	}

--- a/mantle/kola/tests/iso/live-pxe.go
+++ b/mantle/kola/tests/iso/live-pxe.go
@@ -62,9 +62,17 @@ func getAllPxeTests() []string {
 
 func init() {
 	for _, testName := range getAllPxeTests() {
+		opts := getIsoTestOpts(testName)
+		// Doing an install. Allocate more memory.
+		opts.machineOpts.MinMemory = 4096
+		// Increase the memory for pxe tests with appended rootfs in the initrd
+		// we were bumping up into the 4GiB limit in RHCOS/c9s
+		if opts.pxeAppendRootfs {
+			opts.machineOpts.MinMemory = 5120
+		}
+
 		register.RegisterTest(&register.Test{
 			Run: func(c cluster.TestCluster) {
-				opts := getIsoTestOpts(testName)
 				testLivePXE(c, opts)
 			},
 			ClusterSize: 0,
@@ -76,6 +84,9 @@ func init() {
 			// Skip base checks (looks at journal for failures) until bootupd fix lands
 			// https://github.com/coreos/fedora-coreos-tracker/issues/2136
 			Tags: []string{kola.SkipBaseChecksTag, "reprovision"},
+			// With ClusterSize: 0 we create the machine manually below, but at least
+			// MinMemory will be considered by the test harness for scheduling.
+			MachineOptions: opts.machineOpts,
 		})
 	}
 }
@@ -143,7 +154,7 @@ func testLivePXE(c cluster.TestCluster, opts IsoTestOpts) {
 		if err != nil {
 			return err
 		}
-		liveConfig, err := getPXEConfig(opts.instInsecure, opts.isOffline)
+		liveConfig, err := getPXEConfig(opts.isOffline)
 		if err != nil {
 			return err
 		}
@@ -217,23 +228,12 @@ func testLivePXE(c cluster.TestCluster, opts IsoTestOpts) {
 		return nil
 	}
 
-	options := platform.MachineOptions{
-		MinMemory: 4096,
-		Firmware:  opts.firmware,
-	}
-
-	// increase the memory for pxe tests with appended rootfs in the initrd
-	// we were bumping up into the 4GiB limit in RHCOS/c9s
-	if opts.pxeAppendRootfs {
-		options.MinMemory = 5120
-	}
-
 	builder := &qemu.MachineBuilder{
 		InitBuilder:  initBuilder,
 		SetupDisks:   setupDisks,
 		SetupNetwork: setupNet,
 	}
-	m, err := qc.NewMachineWithBuilder(nil, options, builder)
+	m, err := qc.NewMachineWithBuilder(nil, opts.machineOpts, builder)
 	if err != nil {
 		c.Fatal(errors.Wrap(err, "unable to create test machine"))
 	}
@@ -251,11 +251,11 @@ func testLivePXE(c cluster.TestCluster, opts IsoTestOpts) {
 	}
 }
 
-func getPXEConfig(insecure bool, offline bool) (*conf.Conf, error) {
+func getPXEConfig(offline bool) (*conf.Conf, error) {
 	installerConfig := coreosInstallerConfig{
 		Console:     []string{platform.ConsoleKernelArgument[coreosarch.CurrentRpmArch()]},
 		AppendKargs: renderCosaTestIsoDebugKargs(),
-		Insecure:    insecure,
+		Insecure:    ShouldUseInsecureInstallOption(),
 	}
 	installerConfigData, err := yaml.Marshal(installerConfig)
 	if err != nil {
@@ -379,7 +379,7 @@ func (pxe *PXE) setupArchDefaults(opts IsoTestOpts) error {
 	pxe.tftpipaddr = "192.168.76.2"
 	switch coreosarch.CurrentRpmArch() {
 	case "x86_64":
-		if opts.firmware == "uefi" {
+		if opts.machineOpts.Firmware == "uefi" {
 			pxe.boottype = "grub"
 			pxe.bootfile = "/boot/grub2/grubx64.efi"
 			pxe.pxeimagepath = "/boot/efi/EFI/fedora/grubx64.efi"
@@ -500,7 +500,7 @@ func renderInstallKargs(baseurl string, metalname string, opts IsoTestOpts) []st
 		args = append(args, fmt.Sprintf("coreos.inst.image_url=%s/%s", baseurl, metalname))
 	}
 	// FIXME - ship signatures by default too
-	if opts.instInsecure {
+	if ShouldUseInsecureInstallOption() {
 		args = append(args, "coreos.inst.insecure")
 	}
 	return args

--- a/mantle/kola/tests/iso/live-pxe.go
+++ b/mantle/kola/tests/iso/live-pxe.go
@@ -83,7 +83,7 @@ func init() {
 			Platforms:   []string{"qemu"},
 			// Skip base checks (looks at journal for failures) until bootupd fix lands
 			// https://github.com/coreos/fedora-coreos-tracker/issues/2136
-			Tags: []string{kola.SkipBaseChecksTag, "reprovision"},
+			Tags: []string{kola.SkipBaseChecksTag},
 			// With ClusterSize: 0 we create the machine manually below, but at least
 			// MinMemory will be considered by the test harness for scheduling.
 			MachineOptions: opts.machineOpts,

--- a/mantle/platform/machine/qemu/cluster.go
+++ b/mantle/platform/machine/qemu/cluster.go
@@ -61,7 +61,16 @@ func (qc *Cluster) NewMachineWithOptions(userdata *conf.UserData, options platfo
 	if options.InstanceType != "" {
 		return nil, errors.New("platform qemu does not support changing instance types")
 	}
-	return qc.NewMachineWithBuilder(userdata, options, nil)
+	// When NoIgnition is set, pass a true nil (untyped) to
+	// NewMachineWithBuilder so that RenderUserDataIfNeeded
+	// returns nil and no Ignition config is generated or
+	// injected. This is needed for tests like live-login that
+	// require booting without any user-provided config.
+	var ud any
+	if !options.NoIgnition {
+		ud = userdata
+	}
+	return qc.NewMachineWithBuilder(ud, options, nil)
 }
 
 // NewMachineWithBuilder creates a new machine with custom builder hooks.

--- a/mantle/platform/machine/qemu/cluster.go
+++ b/mantle/platform/machine/qemu/cluster.go
@@ -302,37 +302,50 @@ func (qc *Cluster) InitDefaultBuilder(options platform.MachineOptions, builder *
 }
 
 func (qc *Cluster) SetupDefaultDisks(options platform.MachineOptions, builder *platform.QemuBuilder) error {
-	var primaryDisk platform.Disk
-	if options.PrimaryDisk != "" {
-		diskp, err := platform.ParseDisk(options.PrimaryDisk, true)
-		if err != nil {
-			return errors.Wrapf(err, "parsing primary disk spec '%s'", options.PrimaryDisk)
+	switch options.BootFrom {
+	case platform.BootFromISO, platform.BootFromISOAsDisk:
+		if qc.flight.opts.IsoImage == "" {
+			return fmt.Errorf("bootFrom %q requested but no ISO image path is available; does the build have a live ISO artifact?", options.BootFrom)
 		}
-		primaryDisk = *diskp
-	}
-	if qc.flight.opts.Nvme || options.Nvme {
-		primaryDisk.Channel = "nvme"
-	}
-	if qc.flight.opts.Native4k {
-		primaryDisk.SectorSize = 4096
-	} else if qc.flight.opts.Disk512e {
-		primaryDisk.SectorSize = 4096
-		primaryDisk.LogicalSectorSize = 512
-	}
-	if options.MultiPathDisk || qc.flight.opts.MultiPathDisk {
-		primaryDisk.MultiPathDisk = true
-	}
-	if options.MinDiskSize > 0 {
-		primaryDisk.Size = fmt.Sprintf("%dG", options.MinDiskSize)
-	} else if qc.flight.opts.DiskSize != "" {
-		primaryDisk.Size = qc.flight.opts.DiskSize
-	}
-	primaryDisk.BackingFile = qc.flight.opts.DiskImage
-	if options.OverrideBackingFile != "" {
-		primaryDisk.BackingFile = options.OverrideBackingFile
-	}
-	if err := builder.AddBootDisk(&primaryDisk); err != nil {
-		return err
+		asDisk := options.BootFrom == platform.BootFromISOAsDisk
+		if err := builder.AddIso(qc.flight.opts.IsoImage, "", asDisk); err != nil {
+			return err
+		}
+	case platform.BootFromDefault:
+		var primaryDisk platform.Disk
+		if options.PrimaryDisk != "" {
+			diskp, err := platform.ParseDisk(options.PrimaryDisk, true)
+			if err != nil {
+				return errors.Wrapf(err, "parsing primary disk spec '%s'", options.PrimaryDisk)
+			}
+			primaryDisk = *diskp
+		}
+		if qc.flight.opts.Nvme || options.Nvme {
+			primaryDisk.Channel = "nvme"
+		}
+		if qc.flight.opts.Native4k {
+			primaryDisk.SectorSize = 4096
+		} else if qc.flight.opts.Disk512e {
+			primaryDisk.SectorSize = 4096
+			primaryDisk.LogicalSectorSize = 512
+		}
+		if options.MultiPathDisk || qc.flight.opts.MultiPathDisk {
+			primaryDisk.MultiPathDisk = true
+		}
+		if options.MinDiskSize > 0 {
+			primaryDisk.Size = fmt.Sprintf("%dG", options.MinDiskSize)
+		} else if qc.flight.opts.DiskSize != "" {
+			primaryDisk.Size = qc.flight.opts.DiskSize
+		}
+		primaryDisk.BackingFile = qc.flight.opts.DiskImage
+		if options.OverrideBackingFile != "" {
+			primaryDisk.BackingFile = options.OverrideBackingFile
+		}
+		if err := builder.AddBootDisk(&primaryDisk); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("unknown bootFrom value %q; supported values are %q and %q", options.BootFrom, platform.BootFromISO, platform.BootFromISOAsDisk)
 	}
 	if err := builder.AddDisksFromSpecs(options.AdditionalDisks); err != nil {
 		return err

--- a/mantle/platform/machine/qemu/flight.go
+++ b/mantle/platform/machine/qemu/flight.go
@@ -31,6 +31,9 @@ type Options struct {
 	DiskImage string
 	// DiskImageIsUserProvided is true when DiskImage was explicitly set via --qemu-image
 	DiskImageIsUserProvided bool
+	// IsoImage is the full path to the live ISO image to boot in QEMU.
+	// Used when tests request BootFrom ISO or ISO-as-disk.
+	IsoImage string
 	// DiskSize if non-empty will expand the disk
 	DiskSize string
 	// DriveOpts is arbitrary comma-separated list of options

--- a/mantle/platform/platform.go
+++ b/mantle/platform/platform.go
@@ -189,6 +189,7 @@ type MachineOptions struct {
 	Cex                       bool
 	BindMountHostRO           []string
 	BootFrom                  string
+	NoIgnition                bool
 }
 
 // EnsureNoQEMUOnlyOptions returns an error if any QEMU-only options
@@ -239,6 +240,9 @@ func (m *MachineOptions) EnsureNoQEMUOnlyOptions(platformName string) error {
 	}
 	if m.BootFrom != BootFromDefault {
 		return fmt.Errorf("platform %s does not support bootFrom option", platformName)
+	}
+	if m.NoIgnition {
+		return fmt.Errorf("platform %s does not support NoIgnition", platformName)
 	}
 	return nil
 }

--- a/mantle/platform/platform.go
+++ b/mantle/platform/platform.go
@@ -160,6 +160,13 @@ type Flight interface {
 	Destroy()
 }
 
+// BootFrom constants for MachineOptions.BootFrom
+const (
+	BootFromDefault   = ""
+	BootFromISO       = "iso"
+	BootFromISOAsDisk = "iso-as-disk"
+)
+
 type MachineOptions struct {
 	AdditionalDisks []string
 	MinDiskSize     int
@@ -181,6 +188,7 @@ type MachineOptions struct {
 	Nvme                      bool
 	Cex                       bool
 	BindMountHostRO           []string
+	BootFrom                  string
 }
 
 // EnsureNoQEMUOnlyOptions returns an error if any QEMU-only options
@@ -228,6 +236,9 @@ func (m *MachineOptions) EnsureNoQEMUOnlyOptions(platformName string) error {
 	}
 	if len(m.BindMountHostRO) > 0 {
 		return fmt.Errorf("platform %s does not support bind mounting host paths", platformName)
+	}
+	if m.BootFrom != BootFromDefault {
+		return fmt.Errorf("platform %s does not support bootFrom option", platformName)
 	}
 	return nil
 }


### PR DESCRIPTION
Add a BootFrom MachineOptions option and then use it to set BootFrom "iso" or "iso-as-disk"
to simplify the tests so that they can be run by the harness (ClusterSize: 1) instead
of manually.

Also we carry MachineOptions in the iso options and deduplicate options that were in
both and pass in the MachineOptions to register.RegisterTest which also fixes a
bug where ISO tests memory requirements weren't properly being handled in the test
harness when it comes to memory based scheduling (see d142c86). This should fix the
issue raised in https://github.com/coreos/rhel-coreos-config/pull/266#issuecomment-4799047108