### PR TITLE
WIP: COS-3382: renovate: switch RPM automerge from branch to PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -38,7 +38,7 @@
       "branchPrefix": "renovate/rpm/",
       "semanticCommits": "enabled",
       "automerge": true,
-      "automergeType": "branch"
+      "automergeType": "pr"
     },
     {
       "matchDatasources": [


### PR DESCRIPTION
automergeType: "branch" required Renovate to push directly to main, which failed with GH006 because branch protection rules require 4 CI checks to pass.

Switching to "pr" lets Renovate open a pull request so all required checks run normally, then automerges when they pass.

Depends on: https://github.com/konflux-ci/mintmaker/pull/597
See: https://issues.redhat.com/browse/COS-3382