### PR TITLE
kola: Restore kola.json metadata fallback

### DIFF
--- a/mantle/kola/harness.go
+++ b/mantle/kola/harness.go
@@ -1017,7 +1017,7 @@ func metadataFromTestBinary(executable string) (*externalTestMeta, error) {
 	}
 	defer f.Close()
 	r := bufio.NewReader(io.LimitReader(f, 8192))
-	meta := &externalTestMeta{Exclusive: true}
+	var meta *externalTestMeta
 	inmeta := false    // true if we saw a ## kola: prefix after which we expect YAML
 	metadatayaml := "" // accumulated YAML metadata
 	for {
@@ -1048,10 +1048,11 @@ func metadataFromTestBinary(executable string) (*externalTestMeta, error) {
 			if inmeta {
 				return nil, fmt.Errorf("found multiple %s", InstalledTestMetaPrefixYaml)
 			}
+			meta = &externalTestMeta{Exclusive: true}
 			inmeta = true
 		} else if inmeta {
 			if !strings.HasPrefix(line, "## ") {
-				if err := yaml.UnmarshalStrict([]byte(metadatayaml), &meta); err != nil {
+				if err := yaml.UnmarshalStrict([]byte(metadatayaml), meta); err != nil {
 					return nil, err
 				}
 				break

--- a/mantle/kola/harness_test.go
+++ b/mantle/kola/harness_test.go
@@ -1,0 +1,92 @@
+// Copyright 2026 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kola
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestMetadataFromTestBinary(t *testing.T) {
+	tests := []struct {
+		name     string
+		contents string
+		want     *externalTestMeta
+	}{
+		{
+			name:     "no inline metadata",
+			contents: "#!/bin/bash\necho no-metadata\n",
+			want:     nil,
+		},
+		{
+			name:     "JSON metadata defaults to exclusive",
+			contents: "#!/bin/bash\n# kola: {\"tags\":\"json\",\"minMemory\":1024}\necho json\n",
+			want: &externalTestMeta{
+				Tags:      "json",
+				MinMemory: 1024,
+				Exclusive: true,
+			},
+		},
+		{
+			name: "YAML metadata defaults to exclusive",
+			contents: "#!/bin/bash\n" +
+				"## kola:\n" +
+				"## tags: yaml\n" +
+				"## minMemory: 2048\n" +
+				"echo yaml\n",
+			want: &externalTestMeta{
+				Tags:      "yaml",
+				MinMemory: 2048,
+				Exclusive: true,
+			},
+		},
+		{
+			name:     "JSON metadata can disable exclusivity",
+			contents: "#!/bin/bash\n# kola: {\"exclusive\":false}\necho json\n",
+			want: &externalTestMeta{
+				Exclusive: false,
+			},
+		},
+		{
+			name: "YAML metadata can disable exclusivity",
+			contents: "#!/bin/bash\n" +
+				"## kola:\n" +
+				"## exclusive: false\n" +
+				"echo yaml\n",
+			want: &externalTestMeta{
+				Exclusive: false,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			executable := filepath.Join(t.TempDir(), "test.sh")
+			if err := os.WriteFile(executable, []byte(tt.contents), 0755); err != nil {
+				t.Fatal(err)
+			}
+
+			got, err := metadataFromTestBinary(executable)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("metadataFromTestBinary() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #4392

## Summary

- leave external-test metadata unset when an executable has no inline JSON or YAML block, allowing `registerExternalTest` to fall back to the directory's `kola.json`
- preserve the existing `Exclusive: true` default when inline metadata is present
- add regression coverage for absent metadata, JSON and YAML metadata, and explicit non-exclusive settings

## Testing

- `go test -mod=vendor ./mantle/kola`
- `go test -mod=vendor ./mantle/kola -run TestMetadataFromTestBinary -count=1 -v`
- `go vet -mod=vendor ./mantle/...`
- `gofmt -d mantle/kola/harness.go mantle/kola/harness_test.go`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of optional metadata embedded in test scripts.
  * Correctly parses both JSON and YAML metadata, including explicit `exclusive: false` values.
  * Scripts without embedded metadata are now handled appropriately.

* **Tests**
  * Added coverage for JSON and YAML metadata, default values, and scripts without metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->