### PR TITLE
deps: drop golang-github-aliyun-cli

### DIFF
--- a/rpms.in.yaml
+++ b/rpms.in.yaml
@@ -70,7 +70,6 @@ packages:
   - genisoimage
   - git
   - golang
-  - golang-github-aliyun-cli
   - name: grub2
     arches:
       only:

--- a/src/deps.txt
+++ b/src/deps.txt
@@ -39,8 +39,8 @@ podman buildah skopeo
 jq
 yq
 
-# For interacting with AWS/Aliyun/HTTP
-golang-github-aliyun-cli python3-boto3 python3-requests
+# For interacting with AWS/HTTP
+python3-boto3 python3-requests
 
 # For python retries
 python3-tenacity


### PR DESCRIPTION
The package was orphaned in F44, the build succeeds without it.

See: https://github.com/coreos/coreos-assembler/pull/4572

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the declared AWS/HTTP package requirements to align with the current runtime needs.
  * Removed an unused Aliyun command-line dependency from the packaged dependencies list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->