### PR TITLE
mantle/kola: fix port conflict/memory accounting; remove reprovision tags

### DIFF
--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -1909,7 +1909,7 @@ func runTest(h *harness.H, t *register.Test, pltfrm string, flight platform.Flig
 		}
 	}()
 
-	if t.ClusterSize > 0 {
+	if !t.TestManagedMachines {
 		var userdata *conf.UserData = t.UserData
 
 		options := t.MachineOptions
@@ -1964,15 +1964,13 @@ func runTest(h *harness.H, t *register.Test, pltfrm string, flight platform.Flig
 		tcluster.H.WarningOnFailure()
 	}
 
-	// Machines may be created directly by the test (not via the
-	// harness with NewMachines above), so we poll asynchronously
-	// via a goroutine until at least one shows up and then release
-	// the temporary memory reservation.
+	// Poll asynchronously until all expected machines have been
+	// created and then release the temporary memory reservation.
+	// At the point machines show up in tcluster.Machines() they've
+	// already been contacted via SSH in StartMachine() and their
+	// QEMU processes have allocated their memory.
 	go func() {
-		// Wait for at least one machine in the cluster to exist.
-		// At the point machines show up in tcluster.Machines() they've
-		// already been contacted successfully via SSH in StartMachine().
-		for len(tcluster.Machines()) == 0 {
+		for len(tcluster.Machines()) < t.ClusterSize {
 			time.Sleep(1 * time.Second)
 		}
 		releaseMemoryCount(flight, t)

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -132,6 +132,12 @@ var (
 	// reservedMemoryCountMutex protects access to reservedMemoryCountMiB
 	reservedMemoryCountMutex sync.Mutex
 
+	// reservedHostPorts tracks host ports currently reserved by running
+	// tests. This prevents parallel tests from clashing on well-known
+	// ports (e.g., NFS 2049) that cannot be randomized.
+	reservedHostPorts      = make(map[int]string) // port -> test name
+	reservedHostPortsMutex sync.Mutex
+
 	// ForceRunPlatformIndependent will cause tests that claim platform-independence to run
 	ForceRunPlatformIndependent bool
 
@@ -997,6 +1003,7 @@ type externalTestMeta struct {
 	BindMountHostRO           []string `json:"bindMountHostRO,omitempty"           yaml:"bindMountHostRO,omitempty"`
 	CreationDate              string   `json:"creationDate,omitempty"              yaml:"creationDate,omitempty"`
 	BootFrom                  string   `json:"bootFrom,omitempty"                  yaml:"bootFrom,omitempty"`
+	RequiredHostPorts         []int    `json:"requiredHostPorts,omitempty"          yaml:"requiredHostPorts,omitempty"`
 }
 
 // metadataFromTestBinary extracts JSON-in-comment like:
@@ -1232,6 +1239,7 @@ ExecStart=%s
 			AppendFirstbootKernelArgs: targetMeta.AppendFirstbootKernelArgs,
 			InstanceType:              targetMeta.InstanceType,
 			BootFrom:                  targetMeta.BootFrom,
+			RequiredHostPorts:         targetMeta.RequiredHostPorts,
 		},
 		InjectContainer: targetMeta.InjectContainer,
 		NonExclusive:    !targetMeta.Exclusive,
@@ -1757,6 +1765,62 @@ func releaseMemoryCount(flight platform.Flight, t *register.Test) {
 	}
 }
 
+// reserveHostPortsForTest attempts to reserve all required host ports
+// for the given test. Returns true if all ports were successfully
+// reserved, false if any port is already held by another test.
+func reserveHostPortsForTest(t *register.Test) bool {
+	ports := t.MachineOptions.RequiredHostPorts
+	if len(ports) == 0 {
+		return true
+	}
+	reservedHostPortsMutex.Lock()
+	defer reservedHostPortsMutex.Unlock()
+	// Check all ports first before reserving any.
+	for _, port := range ports {
+		if holder, held := reservedHostPorts[port]; held {
+			plog.Debugf("Waiting on host port %d for %s: currently held by %s",
+				port, t.Name, holder)
+			return false
+		}
+	}
+	// All ports are free -- reserve them.
+	for _, port := range ports {
+		reservedHostPorts[port] = t.Name
+	}
+	plog.Debugf("Reserved host ports %v for %s", ports, t.Name)
+	return true
+}
+
+// waitForHostPorts polls until all of the test's required host ports
+// are free and then reserves them. This is called after waitForMemory
+// in runTest to prevent parallel tests from clashing on well-known
+// ports like NFS 2049.
+func waitForHostPorts(h *harness.H, flight platform.Flight, t *register.Test) {
+	if len(t.MachineOptions.RequiredHostPorts) == 0 {
+		return
+	}
+	for !reserveHostPortsForTest(t) {
+		// sleep between 0 and 20 seconds and try again
+		time.Sleep(time.Duration(rand.Intn(20)) * time.Second)
+	}
+}
+
+// releaseHostPorts returns a test's reserved host ports back to the
+// pool. This should be called when the test completes and its QEMU
+// VMs have been destroyed.
+func releaseHostPorts(t *register.Test) {
+	ports := t.MachineOptions.RequiredHostPorts
+	if len(ports) == 0 {
+		return
+	}
+	reservedHostPortsMutex.Lock()
+	defer reservedHostPortsMutex.Unlock()
+	for _, port := range ports {
+		delete(reservedHostPorts, port)
+	}
+	plog.Debugf("Released host ports %v for %s", ports, t.Name)
+}
+
 // getNeededMemoryMiB returns the memory in MiB that a QEMU VM for
 // this test will use. It mirrors the resolution logic in
 // platform/machine/qemu/cluster.go:NewMachineWithOptions.
@@ -1780,6 +1844,9 @@ func getNeededMemoryMiB(t *register.Test) int {
 // analysis after the test run. It should already exist.
 func runTest(h *harness.H, t *register.Test, pltfrm string, flight platform.Flight) {
 	h.Parallel()
+	// Wait for any required host ports to become free first, so we
+	// don't hold a memory reservation while blocked on a port.
+	waitForHostPorts(h, flight, t)
 	// On QEMU we'll consider the amount of memory available in the
 	// system/cgroup before continuing. We do this after taking a
 	// parallel slot above via Parallel() so we are essentiallly
@@ -1815,6 +1882,8 @@ func runTest(h *harness.H, t *register.Test, pltfrm string, flight platform.Flig
 		c.Destroy()
 		// Release the memory reservation (if there was one) now that the VM is gone.
 		releaseMemoryCount(flight, t)
+		// Release any reserved host ports now that the VMs are gone.
+		releaseHostPorts(t)
 		if testSkipBaseChecks(t) {
 			plog.Debugf("Skipping base checks for %s", t.Name)
 			return

--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -1765,6 +1765,16 @@ func releaseMemoryCount(flight platform.Flight, t *register.Test) {
 	}
 }
 
+// isMemoryCountReleased checks whether a test's memory reservation
+// has already been released. This must be used instead of reading
+// t.ReservedMemoryCountMiB directly from other goroutines to avoid
+// a data race with releaseMemoryCount.
+func isMemoryCountReleased(t *register.Test) bool {
+	reservedMemoryCountMutex.Lock()
+	defer reservedMemoryCountMutex.Unlock()
+	return t.ReservedMemoryCountMiB == 0
+}
+
 // reserveHostPortsForTest attempts to reserve all required host ports
 // for the given test. Returns true if all ports were successfully
 // reserved, false if any port is already held by another test.
@@ -1969,8 +1979,23 @@ func runTest(h *harness.H, t *register.Test, pltfrm string, flight platform.Flig
 	// At the point machines show up in tcluster.Machines() they've
 	// already been contacted via SSH in StartMachine() and their
 	// QEMU processes have allocated their memory.
+	//
+	// Some tests (e.g., ignition failure tests) use QemuBuilder
+	// directly and their VMs never appear in the cluster's machine
+	// list. For those tests, the goroutine will keep polling until
+	// the test completes and the defer releases the memory
+	// reservation (setting ReservedMemoryCountMiB to 0). The brief
+	// double-counting of memory for these short-lived tests is
+	// acceptable.
 	go func() {
 		for len(tcluster.Machines()) < t.ClusterSize {
+			// If the memory reservation was already released
+			// (by the defer when the test completes), stop
+			// polling. Uses isMemoryCountReleased to avoid a
+			// data race with releaseMemoryCount.
+			if isMemoryCountReleased(t) {
+				return
+			}
 			time.Sleep(1 * time.Second)
 		}
 		releaseMemoryCount(flight, t)

--- a/mantle/kola/register/register.go
+++ b/mantle/kola/register/register.go
@@ -52,12 +52,18 @@ func CreateNativeFuncWrap(f func() error, exclusions ...string) NativeFuncWrap {
 // statically declare state of the platform.TestCluster before the test
 // function is run.
 type Test struct {
-	Name                 string // should be unique
-	Subtests             []string
-	Run                  func(cluster.TestCluster)
-	NativeFuncs          map[string]NativeFuncWrap
-	UserData             *conf.UserData
-	ClusterSize          int
+	Name        string // should be unique
+	Subtests    []string
+	Run         func(cluster.TestCluster)
+	NativeFuncs map[string]NativeFuncWrap
+	UserData    *conf.UserData
+	ClusterSize int
+	// TestManagedMachines indicates that the test creates its own
+	// machines rather than having the harness create them. When true,
+	// ClusterSize still indicates how many machines the test will
+	// create (used for memory reservation scheduling) but the harness
+	// will not create any machines itself.
+	TestManagedMachines  bool
 	Platforms            []string      // allowlist of platforms to run test against -- defaults to all
 	Firmwares            []string      // allowlist of firmwares to run test against -- defaults to all
 	ExcludePlatforms     []string      // denylist of platforms to ignore -- defaults to none
@@ -75,7 +81,9 @@ type Test struct {
 
 	// MachineOptions contains options for machine creation (disks, memory,
 	// kernel args, etc.). The test harness passes these to
-	// NewMachineWithOptions when ClusterSize > 0.
+	// NewMachineWithOptions when TestManagedMachines is false.
+	// When TestManagedMachines is true, fields like MinMemory and
+	// RequiredHostPorts are still used by the scheduler.
 	MachineOptions platform.MachineOptions
 
 	// InjectContainer will cause the ostree base image to be injected into the target
@@ -117,6 +125,9 @@ var UpgradeTests = map[string]*Test{}
 func Register(m map[string]*Test, t *Test) {
 	if len(t.Conflicts) > 0 && !t.NonExclusive {
 		panic("exclusive test cannot have non-empty conflicts entry")
+	}
+	if t.ClusterSize <= 0 {
+		panic(fmt.Sprintf("test %v must set ClusterSize to the number of expected machines", t.Name))
 	}
 	_, ok := m[t.Name]
 	if ok {

--- a/mantle/kola/tests/docker/docker.go
+++ b/mantle/kola/tests/docker/docker.go
@@ -65,10 +65,11 @@ func init() {
 		ExcludePlatforms: []string{"qemu"},
 	})
 	register.RegisterTest(&register.Test{
-		Run:         dockerOldClient,
-		ClusterSize: 0,
-		Name:        "docker.oldclient",
-		Distros:     []string{"cl"},
+		Run:                 dockerOldClient,
+		ClusterSize:         1,
+		TestManagedMachines: true,
+		Name:                "docker.oldclient",
+		Distros:             []string{"cl"},
 	})
 	register.RegisterTest(&register.Test{
 		Run:         dockerUserns,

--- a/mantle/kola/tests/fips/failure.go
+++ b/mantle/kola/tests/fips/failure.go
@@ -81,6 +81,24 @@ var failConfig = conf.Ignition(`{
 	}
 }`)
 
+// fipsFailureTestMemoryMiB is the memory for the FIPS failure test.
+// Defined here so the test harness can account for memory when
+// scheduling, even though this test uses QemuBuilder directly
+// rather than cluster-managed machines.
+var fipsFailureTestMemoryMiB = fipsFailureTestMemoryDefault()
+
+func fipsFailureTestMemoryDefault() int {
+	// ppc64le uses 64K pages by default which increases memory overhead.
+	// Double the memory request to avoid kernel panics during reprovisioning.
+	// See similar logic in harness.go and luks.go.
+	switch coreosarch.CurrentRpmArch() {
+	case "ppc64le":
+		return 8192
+	default:
+		return 4096
+	}
+}
+
 func init() {
 	register.RegisterTest(&register.Test{
 		Name:        "fips.failure",
@@ -90,6 +108,12 @@ func init() {
 		Platforms:   []string{"qemu"},
 		Tags:        []string{"ignition"},
 		Distros:     []string{"rhcos", "scos"},
+		// With ClusterSize: 0 we use QemuBuilder directly (not cluster-managed
+		// machines), but at least MinMemory will be considered by the test
+		// harness for scheduling.
+		MachineOptions: platform.MachineOptions{
+			MinMemory: fipsFailureTestMemoryMiB,
+		},
 	})
 }
 
@@ -170,11 +194,7 @@ func ignitionFailure(c cluster.TestCluster) error {
 		return err
 	}
 
-	builder.MemoryMiB = 4096
-	switch coreosarch.CurrentRpmArch() {
-	case "ppc64le":
-		builder.MemoryMiB = 8192
-	}
+	builder.MemoryMiB = fipsFailureTestMemoryMiB
 	builder.Firmware = kola.QEMUOptions.Firmware
 
 	searchPattern := "Only PBKDF2 is supported in FIPS mode"

--- a/mantle/kola/tests/fips/failure.go
+++ b/mantle/kola/tests/fips/failure.go
@@ -101,16 +101,15 @@ func fipsFailureTestMemoryDefault() int {
 
 func init() {
 	register.RegisterTest(&register.Test{
-		Name:        "fips.failure",
-		Description: "Verify cryptsetup lukscreate will fail with FIPS and incompatible crypto algorithms.",
-		Run:         runFipsFailure,
-		ClusterSize: 0,
-		Platforms:   []string{"qemu"},
-		Tags:        []string{"ignition"},
-		Distros:     []string{"rhcos", "scos"},
-		// With ClusterSize: 0 we use QemuBuilder directly (not cluster-managed
-		// machines), but at least MinMemory will be considered by the test
-		// harness for scheduling.
+		Name:                "fips.failure",
+		Description:         "Verify cryptsetup lukscreate will fail with FIPS and incompatible crypto algorithms.",
+		Run:                 runFipsFailure,
+		ClusterSize:         1,
+		TestManagedMachines: true,
+		Platforms:           []string{"qemu"},
+		Tags:                []string{"ignition"},
+		Distros:             []string{"rhcos", "scos"},
+		// MinMemory will be considered by the test harness for scheduling.
 		MachineOptions: platform.MachineOptions{
 			MinMemory: fipsFailureTestMemoryMiB,
 		},

--- a/mantle/kola/tests/ignition/kdump.go
+++ b/mantle/kola/tests/ignition/kdump.go
@@ -16,6 +16,17 @@ import (
 
 // Test kdump to remote hosts
 
+// Memory constants for kdump tests. These are defined here so they can
+// be used both in the test registration (for the scheduler's memory
+// accounting) and when creating VMs in the test functions.
+var (
+	// kdumpHelperMemoryMiB is the memory for the helper VM (SSH/NFS server).
+	// It uses the architecture default since no MinMemory is set.
+	kdumpHelperMemoryMiB = platform.DefaultMemoryMiB()
+	// kdumpTestMemoryMiB is the memory for the kdump test VM.
+	kdumpTestMemoryMiB = 2048
+)
+
 func init() {
 	// Create 0 cluster size to allow starting and setup ssh server as needed for the test
 	// See: https://github.com/coreos/coreos-assembler/pull/1310#discussion_r401908836
@@ -26,6 +37,13 @@ func init() {
 		Description: "Verifies kdump logs are exported to SSH destination",
 		Tags:        []string{"kdump", kola.SkipBaseChecksTag, kola.NeedsInternetTag},
 		Platforms:   []string{"qemu"},
+		// With ClusterSize: 0 we create the machines manually, but the
+		// total MinMemory is set here so the test harness can account for
+		// memory when scheduling. This value covers both the helper VM
+		// and the kdump test VM. Only relevant on the qemu platform.
+		MachineOptions: platform.MachineOptions{
+			MinMemory: kdumpHelperMemoryMiB + kdumpTestMemoryMiB,
+		},
 	})
 	// Add tag "reprovision" to run serially to avoid NFS port conflicts.
 	// This is hack until a better solution exists.
@@ -37,6 +55,13 @@ func init() {
 		Description: "Verifies kdump logs are exported to NFS destination",
 		Tags:        []string{"kdump", kola.SkipBaseChecksTag, kola.NeedsInternetTag, "reprovision"},
 		Platforms:   []string{"qemu"},
+		// With ClusterSize: 0 we create the machines manually, but the
+		// total MinMemory is set here so the test harness can account for
+		// memory when scheduling. This value covers both the helper VM
+		// and the kdump test VM. Only relevant on the qemu platform.
+		MachineOptions: platform.MachineOptions{
+			MinMemory: kdumpHelperMemoryMiB + kdumpTestMemoryMiB,
+		},
 	})
 }
 
@@ -109,6 +134,7 @@ func setupSSHMachine(c cluster.TestCluster) SshServer {
 		HostForwardPorts: []platform.HostForwardPort{
 			{Service: "ssh", HostPort: 0, GuestPort: 22},
 		},
+		MinMemory: kdumpHelperMemoryMiB,
 	}
 
 	// temp dir to store SSH keys
@@ -222,7 +248,7 @@ kernel_arguments:
 		ssh_host.PubSSH, padded, ssh_host.MachineAddress, ssh_host.SSHPort, ssh_host.MachineAddress))
 
 	opts := platform.MachineOptions{
-		MinMemory: 2048,
+		MinMemory: kdumpTestMemoryMiB,
 	}
 
 	kdump_machine, err := c.NewMachineWithOptions(butane, opts)
@@ -249,6 +275,7 @@ func setupNFSMachine(c cluster.TestCluster) NfsServer {
 			// Kdump NFS option does not allow a custom port
 			{Service: "nfs", HostPort: 2049, GuestPort: 2049},
 		},
+		MinMemory: kdumpHelperMemoryMiB,
 	}
 
 	nfs_server_butane := conf.Butane(`variant: fcos
@@ -312,7 +339,7 @@ kernel_arguments:
 		nfs_host.MachineAddress))
 
 	opts := platform.MachineOptions{
-		MinMemory: 2048,
+		MinMemory: kdumpTestMemoryMiB,
 	}
 
 	kdump_machine, err := c.NewMachineWithOptions(butane, opts)

--- a/mantle/kola/tests/ignition/kdump.go
+++ b/mantle/kola/tests/ignition/kdump.go
@@ -28,33 +28,32 @@ var (
 )
 
 func init() {
-	// Create 0 cluster size to allow starting and setup ssh server as needed for the test
 	// See: https://github.com/coreos/coreos-assembler/pull/1310#discussion_r401908836
 	register.RegisterTest(&register.Test{
-		Run:         kdumpSSHTest,
-		ClusterSize: 0,
-		Name:        `kdump.crash.ssh`,
-		Description: "Verifies kdump logs are exported to SSH destination",
-		Tags:        []string{"kdump", kola.SkipBaseChecksTag, kola.NeedsInternetTag},
-		Platforms:   []string{"qemu"},
-		// With ClusterSize: 0 we create the machines manually, but the
-		// total MinMemory is set here so the test harness can account for
-		// memory when scheduling. This value covers both the helper VM
+		Run:                 kdumpSSHTest,
+		ClusterSize:         2,
+		TestManagedMachines: true,
+		Name:                `kdump.crash.ssh`,
+		Description:         "Verifies kdump logs are exported to SSH destination",
+		Tags:                []string{"kdump", kola.SkipBaseChecksTag, kola.NeedsInternetTag},
+		Platforms:           []string{"qemu"},
+		// The total MinMemory is set here so the test harness can account
+		// for memory when scheduling. This value covers both the helper VM
 		// and the kdump test VM. Only relevant on the qemu platform.
 		MachineOptions: platform.MachineOptions{
 			MinMemory: kdumpHelperMemoryMiB + kdumpTestMemoryMiB,
 		},
 	})
 	register.RegisterTest(&register.Test{
-		Run:         kdumpNFSTest,
-		ClusterSize: 0,
-		Name:        `kdump.crash.nfs`,
-		Description: "Verifies kdump logs are exported to NFS destination",
-		Tags:        []string{"kdump", kola.SkipBaseChecksTag, kola.NeedsInternetTag},
-		Platforms:   []string{"qemu"},
-		// With ClusterSize: 0 we create the machines manually, but the
-		// total MinMemory is set here so the test harness can account for
-		// memory when scheduling. This value covers both the helper VM
+		Run:                 kdumpNFSTest,
+		ClusterSize:         2,
+		TestManagedMachines: true,
+		Name:                `kdump.crash.nfs`,
+		Description:         "Verifies kdump logs are exported to NFS destination",
+		Tags:                []string{"kdump", kola.SkipBaseChecksTag, kola.NeedsInternetTag},
+		Platforms:           []string{"qemu"},
+		// The total MinMemory is set here so the test harness can account
+		// for memory when scheduling. This value covers both the helper VM
 		// and the kdump test VM. Only relevant on the qemu platform.
 		// RequiredHostPorts declares that this test needs exclusive access
 		// to host port 2049 (NFS) to prevent clashes with other parallel

--- a/mantle/kola/tests/ignition/kdump.go
+++ b/mantle/kola/tests/ignition/kdump.go
@@ -45,15 +45,12 @@ func init() {
 			MinMemory: kdumpHelperMemoryMiB + kdumpTestMemoryMiB,
 		},
 	})
-	// Add tag "reprovision" to run serially to avoid NFS port conflicts.
-	// This is hack until a better solution exists.
-	// See https://github.com/coreos/coreos-assembler/issues/4117#issuecomment-3495048106
 	register.RegisterTest(&register.Test{
 		Run:         kdumpNFSTest,
 		ClusterSize: 0,
 		Name:        `kdump.crash.nfs`,
 		Description: "Verifies kdump logs are exported to NFS destination",
-		Tags:        []string{"kdump", kola.SkipBaseChecksTag, kola.NeedsInternetTag, "reprovision"},
+		Tags:        []string{"kdump", kola.SkipBaseChecksTag, kola.NeedsInternetTag},
 		Platforms:   []string{"qemu"},
 		// With ClusterSize: 0 we create the machines manually, but the
 		// total MinMemory is set here so the test harness can account for

--- a/mantle/kola/tests/ignition/kdump.go
+++ b/mantle/kola/tests/ignition/kdump.go
@@ -59,8 +59,12 @@ func init() {
 		// total MinMemory is set here so the test harness can account for
 		// memory when scheduling. This value covers both the helper VM
 		// and the kdump test VM. Only relevant on the qemu platform.
+		// RequiredHostPorts declares that this test needs exclusive access
+		// to host port 2049 (NFS) to prevent clashes with other parallel
+		// tests. See https://github.com/coreos/coreos-assembler/issues/4117
 		MachineOptions: platform.MachineOptions{
-			MinMemory: kdumpHelperMemoryMiB + kdumpTestMemoryMiB,
+			MinMemory:         kdumpHelperMemoryMiB + kdumpTestMemoryMiB,
+			RequiredHostPorts: []int{2049},
 		},
 	})
 }

--- a/mantle/kola/tests/ignition/luks.go
+++ b/mantle/kola/tests/ignition/luks.go
@@ -53,7 +53,7 @@ func init() {
 		Description: "Verify that the rootfs is encrypted with Tang.",
 		Flags:       []register.Flag{},
 		Distros:     []string{"rhcos", "scos"},
-		Tags:        []string{"luks", "tang", kola.NeedsInternetTag, "reprovision"},
+		Tags:        []string{"luks", "tang", kola.NeedsInternetTag},
 		// With ClusterSize: 0 we create the machines manually, but the
 		// total MinMemory is set here so the test harness can account for
 		// memory when scheduling. This value covers both the Tang server
@@ -71,7 +71,7 @@ func init() {
 		Distros:              []string{"rhcos", "scos"},
 		Platforms:            []string{"qemu"},
 		ExcludeArchitectures: []string{"s390x"}, // no TPM backend support for s390x
-		Tags:                 []string{"luks", "tpm", "tang", "sss", kola.NeedsInternetTag, "reprovision"},
+		Tags:                 []string{"luks", "tpm", "tang", "sss", kola.NeedsInternetTag},
 		// With ClusterSize: 0 we create the machines manually, but the
 		// total MinMemory is set here so the test harness can account for
 		// memory when scheduling. This value covers both the Tang server
@@ -89,7 +89,7 @@ func init() {
 		Distros:              []string{"fcos"},
 		Platforms:            []string{"qemu"},
 		ExcludeArchitectures: []string{"s390x"}, // no TPM backend support for s390x
-		Tags:                 []string{"luks", "tpm", "tang", "sss", kola.NeedsInternetTag, "reprovision"},
+		Tags:                 []string{"luks", "tpm", "tang", "sss", kola.NeedsInternetTag},
 		// With ClusterSize: 0 we create the machines manually, but the
 		// total MinMemory is set here so the test harness can account for
 		// memory when scheduling. This value covers both the Tang server
@@ -108,7 +108,7 @@ func init() {
 		Distros:              []string{"rhcos", "scos"},
 		Platforms:            []string{"qemu"},
 		ExcludeArchitectures: []string{"s390x"}, // no TPM backend support for s390x
-		Tags:                 []string{"luks", "tpm", "tang", "sss", kola.NeedsInternetTag, "fips", "reprovision"},
+		Tags:                 []string{"luks", "tpm", "tang", "sss", kola.NeedsInternetTag, "fips"},
 		// With ClusterSize: 0 we create the machines manually, but the
 		// total MinMemory is set here so the test harness can account for
 		// memory when scheduling. This value covers both the Tang server
@@ -125,7 +125,7 @@ func init() {
 		Flags:         []register.Flag{},
 		Platforms:     []string{"qemu"},
 		Architectures: []string{"s390x"},
-		Tags:          []string{"luks", "cex", "reprovision"},
+		Tags:          []string{"luks", "cex"},
 		// With ClusterSize: 0 we create the machine manually, but at least
 		// MinMemory will be considered by the test harness for scheduling.
 		MachineOptions: platform.MachineOptions{

--- a/mantle/kola/tests/ignition/luks.go
+++ b/mantle/kola/tests/ignition/luks.go
@@ -18,6 +18,31 @@ import (
 	"github.com/coreos/coreos-assembler/mantle/util"
 )
 
+// Memory constants for LUKS tests. These are defined here so they can
+// be used both in the test registration (for the scheduler's memory
+// accounting) and when creating VMs in the test functions.
+var (
+	// luksTangHelperMemoryMiB is the memory for the Tang server VM.
+	// It uses the architecture default since no MinMemory is set.
+	luksTangHelperMemoryMiB = platform.DefaultMemoryMiB()
+	// luksTestMemoryMiB is the memory for the LUKS test VM.
+	luksTestMemoryMiB = luksTestMemoryDefault()
+	// luksCexTestMemoryMiB is the memory for the CEX test VM (s390x only).
+	luksCexTestMemoryMiB = 8192
+)
+
+func luksTestMemoryDefault() int {
+	// ppc64le uses 64K pages by default which increases memory overhead.
+	// Double the memory request to avoid kernel panics during reprovisioning.
+	// See similar logic in harness.go and boot-mirror.go.
+	switch coreosarch.CurrentRpmArch() {
+	case "ppc64le":
+		return 8192
+	default:
+		return 4096
+	}
+}
+
 func init() {
 	// Create 0 cluster size to allow starting and setup of Tang as needed per test
 	// See: https://github.com/coreos/coreos-assembler/pull/1310#discussion_r401908836
@@ -29,6 +54,13 @@ func init() {
 		Flags:       []register.Flag{},
 		Distros:     []string{"rhcos", "scos"},
 		Tags:        []string{"luks", "tang", kola.NeedsInternetTag, "reprovision"},
+		// With ClusterSize: 0 we create the machines manually, but the
+		// total MinMemory is set here so the test harness can account for
+		// memory when scheduling. This value covers both the Tang server
+		// VM and the LUKS test VM. Only relevant on the qemu platform.
+		MachineOptions: platform.MachineOptions{
+			MinMemory: luksTangHelperMemoryMiB + luksTestMemoryMiB,
+		},
 	})
 	register.RegisterTest(&register.Test{
 		Run:                  luksSSST1Test,
@@ -40,6 +72,13 @@ func init() {
 		Platforms:            []string{"qemu"},
 		ExcludeArchitectures: []string{"s390x"}, // no TPM backend support for s390x
 		Tags:                 []string{"luks", "tpm", "tang", "sss", kola.NeedsInternetTag, "reprovision"},
+		// With ClusterSize: 0 we create the machines manually, but the
+		// total MinMemory is set here so the test harness can account for
+		// memory when scheduling. This value covers both the Tang server
+		// VM and the LUKS test VM. Only relevant on the qemu platform.
+		MachineOptions: platform.MachineOptions{
+			MinMemory: luksTangHelperMemoryMiB + luksTestMemoryMiB,
+		},
 	})
 	register.RegisterTest(&register.Test{
 		Run:                  luksSSST2Test,
@@ -51,6 +90,13 @@ func init() {
 		Platforms:            []string{"qemu"},
 		ExcludeArchitectures: []string{"s390x"}, // no TPM backend support for s390x
 		Tags:                 []string{"luks", "tpm", "tang", "sss", kola.NeedsInternetTag, "reprovision"},
+		// With ClusterSize: 0 we create the machines manually, but the
+		// total MinMemory is set here so the test harness can account for
+		// memory when scheduling. This value covers both the Tang server
+		// VM and the LUKS test VM. Only relevant on the qemu platform.
+		MachineOptions: platform.MachineOptions{
+			MinMemory: luksTangHelperMemoryMiB + luksTestMemoryMiB,
+		},
 	})
 	register.RegisterTest(&register.Test{
 		Run:                  luksSSST2FipsTest,
@@ -63,6 +109,13 @@ func init() {
 		Platforms:            []string{"qemu"},
 		ExcludeArchitectures: []string{"s390x"}, // no TPM backend support for s390x
 		Tags:                 []string{"luks", "tpm", "tang", "sss", kola.NeedsInternetTag, "fips", "reprovision"},
+		// With ClusterSize: 0 we create the machines manually, but the
+		// total MinMemory is set here so the test harness can account for
+		// memory when scheduling. This value covers both the Tang server
+		// VM and the LUKS test VM. Only relevant on the qemu platform.
+		MachineOptions: platform.MachineOptions{
+			MinMemory: luksTangHelperMemoryMiB + luksTestMemoryMiB,
+		},
 	})
 	register.RegisterTest(&register.Test{
 		Run:           runCexTest,
@@ -73,6 +126,11 @@ func init() {
 		Platforms:     []string{"qemu"},
 		Architectures: []string{"s390x"},
 		Tags:          []string{"luks", "cex", "reprovision"},
+		// With ClusterSize: 0 we create the machine manually, but at least
+		// MinMemory will be considered by the test harness for scheduling.
+		MachineOptions: platform.MachineOptions{
+			MinMemory: luksCexTestMemoryMiB,
+		},
 		NativeFuncs: map[string]register.NativeFuncWrap{
 			"RHCOSGrowpart": register.CreateNativeFuncWrap(coretest.TestRHCOSGrowfs, []string{"fcos"}...),
 			"FCOSGrowpart":  register.CreateNativeFuncWrap(coretest.TestFCOSGrowfs, []string{"rhcos", "scos"}...),
@@ -91,6 +149,7 @@ func setupTangMachine(c cluster.TestCluster) ut.TangServer {
 			{Service: "ssh", HostPort: 0, GuestPort: 22},
 			{Service: "tang", HostPort: 0, GuestPort: 80},
 		},
+		MinMemory: luksTangHelperMemoryMiB,
 	}
 
 	ignition := conf.Ignition(`{
@@ -181,12 +240,7 @@ func runTest(c cluster.TestCluster, tpm2 bool, threshold int, killTangAfterFirst
 	}`, tpm2, tangd.Address, tangd.Thumbprint, threshold, fipsFileSection(fips)))
 
 	opts := platform.MachineOptions{
-		MinMemory: 4096,
-	}
-	// ppc64le uses 64K pages; see similar logic in harness.go and boot-mirror.go
-	switch coreosarch.CurrentRpmArch() {
-	case "ppc64le":
-		opts.MinMemory = 8192
+		MinMemory: luksTestMemoryMiB,
 	}
 	m, err := c.NewMachineWithOptions(ignition, opts)
 	if err != nil {
@@ -248,7 +302,7 @@ func runCexTest(c cluster.TestCluster) {
 
 	opts := platform.MachineOptions{
 		Cex:       true,
-		MinMemory: 8192,
+		MinMemory: luksCexTestMemoryMiB,
 	}
 
 	m, err = c.Cluster.NewMachineWithOptions(ignition, opts)

--- a/mantle/kola/tests/ignition/luks.go
+++ b/mantle/kola/tests/ignition/luks.go
@@ -44,19 +44,18 @@ func luksTestMemoryDefault() int {
 }
 
 func init() {
-	// Create 0 cluster size to allow starting and setup of Tang as needed per test
 	// See: https://github.com/coreos/coreos-assembler/pull/1310#discussion_r401908836
 	register.RegisterTest(&register.Test{
-		Run:         luksTangTest,
-		ClusterSize: 0,
-		Name:        `luks.tang`,
-		Description: "Verify that the rootfs is encrypted with Tang.",
-		Flags:       []register.Flag{},
-		Distros:     []string{"rhcos", "scos"},
-		Tags:        []string{"luks", "tang", kola.NeedsInternetTag},
-		// With ClusterSize: 0 we create the machines manually, but the
-		// total MinMemory is set here so the test harness can account for
-		// memory when scheduling. This value covers both the Tang server
+		Run:                 luksTangTest,
+		ClusterSize:         2,
+		TestManagedMachines: true,
+		Name:                `luks.tang`,
+		Description:         "Verify that the rootfs is encrypted with Tang.",
+		Flags:               []register.Flag{},
+		Distros:             []string{"rhcos", "scos"},
+		Tags:                []string{"luks", "tang", kola.NeedsInternetTag},
+		// The total MinMemory is set here so the test harness can account
+		// for memory when scheduling. This value covers both the Tang server
 		// VM and the LUKS test VM. Only relevant on the qemu platform.
 		MachineOptions: platform.MachineOptions{
 			MinMemory: luksTangHelperMemoryMiB + luksTestMemoryMiB,
@@ -64,7 +63,8 @@ func init() {
 	})
 	register.RegisterTest(&register.Test{
 		Run:                  luksSSST1Test,
-		ClusterSize:          0,
+		ClusterSize:          2,
+		TestManagedMachines:  true,
 		Name:                 `luks.sss.t1`,
 		Description:          "Verify that the rootfs is encrypted with SSS with t=1.",
 		Flags:                []register.Flag{},
@@ -72,9 +72,8 @@ func init() {
 		Platforms:            []string{"qemu"},
 		ExcludeArchitectures: []string{"s390x"}, // no TPM backend support for s390x
 		Tags:                 []string{"luks", "tpm", "tang", "sss", kola.NeedsInternetTag},
-		// With ClusterSize: 0 we create the machines manually, but the
-		// total MinMemory is set here so the test harness can account for
-		// memory when scheduling. This value covers both the Tang server
+		// The total MinMemory is set here so the test harness can account
+		// for memory when scheduling. This value covers both the Tang server
 		// VM and the LUKS test VM. Only relevant on the qemu platform.
 		MachineOptions: platform.MachineOptions{
 			MinMemory: luksTangHelperMemoryMiB + luksTestMemoryMiB,
@@ -82,7 +81,8 @@ func init() {
 	})
 	register.RegisterTest(&register.Test{
 		Run:                  luksSSST2Test,
-		ClusterSize:          0,
+		ClusterSize:          2,
+		TestManagedMachines:  true,
 		Name:                 `luks.sss.t2`,
 		Description:          "Verify that the rootfs is encrypted with SSS with t=2.",
 		Flags:                []register.Flag{},
@@ -90,9 +90,8 @@ func init() {
 		Platforms:            []string{"qemu"},
 		ExcludeArchitectures: []string{"s390x"}, // no TPM backend support for s390x
 		Tags:                 []string{"luks", "tpm", "tang", "sss", kola.NeedsInternetTag},
-		// With ClusterSize: 0 we create the machines manually, but the
-		// total MinMemory is set here so the test harness can account for
-		// memory when scheduling. This value covers both the Tang server
+		// The total MinMemory is set here so the test harness can account
+		// for memory when scheduling. This value covers both the Tang server
 		// VM and the LUKS test VM. Only relevant on the qemu platform.
 		MachineOptions: platform.MachineOptions{
 			MinMemory: luksTangHelperMemoryMiB + luksTestMemoryMiB,
@@ -100,7 +99,8 @@ func init() {
 	})
 	register.RegisterTest(&register.Test{
 		Run:                  luksSSST2FipsTest,
-		ClusterSize:          0,
+		ClusterSize:          2,
+		TestManagedMachines:  true,
 		Name:                 `luks.sss.t2.fips`,
 		Description:          "Verify that the rootfs is encrypted with SSS with t=2 and FIPS mode enabled.",
 		CreationDate:         "2026-05-01",
@@ -109,24 +109,23 @@ func init() {
 		Platforms:            []string{"qemu"},
 		ExcludeArchitectures: []string{"s390x"}, // no TPM backend support for s390x
 		Tags:                 []string{"luks", "tpm", "tang", "sss", kola.NeedsInternetTag, "fips"},
-		// With ClusterSize: 0 we create the machines manually, but the
-		// total MinMemory is set here so the test harness can account for
-		// memory when scheduling. This value covers both the Tang server
+		// The total MinMemory is set here so the test harness can account
+		// for memory when scheduling. This value covers both the Tang server
 		// VM and the LUKS test VM. Only relevant on the qemu platform.
 		MachineOptions: platform.MachineOptions{
 			MinMemory: luksTangHelperMemoryMiB + luksTestMemoryMiB,
 		},
 	})
 	register.RegisterTest(&register.Test{
-		Run:           runCexTest,
-		ClusterSize:   0,
-		Name:          `luks.cex`,
-		Description:   "Verify that CEX-based rootfs encryption works.",
-		Flags:         []register.Flag{},
-		Platforms:     []string{"qemu"},
-		Architectures: []string{"s390x"},
-		Tags:          []string{"luks", "cex"},
-		// With ClusterSize: 0 we create the machine manually, but at least
+		Run:                 runCexTest,
+		ClusterSize:         1,
+		TestManagedMachines: true,
+		Name:                `luks.cex`,
+		Description:         "Verify that CEX-based rootfs encryption works.",
+		Flags:               []register.Flag{},
+		Platforms:           []string{"qemu"},
+		Architectures:       []string{"s390x"},
+		Tags:                []string{"luks", "cex"},
 		// MinMemory will be considered by the test harness for scheduling.
 		MachineOptions: platform.MachineOptions{
 			MinMemory: luksCexTestMemoryMiB,

--- a/mantle/kola/tests/ignition/mount.go
+++ b/mantle/kola/tests/ignition/mount.go
@@ -30,21 +30,23 @@ import (
 func init() {
 	// mount disks to `/var/log` and `/var/lib/containers`
 	register.RegisterTest(&register.Test{
-		Name:        "coreos.ignition.mount.disks",
-		Description: "Verify that we can mount two disks through Ignition and write to the mountpoints.",
-		Run:         testMountDisks,
-		ClusterSize: 0,
-		Platforms:   []string{"qemu"},
-		Tags:        []string{"ignition"},
+		Name:                "coreos.ignition.mount.disks",
+		Description:         "Verify that we can mount two disks through Ignition and write to the mountpoints.",
+		Run:                 testMountDisks,
+		ClusterSize:         1,
+		TestManagedMachines: true,
+		Platforms:           []string{"qemu"},
+		Tags:                []string{"ignition"},
 	})
 	// create new partitions on disk labeled `coreos-boot-disk
 	register.RegisterTest(&register.Test{
-		Name:        "coreos.ignition.mount.partitions",
-		Description: "Verify that we can create new partitions through Ignition.",
-		Run:         testMountPartitions,
-		ClusterSize: 0,
-		Platforms:   []string{"qemu"},
-		Tags:        []string{"ignition"},
+		Name:                "coreos.ignition.mount.partitions",
+		Description:         "Verify that we can create new partitions through Ignition.",
+		Run:                 testMountPartitions,
+		ClusterSize:         1,
+		TestManagedMachines: true,
+		Platforms:           []string{"qemu"},
+		Tags:                []string{"ignition"},
 	})
 }
 

--- a/mantle/kola/tests/ignition/qemufailure.go
+++ b/mantle/kola/tests/ignition/qemufailure.go
@@ -36,6 +36,12 @@ var (
 	plog = capnslog.NewPackageLogger("github.com/coreos/coreos-assembler/mantle", "kola/tests/ignition/qemufailure")
 )
 
+// qemuFailureTestMemoryMiB is the memory for the raw QemuBuilder
+// failure tests. Defined here so the test harness can account for
+// memory when scheduling, even though these tests use QemuBuilder
+// directly rather than cluster-managed machines.
+var qemuFailureTestMemoryMiB = 2048
+
 func init() {
 	register.RegisterTest(&register.Test{
 		Name:        "coreos.ignition.failure",
@@ -44,6 +50,12 @@ func init() {
 		ClusterSize: 0,
 		Platforms:   []string{"qemu"},
 		Tags:        []string{"ignition"},
+		// With ClusterSize: 0 we use QemuBuilder directly (not cluster-managed
+		// machines), but at least MinMemory will be considered by the test
+		// harness for scheduling.
+		MachineOptions: platform.MachineOptions{
+			MinMemory: qemuFailureTestMemoryMiB,
+		},
 	})
 	register.RegisterTest(&register.Test{
 		Name:        "coreos.unique.boot.failure",
@@ -51,6 +63,12 @@ func init() {
 		Description: "Verify boot fails if there are pre-existing boot filesystems.",
 		Platforms:   []string{"qemu"},
 		Run:         runDualBootfsFailure,
+		// With ClusterSize: 0 we use QemuBuilder directly (not cluster-managed
+		// machines), but at least MinMemory will be considered by the test
+		// harness for scheduling.
+		MachineOptions: platform.MachineOptions{
+			MinMemory: qemuFailureTestMemoryMiB,
+		},
 	})
 	register.RegisterTest(&register.Test{
 		Name:        "coreos.unique.boot.ignition.failure",
@@ -58,6 +76,12 @@ func init() {
 		Description: "Verify boot fails if there are pre-existing boot filesystems created with Ignition.",
 		Platforms:   []string{"qemu"},
 		Run:         runDualBootfsIgnitionFailure,
+		// With ClusterSize: 0 we use QemuBuilder directly (not cluster-managed
+		// machines), but at least MinMemory will be considered by the test
+		// harness for scheduling.
+		MachineOptions: platform.MachineOptions{
+			MinMemory: qemuFailureTestMemoryMiB,
+		},
 	})
 }
 
@@ -173,7 +197,7 @@ func ignitionFailure(c cluster.TestCluster) error {
 		return err
 	}
 
-	builder.MemoryMiB = 2048
+	builder.MemoryMiB = qemuFailureTestMemoryMiB
 	builder.Firmware = kola.QEMUOptions.Firmware
 
 	searchPattern := "error creating /sysroot/notwritable.txt"
@@ -222,7 +246,7 @@ func dualBootfsFailure(c cluster.TestCluster) error {
 	if err != nil {
 		return err
 	}
-	builder.MemoryMiB = 2048
+	builder.MemoryMiB = qemuFailureTestMemoryMiB
 	builder.Firmware = kola.QEMUOptions.Firmware
 
 	searchRegexString := "Error: System has 2 devices with a filesystem labeled 'boot'"
@@ -280,7 +304,7 @@ func dualBootfsIgnitionFailure(c cluster.TestCluster) error {
 		return err
 	}
 
-	builder.MemoryMiB = 2048
+	builder.MemoryMiB = qemuFailureTestMemoryMiB
 	builder.Firmware = kola.QEMUOptions.Firmware
 
 	searchRegexString := "Error: System has 2 devices with a filesystem labeled 'boot'"

--- a/mantle/kola/tests/ignition/qemufailure.go
+++ b/mantle/kola/tests/ignition/qemufailure.go
@@ -44,41 +44,38 @@ var qemuFailureTestMemoryMiB = 2048
 
 func init() {
 	register.RegisterTest(&register.Test{
-		Name:        "coreos.ignition.failure",
-		Description: "Verify ignition will fail with unsupported action.",
-		Run:         runIgnitionFailure,
-		ClusterSize: 0,
-		Platforms:   []string{"qemu"},
-		Tags:        []string{"ignition"},
-		// With ClusterSize: 0 we use QemuBuilder directly (not cluster-managed
-		// machines), but at least MinMemory will be considered by the test
-		// harness for scheduling.
+		Name:                "coreos.ignition.failure",
+		Description:         "Verify ignition will fail with unsupported action.",
+		Run:                 runIgnitionFailure,
+		ClusterSize:         1,
+		TestManagedMachines: true,
+		Platforms:           []string{"qemu"},
+		Tags:                []string{"ignition"},
+		// MinMemory will be considered by the test harness for scheduling.
 		MachineOptions: platform.MachineOptions{
 			MinMemory: qemuFailureTestMemoryMiB,
 		},
 	})
 	register.RegisterTest(&register.Test{
-		Name:        "coreos.unique.boot.failure",
-		ClusterSize: 0,
-		Description: "Verify boot fails if there are pre-existing boot filesystems.",
-		Platforms:   []string{"qemu"},
-		Run:         runDualBootfsFailure,
-		// With ClusterSize: 0 we use QemuBuilder directly (not cluster-managed
-		// machines), but at least MinMemory will be considered by the test
-		// harness for scheduling.
+		Name:                "coreos.unique.boot.failure",
+		ClusterSize:         1,
+		TestManagedMachines: true,
+		Description:         "Verify boot fails if there are pre-existing boot filesystems.",
+		Platforms:           []string{"qemu"},
+		Run:                 runDualBootfsFailure,
+		// MinMemory will be considered by the test harness for scheduling.
 		MachineOptions: platform.MachineOptions{
 			MinMemory: qemuFailureTestMemoryMiB,
 		},
 	})
 	register.RegisterTest(&register.Test{
-		Name:        "coreos.unique.boot.ignition.failure",
-		ClusterSize: 0,
-		Description: "Verify boot fails if there are pre-existing boot filesystems created with Ignition.",
-		Platforms:   []string{"qemu"},
-		Run:         runDualBootfsIgnitionFailure,
-		// With ClusterSize: 0 we use QemuBuilder directly (not cluster-managed
-		// machines), but at least MinMemory will be considered by the test
-		// harness for scheduling.
+		Name:                "coreos.unique.boot.ignition.failure",
+		ClusterSize:         1,
+		TestManagedMachines: true,
+		Description:         "Verify boot fails if there are pre-existing boot filesystems created with Ignition.",
+		Platforms:           []string{"qemu"},
+		Run:                 runDualBootfsIgnitionFailure,
+		// MinMemory will be considered by the test harness for scheduling.
 		MachineOptions: platform.MachineOptions{
 			MinMemory: qemuFailureTestMemoryMiB,
 		},

--- a/mantle/kola/tests/iso/live-iscsi.go
+++ b/mantle/kola/tests/iso/live-iscsi.go
@@ -69,16 +69,16 @@ func init() {
 			Run: func(c cluster.TestCluster) {
 				testLiveSCSI(c, opts)
 			},
-			ClusterSize: 0,
-			Name:        "iso." + testName,
-			Description: "Verify iSCSI install works.",
+			ClusterSize:         1,
+			TestManagedMachines: true,
+			Name:                "iso." + testName,
+			Description:         "Verify iSCSI install works.",
 			// Skip base checks (looks at journal for failures) until bootupd fix lands
 			// https://github.com/coreos/fedora-coreos-tracker/issues/2136
 			Tags:      []string{kola.NeedsInternetTag, kola.SkipBaseChecksTag},
 			Timeout:   installTimeoutMins * time.Minute,
 			Flags:     []register.Flag{},
 			Platforms: []string{"qemu"},
-			// With ClusterSize: 0 we create the machine manually below, but at least
 			// MinMemory will be considered by the test harness for scheduling.
 			MachineOptions: opts.machineOpts,
 		})

--- a/mantle/kola/tests/iso/live-iso.go
+++ b/mantle/kola/tests/iso/live-iso.go
@@ -94,14 +94,14 @@ func init() {
 			Run: func(c cluster.TestCluster) {
 				testLiveIso(c, opts)
 			},
-			ClusterSize: 0,
-			Name:        "iso." + testName,
-			Description: "Verify ISO live install works.",
-			Timeout:     installTimeoutMins * time.Minute,
-			Tags:        tags,
-			Flags:       []register.Flag{},
-			Platforms:   []string{"qemu"},
-			// With ClusterSize: 0 we create the machine manually below, but at least
+			ClusterSize:         1,
+			TestManagedMachines: true,
+			Name:                "iso." + testName,
+			Description:         "Verify ISO live install works.",
+			Timeout:             installTimeoutMins * time.Minute,
+			Tags:                tags,
+			Flags:               []register.Flag{},
+			Platforms:           []string{"qemu"},
 			// MinMemory will be considered by the test harness for scheduling.
 			MachineOptions: opts.machineOpts,
 		})

--- a/mantle/kola/tests/iso/live-pxe.go
+++ b/mantle/kola/tests/iso/live-pxe.go
@@ -75,16 +75,16 @@ func init() {
 			Run: func(c cluster.TestCluster) {
 				testLivePXE(c, opts)
 			},
-			ClusterSize: 0,
-			Name:        "iso." + testName,
-			Description: "Verify PXE install works.",
-			Timeout:     installTimeoutMins * time.Minute,
-			Flags:       []register.Flag{},
-			Platforms:   []string{"qemu"},
+			ClusterSize:         1,
+			TestManagedMachines: true,
+			Name:                "iso." + testName,
+			Description:         "Verify PXE install works.",
+			Timeout:             installTimeoutMins * time.Minute,
+			Flags:               []register.Flag{},
+			Platforms:           []string{"qemu"},
 			// Skip base checks (looks at journal for failures) until bootupd fix lands
 			// https://github.com/coreos/fedora-coreos-tracker/issues/2136
 			Tags: []string{kola.SkipBaseChecksTag},
-			// With ClusterSize: 0 we create the machine manually below, but at least
 			// MinMemory will be considered by the test harness for scheduling.
 			MachineOptions: opts.machineOpts,
 		})

--- a/mantle/kola/tests/misc/boot-mirror.go
+++ b/mantle/kola/tests/misc/boot-mirror.go
@@ -83,7 +83,7 @@ func init() {
 		// skipping this test on UEFI until https://github.com/coreos/coreos-assembler/issues/2039
 		// gets resolved.
 		ExcludeFirmwares: []string{"uefi"},
-		Tags:             []string{"boot-mirror", "raid1", "reprovision"},
+		Tags:             []string{"boot-mirror", "raid1"},
 		FailFast:         true,
 		Timeout:          15 * time.Minute,
 		// With ClusterSize: 0 we create the machine manually, but at least
@@ -102,7 +102,7 @@ func init() {
 		// skipping this test on UEFI until https://github.com/coreos/coreos-assembler/issues/2039
 		// gets resolved.
 		ExcludeFirmwares: []string{"uefi"},
-		Tags:             []string{"boot-mirror", "luks", "raid1", "tpm2", kola.NeedsInternetTag, "reprovision"},
+		Tags:             []string{"boot-mirror", "luks", "raid1", "tpm2", kola.NeedsInternetTag},
 		FailFast:         true,
 		Timeout:          15 * time.Minute,
 		// With ClusterSize: 0 we create the machine manually, but at least

--- a/mantle/kola/tests/misc/boot-mirror.go
+++ b/mantle/kola/tests/misc/boot-mirror.go
@@ -73,11 +73,12 @@ func bootMirrorTestMemoryDefault() int {
 
 func init() {
 	register.RegisterTest(&register.Test{
-		Run:         runBootMirrorTest,
-		ClusterSize: 0,
-		Name:        `coreos.boot-mirror`,
-		Description: "Verify the boot-mirror RAID1 flow works properly in both BIOS and UEFI mode.",
-		Platforms:   []string{"qemu"},
+		Run:                 runBootMirrorTest,
+		ClusterSize:         1,
+		TestManagedMachines: true,
+		Name:                `coreos.boot-mirror`,
+		Description:         "Verify the boot-mirror RAID1 flow works properly in both BIOS and UEFI mode.",
+		Platforms:           []string{"qemu"},
 		// Can't mirror boot disk on s390x
 		ExcludeArchitectures: []string{"s390x"},
 		// skipping this test on UEFI until https://github.com/coreos/coreos-assembler/issues/2039
@@ -86,16 +87,16 @@ func init() {
 		Tags:             []string{"boot-mirror", "raid1"},
 		FailFast:         true,
 		Timeout:          15 * time.Minute,
-		// With ClusterSize: 0 we create the machine manually, but at least
 		// MinMemory will be considered by the test harness for scheduling.
 		MachineOptions: platform.MachineOptions{MinMemory: bootMirrorTestMemoryMiB},
 	})
 	register.RegisterTest(&register.Test{
-		Run:         runBootMirrorLUKSTest,
-		ClusterSize: 0,
-		Name:        `coreos.boot-mirror.luks`,
-		Description: "Verify the boot-mirror+LUKS RAID1 flow works properly in both BIOS and UEFI modes.",
-		Platforms:   []string{"qemu"},
+		Run:                 runBootMirrorLUKSTest,
+		ClusterSize:         1,
+		TestManagedMachines: true,
+		Name:                `coreos.boot-mirror.luks`,
+		Description:         "Verify the boot-mirror+LUKS RAID1 flow works properly in both BIOS and UEFI modes.",
+		Platforms:           []string{"qemu"},
 		// Can't mirror boot disk on s390x, and qemu s390x doesn't
 		// support TPM
 		ExcludeArchitectures: []string{"s390x"},
@@ -105,7 +106,6 @@ func init() {
 		Tags:             []string{"boot-mirror", "luks", "raid1", "tpm2", kola.NeedsInternetTag},
 		FailFast:         true,
 		Timeout:          15 * time.Minute,
-		// With ClusterSize: 0 we create the machine manually, but at least
 		// MinMemory will be considered by the test harness for scheduling.
 		MachineOptions: platform.MachineOptions{MinMemory: bootMirrorTestMemoryMiB},
 	})

--- a/mantle/kola/tests/misc/boot-mirror.go
+++ b/mantle/kola/tests/misc/boot-mirror.go
@@ -54,6 +54,23 @@ boot_device:
       - /dev/vdb`)
 )
 
+// bootMirrorTestMemoryMiB is the memory for the boot-mirror test VM.
+// Defined here so it can be used both in the test registration (for
+// the scheduler's memory accounting) and when creating VMs.
+var bootMirrorTestMemoryMiB = bootMirrorTestMemoryDefault()
+
+func bootMirrorTestMemoryDefault() int {
+	// ppc64le uses 64K pages by default which increases memory overhead.
+	// Double the memory request to avoid kernel panics during reprovisioning.
+	// See similar logic in harness.go and luks.go.
+	switch coreosarch.CurrentRpmArch() {
+	case "ppc64le":
+		return 8192
+	default:
+		return 4096
+	}
+}
+
 func init() {
 	register.RegisterTest(&register.Test{
 		Run:         runBootMirrorTest,
@@ -69,6 +86,9 @@ func init() {
 		Tags:             []string{"boot-mirror", "raid1", "reprovision"},
 		FailFast:         true,
 		Timeout:          15 * time.Minute,
+		// With ClusterSize: 0 we create the machine manually, but at least
+		// MinMemory will be considered by the test harness for scheduling.
+		MachineOptions: platform.MachineOptions{MinMemory: bootMirrorTestMemoryMiB},
 	})
 	register.RegisterTest(&register.Test{
 		Run:         runBootMirrorLUKSTest,
@@ -85,6 +105,9 @@ func init() {
 		Tags:             []string{"boot-mirror", "luks", "raid1", "tpm2", kola.NeedsInternetTag, "reprovision"},
 		FailFast:         true,
 		Timeout:          15 * time.Minute,
+		// With ClusterSize: 0 we create the machine manually, but at least
+		// MinMemory will be considered by the test harness for scheduling.
+		MachineOptions: platform.MachineOptions{MinMemory: bootMirrorTestMemoryMiB},
 	})
 }
 
@@ -95,12 +118,7 @@ func runBootMirrorTest(c cluster.TestCluster) {
 	var err error
 	options := platform.MachineOptions{
 		AdditionalDisks: []string{"5G", "5G"},
-		MinMemory:       4096,
-	}
-	// ppc64le uses 64K pages; see similar logic in harness.go and luks.go
-	switch coreosarch.CurrentRpmArch() {
-	case "ppc64le":
-		options.MinMemory = 8192
+		MinMemory:       bootMirrorTestMemoryMiB,
 	}
 	// FIXME: for QEMU tests kola currently assumes the host CPU architecture
 	// matches the one under test
@@ -145,12 +163,7 @@ func runBootMirrorLUKSTest(c cluster.TestCluster) {
 	var err error
 	options := platform.MachineOptions{
 		AdditionalDisks: []string{"5G"},
-		MinMemory:       4096,
-	}
-	// ppc64le uses 64K pages; see similar logic in harness.go and luks.go
-	switch coreosarch.CurrentRpmArch() {
-	case "ppc64le":
-		options.MinMemory = 8192
+		MinMemory:       bootMirrorTestMemoryMiB,
 	}
 	// FIXME: for QEMU tests kola currently assumes the host CPU architecture
 	// matches the one under test

--- a/mantle/kola/tests/misc/disk.go
+++ b/mantle/kola/tests/misc/disk.go
@@ -28,12 +28,13 @@ import (
 
 func init() {
 	register.RegisterTest(&register.Test{
-		Run:         varLibContainers,
-		ClusterSize: 0,
-		Name:        `coreos.misc.disk.varlibcontainers`,
-		Flags:       []register.Flag{},
-		Distros:     []string{"rhcos", "fcos"},
-		Platforms:   []string{"qemu"},
+		Run:                 varLibContainers,
+		ClusterSize:         1,
+		TestManagedMachines: true,
+		Name:                `coreos.misc.disk.varlibcontainers`,
+		Flags:               []register.Flag{},
+		Distros:             []string{"rhcos", "fcos"},
+		Platforms:           []string{"qemu"},
 	})
 }
 

--- a/mantle/kola/tests/misc/network.go
+++ b/mantle/kola/tests/misc/network.go
@@ -50,13 +50,14 @@ func init() {
 	})
 	// This test follows the same network configuration used on https://github.com/RHsyseng/rhcos-slb
 	register.RegisterTest(&register.Test{
-		Run:         NetworkAdditionalNics,
-		ClusterSize: 0,
-		Name:        "rhcos.network.multiple-nics",
-		Description: "Verify configuring networking with multiple NICs work.",
-		Timeout:     20 * time.Minute,
-		Distros:     []string{"rhcos", "scos"},
-		Platforms:   []string{"qemu"},
+		Run:                 NetworkAdditionalNics,
+		ClusterSize:         1,
+		TestManagedMachines: true,
+		Name:                "rhcos.network.multiple-nics",
+		Description:         "Verify configuring networking with multiple NICs work.",
+		Timeout:             20 * time.Minute,
+		Distros:             []string{"rhcos", "scos"},
+		Platforms:           []string{"qemu"},
 	})
 	// This test follows the same network configuration used on https://github.com/RHsyseng/rhcos-slb
 	// with a slight change, where the script originally run by MCO is run from

--- a/mantle/kola/tests/ostree/sync.go
+++ b/mantle/kola/tests/ostree/sync.go
@@ -82,15 +82,15 @@ var (
 func init() {
 	// See https://github.com/ostreedev/ostree/pull/2968
 	register.RegisterTest(&register.Test{
-		Run:         ostreeSyncTest,
-		ClusterSize: 0,
-		Name:        "ostree.sync",
-		Description: "Verify ostree can sync the filesystem with disconnected the NFS volume.",
-		Distros:     []string{"rhcos", "scos"},
-		Tags:        []string{"ostree", kola.SkipBaseChecksTag, kola.NeedsInternetTag},
-		// With ClusterSize: 0 we create the machines manually, but the
-		// total MinMemory is set here so the test harness can account for
-		// memory when scheduling. This value covers both the NFS server
+		Run:                 ostreeSyncTest,
+		ClusterSize:         2,
+		TestManagedMachines: true,
+		Name:                "ostree.sync",
+		Description:         "Verify ostree can sync the filesystem with disconnected the NFS volume.",
+		Distros:             []string{"rhcos", "scos"},
+		Tags:                []string{"ostree", kola.SkipBaseChecksTag, kola.NeedsInternetTag},
+		// The total MinMemory is set here so the test harness can account
+		// for memory when scheduling. This value covers both the NFS server
 		// VM and the client VM.
 		// RequiredHostPorts declares that this test needs exclusive access
 		// to host port 2049 (NFS) to prevent clashes with other parallel

--- a/mantle/kola/tests/ostree/sync.go
+++ b/mantle/kola/tests/ostree/sync.go
@@ -95,8 +95,12 @@ func init() {
 		// total MinMemory is set here so the test harness can account for
 		// memory when scheduling. This value covers both the NFS server
 		// VM and the client VM.
+		// RequiredHostPorts declares that this test needs exclusive access
+		// to host port 2049 (NFS) to prevent clashes with other parallel
+		// tests. See https://github.com/coreos/coreos-assembler/issues/4117
 		MachineOptions: platform.MachineOptions{
-			MinMemory: ostreeSyncNfsServerMemoryMiB + ostreeSyncClientMemoryMiB,
+			MinMemory:         ostreeSyncNfsServerMemoryMiB + ostreeSyncClientMemoryMiB,
+			RequiredHostPorts: []int{2049},
 		},
 	})
 }

--- a/mantle/kola/tests/ostree/sync.go
+++ b/mantle/kola/tests/ostree/sync.go
@@ -81,16 +81,13 @@ var (
 
 func init() {
 	// See https://github.com/ostreedev/ostree/pull/2968
-	// Add tag "reprovision" to run serially to avoid NFS port conflicts.
-	// This is hack until a better solution exists.
-	// See https://github.com/coreos/coreos-assembler/issues/4117#issuecomment-3495048106
 	register.RegisterTest(&register.Test{
 		Run:         ostreeSyncTest,
 		ClusterSize: 0,
 		Name:        "ostree.sync",
 		Description: "Verify ostree can sync the filesystem with disconnected the NFS volume.",
 		Distros:     []string{"rhcos", "scos"},
-		Tags:        []string{"ostree", kola.SkipBaseChecksTag, kola.NeedsInternetTag, "reprovision"},
+		Tags:        []string{"ostree", kola.SkipBaseChecksTag, kola.NeedsInternetTag},
 		// With ClusterSize: 0 we create the machines manually, but the
 		// total MinMemory is set here so the test harness can account for
 		// memory when scheduling. This value covers both the NFS server

--- a/mantle/kola/tests/ostree/sync.go
+++ b/mantle/kola/tests/ostree/sync.go
@@ -70,6 +70,15 @@ systemd:
     - name: "nfs-server.service"
       enabled: true`)
 
+// Memory constants for the ostree sync test. These are defined here
+// so they can be used both in the test registration (for the
+// scheduler's memory accounting) and when creating VMs in the test
+// functions. This test starts two VMs (NFS server + client).
+var (
+	ostreeSyncNfsServerMemoryMiB = 2048
+	ostreeSyncClientMemoryMiB    = 2048
+)
+
 func init() {
 	// See https://github.com/ostreedev/ostree/pull/2968
 	// Add tag "reprovision" to run serially to avoid NFS port conflicts.
@@ -82,6 +91,13 @@ func init() {
 		Description: "Verify ostree can sync the filesystem with disconnected the NFS volume.",
 		Distros:     []string{"rhcos", "scos"},
 		Tags:        []string{"ostree", kola.SkipBaseChecksTag, kola.NeedsInternetTag, "reprovision"},
+		// With ClusterSize: 0 we create the machines manually, but the
+		// total MinMemory is set here so the test harness can account for
+		// memory when scheduling. This value covers both the NFS server
+		// VM and the client VM.
+		MachineOptions: platform.MachineOptions{
+			MinMemory: ostreeSyncNfsServerMemoryMiB + ostreeSyncClientMemoryMiB,
+		},
 	})
 }
 
@@ -101,7 +117,7 @@ func setupNFSMachine(c cluster.TestCluster) NfsServer {
 			{Service: "ssh", HostPort: 0, GuestPort: 22},
 			{Service: "nfs", HostPort: 2049, GuestPort: 2049},
 		},
-		MinMemory: 2048,
+		MinMemory: ostreeSyncNfsServerMemoryMiB,
 	}
 	// start the machine
 	switch c.Cluster.(type) {
@@ -191,7 +207,7 @@ systemd:
         [Install]
         WantedBy=multi-user.target`)
 	opts := platform.MachineOptions{
-		MinMemory: 2048,
+		MinMemory: ostreeSyncClientMemoryMiB,
 	}
 	var nfs_client platform.Machine
 	var err error

--- a/mantle/kola/tests/rhcos/nfs.go
+++ b/mantle/kola/tests/rhcos/nfs.go
@@ -54,11 +54,12 @@ systemd:
 func init() {
 	// TODO: enable FCOS
 	register.RegisterTest(&register.Test{
-		Run:            NFSv4,
-		ClusterSize:    0,
-		Name:           "rhcos.nfs.v4",
-		Description:    "Verify that NFSv4 works.",
-		ExcludeDistros: []string{"fcos"},
+		Run:                 NFSv4,
+		ClusterSize:         2,
+		TestManagedMachines: true,
+		Name:                "rhcos.nfs.v4",
+		Description:         "Verify that NFSv4 works.",
+		ExcludeDistros:      []string{"fcos"},
 
 		// Disabled on Azure because setting hostname
 		// is required at the instance creation level

--- a/mantle/kola/tests/rhcos/upgrade.go
+++ b/mantle/kola/tests/rhcos/upgrade.go
@@ -87,7 +87,8 @@ func init() {
 
 	register.RegisterTest(&register.Test{
 		Run:                  rhcosUpgradeFromOcpRhcos,
-		ClusterSize:          0,
+		ClusterSize:          1,
+		TestManagedMachines:  true,
 		Name:                 "rhcos.upgrade.from-ocp-rhcos",
 		Description:          "Verify upgrading from the latest RHCOS released for OCP works.",
 		FailFast:             true,

--- a/mantle/platform/platform.go
+++ b/mantle/platform/platform.go
@@ -190,6 +190,12 @@ type MachineOptions struct {
 	BindMountHostRO           []string
 	BootFrom                  string
 	NoIgnition                bool
+
+	// RequiredHostPorts lists host ports that this test requires exclusive
+	// access to (e.g., well-known service ports like NFS 2049 that cannot
+	// be randomized). The test harness uses this for scheduling to prevent
+	// parallel tests from clashing on the same host port.
+	RequiredHostPorts []int
 }
 
 // EnsureNoQEMUOnlyOptions returns an error if any QEMU-only options
@@ -243,6 +249,9 @@ func (m *MachineOptions) EnsureNoQEMUOnlyOptions(platformName string) error {
 	}
 	if m.NoIgnition {
 		return fmt.Errorf("platform %s does not support NoIgnition", platformName)
+	}
+	if len(m.RequiredHostPorts) > 0 {
+		return fmt.Errorf("platform %s does not support RequiredHostPorts", platformName)
 	}
 	return nil
 }

--- a/mantle/platform/qemu.go
+++ b/mantle/platform/qemu.go
@@ -1391,10 +1391,17 @@ func (builder *QemuBuilder) AddIso(path string, bootindexStr string, asDisk bool
 }
 
 // DefaultMemoryMiB returns the default QEMU guest memory in MiB for
-// the given architecture. The historical defaults are 1024 for x86_64
-// and 2048 for all other architectures.
-func DefaultMemoryMiB(arch string) int {
-	switch arch {
+// the given architecture. If no architecture is provided, the current
+// host architecture is used. The historical defaults are 1024 for
+// x86_64 and 2048 for all other architectures.
+func DefaultMemoryMiB(arch ...string) int {
+	a := ""
+	if len(arch) > 0 {
+		a = arch[0]
+	} else {
+		a = coreosarch.CurrentRpmArch()
+	}
+	switch a {
 	case "aarch64", "s390x", "ppc64le":
 		return 2048
 	default:


### PR DESCRIPTION
This patchset fixes issues with memory accounting for `ClusterSize: 0` tests and also fixes a port conflict for tests that start an NFS server. It also removes the `reprovision` tag from all tests as that should no longer be needed because we implemented memory aware scheduling in d142c86.

See individual commit messages for more info.

Assisted-by: <anthropic/claude-opus-4.6>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added exclusive host-port reservations to prevent conflicts between parallel tests.
  * Added architecture-aware memory sizing and explicit resource requirements for test machines.
  * Enabled more tests to use managed machine clusters.

* **Bug Fixes**
  * Improved parallel test reliability through coordinated memory and port allocation.
  * Standardized machine setup across networking, storage, installation, upgrade, encryption, and boot tests.
  * Reduced unnecessary test serialization when resources can be safely scheduled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->