### PR TITLE
src/konflux-rpm-lockfile: do not remove fedora-coreos-pool from local_repos

### DIFF
--- a/src/konflux-rpm-lockfile
+++ b/src/konflux-rpm-lockfile
@@ -58,8 +58,6 @@ def format_packages_with_repoid(pkgs, repos):
     """
     packages = []
     local_repos = list(repos)
-    if "fedora-coreos-pool" in local_repos:
-        local_repos.remove("fedora-coreos-pool")
 
     if not local_repos:
         if pkgs:


### PR DESCRIPTION
Keep fedora-coreos-pool in the local_repos list when formatting packages
with their repo IDs. This is needed to enable RPM signature verification
in Konflux.

ref: https://github.com/coreos/fedora-coreos-tracker/issues/2180

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fedora CoreOS pool repository information is now preserved when assigning repository IDs to packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->