### PR TITLE
kola/tests/iso: use MachineOptions instead of IsoTestOpts.enableMultipath and IsoTestOpts.isISOFromRAM

### DIFF
--- a/mantle/kola/tests/iso/common.go
+++ b/mantle/kola/tests/iso/common.go
@@ -84,7 +84,6 @@ type IsoTestOpts struct {
 	addNmKeyfile    bool
 	enable4k        bool
 	isOffline       bool
-	isISOFromRAM    bool
 	isMiniso        bool
 	enableIbft      bool
 	manual          bool
@@ -111,7 +110,8 @@ func getIsoTestOpts(testName string) IsoTestOpts {
 		opts.isOffline = true
 	}
 	if strings.Contains(testName, "fromram") {
-		opts.isISOFromRAM = true
+		// https://github.com/coreos/fedora-coreos-config/pull/2544
+		opts.machineOpts.AppendKernelArgs = "coreos.liveiso.fromram"
 	}
 	if strings.Contains(testName, "miniso") {
 		opts.isMiniso = true

--- a/mantle/kola/tests/iso/common.go
+++ b/mantle/kola/tests/iso/common.go
@@ -83,7 +83,6 @@ func startHTTPServer(listener net.Listener, dir string) *http.Server {
 type IsoTestOpts struct {
 	addNmKeyfile    bool
 	enable4k        bool
-	enableMultipath bool
 	isOffline       bool
 	isISOFromRAM    bool
 	isMiniso        bool
@@ -106,7 +105,7 @@ func getIsoTestOpts(testName string) IsoTestOpts {
 		opts.machineOpts.Firmware = "uefi"
 	}
 	if strings.Contains(testName, "mpath") {
-		opts.enableMultipath = true
+		opts.machineOpts.MultiPathDisk = true
 	}
 	if strings.Contains(testName, "offline") {
 		opts.isOffline = true

--- a/mantle/kola/tests/iso/live-iscsi.go
+++ b/mantle/kola/tests/iso/live-iscsi.go
@@ -122,7 +122,7 @@ func testLiveSCSI(c cluster.TestCluster, opts IsoTestOpts) {
 
 	// Prepare config
 	var butane string
-	if opts.enableIbft && opts.enableMultipath {
+	if opts.enableIbft && opts.machineOpts.MultiPathDisk {
 		butane = strings.ReplaceAll(iscsi_butane_config, "COREOS_INSTALLER_KARGS", "--append-karg rd.iscsi.firmware=1 --append-karg rd.multipath=default --append-karg root=/dev/disk/by-label/dm-mpath-root --append-karg rw")
 	} else if opts.enableIbft {
 		butane = strings.ReplaceAll(iscsi_butane_config, "COREOS_INSTALLER_KARGS", "--append-karg rd.iscsi.firmware=1")

--- a/mantle/kola/tests/iso/live-iso.go
+++ b/mantle/kola/tests/iso/live-iso.go
@@ -305,9 +305,8 @@ func testLiveIso(c cluster.TestCluster, opts IsoTestOpts) {
 		return builder.AddIso(isopath, "bootindex=3", false)
 	}
 	kargs := renderCosaTestIsoDebugKargs()
-	if opts.isISOFromRAM {
-		// https://github.com/coreos/fedora-coreos-config/pull/2544
-		kargs = append(kargs, "coreos.liveiso.fromram")
+	if opts.machineOpts.AppendKernelArgs != "" {
+		kargs = append(kargs, opts.machineOpts.AppendKernelArgs)
 	}
 	if opts.addNmKeyfile {
 		// We verify that the keyfiles get applied in the initramfs so let's

--- a/mantle/kola/tests/iso/live-iso.go
+++ b/mantle/kola/tests/iso/live-iso.go
@@ -143,7 +143,7 @@ func testLiveIso(c cluster.TestCluster, opts IsoTestOpts) {
 	targetConfig.AddSystemdUnit("coreos-test-installer.service", signalCompletionUnit, conf.Enable)
 	targetConfig.AddSystemdUnit("coreos-test-entered-emergency-target.service", signalFailureUnit, conf.Enable)
 	targetConfig.AddSystemdUnit("coreos-test-installer-no-ignition.service", checkNoIgnition, conf.Enable)
-	if opts.enableMultipath {
+	if opts.machineOpts.MultiPathDisk {
 		targetConfig.AddSystemdUnit("coreos-test-installer-multipathed.service", multipathedRoot, conf.Enable)
 	}
 	if opts.addNmKeyfile {
@@ -227,7 +227,7 @@ func testLiveIso(c cluster.TestCluster, opts IsoTestOpts) {
 	if coreosarch.CurrentRpmArch() != "s390x" {
 		installerConfig.Console = []string{platform.ConsoleKernelArgument[coreosarch.CurrentRpmArch()]}
 	}
-	if opts.enableMultipath {
+	if opts.machineOpts.MultiPathDisk {
 		// we only have one multipath device so it has to be that
 		installerConfig.DestDevice = "/dev/mapper/mpatha"
 		installerConfig.AppendKargs = append(installerConfig.AppendKargs, "rd.multipath=default", "root=/dev/disk/by-label/dm-mpath-root", "rw")
@@ -254,7 +254,7 @@ func testLiveIso(c cluster.TestCluster, opts IsoTestOpts) {
 	}
 	liveConfig.AddFile("/etc/coreos/installer.d/mantle.yaml", string(installerConfigData), mode)
 	liveConfig.AddAutoLogin()
-	if opts.enableMultipath {
+	if opts.machineOpts.MultiPathDisk {
 		liveConfig.AddSystemdUnit("coreos-installer-multipath.service", coreosInstallerMultipathUnit, conf.Enable)
 		liveConfig.AddSystemdUnitDropin("coreos-installer.service", "wait-for-mpath-target.conf", waitForMpathTargetConf)
 	}
@@ -281,7 +281,7 @@ func testLiveIso(c cluster.TestCluster, opts IsoTestOpts) {
 		disk := platform.Disk{
 			Size:          "12G", // Arbitrary
 			SectorSize:    sectorSize,
-			MultiPathDisk: opts.enableMultipath,
+			MultiPathDisk: opts.machineOpts.MultiPathDisk,
 		}
 		//TBD: see if we can remove this and just use AddDisk and inject bootindex during startup
 		if coreosarch.CurrentRpmArch() == "s390x" || coreosarch.CurrentRpmArch() == "aarch64" {
@@ -320,7 +320,6 @@ func testLiveIso(c cluster.TestCluster, opts IsoTestOpts) {
 	kargs = append(kargs, "coreos.inst.skip_reboot")
 
 	opts.machineOpts.AppendKernelArgs = strings.Join(kargs, " ")
-	opts.machineOpts.MultiPathDisk = opts.enableMultipath
 
 	machineBuilder := &qemu.MachineBuilder{
 		SetupDisks: setupDisks,


### PR DESCRIPTION
Remove the redundant `enableMultipath` and `isISOFromRAM` fields from `IsoTestOpts`.
Use `MachineOptions.MultiPathDisk` and `MachineOptions.AppendKernelArgs`
directly instead. This follows the pattern introduced in the previous
commit of configuring ISO tests through `platform.MachineOptions` rather
than duplicating the same information in `IsoTestOpts`.