### PR TITLE
osbuild: update bfb stage

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -182,27 +182,35 @@ write_archive_info() {
 }
 
 patch_osbuild() {
-    return # No patches at this time
-    # # Add a few patches that either haven't made it into a release or
-    # # that will be obsoleted with other work that will be done soon.
-    # #
-    # # To make it easier to apply patches we'll move around the osbuild
-    # # code on the system first:
-    # rmdir /usr/lib/osbuild/osbuild
-    # python_lib_dir=$(ls -d /usr/lib/python*)
-    # mv "${python_lib_dir}/site-packages/osbuild" /usr/lib/osbuild/
-    # mkdir -p /usr/lib/osbuild/tools
-    # mv /usr/bin/osbuild-mpp /usr/lib/osbuild/tools/
-    # # Now all the software is under the /usr/lib/osbuild dir and we can patch
-    # # shellcheck disable=SC2002
-    # cat \
-    #     /usr/lib/coreos-assembler/0003-buildroot-bind-mount-run-udev-for-partition-discovery.patch \
-    #         | patch -d /usr/lib/osbuild -p1
-    # # And then move the files back; supermin appliance creation will need it back
-    # # in the places delivered by the RPM.
-    # mv /usr/lib/osbuild/tools/osbuild-mpp /usr/bin/osbuild-mpp
-    # mv /usr/lib/osbuild/osbuild "${python_lib_dir}/site-packages/osbuild"
-    # mkdir -p /usr/lib/osbuild/osbuild
+    #return # No patches at this time
+    # Add a few patches that either haven't made it into a release or
+    # that will be obsoleted with other work that will be done soon.
+    #
+    # To make it easier to apply patches we'll move around the osbuild
+    # code on the system first:
+    rmdir /usr/lib/osbuild/osbuild
+    python_lib_dir=$(ls -d /usr/lib/python*)
+    mv "${python_lib_dir}/site-packages/osbuild" /usr/lib/osbuild/
+    mkdir -p /usr/lib/osbuild/tools
+    mv /usr/bin/osbuild-mpp /usr/lib/osbuild/tools/
+    # Now all the software is under the /usr/lib/osbuild dir and we can patch
+    # shellcheck disable=SC2002
+    cat \
+        /usr/lib/coreos-assembler/0001-stages-coreos.live-artifacts-refactor-some-EFI-funct.patch \
+        /usr/lib/coreos-assembler/0002-stages-coreos.live-artifacts-drop-separate-make_efi_.patch \
+        /usr/lib/coreos-assembler/0003-util-path-move-ensure_glob-from-coreos-stage-into-os.patch \
+        /usr/lib/coreos-assembler/0004-utils-add-utils.makeefi-library.patch                      \
+        /usr/lib/coreos-assembler/0005-util-makeefi-update-find_efi_vendor_dir_name-to-acce.patch \
+        /usr/lib/coreos-assembler/0006-util-makeefi-make-efiboot.img-align-to-512-byte-boun.patch \
+        /usr/lib/coreos-assembler/0007-util-makeefi-search-more-paths-for-EFI-files.patch         \
+        /usr/lib/coreos-assembler/0008-util-makeefi-move-comment-into-function-description.patch  \
+        /usr/lib/coreos-assembler/0009-BFB-boot-grub-shims-instead-of-booting-kernel-direct.patch \
+            | patch -d /usr/lib/osbuild -p1
+    # And then move the files back; supermin appliance creation will need it back
+    # in the places delivered by the RPM.
+    mv /usr/lib/osbuild/tools/osbuild-mpp /usr/bin/osbuild-mpp
+    mv /usr/lib/osbuild/osbuild "${python_lib_dir}/site-packages/osbuild"
+    mkdir -p /usr/lib/osbuild/osbuild
 }
 
 fixup_file_permissions() {

--- a/src/0001-stages-coreos.live-artifacts-refactor-some-EFI-funct.patch
+++ b/src/0001-stages-coreos.live-artifacts-refactor-some-EFI-funct.patch
@@ -1,0 +1,166 @@
+From 34b6ad676acff7977b74b85e850707794965321b Mon Sep 17 00:00:00 2001
+From: Dusty Mabe <dusty@dustymabe.com>
+Date: Wed, 1 Jul 2026 13:36:02 -0400
+Subject: [PATCH 1/9] stages/coreos.live-artifacts: refactor some EFI functions
+
+This is prep for them being pulled out into a library to be shared
+with another stage.
+
+There should be no difference in behavior introduced with this change.
+---
+ stages/org.osbuild.coreos.live-artifacts.mono | 116 ++++++++++--------
+ 1 file changed, 68 insertions(+), 48 deletions(-)
+
+diff --git a/stages/org.osbuild.coreos.live-artifacts.mono b/stages/org.osbuild.coreos.live-artifacts.mono
+index 5bcf97d8..029af63b 100755
+--- a/stages/org.osbuild.coreos.live-artifacts.mono
++++ b/stages/org.osbuild.coreos.live-artifacts.mono
+@@ -377,8 +377,24 @@ def gen_live_artifacts(paths, tree, filenames, deployed_tree, loop_client, versi
+ 
+     # For x86_64 and aarch64 UEFI booting
+     if basearch in ("x86_64", "aarch64"):
+-        efiboot_path = mkefiboot(paths, deployed_tree, volid, loop_client)
+-        genisoargs += ['-eltorito-alt-boot', '-efi-boot', efiboot_path, '-no-emul-boot']
++        # extract a few directories from paths dict
++        efidir = paths["efi"]
++        output_efiboot_img = paths["iso/images/efiboot.img"]
++        # Copy out the EFI files found from the source_tree to the specified
++        # directory: efidir
++        mkefidir(efidir=efidir, source_tree=deployed_tree)
++        # Discover the vendor ID (can be different on Fedora/RHEL/CentOS)
++        vendor_id = find_efi_vendor_dir_name(efidir)
++        # Get the grub configuration for booting from the ISO and write it out
++        # to $efidir/BOOT/grub.cfg. See the comment in the function for explanation
++        # of config used.
++        # Write out the grub config into $efidir/BOOT/grub.cfg
++        with open(os.path.join(efidir, "BOOT", "grub.cfg"), "w", encoding='utf8') as fh:
++            fh.write(get_grub_cfg_string(volid, vendor_id))
++        # Create the efiboot.img file
++        mkefiboot(efidir, output_efiboot_img, loop_client)
++        # And add arguments to include it in when creating the ISO
++        genisoargs += ['-eltorito-alt-boot', '-efi-boot', 'images/efiboot.img', '-no-emul-boot']
+ 
+     # We've done everything that might affect kargs, so filter out any files
+     # that no longer exist and write out the kargs JSON if it lists any files
+@@ -483,28 +499,35 @@ def update_image_offsets_s390x(paths, kargs_json, igninfo_json):
+     })
+ 
+ 
+-def mkefiboot(paths, deployed_tree, volid, loop_client):
+-    """
+-    Creates an efi boot image (efiboot.img) file, required for EFI
+-    booting the ISO. This is a fat32 formatted filesystem that contains
+-    all the files needed for EFI boot from an ISO.
++def get_grub_cfg_string(volid, vendor_id):
++    # Inject a stub grub.cfg pointing to the one in the main ISO image.
++    #
++    # When booting via El Torito, this stub is not used; GRUB reads
++    # the ISO image directly using its own ISO support.  This
++    # happens when booting from a CD device, or when the ISO is
++    # copied to a USB stick and booted on EFI firmware which prefers
++    # to boot a hard disk from an El Torito image if it has one.
++    # EDK II in QEMU behaves this way.
++    #
++    # This stub is used with EFI firmware which prefers to boot a
++    # hard disk from an ESP, or which cannot boot a hard disk via El
++    # Torito at all.  In that case, GRUB thinks it booted from a
++    # partition of the disk (a fake ESP created by isohybrid,
++    # pointing to efiboot.img) and needs a grub.cfg there.
++    return f'''search --label "{volid}" --set root --no-floppy
++set prefix=($root)/EFI/{vendor_id}
++echo "Booting via ESP..."
++configfile $prefix/grub.cfg
++boot
++'''
+ 
+-    Returns the path to the image file.
+-    """
+-    # In restrictive environments, setgid, setuid and ownership changes
+-    # may be restricted. This sets the file ownership to root and
+-    # removes the setgid and setuid bits in the tarball.
+-    def strip(tarinfo):
+-        tarinfo.uid = 0
+-        tarinfo.gid = 0
+-        if tarinfo.isdir():
+-            tarinfo.mode = 0o755
+-        elif tarinfo.isfile():
+-            tarinfo.mode = 0o0644
+-        return tarinfo
+ 
+-    efidir = paths["efi"]
+-    for path in find_efi_source_paths(deployed_tree):
++def mkefidir(efidir, source_tree):
++    """
++    Searches the source_tree for files used for EFI booting and copies
++    these files into the specified efidir.
++    """
++    for path in find_efi_source_paths(source_tree):
+         shutil.copytree(path, efidir, dirs_exist_ok=True)
+ 
+     vendor_id = find_efi_vendor_dir_name(efidir)
+@@ -532,39 +555,36 @@ def mkefiboot(paths, deployed_tree, volid, loop_client):
+         shutil.move(path, os.path.join(efidir, "BOOT"))
+     os.rmdir(os.path.join(efidir, vendor_id))
+ 
+-    # Inject a stub grub.cfg pointing to the one in the main ISO image.
+-    #
+-    # When booting via El Torito, this stub is not used; GRUB reads
+-    # the ISO image directly using its own ISO support.  This
+-    # happens when booting from a CD device, or when the ISO is
+-    # copied to a USB stick and booted on EFI firmware which prefers
+-    # to boot a hard disk from an El Torito image if it has one.
+-    # EDK II in QEMU behaves this way.
+-    #
+-    # This stub is used with EFI firmware which prefers to boot a
+-    # hard disk from an ESP, or which cannot boot a hard disk via El
+-    # Torito at all.  In that case, GRUB thinks it booted from a
+-    # partition of the disk (a fake ESP created by isohybrid,
+-    # pointing to efiboot.img) and needs a grub.cfg there.
+-    with open(os.path.join(efidir, "BOOT", "grub.cfg"), "w", encoding='utf8') as fh:
+-        fh.write(f'''search --label "{volid}" --set root --no-floppy
+-set prefix=($root)/EFI/{vendor_id}
+-echo "Booting via ESP..."
+-configfile $prefix/grub.cfg
+-boot
+-''')
++
++def mkefiboot(efidir, output_efiboot_img, loop_client):
++    """
++    Creates an efi boot image file at output_efiboot_img (usually named efiboot.img),
++    which is required for EFI booting. This is a fat32 formatted filesystem that
++    contains all the files needed for EFI boot.
++    """
++
++    # In restrictive environments, setgid, setuid and ownership changes
++    # may be restricted. This sets the file ownership to root and
++    # removes the setgid and setuid bits in the tarball.
++    def strip_tar(tarinfo):
++        tarinfo.uid = 0
++        tarinfo.gid = 0
++        if tarinfo.isdir():
++            tarinfo.mode = 0o755
++        elif tarinfo.isfile():
++            tarinfo.mode = 0o0644
++        return tarinfo
+ 
+     # Install binaries from boot partition
+     # Manually construct the tarball to ensure proper permissions and ownership
+     efitarfile = tempfile.NamedTemporaryFile(suffix=".tar")
+     with tarfile.open(efitarfile.name, "w:", dereference=True) as tar:
+-        tar.add(efidir, arcname="/EFI", filter=strip)
++        tar.add(efidir, arcname="/EFI", filter=strip_tar)
+ 
+     # Create the efiboot.img file in the images/ dir
+-    efibootfile = paths["iso/images/efiboot.img"]
+-    make_efi_bootfile(loop_client, input_tarball=efitarfile.name, output_efiboot_img=efibootfile)
+-    return "images/efiboot.img"
+-
++    make_efi_bootfile(loop_client,
++                      input_tarball=efitarfile.name,
++                      output_efiboot_img=output_efiboot_img)
+ 
+ def mkrootfs_metal(paths, workdir, img_metal, fstype, fsoptions, loop_client):
+     """
+-- 
+2.54.0
+

--- a/src/0002-stages-coreos.live-artifacts-drop-separate-make_efi_.patch
+++ b/src/0002-stages-coreos.live-artifacts-drop-separate-make_efi_.patch
@@ -1,0 +1,96 @@
+From 1e7b5bc912c81766597975b8a9a3f8e512d8f520 Mon Sep 17 00:00:00 2001
+From: Dusty Mabe <dusty@dustymabe.com>
+Date: Wed, 1 Jul 2026 13:57:54 -0400
+Subject: [PATCH 2/9] stages/coreos.live-artifacts: drop separate
+ make_efi_bootfile() function
+
+It didn't quite have enough code to justify having it split out on its
+own at this point.
+---
+ stages/org.osbuild.coreos.live-artifacts.mono | 58 +++++++++----------
+ 1 file changed, 26 insertions(+), 32 deletions(-)
+
+diff --git a/stages/org.osbuild.coreos.live-artifacts.mono b/stages/org.osbuild.coreos.live-artifacts.mono
+index 029af63b..5db23e59 100755
+--- a/stages/org.osbuild.coreos.live-artifacts.mono
++++ b/stages/org.osbuild.coreos.live-artifacts.mono
+@@ -171,33 +171,6 @@ def find_efi_vendor_dir_name(efidir):
+     return vendor_id
+ 
+ 
+-# This creates efiboot.img, which is a FAT filesystem.
+-def make_efi_bootfile(loop_client, input_tarball, output_efiboot_img):
+-    # Create the efiboot image file. Determine the size we should make
+-    # it by taking the tarball size and adding 2MiB for fs overhead.
+-    size = os.path.getsize(input_tarball) + 2 * 1024 * 1024
+-    with open(output_efiboot_img, "wb") as out:
+-        out.truncate(size)
+-    # Make loopback device; mkfs; populate with files
+-    with loop_client.device(output_efiboot_img) as loopdev:
+-        # On RHEL 8, when booting from a disk device (rather than a CD),
+-        # https://github.com/systemd/systemd/issues/14408 causes the
+-        # hybrid ESP to race with the ISO9660 filesystem for the
+-        # /dev/disk/by-label symlink unless the ESP has its own label,
+-        # so set EFI-SYSTEM for consistency with the metal image.
+-        # This should not be needed on Fedora or RHEL 9, but seems like
+-        # a good thing to do anyway.
+-        label = 'EFI-SYSTEM'
+-        # NOTE: the arguments to mkfs here match how virt-make-fs calls mkfs
+-        subprocess.check_call(['mkfs', '-t', 'vfat', '-I', '--mbr=n', '-n', label, loopdev])
+-        with tempfile.TemporaryDirectory() as d:
+-            try:
+-                subprocess.check_call(['mount', '-o', 'utf8', loopdev, d])
+-                subprocess.check_call(['tar', '-C', d, '-xf', input_tarball])
+-            finally:
+-                subprocess.check_call(['umount', d])
+-
+-
+ def parse_metal_inputs(inputs):
+     def get_filepath_from_input(name):
+         files = inputs[name]["data"]["files"]
+@@ -575,16 +548,37 @@ def mkefiboot(efidir, output_efiboot_img, loop_client):
+             tarinfo.mode = 0o0644
+         return tarinfo
+ 
+-    # Install binaries from boot partition
++    # Install binaries from the efidir
+     # Manually construct the tarball to ensure proper permissions and ownership
+     efitarfile = tempfile.NamedTemporaryFile(suffix=".tar")
+     with tarfile.open(efitarfile.name, "w:", dereference=True) as tar:
+         tar.add(efidir, arcname="/EFI", filter=strip_tar)
+ 
+-    # Create the efiboot.img file in the images/ dir
+-    make_efi_bootfile(loop_client,
+-                      input_tarball=efitarfile.name,
+-                      output_efiboot_img=output_efiboot_img)
++    # Create the efiboot image file. Determine the size we should make
++    # it by taking the tarball size and adding 2MiB for fs overhead.
++    size = os.path.getsize(efitarfile.name) + 2 * 1024 * 1024
++    with open(output_efiboot_img, "wb") as out:
++        out.truncate(size)
++
++    # Make loopback device; mkfs; populate with files
++    with loop_client.device(output_efiboot_img) as loopdev:
++        # On RHEL 8, when booting from a disk device (rather than a CD),
++        # https://github.com/systemd/systemd/issues/14408 causes the
++        # hybrid ESP to race with the ISO9660 filesystem for the
++        # /dev/disk/by-label symlink unless the ESP has its own label,
++        # so set EFI-SYSTEM for consistency with the metal image.
++        # This should not be needed on Fedora or RHEL 9, but seems like
++        # a good thing to do anyway.
++        label = 'EFI-SYSTEM'
++        # NOTE: the arguments to mkfs here match how virt-make-fs calls mkfs
++        subprocess.check_call(['mkfs', '-t', 'vfat', '-I', '--mbr=n', '-n', label, loopdev])
++        with tempfile.TemporaryDirectory() as d:
++            try:
++                subprocess.check_call(['mount', '-o', 'utf8', loopdev, d])
++                subprocess.check_call(['tar', '-C', d, '-xf', efitarfile.name])
++            finally:
++                subprocess.check_call(['umount', d])
++
+ 
+ def mkrootfs_metal(paths, workdir, img_metal, fstype, fsoptions, loop_client):
+     """
+-- 
+2.54.0
+

--- a/src/0003-util-path-move-ensure_glob-from-coreos-stage-into-os.patch
+++ b/src/0003-util-path-move-ensure_glob-from-coreos-stage-into-os.patch
@@ -1,0 +1,81 @@
+From 30df19ea3f3f7b3d98f6e64333237b4bcd523e18 Mon Sep 17 00:00:00 2001
+From: Dusty Mabe <dusty@dustymabe.com>
+Date: Wed, 1 Jul 2026 18:44:35 +0000
+Subject: [PATCH 3/9] util/path: move ensure_glob() from coreos stage into
+ osbuild.util.path
+
+Factor out the ensure_glob() helper function from the
+coreos.live-artifacts stage into osbuild.util.path, where it sits
+alongside other path-related utilities (in_tree, join_abs, etc.).
+
+This makes the function available for reuse by other stages.
+
+Assisted-By: <anthropic/claude-opus-4.6>
+---
+ osbuild/util/path.py                          | 14 ++++++++++++++
+ stages/org.osbuild.coreos.live-artifacts.mono | 14 +-------------
+ 2 files changed, 15 insertions(+), 13 deletions(-)
+
+diff --git a/osbuild/util/path.py b/osbuild/util/path.py
+index 035b385f..f9348e93 100644
+--- a/osbuild/util/path.py
++++ b/osbuild/util/path.py
+@@ -1,5 +1,6 @@
+ """Path handling utility functions"""
+ import errno
++import glob
+ import os
+ import os.path
+ from typing import Optional, Union
+@@ -56,3 +57,16 @@ def join_abs(root: Union[str, os.PathLike], *paths: Union[str, os.PathLike]) ->
+         else:
+             final_path = os.path.join(final_path, path)
+     return os.path.normpath(os.path.join(os.sep, final_path))
++
++
++def ensure_glob(pathname, n="", **kwargs):
++    """
++    Call glob.glob() and fail if there are no results or
++    if the number of results doesn't match provided n
++    """
++    ret = glob.glob(pathname, **kwargs)
++    if not ret:
++        raise ValueError(f'No matches for {pathname}')
++    if n != "" and len(ret) != int(n):
++        raise ValueError(f'Matches for {pathname} does not match expected ({n})')
++    return ret
+diff --git a/stages/org.osbuild.coreos.live-artifacts.mono b/stages/org.osbuild.coreos.live-artifacts.mono
+index 5db23e59..ecbfba7a 100755
+--- a/stages/org.osbuild.coreos.live-artifacts.mono
++++ b/stages/org.osbuild.coreos.live-artifacts.mono
+@@ -27,6 +27,7 @@ import osbuild.api
+ import osbuild.remoteloop as remoteloop
+ from osbuild.util import checksum, osrelease
+ from osbuild.util.chroot import Chroot
++from osbuild.util.path import ensure_glob
+ 
+ # Size of file used to embed an Ignition config within a CPIO.
+ IGNITION_IMG_SIZE = 256 * 1024
+@@ -130,19 +131,6 @@ def make_stream_hash(src, dest):
+                 outf.write(hashlib.sha256(buf).hexdigest() + '\n')
+ 
+ 
+-def ensure_glob(pathname, n="", **kwargs):
+-    """
+-    Call glob.glob() and fail if there are no results or
+-    if the number of results doesn't match provided n
+-    """
+-    ret = glob.glob(pathname, **kwargs)
+-    if not ret:
+-        raise ValueError(f'No matches for {pathname}')
+-    if n != "" and len(ret) != int(n):
+-        raise ValueError(f'Matches for {pathname} does not match expected ({n})')
+-    return ret
+-
+-
+ # This function finds the source EFI paths to copy from /usr/ to the EFI/
+ # directory. Historically this was just the usr/lib/bootupd/updates/EFI/
+ # directory (populated by bootupd), but as part of BootLoaderUpdatesPhase1 [1]
+-- 
+2.54.0
+

--- a/src/0004-utils-add-utils.makeefi-library.patch
+++ b/src/0004-utils-add-utils.makeefi-library.patch
@@ -1,0 +1,329 @@
+From 5d65665c5acf0be46814472507022080853cc3ee Mon Sep 17 00:00:00 2001
+From: Dusty Mabe <dusty@dustymabe.com>
+Date: Wed, 1 Jul 2026 14:50:18 -0400
+Subject: [PATCH 4/9] utils: add utils.makeefi library
+
+These are functions related to making EFI bootable images that can
+be shared among stages that need to do that. These are factored out
+of the org.osbuild.coreos.live-artifacts.mono stage at this point.
+---
+ osbuild/util/makeefi.py                       | 126 ++++++++++++++++++
+ stages/org.osbuild.coreos.live-artifacts.mono | 126 +-----------------
+ 2 files changed, 132 insertions(+), 120 deletions(-)
+ create mode 100644 osbuild/util/makeefi.py
+
+diff --git a/osbuild/util/makeefi.py b/osbuild/util/makeefi.py
+new file mode 100644
+index 00000000..fab56507
+--- /dev/null
++++ b/osbuild/util/makeefi.py
+@@ -0,0 +1,126 @@
++"""EFI boot image utilities
++
++Functions for building EFI boot directory layouts and
++FAT filesystem images suitable for ISO / removable-media boot.
++"""
++import glob
++import os
++import shutil
++import subprocess
++import tarfile
++import tempfile
++
++from osbuild.util.path import ensure_glob
++
++
++# This function finds the source EFI paths to copy from /usr/ to the EFI/
++# directory. Historically this was just the usr/lib/bootupd/updates/EFI/
++# directory (populated by bootupd), but as part of BootLoaderUpdatesPhase1 [1]
++# the shim and grub packages started delivering files in
++# /usr/lib/efi/(grub|shim)/<version>/EFI/ directly. Lets prefer the
++# new paths and fallback to the legacy path if those don't exist.
++#
++# [1] https://fedoraproject.org/wiki/Changes/BootLoaderUpdatesPhase1
++def find_efi_source_paths(tree):
++    if glob.glob(os.path.join(tree, 'usr/lib/efi/*/*/EFI')):
++        # BootLoaderUpdatesPhase1 has been implemented and we should
++        # be able to pick up files from usr/lib/efi/(grub|shim)/<version>/EFI/
++        # Let's ensure there's only 2 dirs that match (i.e. one for grub
++        # one for shim) and return that list.
++        return ensure_glob(os.path.join(tree, 'usr/lib/efi/*/*/EFI'), n=2)
++    # Legacy path. Just return a single entry list with the old path.
++    return [os.path.join(tree, 'usr/lib/bootupd/updates/EFI')]
++
++
++def find_efi_vendor_dir_name(efidir):
++    # Find name of vendor directory for this distro. i.e. "fedora" or "redhat".
++    dirs = [n for n in os.listdir(efidir) if n != "BOOT"]
++    if len(dirs) != 1:
++        raise ValueError(f"did not find exactly one EFI vendor ID: {dirs}")
++    vendor_id = dirs[0]
++    return vendor_id
++
++
++def mkefidir(efidir, source_tree):
++    """
++    Searches the source_tree for files used for EFI booting and copies
++    these files into the specified efidir.
++    """
++    for path in find_efi_source_paths(source_tree):
++        shutil.copytree(path, efidir, dirs_exist_ok=True)
++
++    vendor_id = find_efi_vendor_dir_name(efidir)
++
++    # Delete fallback and its CSV file.  Its purpose is to create
++    # EFI boot variables, which we don't want when booting from
++    # removable media.
++    #
++    # A future shim release will merge fallback.efi into the main
++    # shim binary and enable the fallback behavior when the CSV
++    # exists.  But for now, fail if fallback.efi is missing.
++    for path in ensure_glob(os.path.join(efidir, "BOOT", "fb*.efi")):
++        os.unlink(path)
++    for path in ensure_glob(os.path.join(efidir, vendor_id, "BOOT*.CSV")):
++        os.unlink(path)
++
++    # Drop vendor copies of shim; we already have it in BOOT*.EFI in
++    # BOOT
++    for path in ensure_glob(os.path.join(efidir, vendor_id, "shim*.efi")):
++        os.unlink(path)
++
++    # Consolidate remaining files into BOOT.  shim needs GRUB to be
++    # there, and the rest doesn't hurt.
++    for path in ensure_glob(os.path.join(efidir, vendor_id, "*")):
++        shutil.move(path, os.path.join(efidir, "BOOT"))
++    os.rmdir(os.path.join(efidir, vendor_id))
++
++
++def mkefiboot(efidir, output_efiboot_img, loop_client):
++    """
++    Creates an efi boot image file at output_efiboot_img (usually named efiboot.img),
++    which is required for EFI booting. This is a fat32 formatted filesystem that
++    contains all the files needed for EFI boot.
++    """
++
++    # In restrictive environments, setgid, setuid and ownership changes
++    # may be restricted. This sets the file ownership to root and
++    # removes the setgid and setuid bits in the tarball.
++    def strip_tar(tarinfo):
++        tarinfo.uid = 0
++        tarinfo.gid = 0
++        if tarinfo.isdir():
++            tarinfo.mode = 0o755
++        elif tarinfo.isfile():
++            tarinfo.mode = 0o0644
++        return tarinfo
++
++    # Install binaries from the efidir
++    # Manually construct the tarball to ensure proper permissions and ownership
++    efitarfile = tempfile.NamedTemporaryFile(suffix=".tar")
++    with tarfile.open(efitarfile.name, "w:", dereference=True) as tar:
++        tar.add(efidir, arcname="/EFI", filter=strip_tar)
++
++    # Create the efiboot image file. Determine the size we should make
++    # it by taking the tarball size and adding 2MiB for fs overhead.
++    size = os.path.getsize(efitarfile.name) + 2 * 1024 * 1024
++    with open(output_efiboot_img, "wb") as out:
++        out.truncate(size)
++
++    # Make loopback device; mkfs; populate with files
++    with loop_client.device(output_efiboot_img) as loopdev:
++        # On RHEL 8, when booting from a disk device (rather than a CD),
++        # https://github.com/systemd/systemd/issues/14408 causes the
++        # hybrid ESP to race with the ISO9660 filesystem for the
++        # /dev/disk/by-label symlink unless the ESP has its own label,
++        # so set EFI-SYSTEM for consistency with the metal image.
++        # This should not be needed on Fedora or RHEL 9, but seems like
++        # a good thing to do anyway.
++        label = 'EFI-SYSTEM'
++        # NOTE: the arguments to mkfs here match how virt-make-fs calls mkfs
++        subprocess.check_call(['mkfs', '-t', 'vfat', '-I', '--mbr=n', '-n', label, loopdev])
++        with tempfile.TemporaryDirectory() as d:
++            try:
++                subprocess.check_call(['mount', '-o', 'utf8', loopdev, d])
++                subprocess.check_call(['tar', '-C', d, '-xf', efitarfile.name])
++            finally:
++                subprocess.check_call(['umount', d])
+diff --git a/stages/org.osbuild.coreos.live-artifacts.mono b/stages/org.osbuild.coreos.live-artifacts.mono
+index ecbfba7a..d136f708 100755
+--- a/stages/org.osbuild.coreos.live-artifacts.mono
++++ b/stages/org.osbuild.coreos.live-artifacts.mono
+@@ -18,14 +18,13 @@ import shutil
+ import struct
+ import subprocess
+ import sys
+-import tarfile
+ import tempfile
+ 
+ import yaml
+ 
+ import osbuild.api
+ import osbuild.remoteloop as remoteloop
+-from osbuild.util import checksum, osrelease
++from osbuild.util import checksum, makeefi, osrelease
+ from osbuild.util.chroot import Chroot
+ from osbuild.util.path import ensure_glob
+ 
+@@ -131,34 +130,6 @@ def make_stream_hash(src, dest):
+                 outf.write(hashlib.sha256(buf).hexdigest() + '\n')
+ 
+ 
+-# This function finds the source EFI paths to copy from /usr/ to the EFI/
+-# directory. Historically this was just the usr/lib/bootupd/updates/EFI/
+-# directory (populated by bootupd), but as part of BootLoaderUpdatesPhase1 [1]
+-# the shim and grub packages started delivering files in
+-# /usr/lib/efi/(grub|shim)/<version>/EFI/ directly. Lets prefer the
+-# new paths and fallback to the legacy path if those don't exist.
+-#
+-# [1] https://fedoraproject.org/wiki/Changes/BootLoaderUpdatesPhase1
+-def find_efi_source_paths(tree):
+-    if glob.glob(os.path.join(tree, 'usr/lib/efi/*/*/EFI')):
+-        # BootLoaderUpdatesPhase1 has been implemented and we should
+-        # be able to pick up files from usr/lib/efi/(grub|shim)/<version>/EFI/
+-        # Let's ensure there's only 2 dirs that match (i.e. one for grub
+-        # one for shim) and return that list.
+-        return ensure_glob(os.path.join(tree, 'usr/lib/efi/*/*/EFI'), n=2)
+-    # Legacy path. Just return a single entry list with the old path.
+-    return [os.path.join(tree, 'usr/lib/bootupd/updates/EFI')]
+-
+-
+-def find_efi_vendor_dir_name(efidir):
+-    # Find name of vendor directory for this distro. i.e. "fedora" or "redhat".
+-    dirs = [n for n in os.listdir(efidir) if n != "BOOT"]
+-    if len(dirs) != 1:
+-        raise ValueError(f"did not find exactly one EFI vendor ID: {dirs}")
+-    vendor_id = dirs[0]
+-    return vendor_id
+-
+-
+ def parse_metal_inputs(inputs):
+     def get_filepath_from_input(name):
+         files = inputs[name]["data"]["files"]
+@@ -343,9 +314,9 @@ def gen_live_artifacts(paths, tree, filenames, deployed_tree, loop_client, versi
+         output_efiboot_img = paths["iso/images/efiboot.img"]
+         # Copy out the EFI files found from the source_tree to the specified
+         # directory: efidir
+-        mkefidir(efidir=efidir, source_tree=deployed_tree)
++        makeefi.mkefidir(efidir=efidir, source_tree=deployed_tree)
+         # Discover the vendor ID (can be different on Fedora/RHEL/CentOS)
+-        vendor_id = find_efi_vendor_dir_name(efidir)
++        vendor_id = makeefi.find_efi_vendor_dir_name(efidir)
+         # Get the grub configuration for booting from the ISO and write it out
+         # to $efidir/BOOT/grub.cfg. See the comment in the function for explanation
+         # of config used.
+@@ -353,7 +324,7 @@ def gen_live_artifacts(paths, tree, filenames, deployed_tree, loop_client, versi
+         with open(os.path.join(efidir, "BOOT", "grub.cfg"), "w", encoding='utf8') as fh:
+             fh.write(get_grub_cfg_string(volid, vendor_id))
+         # Create the efiboot.img file
+-        mkefiboot(efidir, output_efiboot_img, loop_client)
++        makeefi.mkefiboot(efidir, output_efiboot_img, loop_client)
+         # And add arguments to include it in when creating the ISO
+         genisoargs += ['-eltorito-alt-boot', '-efi-boot', 'images/efiboot.img', '-no-emul-boot']
+ 
+@@ -483,91 +454,6 @@ boot
+ '''
+ 
+ 
+-def mkefidir(efidir, source_tree):
+-    """
+-    Searches the source_tree for files used for EFI booting and copies
+-    these files into the specified efidir.
+-    """
+-    for path in find_efi_source_paths(source_tree):
+-        shutil.copytree(path, efidir, dirs_exist_ok=True)
+-
+-    vendor_id = find_efi_vendor_dir_name(efidir)
+-
+-    # Delete fallback and its CSV file.  Its purpose is to create
+-    # EFI boot variables, which we don't want when booting from
+-    # removable media.
+-    #
+-    # A future shim release will merge fallback.efi into the main
+-    # shim binary and enable the fallback behavior when the CSV
+-    # exists.  But for now, fail if fallback.efi is missing.
+-    for path in ensure_glob(os.path.join(efidir, "BOOT", "fb*.efi")):
+-        os.unlink(path)
+-    for path in ensure_glob(os.path.join(efidir, vendor_id, "BOOT*.CSV")):
+-        os.unlink(path)
+-
+-    # Drop vendor copies of shim; we already have it in BOOT*.EFI in
+-    # BOOT
+-    for path in ensure_glob(os.path.join(efidir, vendor_id, "shim*.efi")):
+-        os.unlink(path)
+-
+-    # Consolidate remaining files into BOOT.  shim needs GRUB to be
+-    # there, and the rest doesn't hurt.
+-    for path in ensure_glob(os.path.join(efidir, vendor_id, "*")):
+-        shutil.move(path, os.path.join(efidir, "BOOT"))
+-    os.rmdir(os.path.join(efidir, vendor_id))
+-
+-
+-def mkefiboot(efidir, output_efiboot_img, loop_client):
+-    """
+-    Creates an efi boot image file at output_efiboot_img (usually named efiboot.img),
+-    which is required for EFI booting. This is a fat32 formatted filesystem that
+-    contains all the files needed for EFI boot.
+-    """
+-
+-    # In restrictive environments, setgid, setuid and ownership changes
+-    # may be restricted. This sets the file ownership to root and
+-    # removes the setgid and setuid bits in the tarball.
+-    def strip_tar(tarinfo):
+-        tarinfo.uid = 0
+-        tarinfo.gid = 0
+-        if tarinfo.isdir():
+-            tarinfo.mode = 0o755
+-        elif tarinfo.isfile():
+-            tarinfo.mode = 0o0644
+-        return tarinfo
+-
+-    # Install binaries from the efidir
+-    # Manually construct the tarball to ensure proper permissions and ownership
+-    efitarfile = tempfile.NamedTemporaryFile(suffix=".tar")
+-    with tarfile.open(efitarfile.name, "w:", dereference=True) as tar:
+-        tar.add(efidir, arcname="/EFI", filter=strip_tar)
+-
+-    # Create the efiboot image file. Determine the size we should make
+-    # it by taking the tarball size and adding 2MiB for fs overhead.
+-    size = os.path.getsize(efitarfile.name) + 2 * 1024 * 1024
+-    with open(output_efiboot_img, "wb") as out:
+-        out.truncate(size)
+-
+-    # Make loopback device; mkfs; populate with files
+-    with loop_client.device(output_efiboot_img) as loopdev:
+-        # On RHEL 8, when booting from a disk device (rather than a CD),
+-        # https://github.com/systemd/systemd/issues/14408 causes the
+-        # hybrid ESP to race with the ISO9660 filesystem for the
+-        # /dev/disk/by-label symlink unless the ESP has its own label,
+-        # so set EFI-SYSTEM for consistency with the metal image.
+-        # This should not be needed on Fedora or RHEL 9, but seems like
+-        # a good thing to do anyway.
+-        label = 'EFI-SYSTEM'
+-        # NOTE: the arguments to mkfs here match how virt-make-fs calls mkfs
+-        subprocess.check_call(['mkfs', '-t', 'vfat', '-I', '--mbr=n', '-n', label, loopdev])
+-        with tempfile.TemporaryDirectory() as d:
+-            try:
+-                subprocess.check_call(['mount', '-o', 'utf8', loopdev, d])
+-                subprocess.check_call(['tar', '-C', d, '-xf', efitarfile.name])
+-            finally:
+-                subprocess.check_call(['umount', d])
+-
+-
+ def mkrootfs_metal(paths, workdir, img_metal, fstype, fsoptions, loop_client):
+     """
+     Mounts a copy of the metal image and modifies it accordingly to create a (fstype) rootfs from its contents for the
+@@ -737,9 +623,9 @@ def copy_configs_and_init_kargs_json(deployed_tree, paths, blsentry_kargs, volid
+     #
+     # To find the string for the vendor ID we only need to inspect one
+     # of the source EFI directories. Grab one here.
+-    efidir = find_efi_source_paths(deployed_tree)[0]
++    efidir = makeefi.find_efi_source_paths(deployed_tree)[0]
+     if os.path.exists(efidir):
+-        vendor_id = find_efi_vendor_dir_name(efidir)
++        vendor_id = makeefi.find_efi_vendor_dir_name(efidir)
+         grubfilepath = ensure_glob(os.path.join(paths["iso"], 'EFI/*/grub.cfg'), n=1)[0]
+         srcdir = os.path.dirname(grubfilepath)
+         dstdir = os.path.join(paths["iso"], f"EFI/{vendor_id}")
+-- 
+2.54.0
+

--- a/src/0005-util-makeefi-update-find_efi_vendor_dir_name-to-acce.patch
+++ b/src/0005-util-makeefi-update-find_efi_vendor_dir_name-to-acce.patch
@@ -1,0 +1,106 @@
+From 0119eac7edb607d612a95a69c8751f0a36e24b15 Mon Sep 17 00:00:00 2001
+From: Dusty Mabe <dusty@dustymabe.com>
+Date: Wed, 1 Jul 2026 22:08:16 -0400
+Subject: [PATCH 5/9] util/makeefi: update find_efi_vendor_dir_name to accept
+ source_tree
+
+It will conveniently now accept either an efidir if the caller already
+knows where one is or a source filesystem tree which can be passed to
+find_efi_source_paths() to find the efidir from.
+
+This fixes a bug (introduced a few commits back) in the
+coreos.live-artifacts.mono stage where we had removed the vendor dir
+from an efidir but then tried to find the vendor dir name on the same
+efidir right after.
+---
+ osbuild/util/makeefi.py                       | 20 +++++++++++++++++--
+ stages/org.osbuild.coreos.live-artifacts.mono | 14 +++++--------
+ 2 files changed, 23 insertions(+), 11 deletions(-)
+
+diff --git a/osbuild/util/makeefi.py b/osbuild/util/makeefi.py
+index fab56507..97d5e881 100644
+--- a/osbuild/util/makeefi.py
++++ b/osbuild/util/makeefi.py
+@@ -32,7 +32,23 @@ def find_efi_source_paths(tree):
+     return [os.path.join(tree, 'usr/lib/bootupd/updates/EFI')]
+ 
+ 
+-def find_efi_vendor_dir_name(efidir):
++def find_efi_vendor_dir_name(efidir=None, source_tree=None):
++    """
++    Searches either an EFI directory structure (efidir) or a source tree
++    (source_tree) for an EFI vendor directory name (usually fedora,
++    redhat, or centos). If source_tree is given the efidir will be found
++    first using find_efi_source_paths().
++    """
++    if source_tree and efidir:
++        raise ValueError("find_efi_vendor_dir_name: cannot pass both efidir and source_tree")
++    if not source_tree and not efidir:
++        raise ValueError("find_efi_vendor_dir_name: must pass either efidir or source_tree")
++    # If the user provided a source_tree and not an efidir then
++    # we must first find the efidir within the source_tree.
++    if source_tree:
++        # To find the string for the vendor ID we only need to inspect one
++        # of the source EFI directories. Grab one here.
++        efidir = find_efi_source_paths(source_tree)[0]
+     # Find name of vendor directory for this distro. i.e. "fedora" or "redhat".
+     dirs = [n for n in os.listdir(efidir) if n != "BOOT"]
+     if len(dirs) != 1:
+@@ -49,7 +65,7 @@ def mkefidir(efidir, source_tree):
+     for path in find_efi_source_paths(source_tree):
+         shutil.copytree(path, efidir, dirs_exist_ok=True)
+ 
+-    vendor_id = find_efi_vendor_dir_name(efidir)
++    vendor_id = find_efi_vendor_dir_name(efidir=efidir)
+ 
+     # Delete fallback and its CSV file.  Its purpose is to create
+     # EFI boot variables, which we don't want when booting from
+diff --git a/stages/org.osbuild.coreos.live-artifacts.mono b/stages/org.osbuild.coreos.live-artifacts.mono
+index d136f708..2d9b7f7c 100755
+--- a/stages/org.osbuild.coreos.live-artifacts.mono
++++ b/stages/org.osbuild.coreos.live-artifacts.mono
+@@ -277,7 +277,7 @@ def gen_live_artifacts(paths, tree, filenames, deployed_tree, loop_client, versi
+     test_fixture = check_for_test_fixture(deployed_tree)
+     basearch = os.uname().machine
+ 
+-    kargs_json = copy_configs_and_init_kargs_json(deployed_tree, paths, blsentry_kargs, volid)
++    kargs_json = copy_configs_and_init_kargs_json(deployed_tree, paths, blsentry_kargs, volid, basearch)
+ 
+     # Add placeholder for Ignition CPIO file.  This allows an external tool,
+     # `coreos-installer iso ignition embed`, to modify an existing ISO image
+@@ -316,7 +316,7 @@ def gen_live_artifacts(paths, tree, filenames, deployed_tree, loop_client, versi
+         # directory: efidir
+         makeefi.mkefidir(efidir=efidir, source_tree=deployed_tree)
+         # Discover the vendor ID (can be different on Fedora/RHEL/CentOS)
+-        vendor_id = makeefi.find_efi_vendor_dir_name(efidir)
++        vendor_id = makeefi.find_efi_vendor_dir_name(source_tree=deployed_tree)
+         # Get the grub configuration for booting from the ISO and write it out
+         # to $efidir/BOOT/grub.cfg. See the comment in the function for explanation
+         # of config used.
+@@ -553,7 +553,7 @@ def mkrootfs_metal(paths, workdir, img_metal, fstype, fsoptions, loop_client):
+ 
+ 
+ # pylint: disable=too-many-branches
+-def copy_configs_and_init_kargs_json(deployed_tree, paths, blsentry_kargs, volid):
++def copy_configs_and_init_kargs_json(deployed_tree, paths, blsentry_kargs, volid, basearch):
+     # Filter kernel arguments for substituting into ISO bootloader
+     kargs_array = [karg for karg in blsentry_kargs
+                    if karg.split('=')[0] not in LIVE_EXCLUDE_KARGS]
+@@ -620,12 +620,8 @@ def copy_configs_and_init_kargs_json(deployed_tree, paths, blsentry_kargs, volid
+     # [1] https://github.com/coreos/fedora-coreos-config/tree/testing-devel/live/EFI/fedora
+     # [2] https://github.com/openshift/os/tree/master/live/EFI/vendor
+     # [3] https://github.com/openshift/os/issues/954
+-    #
+-    # To find the string for the vendor ID we only need to inspect one
+-    # of the source EFI directories. Grab one here.
+-    efidir = makeefi.find_efi_source_paths(deployed_tree)[0]
+-    if os.path.exists(efidir):
+-        vendor_id = makeefi.find_efi_vendor_dir_name(efidir)
++    if basearch in ("x86_64", "aarch64"):
++        vendor_id = makeefi.find_efi_vendor_dir_name(source_tree=deployed_tree)
+         grubfilepath = ensure_glob(os.path.join(paths["iso"], 'EFI/*/grub.cfg'), n=1)[0]
+         srcdir = os.path.dirname(grubfilepath)
+         dstdir = os.path.join(paths["iso"], f"EFI/{vendor_id}")
+-- 
+2.54.0
+

--- a/src/0006-util-makeefi-make-efiboot.img-align-to-512-byte-boun.patch
+++ b/src/0006-util-makeefi-make-efiboot.img-align-to-512-byte-boun.patch
@@ -1,0 +1,30 @@
+From a9677c19f60cc8de174169c11d97077d9f2b8cbb Mon Sep 17 00:00:00 2001
+From: Dusty Mabe <dusty@dustymabe.com>
+Date: Wed, 1 Jul 2026 22:57:28 -0400
+Subject: [PATCH 6/9] util/makeefi: make efiboot.img align to 512 byte boundary
+
+Align to 512 byte boundary. Some firmeware (like nvidiabluefield)
+derives block device sector size from image size; unaligned sizes
+produce sector size 1 which GRUB cannot handle
+---
+ osbuild/util/makeefi.py | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/osbuild/util/makeefi.py b/osbuild/util/makeefi.py
+index 97d5e881..4d0c173b 100644
+--- a/osbuild/util/makeefi.py
++++ b/osbuild/util/makeefi.py
+@@ -119,6 +119,10 @@ def mkefiboot(efidir, output_efiboot_img, loop_client):
+     # Create the efiboot image file. Determine the size we should make
+     # it by taking the tarball size and adding 2MiB for fs overhead.
+     size = os.path.getsize(efitarfile.name) + 2 * 1024 * 1024
++    # Align to 512 byte boundary. Some firmeware (like nvidiabluefield)
++    # derives block device sector size from image size; unaligned sizes
++    # produce sector size 1 which GRUB cannot handle
++    size = (size + 511) & ~511
+     with open(output_efiboot_img, "wb") as out:
+         out.truncate(size)
+ 
+-- 
+2.54.0
+

--- a/src/0007-util-makeefi-search-more-paths-for-EFI-files.patch
+++ b/src/0007-util-makeefi-search-more-paths-for-EFI-files.patch
@@ -1,0 +1,50 @@
+From fd1ad528fe99da6137a36963ac38908b313da1b1 Mon Sep 17 00:00:00 2001
+From: Dusty Mabe <dusty@dustymabe.com>
+Date: Mon, 6 Jul 2026 10:15:40 -0400
+Subject: [PATCH 7/9] util/makeefi: search more paths for EFI files
+
+Notably this makes it so that package mode filesystem trees
+with files in boot/efi/EFI will manage to find an EFI directory.
+---
+ osbuild/util/makeefi.py | 18 ++++++++++++------
+ 1 file changed, 12 insertions(+), 6 deletions(-)
+
+diff --git a/osbuild/util/makeefi.py b/osbuild/util/makeefi.py
+index 4d0c173b..70acd2fb 100644
+--- a/osbuild/util/makeefi.py
++++ b/osbuild/util/makeefi.py
+@@ -15,10 +15,10 @@ from osbuild.util.path import ensure_glob
+ 
+ # This function finds the source EFI paths to copy from /usr/ to the EFI/
+ # directory. Historically this was just the usr/lib/bootupd/updates/EFI/
+-# directory (populated by bootupd), but as part of BootLoaderUpdatesPhase1 [1]
+-# the shim and grub packages started delivering files in
+-# /usr/lib/efi/(grub|shim)/<version>/EFI/ directly. Lets prefer the
+-# new paths and fallback to the legacy path if those don't exist.
++# directory (populated by bootupd) or boot/efi/EFI (package mode), but
++# as part of BootLoaderUpdatesPhase1 [1] the shim and grub packages started
++# delivering files in /usr/lib/efi/(grub|shim)/<version>/EFI/ directly.
++# Lets prefer the new paths and fallback to the legacy paths.
+ #
+ # [1] https://fedoraproject.org/wiki/Changes/BootLoaderUpdatesPhase1
+ def find_efi_source_paths(tree):
+@@ -28,8 +28,14 @@ def find_efi_source_paths(tree):
+         # Let's ensure there's only 2 dirs that match (i.e. one for grub
+         # one for shim) and return that list.
+         return ensure_glob(os.path.join(tree, 'usr/lib/efi/*/*/EFI'), n=2)
+-    # Legacy path. Just return a single entry list with the old path.
+-    return [os.path.join(tree, 'usr/lib/bootupd/updates/EFI')]
++    # Legacy paths:
++    #   - 'usr/lib/bootupd/updates/EFI' - on Image Mode systems
++    #   - 'boot/efi/EFI'                - on Package Mode systems
++    for path in ['usr/lib/bootupd/updates/EFI', 'boot/efi/EFI']:
++        fullpath = os.path.join(tree, path)
++        if os.path.exists(fullpath):
++            return [fullpath]
++    raise ValueError(f'No EFI source paths found in {tree}')
+ 
+ 
+ def find_efi_vendor_dir_name(efidir=None, source_tree=None):
+-- 
+2.54.0
+

--- a/src/0008-util-makeefi-move-comment-into-function-description.patch
+++ b/src/0008-util-makeefi-move-comment-into-function-description.patch
@@ -1,0 +1,44 @@
+From 30e7b25bfdcafedb795e009f22d1065458ec8499 Mon Sep 17 00:00:00 2001
+From: Dusty Mabe <dusty@dustymabe.com>
+Date: Mon, 6 Jul 2026 11:23:02 -0400
+Subject: [PATCH 8/9] util/makeefi: move comment into function description
+
+To match the rest of the function descriptions of functions in this
+file.
+---
+ osbuild/util/makeefi.py | 18 ++++++++++--------
+ 1 file changed, 10 insertions(+), 8 deletions(-)
+
+diff --git a/osbuild/util/makeefi.py b/osbuild/util/makeefi.py
+index 70acd2fb..b1449a1d 100644
+--- a/osbuild/util/makeefi.py
++++ b/osbuild/util/makeefi.py
+@@ -13,15 +13,17 @@ import tempfile
+ from osbuild.util.path import ensure_glob
+ 
+ 
+-# This function finds the source EFI paths to copy from /usr/ to the EFI/
+-# directory. Historically this was just the usr/lib/bootupd/updates/EFI/
+-# directory (populated by bootupd) or boot/efi/EFI (package mode), but
+-# as part of BootLoaderUpdatesPhase1 [1] the shim and grub packages started
+-# delivering files in /usr/lib/efi/(grub|shim)/<version>/EFI/ directly.
+-# Lets prefer the new paths and fallback to the legacy paths.
+-#
+-# [1] https://fedoraproject.org/wiki/Changes/BootLoaderUpdatesPhase1
+ def find_efi_source_paths(tree):
++    """
++    This function finds the source EFI paths to copy from /usr/ to the EFI/
++    directory. Historically this was just the usr/lib/bootupd/updates/EFI/
++    directory (populated by bootupd) or boot/efi/EFI (package mode), but
++    as part of BootLoaderUpdatesPhase1 [1] the shim and grub packages started
++    delivering files in /usr/lib/efi/(grub|shim)/<version>/EFI/ directly.
++    Lets prefer the new paths and fallback to the legacy paths.
++
++    [1] https://fedoraproject.org/wiki/Changes/BootLoaderUpdatesPhase1
++    """
+     if glob.glob(os.path.join(tree, 'usr/lib/efi/*/*/EFI')):
+         # BootLoaderUpdatesPhase1 has been implemented and we should
+         # be able to pick up files from usr/lib/efi/(grub|shim)/<version>/EFI/
+-- 
+2.54.0
+

--- a/src/0009-BFB-boot-grub-shims-instead-of-booting-kernel-direct.patch
+++ b/src/0009-BFB-boot-grub-shims-instead-of-booting-kernel-direct.patch
@@ -1,0 +1,220 @@
+From 60bfbbcc73e8b2e85a3716697a6a566da1847252 Mon Sep 17 00:00:00 2001
+From: Eli Elgaev <eelgaev@redhat.com>
+Date: Wed, 1 Jul 2026 07:10:54 -0400
+Subject: [PATCH 9/9] BFB boot grub shims instead of booting kernel directly
+
+---
+ stages/org.osbuild.bfb           | 119 +++++++++++++++++++------------
+ stages/org.osbuild.bfb.meta.json |  22 +++---
+ 2 files changed, 81 insertions(+), 60 deletions(-)
+
+diff --git a/stages/org.osbuild.bfb b/stages/org.osbuild.bfb
+index 9f16ed58..5138345f 100755
+--- a/stages/org.osbuild.bfb
++++ b/stages/org.osbuild.bfb
+@@ -6,10 +6,14 @@ Buildhost commands used: `mlx-mkbfb`
+ """
+ 
+ import os
++import shutil
+ import subprocess
+ import sys
++import tempfile
+ 
+ import osbuild.api
++import osbuild.remoteloop as remoteloop
++from osbuild.util import makeefi
+ 
+ # BlueField enablement software is typically from these RPMs:
+ # - mlxbf-bfscripts: provides /usr/bin/mlx-mkbfb tool
+@@ -17,8 +21,28 @@ import osbuild.api
+ #
+ # Hardcode some firmware file paths in constants that we use below
+ DEFAULT_BFB_PATH = "/lib/firmware/mellanox/boot/default.bfb"
++
+ BOOT_CAPSULE_PATH = "/lib/firmware/mellanox/boot/capsule/boot_update2.cap"
+ 
++DEFAULT_KERNEL_ARGS = [
++    "console=hvc0",            # rshim virtual console (/dev/rshim0/console)
++    "console=ttyAMA0",         # IPMI serial console
++    "earlycon=pl011,0x13010000",  # early serial output on BF3
++]
++
++
++def make_grub_cfg(kernel_args):
++    args_str = " ".join(kernel_args)
++    return f"""
++set timeout=5
++set default=0
++
++menuentry "RHCOS Live" {{
++    linux /EFI/BOOT/vmlinuz {args_str}
++    initrd /EFI/BOOT/initramfs.img
++}}
++"""
++
+ 
+ def parse_input(inputs, name):
+     data = inputs[name]
+@@ -28,60 +52,63 @@ def parse_input(inputs, name):
+     return os.path.join(data["path"], filename)
+ 
+ 
+-def main(inputs, output, options):
++def main(inputs, output, options, loop_client):
+     filename = options["filename"].lstrip("/")
+     kernel = parse_input(inputs, "kernel")
+     initramfs = parse_input(inputs, "initramfs")
+ 
+-    # Combine initramfs + rootfs if rootfs provided
+-    if "rootfs" in inputs:
+-        rootfs = parse_input(inputs, "rootfs")
+-        combined = os.path.join(output, "combined.img")
+-        with open(combined, "wb") as out:
+-            for path in [initramfs, rootfs]:
+-                with open(path, "rb") as f:
+-                    out.write(f.read())
+-        initramfs = combined
+-
+-    # We don't plan to support BF1/BF2 hardware where v0 args are used
+-    default_args_v0 = []
+-    # Sourced from https://github.com/Mellanox/bfb-build
+-    # - console=hvc0: rshim virtual console (/dev/rshim0/console)
+-    # - console=ttyAMA0: IPMI serial console
+-    # - earlycon=pl011,0x13010000: early serial output on BF3
+-    # - initrd=initramfs: initramfs selection
+-    # - modprobe.blacklist=mlxbf_pmc: avoid PMC driver conflicts on BF3
+-    default_args_v2 = [
+-        "console=hvc0",
+-        "console=ttyAMA0",
+-        "earlycon=pl011,0x13010000",
+-        "initrd=initramfs",
+-        "modprobe.blacklist=mlxbf_pmc"
+-    ]
+-    boot_args_v0 = " ".join(options.get("boot_args_v0", default_args_v0))
+-    boot_args_v2 = " ".join(options.get("boot_args_v2", default_args_v2))
+-    boot_path = options.get("boot_path", "VenHw(F019E406-8C9C-11E5-8797-001ACA00BFC4)/Image")
+-    boot_desc = options.get("boot_desc", "Linux from rshim")
+-
+-    cmd = [
+-        "/usr/bin/mlx-mkbfb",
+-        "--image", kernel,
+-        "--initramfs", initramfs,
+-        "--capsule", BOOT_CAPSULE_PATH,
+-        "--boot-args-v0", f"={boot_args_v0}",
+-        "--boot-args-v2", f"={boot_args_v2}",
+-        "--boot-path", f"={boot_path}",
+-        "--boot-desc", f"={boot_desc}",
+-        DEFAULT_BFB_PATH,
+-        os.path.join(output, filename)
+-    ]
+-
+-    subprocess.run(cmd, check=True)
++    with tempfile.TemporaryDirectory(dir=output) as workdir:
++        # Optionally combine initramfs + rootfs
++        if "rootfs" in inputs:
++            rootfs = parse_input(inputs, "rootfs")
++            combined_initramfs = os.path.join(workdir, "combined.img")
++            with open(combined_initramfs, "wb") as out:
++                for path in [initramfs, rootfs]:
++                    with open(path, "rb") as f:
++                        shutil.copyfileobj(f, out)
++            initramfs = combined_initramfs
++
++        # Copy in all files needed for EFI booting into a tmpdir
++        # We'll pull the files from the buildroot "/".
++        efidir = os.path.join(workdir, 'efidir')
++        makeefi.mkefidir(efidir=efidir, source_tree="/")
++
++        # Create the grub.cfg
++        kernel_args = options.get("kernel_args", DEFAULT_KERNEL_ARGS)
++        grub_cfg = make_grub_cfg(kernel_args)
++        with open(os.path.join(efidir, "BOOT", "grub.cfg"), "w", encoding='utf8') as fh:
++            fh.write(grub_cfg)
++
++        # Copy in the kernel+initramfs
++        shutil.copy2(kernel, os.path.join(efidir, "BOOT", "vmlinuz"))
++        shutil.copy2(initramfs, os.path.join(efidir, "BOOT", "initramfs.img"))
++
++        # Create the efiboot.img file
++        ramdisk = os.path.join(workdir, "ramdisk.img")
++        makeefi.mkefiboot(efidir=efidir,
++                          output_efiboot_img=ramdisk,
++                          loop_client=loop_client)
++
++        boot_path = options.get("boot_path", "VenHw(F019E406-8C9C-11E5-8797-001ACA00BFC4)/EFI/BOOT/BOOTAA64.EFI")
++        boot_desc = options.get("boot_desc", "Linux via EFI+GRUB")
++
++        cmd = [
++            "/usr/bin/mlx-mkbfb",
++            "--ramdisk", ramdisk,
++            "--capsule", options.get("capsule", BOOT_CAPSULE_PATH),
++            "--boot-path", f"={boot_path}",
++            "--boot-desc", f"={boot_desc}",
++            DEFAULT_BFB_PATH,
++            os.path.join(output, filename)
++        ]
++
++        subprocess.run(cmd, check=True)
+ 
+     return 0
+ 
+ 
+ if __name__ == '__main__':
+     args = osbuild.api.arguments()
+-    r = main(args["inputs"], args["tree"], args["options"])
++    r = main(args["inputs"], args["tree"], args["options"],
++             loop_client=remoteloop.LoopClient("/run/osbuild/api/remoteloop"))
+     sys.exit(r)
+diff --git a/stages/org.osbuild.bfb.meta.json b/stages/org.osbuild.bfb.meta.json
+index c519a1f8..644a1bc8 100644
+--- a/stages/org.osbuild.bfb.meta.json
++++ b/stages/org.osbuild.bfb.meta.json
+@@ -4,7 +4,7 @@
+     "Packages Linux live artifacts into NVIDIA BFB format for BlueField DPUs.",
+     "Takes kernel, initramfs, and optionally rootfs as inputs.",
+     "If rootfs is provided, it is concatenated with initramfs.",
+-    "Provides hardware-specific boot arguments for BlueField DPUs.",
++    "Boots via GRUB shims discovered from the buildroot EFI paths.",
+     "Buildhost commands used: `mlx-mkbfb`"
+   ],
+   "schema_2": {
+@@ -40,28 +40,22 @@
+           "type": "string",
+           "description": "Output BFB filename"
+         },
+-        "boot_args_v0": {
++        "kernel_args": {
+           "type": "array",
+           "items": {
+             "type": "string"
+           },
+-          "description": "Boot arguments for older DPU firmware (BF1/BF2). Empty by default as BF1/BF2 support is not planned.",
+-          "default": []
+-        },
+-        "boot_args_v2": {
+-          "type": "array",
+-          "items": {
+-            "type": "string"
+-          },
+-          "description": "Boot arguments for newer DPU firmware (BF3). Defaults include essential hardware-specific arguments (console, earlycon, initrd).",
++          "description": "Kernel command-line arguments.",
+           "default": [
+             "console=hvc0",
+             "console=ttyAMA0",
+-            "earlycon=pl011,0x13010000",
+-            "initrd=initramfs",
+-            "modprobe.blacklist=mlxbf_pmc"
++            "earlycon=pl011,0x13010000"
+           ]
+         },
++        "capsule": {
++          "type": "string",
++          "description": "Path to UEFI capsule for firmware update, passed to mlx-mkbfb --capsule."
++        },
+         "boot_path": {
+           "type": "string",
+           "description": "UEFI boot path"
+-- 
+2.54.0
+

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -243,10 +243,6 @@ runvm() {
 
     # include COSA in the image
     find /usr/lib/coreos-assembler/ -type f > "${vmpreparedir}/hostfiles"
-    cat <<EOF >> "${vmpreparedir}/hostfiles"
-/usr/lib/osbuild/stages/org.osbuild.bfb
-/usr/lib/osbuild/stages/org.osbuild.bfb.meta.json
-EOF
 
     # and include all GPG keys
     echo '/etc/pki/rpm-gpg/*' >> "${vmpreparedir}/hostfiles"

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -244,6 +244,13 @@ runvm() {
     # include COSA in the image
     find /usr/lib/coreos-assembler/ -type f > "${vmpreparedir}/hostfiles"
 
+    # osbuild files not yet owned by an RPM. This happens from time to
+    # time when we are backporting patches that contain newly created
+    # files that aren't yet owned by the osbuild RPMs in Fedora.
+    cat <<EOF >> "${vmpreparedir}/hostfiles"
+/usr/lib/python3.14/site-packages/osbuild/util/makeefi.py
+EOF
+
     # and include all GPG keys
     echo '/etc/pki/rpm-gpg/*' >> "${vmpreparedir}/hostfiles"
 

--- a/src/osbuild-manifests/platform.nvidiabluefield.yaml
+++ b/src/osbuild-manifests/platform.nvidiabluefield.yaml
@@ -103,12 +103,10 @@ pipelines:
                 file:
                   mpp-format-string: '/{artifact_name_prefix}-live-rootfs.{arch}.img'
         options:
-          boot_args_v2:
+          kernel_args:
             - "console=hvc0"
             - "console=ttyAMA0"
             - "earlycon=pl011,0x13010000"
-            - "initrd=initramfs"
-            - "modprobe.blacklist=mlxbf_pmc"
             - "ignition.firstboot"
             - "ignition.platform.id=nvidiabluefield"
           filename:


### PR DESCRIPTION
This PR updates the `nvidiabluefield` stage to be up to date with the BFB stage in [osbuild#2471](https://github.com/osbuild/osbuild/pull/2471).

- Renamed `boot_args_v2` to `kernel_args`.
- Dropped `modprobe.blacklist=mlxbf_pmc` kernel argument following recent fixes in RHEL kernels.
- Dropped `initrd=initramfs` kernel argument.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the BlueField boot flow to use an EFI GRUB shim and generate an EFI boot image from the buildroot.
  * Added a `capsule` option to support the new boot image delivery.
* **Bug Fixes**
  * Simplified BlueField boot arguments to console/early boot settings only, removing `initrd` and the module blacklist entries.
* **Refactor**
  * Centralized EFI image creation into shared utilities for consistent behavior across stages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->