### PR TITLE
[rhel-9.6] deps: drop golang-github-aliyun-cli

### DIFF
--- a/rpms.in.yaml
+++ b/rpms.in.yaml
@@ -70,7 +70,6 @@ packages:
   - genisoimage
   - git
   - golang
-  - golang-github-aliyun-cli
   - name: grub2
     arches:
       only:

--- a/src/deps.txt
+++ b/src/deps.txt
@@ -37,8 +37,8 @@ podman buildah skopeo
 jq
 yq
 
-# For interacting with AWS/Aliyun/HTTP
-golang-github-aliyun-cli python3-boto3 python3-requests
+# For interacting with AWS/HTTP
+python3-boto3 python3-requests
 
 # For python retries
 python3-tenacity


### PR DESCRIPTION
The package was orphaned in F44, the build succeeds without it.