### PR TITLE
secex: switch to pvimg in butane for fake secure VM

### DIFF
--- a/src/secex-genprotimgvm-scripts/genprotimg.bu
+++ b/src/secex-genprotimgvm-scripts/genprotimg.bu
@@ -26,7 +26,7 @@ storage:
           while [ ! -e "/var/genprotimg/signal.file" ]; do
               sleep 1
           done
-          genprotimg -V --no-verify -i /var/genprotimg/vmlinuz -r /var/genprotimg/initrd.img  -p /var/genprotimg/parmfile -k /etc/se-hostkeys/ibm-z-hostkey-1 -o /var/genprotimg/se.img
+          pvimg create --verbose --no-verify -i /var/genprotimg/vmlinuz -r /var/genprotimg/initrd.img  -p /var/genprotimg/parmfile -k /etc/se-hostkeys/ibm-z-hostkey-1 -o /var/genprotimg/se.img
           rm -f /var/genprotimg/signal.file
           bash /var/build/post-script.sh
     - path: /etc/systemd/system-generators/coreos-genprotimg-generator


### PR DESCRIPTION
el9,el10 and rhel-9.6 now ship s390utils-base >= 2.36.0, so switch from the obsolete `genprotimg` tool to `pvimg`. This change doesn't affect official qemu-secex builds, but only local dev builds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated secure boot image generation to use the current image creation tool.
  * Preserved existing inputs and output behavior while adding explicit image creation options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->