### PR TITLE
renovate: run update_artifacts_lockfile as postUpgradeTasks

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -44,7 +44,17 @@
       "matchDatasources": [
         "custom.oc"
       ],
-      "extractVersion": "openshift-client-linux-(?<version>.+)\\.tar\\.gz"
+      "extractVersion": "openshift-client-linux-(?<version>.+)\\.tar\\.gz",
+      "postUpgradeTasks": {
+        "commands": [
+          "update_artifacts_lockfile -f \"$RENOVATE_POST_UPGRADE_COMMAND_DATA_FILE\""
+        ],
+        "dataFileTemplate": "[{{#each upgrades}}{\"packageFile\": \"{{{packageFile}}}\"}{{#unless @last}},{{/unless}}{{/each}}]",
+        "executionMode": "branch",
+        "fileFilters": [
+          "ci/hermetic/artifacts.lock.yaml"
+        ]
+      }
     }
   ],
   "customManagers": [


### PR DESCRIPTION
When MintMaker bumps the OpenShift client version in ci/hermetic/artifacts.lock.yaml it only updates the download_url fields, leaving the checksum fields pointing at the old version. The hermetic build then fails because the downloaded file doesn't match the stored fingerprint. Example: PR #4524.

postUpgradeTasks is a standard Renovate feature that runs a shell command after a dependency is updated. This PR adds it to the custom.oc package rule so MintMaker calls: 

```text
update_artifacts_lockfile -f "$RENOVATE_POST_UPGRADE_COMMAND_DATA_FILE"
```
The Renovate data file provides the affected packageFile paths. The tool then refreshes all four architecture checksums in the same PR commit as the OC version bump.

The tool is maintained at https://github.com/konflux-ci/update-artifacts-lockfile, tagged as v0.2.0, and installed in the MintMaker image via pipx.

The required supporting changes have merged:
- https://github.com/konflux-ci/update-artifacts-lockfile/pull/1 adds Renovate data-file support.
- https://github.com/konflux-ci/mintmaker-renovate-image/pull/576 installs update-artifacts-lockfile v0.2.0.
- https://github.com/konflux-ci/mintmaker/pull/597 adds the command to allowedCommands.

See: https://issues.redhat.com/browse/COS-3382