### PR TITLE
cmd-build: prefix container build secret IDs

### DIFF
--- a/src/cmd-build
+++ b/src/cmd-build
@@ -184,8 +184,8 @@ build_with_buildah() {
 
     # Add --secret args for the yumrepo/contentsets if the repo file exists
     if [ -d "src/yumrepos" ] && [ -e "src/yumrepos/${yumrepo_filename}" ]; then
-        set -- "$@" --secret id=yumrepos,src="$(realpath "src/yumrepos/${yumrepo_filename}")" \
-                    --secret id=contentsets,src="$(realpath src/yumrepos/content_sets.yaml)" \
+        set -- "$@" --secret id=container-image-build/yumrepos,src="$(realpath "src/yumrepos/${yumrepo_filename}")" \
+                    --secret id=container-image-build/contentsets,src="$(realpath src/yumrepos/content_sets.yaml)" \
                     -v /etc/pki/ca-trust:/etc/pki/ca-trust:ro
     fi
 


### PR DESCRIPTION
Konflux exposes files from ADDITIONAL_SECRET using IDs in the form `<secret-name>/<filename>`. Prefix the yumrepos and contentsets IDs with container-image-build.

Supports https://github.com/coreos/fedora-coreos-config/pull/4350

ref: https://github.com/coreos/rhel-coreos-config/issues/307