### PR TITLE
Switch our gpg key path locations to /usr/

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -124,19 +124,6 @@ install_ocp_tools() {
     mv oc /usr/bin
 }
 
-# By default, we trust the official Red Hat GPG keys
-trust_redhat_gpg_keys() {
-    for f in /usr/share/distribution-gpg-keys/redhat/*; do
-        local base
-        base=$(basename "$f")
-        if [ ! -e "/etc/pki/rpm-gpg/$base" ]; then
-            # libdnf at least ignores symlinks, so we need to copy.
-            # but might as well keep symlinks as symlinks.
-            cp -vPt /etc/pki/rpm-gpg "$f"
-        fi
-    done
-}
-
 make_and_makeinstall() {
     make
     make install

--- a/src/cmd-sign
+++ b/src/cmd-sign
@@ -67,7 +67,7 @@ def parse_args():
                          help="target the stg infra rather than prod")
     robosig.add_argument("--gpgkeypath", help="path to directory containing "
                          "public keys to use for signature verification",
-                         default="/etc/pki/rpm-gpg")
+                         default="/usr/share/pki/rpm-gpg")
     robosig.add_argument("--s3-sigstore", help="bucket and prefix to S3 sigstore")
     robosig.add_argument("--verify-only", action='store_true',
                          help="verify only that the sigs are valid and make public")

--- a/src/cmdlib.sh
+++ b/src/cmdlib.sh
@@ -253,7 +253,7 @@ runvm() {
 	# EOF
 
     # and include all GPG keys
-    echo '/etc/pki/rpm-gpg/*' >> "${vmpreparedir}/hostfiles"
+    echo '/usr/share/pki/rpm-gpg/*' >> "${vmpreparedir}/hostfiles"
 
     # the reason we do a heredoc here is so that the var substition takes
     # place immediately instead of having to proxy them through to the VM


### PR DESCRIPTION
Part of:

- https://github.com/coreos/fedora-coreos-tracker/issues/2172
- https://fedoraproject.org/wiki/Changes/RelocateRpmRepoConfigsToUsr

Because of [1][2] we now have the gpgkeys also in /usr on F44/F43 so
we can go ahead and start using those paths everywhere.

[1] https://src.fedoraproject.org/rpms/fedora-repos/c/107895f6f8dc26d329d3e40dbd5ccbabe1e8f301?branch=f44
[2] https://src.fedoraproject.org/rpms/fedora-repos/c/86ce6ca389b2d6018caefa94a291c6236060ff1d?branch=f43

---

Also a second commit in there to drop some dead code.